### PR TITLE
UI: Display active task history, retry sector button

### DIFF
--- a/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
+++ b/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
@@ -136,3 +136,7 @@ create table sectors_allocated_numbers (
     sp_id bigint not null primary key,
     allocated jsonb not null
 );
+
+-- Added in 20240529-sdr-pipeline-task-extract.sql
+-- CREATE FUNCTION get_sdr_pipeline_tasks(sp_id_param bigint, sector_number_param bigint)
+-- CREATE FUNCTION unset_task_id(task_id_param bigint, sp_id_param bigint, sector_number_param bigint)

--- a/harmony/harmonydb/sql/20240529-sdr-pipeline-task-extract.sql
+++ b/harmony/harmonydb/sql/20240529-sdr-pipeline-task-extract.sql
@@ -1,0 +1,56 @@
+CREATE OR REPLACE FUNCTION get_sdr_pipeline_tasks(sp_id_param bigint, sector_number_param bigint)
+    RETURNS bigint[] AS $$
+DECLARE
+    task_ids bigint[];
+BEGIN
+    SELECT ARRAY_REMOVE(ARRAY[
+                            task_id_sdr,
+                            task_id_tree_d,
+                            task_id_tree_c,
+                            task_id_tree_r,
+                            task_id_precommit_msg,
+                            task_id_porep,
+                            task_id_finalize,
+                            task_id_move_storage,
+                            task_id_commit_msg
+                            ], NULL)
+    INTO task_ids
+    FROM sectors_sdr_pipeline
+    WHERE sp_id = sp_id_param
+      AND sector_number = sector_number_param;
+
+    RETURN task_ids;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION unset_task_id(sp_id_param bigint, sector_number_param bigint)
+    RETURNS void AS $$
+DECLARE
+    column_name text;
+    column_names text[] := ARRAY[
+        'task_id_sdr',
+        'task_id_tree_d',
+        'task_id_tree_c',
+        'task_id_tree_r',
+        'task_id_precommit_msg',
+        'task_id_porep',
+        'task_id_finalize',
+        'task_id_move_storage',
+        'task_id_commit_msg'
+        ];
+    update_query text;
+    task_ids bigint[];
+    task_id bigint;
+BEGIN
+    -- Get all non-null task IDs
+    task_ids := get_sdr_pipeline_tasks(sp_id_param, sector_number_param);
+
+    -- Loop through each task ID and each column
+    FOREACH column_name IN ARRAY column_names LOOP
+            FOREACH task_id IN ARRAY task_ids LOOP
+                    update_query := format('UPDATE sectors_sdr_pipeline SET %I = NULL WHERE %I = $1 AND sp_id = $2 AND sector_number = $3', column_name, column_name);
+                    EXECUTE update_query USING task_id, sp_id_param, sector_number_param;
+                END LOOP;
+        END LOOP;
+END;
+$$ LANGUAGE plpgsql;

--- a/web/api/webrpc/harmony_stats.go
+++ b/web/api/webrpc/harmony_stats.go
@@ -1,0 +1,27 @@
+package webrpc
+
+import "context"
+
+// SELECT name, count(case when result = 'true' then 1 end) as true_count,
+//    count(case when result = 'false' then 1 end) as false_count, count(*) as total_count
+//    from harmony_task_history where work_end > current_timestamp - interval '1 day'
+//    group by name order by total_count desc
+
+type HarmonyTaskStats struct {
+	Name       string `db:"name"`
+	TrueCount  int    `db:"true_count"`
+	FalseCount int    `db:"false_count"`
+	TotalCount int    `db:"total_count"`
+}
+
+func (a *WebRPC) HarmonyTaskStats(ctx context.Context) ([]HarmonyTaskStats, error) {
+	var stats []HarmonyTaskStats
+	err := a.deps.DB.Select(ctx, &stats, `SELECT name, count(case when result = 'true' then 1 end) as true_count,
+		count(case when result = 'false' then 1 end) as false_count, count(*) as total_count
+		from harmony_task_history where work_end > current_timestamp - interval '1 day'
+		group by name order by total_count desc`)
+	if err != nil {
+		return nil, err
+	}
+	return stats, nil
+}

