### PR TITLE
FFISelect improvements

### DIFF
--- a/lib/ffiselect/ffi_test.go
+++ b/lib/ffiselect/ffi_test.go
@@ -1,0 +1,16 @@
+package ffiselect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelf(t *testing.T) {
+	testCID := cid.NewCidV1(1, []byte("test"))
+	cid, err := FFISelect.SelfTest(context.Background(), 12345678, testCID)
+	require.NoError(t, err)
+	require.Equal(t, testCID, cid)
+}

--- a/lib/ffiselect/ffiselect.go
+++ b/lib/ffiselect/ffiselect.go
@@ -59,10 +59,9 @@ func init() {
 		ffiDirectType := ffiDirectValue.Type()
 
 		for i := 0; i < ffiDirectType.NumMethod(); i++ {
-			m := ffiDirectType.Method(i)
-			f := ffiSelect.FieldByName(m.Name)
+			f := ffiSelect.FieldByName(ffiDirectType.Method(i).Name)
 			f.Set(reflect.MakeFunc(f.Type(), func(args []reflect.Value) []reflect.Value {
-				return ffiDirectValue.MethodByName(m.Name).Call(args[1:])
+				return ffiDirectValue.Method(i).Call(args[1:]) // avoid sending ctx
 			}))
 		}
 	}


### PR DESCRIPTION
Change:
   Whenever we see <2 GPUs, we just do a call locally. 

Reasoning: 
 -  I'm unsure why we saw recursion, but this should resolve it because the subsequent depth will only see 1 GPU. 
 - Performance improvement for machines with 1 card
 - It implicitly supports the 0 GPU "dev-net" case. 
   