### PR TITLE
fix: Resolve shadowed error in SaveConfigToLayerMigrateSectors

### DIFF
--- a/cmd/curio/guidedsetup/shared.go
+++ b/cmd/curio/guidedsetup/shared.go
@@ -58,7 +58,7 @@ func SaveConfigToLayerMigrateSectors(minerRepoPath, chainApiInfo string, unmigSe
 		return minerAddress, fmt.Errorf("locking repo: %w", err)
 	}
 	defer func() {
-		err = lr.Close()
+		err := lr.Close()
 		if err != nil {
 			fmt.Println("error closing repo: ", err)
 		}


### PR DESCRIPTION
This PR fixes a shadowed error in the `SaveConfigToLayerMigrateSectors` function.