### PR TITLE
Fix winning PoSt, track inclusion, display in webui

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -138,7 +138,8 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps) (*harmonytask.Task
 		if cfg.Subsystems.EnableWinningPost {
 			pl := dependencies.LocalStore
 			winPoStTask := winning.NewWinPostTask(cfg.Subsystems.WinningPostMaxTasks, db, pl, verif, asyncParams(), full, maddrs)
-			activeTasks = append(activeTasks, winPoStTask)
+			inclCkTask := winning.NewInclusionCheckTask(db, full)
+			activeTasks = append(activeTasks, winPoStTask, inclCkTask)
 		}
 	}
 

--- a/harmony/harmonydb/sql/20231110-mining_tasks.sql
+++ b/harmony/harmonydb/sql/20231110-mining_tasks.sql
@@ -14,6 +14,8 @@ create table mining_tasks
 
     submitted_at timestamp,
 
+    -- included BOOLEAN DEFAULT NULL, -- 20240610-mining-inclusion-checks.sql
+
     constraint mining_tasks_sp_epoch
         unique (sp_id, epoch)
 );

--- a/harmony/harmonydb/sql/20240610-mining-inclusion-checks.sql
+++ b/harmony/harmonydb/sql/20240610-mining-inclusion-checks.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mining_tasks ADD COLUMN included BOOLEAN DEFAULT NULL;

--- a/tasks/winning/inclusion_check_task.go
+++ b/tasks/winning/inclusion_check_task.go
@@ -1,0 +1,101 @@
+package winning
+
+import (
+	"context"
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+	"github.com/filecoin-project/curio/harmony/resources"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/chain/types"
+	"golang.org/x/xerrors"
+	"time"
+)
+
+const InclusionCheckInterval = 5 * time.Minute
+const MinInclusionEpochs = 5
+
+type InclusionCheckNodeApi interface {
+	ChainGetTipSetByHeight(context.Context, abi.ChainEpoch, types.TipSetKey) (*types.TipSet, error)
+	ChainHead(context.Context) (*types.TipSet, error)
+}
+
+type InclusionCheckTask struct {
+	db  *harmonydb.DB
+	api InclusionCheckNodeApi
+}
+
+func NewInclusionCheckTask(db *harmonydb.DB, api InclusionCheckNodeApi) *InclusionCheckTask {
+	return &InclusionCheckTask{db: db, api: api}
+}
+
+func (i *InclusionCheckTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+	ctx := context.Background()
+
+	var toCheck []struct {
+		Epoch    int64  `db:"epoch"`
+		MinedCID string `db:"mined_cid"`
+	}
+
+	err = i.db.Select(ctx, &toCheck, `SELECT epoch, mined_cid FROM mining_tasks WHERE won = true AND included IS NULL`)
+	if err != nil {
+		return false, err
+	}
+
+	head, err := i.api.ChainHead(ctx)
+	if err != nil {
+		return false, err
+
+	}
+
+	for _, check := range toCheck {
+		var included bool
+		if check.Epoch > int64(head.Height())-MinInclusionEpochs {
+			continue
+		}
+
+		// Check if the block is included in the chain
+		// If it is, update the included column in the database
+		// If it is not, do nothing
+
+		tsAt, err := i.api.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(check.Epoch), types.EmptyTSK)
+		if err != nil {
+			return false, xerrors.Errorf("getting tipset at epoch %d: %w", check.Epoch, err)
+		}
+
+		for _, b := range tsAt.Blocks() {
+			if b.Cid().String() == check.MinedCID {
+				included = true
+				break
+			}
+		}
+		_, err = i.db.Exec(ctx, `UPDATE mining_tasks SET included = $1 WHERE epoch = $2`, included, check.Epoch)
+		if err != nil {
+			return false, xerrors.Errorf("updating included column: %w", err)
+		}
+	}
+
+	return true, nil
+}
+
+func (i *InclusionCheckTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+	id := ids[0]
+	return &id, nil
+}
+
+func (i *InclusionCheckTask) TypeDetails() harmonytask.TaskTypeDetails {
+	return harmonytask.TaskTypeDetails{
+		Max:  1,
+		Name: "WinInclCheck",
+		Cost: resources.Resources{
+			Cpu: 1,
+			Ram: 64 << 20,
+			Gpu: 0,
+		},
+		IAmBored: harmonytask.SingletonTaskAdder(InclusionCheckInterval, i),
+	}
+}
+
+func (i *InclusionCheckTask) Adder(taskFunc harmonytask.AddTaskFunc) {
+}
+
+var _ harmonytask.TaskInterface = &InclusionCheckTask{}

--- a/tasks/winning/winning_task.go
+++ b/tasks/winning/winning_task.go
@@ -275,8 +275,7 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 			}
 		}
 
