### PR TITLE
Fix occasional lmrpc SectorStatus panic

### DIFF
--- a/market/fakelm/lmimpl.go
+++ b/market/fakelm/lmimpl.go
@@ -17,9 +17,9 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/network"
 
+	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
-	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/lotus/node/config"
 	"github.com/filecoin-project/lotus/storage/paths"
 	sealing "github.com/filecoin-project/lotus/storage/pipeline"
@@ -182,12 +182,14 @@ func (l *LMRPCProvider) SectorsStatus(ctx context.Context, sid abi.SectorNumber,
 	}
 
 	// If no rows found i.e. sector doesn't exist in DB
-	//assign ssip[0] to a local variable for easier reading.
+
+	if len(ssip) == 0 {
+		ret.State = api.SectorState(sealing.UndefinedSectorState)
+		return ret, nil
+	}
 	currentSSIP := ssip[0]
 
 	switch {
-	case len(ssip) == 0:
-		ret.State = api.SectorState(sealing.UndefinedSectorState)
 	case currentSSIP.Failed:
 		ret.State = api.SectorState(sealing.FailedUnrecoverable)
 	case !currentSSIP.SDR:


### PR DESCRIPTION
Occasionally seeing this in my curio logs

```
reflect.Value.Call
	/home/magik6k/.opt/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.3.linux-amd64/src/reflect/value.go:380
github.com/filecoin-project/lotus/metrics/proxy.proxy.func1
	/home/magik6k/.opt/go/pkg/mod/github.com/filecoin-project/lotus@v1.27.0-rc1.0.20240527035155-18795706288e/metrics/proxy/proxy.go:69
github.com/filecoin-project/lotus/api.(*StorageMinerStruct).SectorsStatus
	/home/magik6k/.opt/go/pkg/mod/github.com/filecoin-project/lotus@v1.27.0-rc1.0.20240527035155-18795706288e/api/proxy_gen.go:6984
reflect.Value.call
	/home/magik6k/.opt/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.3.linux-amd64/src/reflect/value.go:596
```