### PR TITLE
fix: sector size in guided-setup

### DIFF
--- a/cmd/curio/guidedsetup/guidedsetup.go
+++ b/cmd/curio/guidedsetup/guidedsetup.go
@@ -25,15 +25,15 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/docker/go-units"
 	"github.com/filecoin-project/curio/build"
 	_ "github.com/filecoin-project/curio/cmd/curio/internal/translations"
 	"github.com/filecoin-project/curio/deps"
+	"github.com/filecoin-project/curio/deps/config"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/go-state-types/abi"
-
-	"github.com/filecoin-project/curio/deps/config"
 
 	"github.com/manifoldco/promptui"
 	"github.com/mitchellh/go-homedir"
@@ -656,7 +656,7 @@ func stepCreateActor(d *MigrationData) {
 				d.T("Owner Wallet: %s", d.owner.String()),
 				d.T("Worker Wallet: %s", d.worker.String()),
 				d.T("Sender Wallet: %s", d.sender.String()),
-				d.T("Sector Size: %d", d.ssize),
+				d.T("Sector Size: %s", d.ssize),
 				d.T("Continue to verify the addresses and create a new miner actor.")},
 			Size:      6,
 			Templates: d.selectTemplates,
@@ -724,7 +724,12 @@ func stepCreateActor(d *MigrationData) {
 	}
 
 minerInit:
-	var ss abi.SectorSize
+	sectorSize, err := units.RAMInBytes(d.ssize)
+	if err != nil {
+		d.say(notice, "Failed to parse sector size: %s", err.Error())
+		os.Exit(1)
+	}
+	ss := abi.SectorSize(sectorSize)
 
 	miner, err := spcli.CreateStorageMiner(d.ctx, d.full, d.owner, d.worker, d.sender, ss, CONFIDENCE)
 	if err != nil {


### PR DESCRIPTION
Guided setup is now fixed

```
Defaulting to English. Please reach out to the Curio team if you would like to have additional language support.
✔ Create a new miner
                                                                
 ┌────────────────────────────────────────────────────────────┐ 
 │This interactive tool creates a new miner actor and creates │ 
 │the basic configuration layer for it.                       │ 
 └────────────────────────────────────────────────────────────┘ 
                                                                
This process is partially idempotent. Once a new miner actor has been created and subsequent steps fail, the user need to run 'curio config new-cluster < miner ID >' to finish the configuration.
                                                                                                                                                                                                  
✔ Continue to connect and update schema.
✔ Step Complete: Pre-initialization steps complete
                                                
Initializing a new miner actor.
✔ Owner Wallet: <empty>
Enter the owner address: t3s5gk5cbwogmlyywlkynsfnz5j7upum337rbgyiey5rhe5jdqwsfnmrw24r26agh6tdqotaxqdgdvuoce2mya
✔ Sender Wallet: <empty>
Enter sender address: t3s5gk5cbwogmlyywlkynsfnz5j7upum337rbgyiey5rhe5jdqwsfnmrw24r26agh6tdqotaxqdgdvuoce2mya
✔ Worker Wallet: <empty>
Enter worker address: t3s5gk5cbwogmlyywlkynsfnz5j7upum337rbgyiey5rhe5jdqwsfnmrw24r26agh6tdqotaxqdgdvuoce2mya
✔ Sector Size: 32 GiB
✔ 2 KiB
✔ Continue to verify the addresses and create a new miner actor.
Pushed CreateMiner message: bafy2bzacebkkpmwn6j4o6acmwkvjehbkhmcoqbdun2zggldqh24gu2qs7figm
Waiting for confirmation
New miners address is: t01007 (t23nhrk4rwcredm32faw6n4avprmy3c6ntjwcleda)
✔ Step Complete: Miner t01007 created successfully
                                                
✔ Step Complete: Configuration 'base' was updated to include this miner's address
                                                                               
Documentation: 
The 'base' layer stores common configuration. All curio instances can include it in their --layers argument.
You can add other layers for per-machine configuration changes.
Filecoin Slack channels: #fil-curio-help and #fil-curio-dev
Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'
One database can serve multiple miner IDs: Run a migration for each lotus-miner.
The Curio team wants to improve the software you use. Tell the team you're using `curio`.
✔ Nothing.
✔ Step Complete: New Miner initialization complete.
                                                 
✔ ./curio/curio.env
Error writing file: open ./curio/curio.env: not a directory
                                                           
✔ /Users/lexluthr/curio.env
Try the web interface with curio run --layers=gui 
For more servers, make /etc/curio.env with the curio.env database env and add the CURIO_LAYERS env to assign purposes.
You can now migrate your market node (Boost), if applicable.
Additional info is at http://docs.curiostorage.org
```
