### PR TITLE
Fix WinningPoSt with remote sectors

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -136,8 +136,8 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps) (*harmonytask.Task
 		}
 
 		if cfg.Subsystems.EnableWinningPost {
-			pl := dependencies.LocalStore
-			winPoStTask := winning.NewWinPostTask(cfg.Subsystems.WinningPostMaxTasks, db, pl, verif, asyncParams(), full, maddrs)
+			store := dependencies.Stor
+			winPoStTask := winning.NewWinPostTask(cfg.Subsystems.WinningPostMaxTasks, db, store, verif, asyncParams(), full, maddrs)
 			inclCkTask := winning.NewInclusionCheckTask(db, full)
 			activeTasks = append(activeTasks, winPoStTask, inclCkTask)
 		}

--- a/tasks/winning/winning_task.go
+++ b/tasks/winning/winning_task.go
@@ -43,7 +43,7 @@ type WinPostTask struct {
 	max int
 	db  *harmonydb.DB
 
-	paths       *paths.Local
+	paths       *paths.Remote
 	verifier    storiface.Verifier
 	paramsReady func() (bool, error)
 
@@ -72,11 +72,11 @@ type WinPostAPI interface {
 	WalletSign(context.Context, address.Address, []byte) (*crypto.Signature, error)
 }
 
-func NewWinPostTask(max int, db *harmonydb.DB, pl *paths.Local, verifier storiface.Verifier, paramck func() (bool, error), api WinPostAPI, actors map[dtypes.MinerAddress]bool) *WinPostTask {
+func NewWinPostTask(max int, db *harmonydb.DB, remote *paths.Remote, verifier storiface.Verifier, paramck func() (bool, error), api WinPostAPI, actors map[dtypes.MinerAddress]bool) *WinPostTask {
 	t := &WinPostTask{
 		max:         max,
 		db:          db,
-		paths:       pl,
+		paths:       remote,
 		verifier:    verifier,
 		paramsReady: paramck,
 		api:         api,
@@ -455,10 +455,10 @@ func (t *WinPostTask) generateWinningPost(
 		eg.Go(func() error {
 			vanilla, err := t.paths.GenerateSingleVanillaProof(ctx, mid, s, ppt)
 			if err != nil {
-				return xerrors.Errorf("get winning sector:%d,vanila failed: %w", s.SectorNumber, err)
+				return xerrors.Errorf("get winning sector:%d, vanilla failed: %w", s.SectorNumber, err)
 			}
 			if vanilla == nil {
-				return xerrors.Errorf("get winning sector:%d,vanila is nil", s.SectorNumber)
+				return xerrors.Errorf("get winning sector:%d, vanilla is nil", s.SectorNumber)
 			}
 			vproofs[i] = vanilla
 			return nil


### PR DESCRIPTION
Another regression from ffiselect, apparently made me loose 32 FIL on mainnet.


Not having this resulted in errors like
```
error: failed to compute winning post proof: get winning sector:6822,vanila failed: fsstat: path not found
```