### PR TITLE
fix: update piece metadata to get deal details

### DIFF
--- a/cmd/curio/guidedsetup/shared.go
+++ b/cmd/curio/guidedsetup/shared.go
@@ -299,7 +299,7 @@ func MigrateSectors(ctx context.Context, maddr address.Address, mmeta datastore.
 
 	migratableState := func(state sealing.SectorState) bool {
 		switch state {
-		case sealing.Proving, sealing.Available, sealing.Removed:
+		case sealing.Proving, sealing.Available, sealing.UpdateActivating, sealing.Removed:
 			return true
 		default:
 			return false

--- a/harmony/harmonydb/sql/20240425-sector_meta.sql
+++ b/harmony/harmonydb/sql/20240425-sector_meta.sql
@@ -39,6 +39,8 @@ CREATE TABLE sectors_meta_pieces (
     f05_deal_id BIGINT,
     ddo_pam jsonb,
 
+    -- f05_deal_proposal jsonb added in 20240612-deal-proposal.sql
+
     PRIMARY KEY (sp_id, sector_num, piece_num),
     FOREIGN KEY (sp_id, sector_num) REFERENCES sectors_meta(sp_id, sector_num) ON DELETE CASCADE
 );

--- a/harmony/harmonydb/sql/20240612-deal-proposal.sql
+++ b/harmony/harmonydb/sql/20240612-deal-proposal.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sectors_meta_pieces
+    ADD COLUMN f05_deal_proposal jsonb;

--- a/tasks/seal/task_submit_commit.go
+++ b/tasks/seal/task_submit_commit.go
@@ -331,7 +331,8 @@ func (s *SubmitCommitTask) transferFinalizedSectorData(ctx context.Context, spID
             start_epoch,
             orig_end_epoch,
             f05_deal_id,
-            ddo_pam
+            ddo_pam,
+            f05_deal_proposal                          
         )
         SELECT
             sp_id,
@@ -344,7 +345,8 @@ func (s *SubmitCommitTask) transferFinalizedSectorData(ctx context.Context, spID
             COALESCE(f05_deal_start_epoch, direct_start_epoch) as start_epoch,
             COALESCE(f05_deal_end_epoch, direct_end_epoch) as orig_end_epoch,
             f05_deal_id,
-            direct_piece_activation_manifest as ddo_pam
+            direct_piece_activation_manifest as ddo_pam,
+            f05_deal_proposal
         FROM
             sectors_sdr_initial_pieces
         WHERE
@@ -358,7 +360,8 @@ func (s *SubmitCommitTask) transferFinalizedSectorData(ctx context.Context, spID
             start_epoch = excluded.start_epoch,
             orig_end_epoch = excluded.orig_end_epoch,
             f05_deal_id = excluded.f05_deal_id,
-            ddo_pam = excluded.ddo_pam;
+            ddo_pam = excluded.ddo_pam,
+            f05_deal_proposal = excluded.f05_deal_proposal;
     `, spID, sectorNum); err != nil {
 		return fmt.Errorf("failed to insert/update sector_meta_pieces: %w", err)
 	}

--- a/web/api/sector/sector.go
+++ b/web/api/sector/sector.go
@@ -162,6 +162,17 @@ func (c *cfg) getSectors(w http.ResponseWriter, r *http.Request) {
 										direct_piece_activation_manifest  
 										FROM sectors_sdr_initial_pieces 
 										ORDER BY sp_id, sector_number`))
+	var mpieces []piece
+	apihelper.OrHTTPFail(w, c.DB.Select(r.Context(), &mpieces, `SELECT 
+										sp_id,
+										sector_num,
+										piece_size,
+										COALESCE(f05_deal_id, 0) AS f05_deal_id,
+										f05_deal_proposal,
+										ddo_pam  
+										FROM sectors_meta_pieces 
+										ORDER BY sp_id, sector_num`))
+	pieces = append(pieces, mpieces...)
 	pieceIndex := map[sectorID][]int{}
 	for i, piece := range pieces {
 		piece := piece


### PR DESCRIPTION
This PR does the following:
1. Expand sectors_meta_pieces to have f05_deal_proposal column
2. When migrating from miner, also copy over f05_deal_proposal
3. Sector UI now uses both sectors_meta_pieces and sectors_sdr_initial_pieces tables to put together the details