### PR TITLE
Async paramfetch

### DIFF
--- a/cmd/curio/proving.go
+++ b/cmd/curio/proving.go
@@ -168,7 +168,7 @@ It will not send any messages to the chain. Since it can compute any deadline, o
 		}
 
 		wdPostTask, wdPoStSubmitTask, derlareRecoverTask, err := tasks.WindowPostScheduler(
-			ctx, deps.Cfg.Fees, deps.Cfg.Proving, deps.Full, deps.Verif, nil, nil,
+			ctx, deps.Cfg.Fees, deps.Cfg.Proving, deps.Full, deps.Verif, nil, nil, nil,
 			deps.As, deps.Maddrs, deps.DB, deps.Stor, deps.Si, deps.Cfg.Subsystems.WindowPostMaxTasks)
 		if err != nil {
 			return err

--- a/tasks/window/compute_task.go
+++ b/tasks/window/compute_task.go
@@ -24,10 +24,10 @@ import (
 	"github.com/filecoin-project/go-state-types/dline"
 	"github.com/filecoin-project/go-state-types/network"
 
+	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/types"
-	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/lotus/lib/promise"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 	"github.com/filecoin-project/lotus/storage/paths"
@@ -69,6 +69,7 @@ type WdPostTask struct {
 	faultTracker sealer.FaultTracker
 	storage      paths.Store
 	verifier     storiface.Verifier
+	paramsReady  func() (bool, error)
 
 	windowPoStTF promise.Promise[harmonytask.AddTaskFunc]
 
@@ -90,6 +91,7 @@ func NewWdPostTask(db *harmonydb.DB,
 	faultTracker sealer.FaultTracker,
 	storage paths.Store,
 	verifier storiface.Verifier,
+	paramck func() (bool, error),
 	pcs *chainsched.CurioChainSched,
 	actors map[dtypes.MinerAddress]bool,
 	max int,
@@ -103,6 +105,7 @@ func NewWdPostTask(db *harmonydb.DB,
 		faultTracker: faultTracker,
 		storage:      storage,
 		verifier:     verifier,
+		paramsReady:  paramck,
 
 		actors:               actors,
 		max:                  max,
@@ -256,6 +259,15 @@ func entToStr[T any](t T, i int) string {
 }
 
 func (t *WdPostTask) CanAccept(ids []harmonytask.TaskID, te *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+	rdy, err := t.paramsReady()
+	if err != nil {
+		return nil, xerrors.Errorf("failed to setup params: %w", err)
+	}
+	if !rdy {
+		log.Infow("WdPostTask.CanAccept() params not ready, not scheduling")
+		return nil, nil
+	}
+
 	// GetEpoch
 	ts, err := t.api.ChainHead(context.Background())
 


### PR DESCRIPTION
Small feature making my life much faster when testing with a calib node - basically now when starting a node with tasks which require tasks we'll start the node instantly, and paramfetch checks will run in the background. Tasks which compute snarks will be registered, but will not accept tasks until paramfetch is finished. Other tasks are allowed to run in the background though.