### PR TITLE
UI: Add task deatails page

### DIFF
--- a/web/api/webrpc/harmony_stats.go
+++ b/web/api/webrpc/harmony_stats.go
@@ -1,6 +1,9 @@
 package webrpc
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // SELECT name, count(case when result = 'true' then 1 end) as true_count,
 //    count(case when result = 'false' then 1 end) as false_count, count(*) as total_count
@@ -20,6 +23,57 @@ func (a *WebRPC) HarmonyTaskStats(ctx context.Context) ([]HarmonyTaskStats, erro
 		count(case when result = 'false' then 1 end) as false_count, count(*) as total_count
 		from harmony_task_history where work_end > current_timestamp - interval '1 day'
 		group by name order by total_count desc`)
+	if err != nil {
+		return nil, err
+	}
+	return stats, nil
+}
+
+type HarmonyMachineDesc struct {
+	MachineID   int64  `db:"machine_id"`
+	Name        string `db:"machine_name"`
+	MachineAddr string `db:"host_and_port"`
+	Actors      string `db:"miners"`
+}
+
+func (a *WebRPC) HarmonyTaskMachines(ctx context.Context, taskName string) ([]HarmonyMachineDesc, error) {
+	var stats []HarmonyMachineDesc
+	err := a.deps.DB.Select(ctx, &stats, `SELECT md.machine_id, md.machine_name, hm.host_and_port, md.miners FROM harmony_machine_details md
+	    INNER JOIN harmony_machines hm ON md.machine_id = hm.id
+	    WHERE $1 = ANY(string_to_array(md.tasks, ','))
+	    ORDER BY md.miners DESC`, taskName)
+	if err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+type HarmonyTaskHistory struct {
+	TaskID int64  `db:"task_id"`
+	Name   string `db:"name"`
+
+	WorkStart time.Time `db:"work_start"`
+	WorkEnd   time.Time `db:"work_end"`
+	Posted    time.Time `db:"posted"`
+
+	Result bool   `db:"result"`
+	Err    string `db:"err"`
+
+	CompletedBy     string  `db:"completed_by_host_and_port"`
+	CompletedById   *int64  `db:"completed_by_machine"`
+	CompletedByName *string `db:"completed_by_machine_name"`
+}
+
+func (a *WebRPC) HarmonyTaskHistory(ctx context.Context, taskName string) ([]HarmonyTaskHistory, error) {
+	var stats []HarmonyTaskHistory
+	err := a.deps.DB.Select(ctx, &stats, `SELECT
+	hist.task_id, hist.name, hist.work_start, hist.work_end, hist.posted, hist.result, hist.err,
+	hist.completed_by_host_and_port, mach.id as completed_by_machine, hmd.machine_name as completed_by_machine_name
+    FROM harmony_task_history hist
+    LEFT JOIN harmony_machines mach ON hist.completed_by_host_and_port = mach.host_and_port
+    LEFT JOIN curio.harmony_machine_details hmd on mach.id = hmd.machine_id
+    WHERE name = $1 AND work_end > current_timestamp - interval '1 day' ORDER BY work_end DESC LIMIT 30`, taskName)
 	if err != nil {
 		return nil, err
 	}

--- a/web/static/harmony-task-counts.mjs
+++ b/web/static/harmony-task-counts.mjs
@@ -36,6 +36,7 @@ class HarmonyTaskStatsTable extends LitElement {
     render() {
         return html`
             <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+            <link rel="stylesheet" href="/ux/main.css" onload="document.body.style.visibility = 'initial'">
             <table class="table table-dark">
                 <thead>
                     <tr>
@@ -47,7 +48,7 @@ class HarmonyTaskStatsTable extends LitElement {
                 <tbody>
                     ${this.data.map(task => html`
                     <tr class="${task.FalseCount > task.TrueCount && task.TrueCount === 0 ? 'row-error' : ''}">
-                        <td>${task.Name}</td>
+                        <td><a href="/task/?name=${task.Name}">${task.Name}</a></td>
                         <td>${task.TrueCount}</td>
                         <td>${task.FalseCount} (${task.FailedPercentage})</td>
                     </tr>

--- a/web/static/task/index.html
+++ b/web/static/task/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Task Info</title>
+    <script type="module" src="/ux/curio-ux.mjs"></script>
+    <script type="module" src="/task/task-machines.mjs"></script>
+    <script type="module" src="/task/task-history.mjs"></script>
+</head>
+
+<body style="visibility:hidden" data-bs-theme="dark">
+<curio-ux>
+    <section class="section">
+        <div class="row">
+            <h1>Task Details</h1>
+        </div>
+    </section>
+    <section class="section">
+        <div class="row">
+            <div class="col-md-auto" style="max-width: 95%">
+                <h4>Machines</h4>
+                <harmony-task-machines></harmony-task-machines>
+            </div>
+        </div>
+    </section>
+    <section class="section">
+        <div class="row">
+            <div class="col-md-auto" style="max-width: 95%">
+                <h4>History</h4>
+                <harmony-task-history></harmony-task-history>
+            </div>
+        </div>
+    </section>
+</curio-ux>
+</body>
+
+</html>

--- a/web/static/task/task-history.mjs
+++ b/web/static/task/task-history.mjs
@@ -1,0 +1,65 @@
+import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
+import RPCCall from '/lib/jsonrpc.mjs';
+
+class HarmonyTaskHistoryTable extends LitElement {
+    constructor() {
+        super();
+        this.history = [];
+        this.taskName = new URLSearchParams(window.location.search).get('name');
+        this.loadHistory();
+    }
+
+    async loadHistory() {
+        try {
+            this.history = await RPCCall('HarmonyTaskHistory', [this.taskName]);
+            this.requestUpdate();
+        } catch (error) {
+            console.error('Error fetching task history data:', error);
+        }
+    }
+
+    static get styles() {
+        return css`
+        .error {
+            color: red;
+        }
+        `;
+    }
+
+    render() {
+        return html`
+            <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+            <link rel="stylesheet" href="/ux/main.css" onload="document.body.style.visibility = 'initial'">
+            <table class="table table-dark">
+                <thead>
+                    <tr>
+                        <th>Task ID</th>
+                        <th>Name</th>
+                        <th>Work Start</th>
+                        <th>Work End</th>
+                        <th>Posted</th>
+                        <th>Completed By</th>
+                        <th>Result</th>
+                        <th>Error</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${this.history.map(task => html`
+                        <tr>
+                            <td>${task.TaskID}</td>
+                            <td>${task.Name}</td>
+                            <td>${new Date(task.WorkStart).toLocaleString()}</td>
+                            <td>${new Date(task.WorkEnd).toLocaleString()}</td>
+                            <td>${new Date(task.Posted).toLocaleString()}</td>
+                            <td>${task.CompletedById ? html`<a href="/hapi/node/${task.CompletedById}">${task.CompletedByName} (${task.CompletedBy})</a>` : task.CompletedBy}</td>
+                            <td class="${task.Result ? '' : 'error'}">${task.Result ? 'Success' : 'Failed'}</td>
+                            <td>${task.Err}</td>
+                        </tr>
+                    `)}
+                </tbody>
+            </table>
+        `;
+    }
+}
+
+customElements.define('harmony-task-history', HarmonyTaskHistoryTable);

--- a/web/static/task/task-machines.mjs
+++ b/web/static/task/task-machines.mjs
@@ -1,0 +1,53 @@
+import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
+import RPCCall from '/lib/jsonrpc.mjs';
+
+class HarmonyMachineTable extends LitElement {
+    constructor() {
+        super();
+        this.machines = [];
+        // url ?name=taskName
+        this.taskName = new URLSearchParams(window.location.search).get('name');
+        this.loadMachines();
+    }
+
+    async loadMachines() {
+        try {
+            this.machines = await RPCCall('HarmonyTaskMachines', [this.taskName]);
+            this.requestUpdate();
+        } catch (error) {
+            console.error('Error fetching machine data:', error);
+        }
+    }
+
+    static get styles() {
+        return css`
+    `;
+    }
+
+    render() {
+        return html`
+      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+      <link rel="stylesheet" href="/ux/main.css" onload="document.body.style.visibility = 'initial'">
+      <table class="table table-dark">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Machine Address</th>
+            <th>Actors</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${this.machines.map(machine => html`
+            <tr>
+              <td><a href="/hapi/node/${machine.MachineID}">${machine.Name}</a></td>
+              <td><a href="/hapi/node/${machine.MachineID}">${machine.MachineAddr}</a></td>
+              <td>${machine.Actors}</td>
+            </tr>
+          `)}
+        </tbody>
+      </table>
+    `;
+    }
+}
+
+customElements.define('harmony-task-machines', HarmonyMachineTable);

--- a/web/static/ux/curio-ux.mjs
+++ b/web/static/ux/curio-ux.mjs
@@ -42,7 +42,7 @@ class CurioUX extends LitElement {
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
         <nav class="navbar navbar-expand-lg navbar-expand-sm navbar-dark bg-dark">
         <div class="container-fluid">
-          <a class="navbar-brand" href="#">
+          <a class="navbar-brand" href="/">
             <img src="/favicon.svg" width="30" height="30" class="d-inline-block align-top" alt="">
             Curio Cluster <span class="alert alert-warning">Beta</span>
           </a>


### PR DESCRIPTION
Clickable from the tasks table on the main page; One page per task type detailing what's going on with that task in the cluster.

Mainly useful to see:
* Recent errors
* If any machine in the cluster is setup to handle the task type. 

![2024-05-30-142358_1361x738_scrot](https://github.com/filecoin-project/curio/assets/3867941/73b82023-1be0-44f9-a6f1-db420a040bf4)
