### PR TITLE
Paramfetch with aria2 support

### DIFF
--- a/apt/DEBIAN/control
+++ b/apt/DEBIAN/control
@@ -9,7 +9,7 @@ Rules-Requires-Root: no
 Package: $PACKAGE
 Version: $VERSION
 Architecture: amd64
-Depends: hwloc, mesa-opencl-icd
+Depends: hwloc, mesa-opencl-icd, aria2
 Description: A Filecoin Storage Provider implementation.
  This Filecoin Storage Provider implementation is a fork of the Lotus project.
  It improves upon the previous by solving more complete problem sets including

--- a/cmd/curio/main.go
+++ b/cmd/curio/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/filecoin-project/curio/cmd/curio/guidedsetup"
 	"github.com/filecoin-project/curio/deps"
+	"github.com/filecoin-project/curio/lib/fastparamfetch"
 	"os"
 	"os/signal"
 	"runtime/pprof"
@@ -16,8 +17,6 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
-
-	"github.com/filecoin-project/go-paramfetch"
 
 	"github.com/filecoin-project/lotus/build"
 	lcli "github.com/filecoin-project/lotus/cli"
@@ -179,7 +178,7 @@ var fetchParamCmd = &cli.Command{
 		}
 		sectorSize := uint64(sectorSizeInt)
 