--- a/web/hapi/routes.go
+++ b/web/hapi/routes.go
@@ -44,6 +44,7 @@ func Routes(r *mux.Router, deps *deps.Deps) error {
 
 	// sector info page
 	r.HandleFunc("/sector/{sp}/{id}", a.sectorInfo)
+	r.HandleFunc("/sector/{sp}/{id}/resume", a.sectorResume)
 	return nil
 }
 

--- a/web/hapi/web/cluster_machines.gohtml
+++ b/web/hapi/web/cluster_machines.gohtml
@@ -2,15 +2,17 @@
 {{range .}}
     <tr>
         <td><a href="/hapi/node/{{.ID}}">{{.Name}}</a></td>
-        <td>{{.Address}}</td>
+        <td><a href="/hapi/node/{{.ID}}">{{.Address}}</a></td>
         <td>{{.ID}}</td>
         <td>{{.Cpu}}</td>
         <td>{{.RamHumanized}}</td>
         <td>{{.Gpu}}</td>
         <td>{{.SinceContact}}</td>
-        {{range .RecentTasks}}
-            <td>{{.TaskName}}:{{.Success}}{{if ne 0 .Fail}}(<i class="{{if eq 0 .Success}}error{{else}}warning{{end}}">{{.Fail}}</i>){{end}}</td>
-        {{end}}
+        <td>
+            {{range .RecentTasks}}
+                {{.TaskName}}:{{.Success}}{{if ne 0 .Fail}}(<i class="{{if eq 0 .Success}}error{{else}}warning{{end}}">{{.Fail}}</i>){{end}}
+            {{end}}
+        </td>
     </tr>
 {{end}}
 {{end}}

--- a/web/hapi/web/sector_info.gohtml
+++ b/web/hapi/web/sector_info.gohtml
@@ -1,12 +1,17 @@
 {{define "sector_info"}}
     <h2>Sector {{.SectorNumber}}</h2>
+    {{if .Resumable}}
+        <div>
+            <button class="btn btn-primary" onclick="window.location.href='/hapi/sector/f0{{.SpID}}/{{.SectorNumber}}/resume'">Resume</button>
+        </div>
+    {{end}}
     <div>
         <h3>PoRep Pipeline</h3>
         {{template "sector_porep_state" .PipelinePoRep}}
     </div>
     <div>
         <h3>Pieces</h3>
-        <table class="porep-state">
+        <table class="table table-dark">
             <tr>
                 <th>Piece Index</th>
                 <th>Piece CID</th>
@@ -54,7 +59,7 @@
     </div>
     <div>
         <h3>Storage</h3>
-        <table class="porep-state">
+        <table class="table table-dark">
             <tr>
                 <th>Path Type</th>
                 <th>File Type</th>
@@ -100,6 +105,33 @@
                 <td>{{if ne nil .OwnerID}}<a href="/hapi/node/{{.OwnerID}}">{{.Owner}}</a>{{end}}</td>
             </tr>
         {{end}}
+        </table>
+    </div>
+    <div>
+        <h3>Current task history</h3>
+        <table class="table table-dark">
+            <tr>
+                <th>Task ID</th>
+                <th>Task Type</th>
+                <th>Completed By</th>
+                <th>Result</th>
+                <th>Started</th>
+                <th>Took</th>
+                <th>Error</th>
+            </tr>
+            {{range .TaskHistory}}
+                {{if ne nil .Name}}
+                    <tr>
+                        <td>{{.PipelineTaskID}}</td>
+                        <td>{{.Name}}</td>
+                        <td>{{.CompletedBy}}</td>
+                        <td>{{if .Result}}Success{{else}}Failed{{end}}</td>
+                        <td>{{.WorkStart}}</td>
+                        <td>{{.Took}}</td>
+                        <td>{{.Err}}</td>
+                    </tr>
+                {{end}}
+            {{end}}
         </table>
     </div>
 {{end}}