-		_, err = t.generateWinningPost(ctx, ppt, abi.ActorID(details.SpID), sectorChallenges, prand)
-		//wpostProof, err = t.prover.GenerateWinningPoSt(ctx, ppt, abi.ActorID(details.SpID), sectorChallenges, prand)
+		wpostProof, err = t.generateWinningPost(ctx, ppt, abi.ActorID(details.SpID), sectorChallenges, prand)
 		if err != nil {
 			err = xerrors.Errorf("failed to compute winning post proof: %w", err)
 			return false, err

--- a/web/api/webrpc/win_stats.go
+++ b/web/api/webrpc/win_stats.go
@@ -1,0 +1,80 @@
+package webrpc
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type WinStats struct {
+	Actor       int64      `db:"sp_id"`
+	Epoch       int64      `db:"epoch"`
+	Block       string     `db:"mined_cid"`
+	TaskID      int64      `db:"task_id"`
+	SubmittedAt *time.Time `db:"submitted_at"`
+	Included    *bool      `db:"included"`
+
+	BaseComputeTime *time.Time `db:"base_compute_time"`
+	MinedAt         *time.Time `db:"mined_at"`
+
+	SubmittedAtStr string `db:"-"`
+	TaskSuccess    string `db:"-"`
+	IncludedStr    string `db:"-"`
+	ComputeTime    string `db:"-"`
+}
+
+func (a *WebRPC) WinStats(ctx context.Context) ([]WinStats, error) {
+	var marks []WinStats
+	err := a.deps.DB.Select(ctx, &marks, `SELECT sp_id, epoch, mined_cid, task_id, submitted_at, included, base_compute_time, mined_at FROM mining_tasks WHERE won = true ORDER BY epoch DESC LIMIT 8`)
+	if err != nil {
+		return nil, err
+	}
+	for i := range marks {
+		if marks[i].SubmittedAt == nil {
+			marks[i].SubmittedAtStr = "Not Submitted"
+		} else {
+			marks[i].SubmittedAtStr = marks[i].SubmittedAt.Format(time.RFC822)
+		}
+
+		if marks[i].Included == nil {
+			marks[i].IncludedStr = "Not Checked"
+		} else if *marks[i].Included {
+			marks[i].IncludedStr = "Included"
+		} else {
+			marks[i].IncludedStr = "Not Included"
+		}
+
+		if marks[i].BaseComputeTime != nil && marks[i].MinedAt != nil {
+			marks[i].ComputeTime = marks[i].MinedAt.Sub(*marks[i].BaseComputeTime).Truncate(10 * time.Millisecond).String()
+		}
+
+		var taskRes []struct {
+			Result bool   `db:"result"`
+			Err    string `db:"error"`
+		}
+
+		err := a.deps.DB.Select(ctx, &taskRes, `SELECT result FROM harmony_task_history WHERE task_id = $1`, marks[i].TaskID)
+		if err != nil {
+			return nil, err
+		}
+
+		var success, fail int
+
+		for _, tr := range taskRes {
+			if tr.Result {
+				success++
+			} else {
+				fail++
+			}
+		}
+
+		if fail > 0 {
+			marks[i].TaskSuccess = fmt.Sprintf("Fail(%d) ", fail)
+		}
+		if success > 0 {
+			marks[i].TaskSuccess += "Success"
+		}
+	}
+
+	return marks, nil
+}

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -9,6 +9,7 @@
     <script type="module" src="harmony-task-counts.mjs"></script>
     <script type="module" src="storage-gc.mjs"></script>
     <script type="module" src="storage-use.mjs"></script>
+    <script type="module" src="win-stats.mjs"></script>
     <script type="module" src="/ux/curio-ux.mjs"></script>
     <style>
         .deadline-box {
@@ -149,6 +150,8 @@
                     </div>
                 </div>
                 <div class="col-md-auto">
+                    <h2>Recent Wins</h2>
+                    <win-stats></win-stats>
                 </div>
             </div>
 

--- a/web/static/win-stats.mjs
+++ b/web/static/win-stats.mjs
@@ -1,0 +1,54 @@
+import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
+import RPCCall from '/lib/jsonrpc.mjs';
+
+class WinStats extends LitElement {
+    static properties = {
+        data: { type: Array }
+    };
+
+    constructor() {
+        super();
+        this.data = [];
+        this.loadData();
+    }
+
+    async loadData() {
+        this.data = await RPCCall('WinStats');
+        super.requestUpdate();
+    }
+
+    render() {
+        return html`
+            <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+            <link rel="stylesheet" href="/ux/main.css" onload="document.body.style.visibility = 'initial'">
+            <table class="table table-dark">
+                <thead>
+                <tr>
+                    <th>Address</th>
+                    <th>Epoch</th>
+                    <th>Block</th>
+                    <th>Task Success</th>
+                    <th>Submitted At</th>
+                    <th>Compute Time</th>
+                    <th>Included</th>
+                </tr>
+                </thead>
+                <tbody>
+                    ${this.data.map(entry => html`
+                    <tr>
+                        <td>f0${entry.Actor}</td>
+                        <td>${entry.Epoch}</td>
+                        <td><abbr title="${entry.Block}">...${entry.Block.slice(-10)}</abbr></td>
+                        <td>${entry.TaskSuccess}</td>
+                        <td>${entry.SubmittedAtStr}</td>
+                        <td>${entry.ComputeTime}</td>
+                        <td>${entry.IncludedStr}</td>
+                    </tr>
+                    `)}
+                </tbody>
+            </table>
+        `;
+    }
+}
+
+customElements.define('win-stats', WinStats);


### PR DESCRIPTION
This PR:
* Makes WinnigPoSt work (a regression when ffiselect broke it in a subtle way)
* Adds a new task tracking inclusion of previously mined blocks
* Adds a table to the UI which shows stats for up to 8 recently won blocks

![2024-06-10-222215_1065x633_scrot](https://github.com/filecoin-project/curio/assets/3867941/9fda716b-6ed6-4e3b-9932-fdcdb1f0fa1c)