-		err = paramfetch.GetParams(lcli.ReqContext(cctx), build.ParametersJSON(), build.SrsJSON(), sectorSize)
+		err = fastparamfetch.GetParams(lcli.ReqContext(cctx), build.ParametersJSON(), build.SrsJSON(), sectorSize)
 		if err != nil {
 			return xerrors.Errorf("fetching proof parameters: %w", err)
 		}

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -3,6 +3,8 @@ package tasks
 
 import (
 	"context"
+	"github.com/filecoin-project/curio/lib/fastparamfetch"
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/lib/result"
 	"sort"
 	"strings"
@@ -36,7 +38,6 @@ import (
 
 	"github.com/filecoin-project/lotus/lib/lazy"
 	"github.com/filecoin-project/lotus/lib/must"
-	"github.com/filecoin-project/lotus/node/modules"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 
@@ -93,7 +94,10 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps) (*harmonytask.Task
 		fetchOnce.Do(func() {
 			go func() {
 				for spt := range dependencies.ProofTypes {
-					err := modules.GetParams(true)(spt)
+
+					provingSize := uint64(must.One(spt.SectorSize()))
+					err := fastparamfetch.GetParams(context.TODO(), build.ParametersJSON(), build.SrsJSON(), provingSize)
+
 					if err != nil {
 						log.Errorw("failed to fetch params", "error", err)
 						fetchResult.Store(&result.Result[bool]{Value: false, Error: err})

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/filecoin-project/go-fil-commcid v0.1.0
 	github.com/filecoin-project/go-jsonrpc v0.4.0
 	github.com/filecoin-project/go-padreader v0.0.1
-	github.com/filecoin-project/go-paramfetch v0.0.4
 	github.com/filecoin-project/go-state-types v0.14.0-dev
 	github.com/filecoin-project/go-statestore v0.2.0
 	github.com/filecoin-project/lotus v1.27.0-rc1.0.20240527035155-18795706288e
@@ -35,11 +34,13 @@ require (
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0
+	github.com/ipfs/go-fs-lock v0.0.7
 	github.com/ipfs/go-ipld-cbor v0.1.0
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/libp2p/go-buffer-pool v0.1.0
 	github.com/manifoldco/promptui v0.9.0
+	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
 	github.com/minio/sha256-simd v1.0.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.12.3
@@ -113,6 +114,7 @@ require (
 	github.com/filecoin-project/go-hamt-ipld v0.1.5 // indirect
 	github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 // indirect
 	github.com/filecoin-project/go-hamt-ipld/v3 v3.1.0 // indirect
+	github.com/filecoin-project/go-paramfetch v0.0.4 // indirect
 	github.com/filecoin-project/go-statemachine v1.0.3 // indirect
 	github.com/filecoin-project/go-storedcounter v0.1.0 // indirect
 	github.com/filecoin-project/pubsub v1.0.0 // indirect
@@ -160,7 +162,6 @@ require (
 	github.com/ipfs/go-ds-badger2 v0.1.3 // indirect
 	github.com/ipfs/go-ds-leveldb v0.5.0 // indirect
 	github.com/ipfs/go-ds-measure v0.2.0 // indirect
-	github.com/ipfs/go-fs-lock v0.0.7 // indirect
 	github.com/ipfs/go-graphsync v0.17.0 // indirect
 	github.com/ipfs/go-ipfs-blockstore v1.3.0 // indirect
 	github.com/ipfs/go-ipfs-delay v0.0.1 // indirect
@@ -226,7 +227,6 @@ require (
 	github.com/miekg/dns v1.1.58 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
-	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect

--- a/lib/fastparamfetch/paramfetch.go
+++ b/lib/fastparamfetch/paramfetch.go
@@ -307,7 +307,7 @@ func fetchWithAria2c(ctx context.Context, out, url string) error {
 		return xerrors.New("aria2c not found in PATH")
 	}
 
-	cmd := exec.CommandContext(ctx, aria2cPath, "--continue", "-x5", "-o", out, url)
+	cmd := exec.CommandContext(ctx, aria2cPath, "--continue", "-x16", "-s16", "-o", out, url)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/lib/fastparamfetch/paramfetch.go
+++ b/lib/fastparamfetch/paramfetch.go
@@ -1,0 +1,305 @@
+package fastparamfetch
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	fslock "github.com/ipfs/go-fs-lock"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/minio/blake2b-simd"
+	"go.uber.org/multierr"
+	"golang.org/x/xerrors"
+)
+
+var log = logging.Logger("paramfetch")
+
+// const gateway = "http://198.211.99.118/ipfs/"
+const gateway = "https://proofs.filecoin.io/ipfs/"
+const paramdir = "/var/tmp/filecoin-proof-parameters"
+const dirEnv = "FIL_PROOFS_PARAMETER_CACHE"
+const lockFile = "fetch.lock"
+const lockRetry = time.Second * 10
+
+var checked = map[string]struct{}{}
+var checkedLk sync.Mutex
+
+type paramFile struct {
+	Cid        string `json:"cid"`
+	Digest     string `json:"digest"`
+	SectorSize uint64 `json:"sector_size"`
+}
+
+type fetch struct {
+	wg      sync.WaitGroup
+	fetchLk sync.Mutex
+
+	errs []error
+}
+
+func getParamDir() string {
+	if os.Getenv(dirEnv) == "" {
+		return paramdir
+	}
+	return os.Getenv(dirEnv)
+}
+
+func GetParams(ctx context.Context, paramBytes []byte, srsBytes []byte, storageSize uint64) error {
+	if err := os.Mkdir(getParamDir(), 0755); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	var params map[string]paramFile
+
+	if err := json.Unmarshal(paramBytes, &params); err != nil {
+		return err
+	}
+
+	ft := &fetch{}
+
+	for name, info := range params {
+		if storageSize != info.SectorSize && strings.HasSuffix(name, ".params") {
+			continue
+		}
+
+		ft.maybeFetchAsync(ctx, name, info)
+	}
+
+	var srs map[string]paramFile
+
+	if err := json.Unmarshal(srsBytes, &srs); err != nil {
+		return err
+	}
+
+	for name, info := range srs {
+		ft.maybeFetchAsync(ctx, name, info)
+	}
+
+	return ft.wait(ctx)
+}
+
+func (ft *fetch) maybeFetchAsync(ctx context.Context, name string, info paramFile) {
+	ft.wg.Add(1)
+
+	go func() {
+		defer ft.wg.Done()
+
+		path := filepath.Join(getParamDir(), name)
+
+		err := ft.checkFile(path, info)
+		if !os.IsNotExist(err) && err != nil {
+			log.Warn(err)
+		}
+		if err == nil {
+			return
+		}
+
+		ft.fetchLk.Lock()
+		defer ft.fetchLk.Unlock()
+
+		var lockfail bool
+		var unlocker io.Closer
+		for {
+			unlocker, err = fslock.Lock(getParamDir(), lockFile)
+			if err == nil {
+				break
+			}
+
+			lockfail = true
+
+			le := fslock.LockedError("")
+			if xerrors.As(err, &le) {
+				log.Warnf("acquiring filesystem fetch lock: %s; will retry in %s", err, lockRetry)
+				time.Sleep(lockRetry)
+				continue
+			}
+			ft.errs = append(ft.errs, xerrors.Errorf("acquiring filesystem fetch lock: %w", err))
+			return
+		}
+		defer func() {
+			err := unlocker.Close()
+			if err != nil {
+				log.Errorw("unlock fs lock", "error", err)
+			}
+		}()
+		if lockfail {
+			// we've managed to get the lock, but we need to re-check file contents - maybe it's fetched now
+			ft.maybeFetchAsync(ctx, name, info)
+			return
+		}
+
+		if err := doFetch(ctx, path, info); err != nil {
+			ft.errs = append(ft.errs, xerrors.Errorf("fetching file %s failed: %w", path, err))
+			return
+		}
+		err = ft.checkFile(path, info)
+		if err != nil {
+			log.Errorf("sanity checking fetched file failed, removing and retrying: %w", err)
+			// remove and retry once more
+			err := os.Remove(path)
+			if err != nil {
+				ft.errs = append(ft.errs, xerrors.Errorf("remove file %s failed: %w", path, err))
+				return
+			}
+
+			if err := doFetch(ctx, path, info); err != nil {
+				ft.errs = append(ft.errs, xerrors.Errorf("fetching file %s failed: %w", path, err))
+				return
+			}
+
+			err = ft.checkFile(path, info)
+			if err != nil {
+				ft.errs = append(ft.errs, xerrors.Errorf("checking file %s failed: %w", path, err))
+				err := os.Remove(path)
+				if err != nil {
+					ft.errs = append(ft.errs, xerrors.Errorf("remove file %s failed: %w", path, err))
+				}
+			}
+		}
+	}()
+}
+
+func hasTrustableExtension(path string) bool {
+	// known extensions include "vk", "srs", and "params"
+	// expected to only treat "params" ext as trustable
+	// via allowlist
+	return strings.HasSuffix(path, "params")
+}
+
+func (ft *fetch) checkFile(path string, info paramFile) error {
+	isSnapParam := strings.HasPrefix(filepath.Base(path), "v28-empty-sector-update")
+
+	if !isSnapParam && os.Getenv("TRUST_PARAMS") == "1" && hasTrustableExtension(path) {
+		log.Debugf("Skipping param check: %s", path)
+		log.Warn("Assuming parameter files are ok. DO NOT USE IN PRODUCTION")
+		return nil
+	}
+
+	checkedLk.Lock()
+	_, ok := checked[path]
+	checkedLk.Unlock()
+	if ok {
+		return nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	h := blake2b.New512()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+
+	sum := h.Sum(nil)
+	strSum := hex.EncodeToString(sum[:16])
+	if strSum == info.Digest {
+		log.Infof("Parameter file %s is ok", path)
+
+		checkedLk.Lock()
+		checked[path] = struct{}{}
+		checkedLk.Unlock()
+
+		return nil
+	}
+
+	return xerrors.Errorf("checksum mismatch in param file %s, %s != %s", path, strSum, info.Digest)
+}
+
+func (ft *fetch) wait(ctx context.Context) error {
+	waitChan := make(chan struct{}, 1)
+
+	go func() {
+		defer close(waitChan)
+		ft.wg.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Infof("context closed... shutting down")
+	case <-waitChan:
+		log.Infof("parameter and key-fetching complete")
+	}
+
+	return multierr.Combine(ft.errs...)
+}
+
+func doFetch(ctx context.Context, out string, info paramFile) error {
+	gw := os.Getenv("IPFS_GATEWAY")
+	if gw == "" {
+		gw = gateway
+	}
+	log.Infof("Fetching %s from %s", out, gw)
+
+	url, err := url.Parse(gw + info.Cid)
+	if err != nil {
+		return err
+	}
+	log.Infof("GET %s", url)
+
+	// Try aria2c first
+	if err := fetchWithAria2c(ctx, out, url.String()); err == nil {
+		return nil
+	} else {
+		log.Warnf("aria2c fetch failed: %s", err)
+	}
+
+	outf, err := os.OpenFile(out, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		return err
+	}
+	defer outf.Close()
+
+	fStat, err := outf.Stat()
+	if err != nil {
+		return err
+	}
+	header := http.Header{}
+	header.Set("Range", "bytes="+strconv.FormatInt(fStat.Size(), 10)+"-")
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Close = true
+	req.Header = header
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(outf, resp.Body)
+
+	return err
+}
+
+func fetchWithAria2c(ctx context.Context, out, url string) error {
+	aria2cPath, err := exec.LookPath("aria2c")
+	if err != nil {
+		return xerrors.New("aria2c not found in PATH")
+	}
+
+	cmd := exec.CommandContext(ctx, aria2cPath, "--continue", "-x5", "-o", out, url)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lib/fastparamfetch/paramfetch.go
+++ b/lib/fastparamfetch/paramfetch.go
@@ -42,15 +42,13 @@ type paramFile struct {
 }
 
 type fetch struct {
-	wg      sync.WaitGroup
-	fetchLk sync.Mutex
+	wg sync.WaitGroup
 
 	errs []error
 
 	fsLockRelease func()
 	fsLockOnce    sync.Once
 	lockFail      bool // true if we failed to acquire the lock at least once, meaning that is was claimed by another process
-	lockErr       error
 }
 
 func getParamDir() string {


### PR DESCRIPTION
This is a copy of https://github.com/filecoin-project/go-paramfetch/blob/master/paramfetch.go with:
* Heavily opinionated support for aria2
* Parallel fetch support

In the future we can think of adding support for p2p fetches from the cluster, but for now this makes my paramfetch operations 7-10x faster