--- a/web/static/harmony-task-counts.mjs
+++ b/web/static/harmony-task-counts.mjs
@@ -1,0 +1,61 @@
+import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
+import RPCCall from '/lib/jsonrpc.mjs';
+
+class HarmonyTaskStatsTable extends LitElement {
+    static properties = {
+        data: { type: Array }
+    };
+
+    constructor() {
+        super();
+        this.data = [];
+        this.loadData();
+    }
+
+    async loadData() {
+        this.data = await RPCCall('HarmonyTaskStats');
+        this.calculatePercentages();
+        super.requestUpdate();
+    }
+
+    calculatePercentages() {
+        this.data = this.data.map(task => ({
+            ...task,
+            FailedPercentage: task.FalseCount > 0 ? `${((task.FalseCount / task.TotalCount) * 100).toFixed(2)}%` : '0%'
+        }));
+    }
+
+    static get styles() {
+        return [css`
+        .row-error > td {
+            color: red;
+        }
+    `];
+    }
+
+    render() {
+        return html`
+            <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+            <table class="table table-dark">
+                <thead>
+                    <tr>
+                        <th>Task</th>
+                        <th>Successful</th>
+                        <th>Failed</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${this.data.map(task => html`
+                    <tr class="${task.FalseCount > task.TrueCount && task.TrueCount === 0 ? 'row-error' : ''}">
+                        <td>${task.Name}</td>
+                        <td>${task.TrueCount}</td>
+                        <td>${task.FalseCount} (${task.FailedPercentage})</td>
+                    </tr>
+                    `)}
+                </tbody>
+            </table>
+        `;
+    }
+}
+
+customElements.define('harmony-task-counts', HarmonyTaskStatsTable);

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -6,6 +6,7 @@
         integrity="sha384-xcuj3WpfgjlKF+FXhSQFQ0ZNr39ln+hwjN3npfM9VBnUskLolQAcN80McRIVOPuO"
         crossorigin="anonymous"></script>
     <script type="module" src="chain-connectivity.mjs"></script>
+    <script type="module" src="harmony-task-counts.mjs"></script>
     <script type="module" src="/ux/curio-ux.mjs"></script>
     <style>
         .deadline-box {
@@ -99,7 +100,7 @@
             <div class="row">
                 <div class="col-md-auto" style="max-width: 1000px">
                     <div class="info-block">
-                        <h2><a href="/pipeline_porep.html">PoRep Pipeline</a></h2>
+                        <h2>PoRep Pipeline</h2>
                         <table class="table table-dark">
                             <thead>
                             <tr>
@@ -149,7 +150,6 @@
                 </div>
             </div>
 
-
             <div class="row">
                 <div class="col-md-auto" style="max-width: 1000px">
                     <div class="info-block">
@@ -174,6 +174,10 @@
                     </div>
                 </div>
                 <div class="col-md-auto">
+                    <div class="info-block">
+                        <h2>24h task counts</h2>
+                        <harmony-task-counts></harmony-task-counts>
+                    </div>
                 </div>
             </div>
 

--- a/web/static/pipeline_porep.html
+++ b/web/static/pipeline_porep.html
@@ -84,6 +84,7 @@
                         <th>Sector ID</th>
                         <th>Create Time</th>
                         <th>State</th>
+                        <th>Actions</th>
                     </tr>
                     </thead>
                     <tbody hx-get="/hapi/pipeline-porep/sectors" hx-trigger="load,every 3s">


### PR DESCRIPTION
This PR adds a table showing recent task history on the sector page (for tasks in the pipeline table, so really useful for debugging what caused the sector to halt progress) + Adds a "Resume" button on sectors which have tasks that have been retried too many times

The retry button removes failed taskIDs from the pipeline table so that the poller can start a new task in its place.

Tested on my setup, works as intended and looks coherent with the rest of the UI; Unfortunately I retried my failed sector before making this PR, so not much to share in the form of a screenshot.