### PR TITLE
Set more accurate SDR memory use

### DIFF
--- a/tasks/seal/task_sdr.go
+++ b/tasks/seal/task_sdr.go
@@ -16,11 +16,11 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"
 
+	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors/policy"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/lib/filler"
-	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/lotus/storage/paths"
 	"github.com/filecoin-project/lotus/storage/sealer/ffiwrapper"
 	"github.com/filecoin-project/lotus/storage/sealer/storiface"
@@ -242,7 +242,7 @@ func (s *SDRTask) TypeDetails() harmonytask.TaskTypeDetails {
 		Cost: resources.Resources{ // todo offset for prefetch?
 			Cpu:     4, // todo multicore sdr
 			Gpu:     0,
-			Ram:     54 << 30,
+			Ram:     (64 << 30) + (256 << 20),
 			Storage: s.sc.Storage(s.taskToSector, storiface.FTCache, storiface.FTNone, ssize, storiface.PathSealing, paths.MinFreeStoragePercentage),
 		},
 		MaxFailures: 2,


### PR DESCRIPTION
There were some reports that doing a bunch of SDR at once could make curio run out of memory, and indeed after running lotus-bench with parallel checks it seems like we need 64G per sector

3 bench runs, second column is KiB RSS use:
```
==> memuse_1sec.log <==
1717344767, 70281792
1717344768, 70281792

==> memuse_2sec.log <==
1717357842, 137359712
1717357843, 137359712

==> memuse_3.log <==
1717361173, 204664776
1717361174, 204664776

```