### PR TITLE
feat: Add support for alert plugin and integrate Lark bot plugin

### DIFF
--- a/alertmanager/plugins/lark_bot.go
+++ b/alertmanager/plugins/lark_bot.go
@@ -1,0 +1,248 @@
+package plugins
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/filecoin-project/curio/deps/config"
+	"github.com/samber/lo"
+)
+
+// LarkCustomBot is a plugin for sending alerts to Lark Custom Bot.
+// More information about Lark Custom Bot can be found at
+// https://open.larksuite.com/document/client-docs/bot-v3/add-custom-bot
+type LarkCustomBot struct {
+	cfg config.LarkBotConfig
+}
+
+func (p *LarkCustomBot) SendAlert(data *AlertPayload) error {
+	if p.cfg.WebhookURL == "" {
+		log.Warnf("WebhookURL is not set, skipping alert.")
+		return nil
+	}
+	type botData struct {
+		Timestamp int64    `json:"timestamp,omitempty"`
+		Sign      string   `json:"sign,omitempty"`
+		MsgType   string   `json:"msg_type"`
+		Card      larkCard `json:"card"`
+	}
+
+	payload := &botData{
+		MsgType: "interactive",
+		Card: larkCard{
+			Header: larkHeader{
+				Template: "red",
+				Title: larkText{
+					Content: fmt.Sprintf("%s %s - %s", data.Summary, data.Severity, data.Source),
+					Tag:     "plain_text",
+				},
+			},
+			Elements: []larkElement{
+				{
+					Tag:             "column_set",
+					FlexMode:        "none",
+					BackgroundStyle: "default",
+					Columns: []larkColumn{
+						{
+							Tag:           "column",
+							Width:         "weighted",
+							Weight:        1,
+							VerticalAlign: "top",
+							Elements: []larkElement{
+								{
+									Tag: "div",
+									Text: larkText{
+										Tag:     "lark_md",
+										Content: fmt.Sprintf("**🔴 Project:**\n%s", data.Source),
+									},
+								},
+							},
+						},
+						{
+							Tag:           "column",
+							Width:         "weighted",
+							Weight:        1,
+							VerticalAlign: "top",
+							Elements: []larkElement{
+								{
+									Tag: "div",
+									Text: larkText{
+										Tag:     "lark_md",
+										Content: fmt.Sprintf("**🕐 Time:**\n%s", data.Time.Format(time.RFC3339)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if len(p.cfg.AtUserIds) > 0 {
+		elements := larkElement{
+			Tag:             "column_set",
+			FlexMode:        "none",
+			BackgroundStyle: "default",
+		}
+		for idx, oid := range p.cfg.AtUserIds {
+			elements.Columns = append(elements.Columns, larkColumn{
+				Tag:           "column",
+				Width:         "weighted",
+				Weight:        1,
+				VerticalAlign: "top",
+				Elements: []larkElement{
+					{
+						Tag: "div",
+						Text: larkText{
+							Tag:     "lark_md",
+							Content: fmt.Sprintf("**👤 Level %d on call:**\n<at id=%s></at>", idx+1, oid),
+						},
+					},
+				},
+			})
+			if len(elements.Columns) == 2 {
+				payload.Card.Elements = append(payload.Card.Elements, elements)
+				elements = larkElement{
+					Tag:             "column_set",
+					FlexMode:        "none",
+					BackgroundStyle: "default",
+				}
+			}
+		}
+		if len(elements.Columns) > 0 {
+			payload.Card.Elements = append(payload.Card.Elements, elements)
+		}
+	}
+
+	for k, v := range data.Details {
+		payload.Card.Elements = append(payload.Card.Elements, larkElement{
+			Tag: "div",
+			Text: larkText{
+				Tag:     "lark_md",
+				Content: fmt.Sprintf("**%s :**\n%s", k, v),
+			},
+		})
+	}
+	if p.cfg.Footer != "" {
+		payload.Card.Elements = append(payload.Card.Elements, larkElement{
+			Tag: "hr",
+		})
+		payload.Card.Elements = append(payload.Card.Elements, larkElement{
+			Tag: "div",
+			Text: larkText{
+				Tag:     "lark_md",
+				Content: p.cfg.Footer,
+			},
+		})
+	}
+
+	if p.cfg.Secret != "" {
+		timestamp, sign, err := p.genSign()
+		if err != nil {
+			return fmt.Errorf("error generating sign: %w", err)
+		}
+		payload.Timestamp = timestamp
+		payload.Sign = sign
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("error marshaling JSON: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", p.cfg.WebhookURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+	}
+	iter, duration, err := lo.AttemptWithDelay(5, time.Second,
+		func(i int, duration time.Duration) error {
+			resp, err := client.Do(req)
+			if err != nil {
+				time.Sleep(duration * time.Duration(i))
+				return err
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			switch resp.StatusCode {
+			case http.StatusOK:
+				type response struct {
+					Code int    `json:"code"`
+					Msg  string `json:"msg"`
+				}
+				var r response
+				err = json.NewDecoder(resp.Body).Decode(&r)
+				if err != nil {
+					return fmt.Errorf("error decoding response: %v", err)
+				}
+				if r.Code != 0 {
+					return fmt.Errorf("error response: %v", r)
+				}
+				return nil
+			default:
+				return fmt.Errorf("unexpected HTTP response: %v", resp.Status)
+			}
+		},
+	)
+	if err != nil {
+		log.Errorw("error sending alert", "retry", iter, "duration", duration, "error", err)
+		return err
+	}
+	return nil
+}
+
+func (p *LarkCustomBot) genSign() (int64, string, error) {
+	timestamp := time.Now().Unix()
+	stringToSign := fmt.Sprintf("%v", timestamp) + "\n" + p.cfg.Secret
+	var data []byte
+	h := hmac.New(sha256.New, []byte(stringToSign))
+	_, err := h.Write(data)
+	if err != nil {
+		return 0, "", err
+	}
+	signature := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	return timestamp, signature, nil
+}
+
+type larkCard struct {
+	Elements []larkElement `json:"elements"`
+	Header   larkHeader    `json:"header"`
+}
+
+type larkHeader struct {
+	Template string   `json:"template"`
+	Title    larkText `json:"title"`
+}
+
+type larkText struct {
+	Content string `json:"content"`
+	Tag     string `json:"tag"`
+}
+
+type larkColumn struct {
+	Tag           string        `json:"tag"`
+	Width         string        `json:"width"`
+	Weight        int           `json:"weight"`
+	VerticalAlign string        `json:"vertical_align"`
+	Elements      []larkElement `json:"elements"`
+}
+
+type larkElement struct {
+	Tag             string       `json:"tag"`
+	FlexMode        string       `json:"flex_mode,omitempty"`
+	BackgroundStyle string       `json:"background_style,omitempty"`
+	Columns         []larkColumn `json:"columns,omitempty"`
+	Text            larkText     `json:"text,omitempty"`
+	Elements        []larkText   `json:"elements,omitempty"`
+}

--- a/alertmanager/plugins/pagerduty.go
+++ b/alertmanager/plugins/pagerduty.go
@@ -1,0 +1,111 @@
+package plugins
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/filecoin-project/curio/deps/config"
+	"github.com/samber/lo"
+	"golang.org/x/xerrors"
+)
+
+type PagerDuty struct {
+	cfg config.PagerDutyConfig
+}
+
+type pagerDutyPayload struct {
+	Summary       string      `json:"summary"`
+	Severity      string      `json:"severity"`
+	Source        string      `json:"source"`
+	Component     string      `json:"component,omitempty"`
+	Group         string      `json:"group,omitempty"`
+	Class         string      `json:"class,omitempty"`
+	CustomDetails interface{} `json:"custom_details,omitempty"`
+}
+
+// SendAlert sends an alert to PagerDuty with the provided payload data.
+// It creates a PDData struct with the provided routing key, event action and payload.
+// It creates an HTTP POST request with the PagerDuty event URL as the endpoint and the marshaled JSON data as the request body.
+// It sends the request using an HTTP client with a maximum of 5 retries for network errors with exponential backoff before each retry.
+// It handles different HTTP response status codes and returns an error based on the status code().
+// If all retries fail, it returns an error indicating the last network error encountered.
+func (p *PagerDuty) SendAlert(data *AlertPayload) error {
+	if p.cfg.PageDutyIntegrationKey == "" {
+		log.Warnf("PageDutyIntegrationKey is not set, skipping alert.")
+		return nil
+	}
+
+	type pdData struct {
+		RoutingKey  string            `json:"routing_key"`
+		EventAction string            `json:"event_action"`
+		Payload     *pagerDutyPayload `json:"payload"`
+	}
+
+	payload := &pdData{
+		RoutingKey:  p.cfg.PageDutyIntegrationKey,
+		EventAction: "trigger",
+		Payload: &pagerDutyPayload{
+			Summary:       data.Summary,
+			Severity:      data.Severity,
+			CustomDetails: data.Details,
+			Source:        data.Source,
+		},
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("error marshaling JSON: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", p.cfg.PagerDutyEventURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Timeout: time.Second * 15,
+	}
+	var resp *http.Response
+
+	iter, duration, err := lo.AttemptWithDelay(5, time.Second,
+		func(i int, duration time.Duration) error {
+			resp, err = client.Do(req)
+			if err != nil {
+				time.Sleep(time.Duration(2*i) * duration) // Exponential backoff
+				return err
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			switch resp.StatusCode {
+			case 202:
+				log.Debug("Accepted: The event has been accepted by PagerDuty.")
+				return nil
+			case 400:
+				bd, rerr := io.ReadAll(resp.Body)
+				if rerr != nil {
+					return xerrors.Errorf("Bad request: payload JSON is invalid. Failed to read the body: %w", err)
+				}
+				return xerrors.Errorf("Bad request: payload JSON is invalid %s", string(bd))
+			case 429:
+				log.Debug("Too many API calls, retrying after backoff...")
+				time.Sleep(time.Duration(5*i) * time.Second) // Exponential backoff
+			case 500, 501, 502, 503, 504:
+				log.Debug("Server error, retrying after backoff...")
+				time.Sleep(time.Duration(5*i) * time.Second) // Exponential backoff
+			default:
+				log.Errorw("Response status:", resp.Status)
+				return fmt.Errorf("unexpected HTTP response: %s", resp.Status)
+			}
+			return nil
+		})
+	if err != nil {
+		log.Errorw("error sending alert", "retry", iter, "duration", duration, "error", err)
+		return err
+	}
+	return nil
+}

--- a/alertmanager/plugins/plugins.go
+++ b/alertmanager/plugins/plugins.go
@@ -1,0 +1,33 @@
+package plugins
+
+import (
+	"time"
+
+	"github.com/filecoin-project/curio/deps/config"
+	logging "github.com/ipfs/go-log/v2"
+)
+
+var log = logging.Logger("curio/alertplugins")
+
+type AlertPayload struct {
+	Severity string
+	Summary  string
+	Source   string
+	Details  map[string]string
+	Time     time.Time
+}
+
+type Plugin interface {
+	SendAlert(data *AlertPayload) error
+}
+
+func LoadAlertPlugins(cfg config.CurioAlertingConfig) []Plugin {
+	var plugins []Plugin
+	if cfg.PagerDuty.Enable {
+		plugins = append(plugins, &PagerDuty{cfg: cfg.PagerDuty})
+	}
+	if cfg.LarkBot.Enable {
+		plugins = append(plugins, &LarkCustomBot{cfg: cfg.LarkBot})
+	}
+	return plugins
+}

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -81,28 +81,25 @@ over the worker address if this flag is set.`,
 			Comment: `MinerAddresses are the addresses of the miner actors to use for sending messages`,
 		},
 	},
-	"CurioAlerting": {
-		{
-			Name: "PagerDutyEventURL",
-			Type: "string",
-
-			Comment: `PagerDutyEventURL is URL for PagerDuty.com Events API v2 URL. Events sent to this API URL are ultimately
-routed to a PagerDuty.com service and processed.
-The default is sufficient for integration with the stock commercial PagerDuty.com company's service.`,
-		},
-		{
-			Name: "PageDutyIntegrationKey",
-			Type: "string",
-
-			Comment: `PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
-identifier in the integration page for the service.`,
-		},
+	"CurioAlertingConfig": {
 		{
 			Name: "MinimumWalletBalance",
 			Type: "types.FIL",
 
 			Comment: `MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
 alerts will be triggered for the wallet`,
+		},
+		{
+			Name: "PagerDuty",
+			Type: "PagerDutyConfig",
+
+			Comment: `PagerDuty is the configuration for the PagerDuty integration.`,
+		},
+		{
+			Name: "LarkBot",
+			Type: "LarkBotConfig",
+
+			Comment: `LarkBot is the configuration for the Lark custom bot integration.`,
 		},
 	},
 	"CurioConfig": {
@@ -150,7 +147,7 @@ alerts will be triggered for the wallet`,
 		},
 		{
 			Name: "Alerting",
-			Type: "CurioAlerting",
+			Type: "CurioAlertingConfig",
 
 			Comment: ``,
 		},
@@ -608,6 +605,67 @@ only need to be run on a single machine in the cluster.`,
 			Type: "string",
 
 			Comment: `Events of the form: "system1:event1,system1:event2[,...]"`,
+		},
+	},
+	"LarkBotConfig": {
+		{
+			Name: "Enable",
+			Type: "bool",
+
+			Comment: `Enable is a flag to enable or disable the Lark custom bot integration.`,
+		},
+		{
+			Name: "WebhookURL",
+			Type: "string",
+
+			Comment: `WebhookURL is the URL for the Lark custom bot webhook.`,
+		},
+		{
+			Name: "Secret",
+			Type: "string",
+
+			Comment: `Secret is the secret for the Lark custom bot webhook.
+Optional, if set, the secret will be used to sign the request body.`,
+		},
+		{
+			Name: "AtUserIds",
+			Type: "[]string",
+
+			Comment: `AtUserIds is the list of users to @ in the Lark custom bot message.
+The user IDs are unique identifiers for users in the Lark system.
+The format is "ou_id1,ou_id2", 'all' can be used to @ all users.
+Optional, if set, the users will be @ in the message.`,
+		},
+		{
+			Name: "Footer",
+			Type: "string",
+
+			Comment: `Footer is the footer for the Lark custom bot message.
+lark markdown is supported.
+Optional, if set, the footer will be added to the message.`,
+		},
+	},
+	"PagerDutyConfig": {
+		{
+			Name: "Enable",
+			Type: "bool",
+
+			Comment: `Enable is a flag to enable or disable the PagerDuty integration.`,
+		},
+		{
+			Name: "PagerDutyEventURL",
+			Type: "string",
+
+			Comment: `PagerDutyEventURL is URL for PagerDuty.com Events API v2 URL. Events sent to this API URL are ultimately
+routed to a PagerDuty.com service and processed.
+The default is sufficient for integration with the stock commercial PagerDuty.com company's service.`,
+		},
+		{
+			Name: "PageDutyIntegrationKey",
+			Type: "string",
+
+			Comment: `PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
+identifier in the integration page for the service.`,
 		},
 	},
 }

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -52,10 +52,13 @@ func DefaultCurioConfig() *CurioConfig {
 			MaxQueuePoRep:      0, // default don't use this limit
 			MaxDealWaitTime:    Duration(1 * time.Hour),
 		},
-		Alerting: CurioAlerting{
-			PagerDutyEventURL:      "https://events.pagerduty.com/v2/enqueue",
-			PageDutyIntegrationKey: "",
-			MinimumWalletBalance:   types.MustParseFIL("5"),
+		Alerting: CurioAlertingConfig{
+			MinimumWalletBalance: types.MustParseFIL("5"),
+			PagerDuty: PagerDutyConfig{
+				Enable:                 true,
+				PagerDutyEventURL:      "https://events.pagerduty.com/v2/enqueue",
+				PageDutyIntegrationKey: "",
+			},
 		},
 	}
 }
@@ -71,7 +74,7 @@ type CurioConfig struct {
 	Ingest    CurioIngestConfig
 	Journal   JournalConfig
 	Apis      ApisConfig
-	Alerting  CurioAlerting
+	Alerting  CurioAlertingConfig
 }
 
 func DefaultDefaultMaxFee() types.FIL {
@@ -398,7 +401,22 @@ type CurioIngestConfig struct {
 	MaxDealWaitTime Duration
 }
 
-type CurioAlerting struct {
+type CurioAlertingConfig struct {
+	// MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
+	// alerts will be triggered for the wallet
+	MinimumWalletBalance types.FIL
+
+	// PagerDuty is the configuration for the PagerDuty integration.
+	PagerDuty PagerDutyConfig
+
+	// LarkBot is the configuration for the Lark custom bot integration.
+	LarkBot LarkBotConfig
+}
+
+type PagerDutyConfig struct {
+	// Enable is a flag to enable or disable the PagerDuty integration.
+	Enable bool
+
 	// PagerDutyEventURL is URL for PagerDuty.com Events API v2 URL. Events sent to this API URL are ultimately
 	// routed to a PagerDuty.com service and processed.
 	// The default is sufficient for integration with the stock commercial PagerDuty.com company's service.
@@ -407,10 +425,29 @@ type CurioAlerting struct {
 	// PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
 	// identifier in the integration page for the service.
 	PageDutyIntegrationKey string
+}
 
-	// MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
-	// alerts will be triggered for the wallet
-	MinimumWalletBalance types.FIL
+type LarkBotConfig struct {
+	// Enable is a flag to enable or disable the Lark custom bot integration.
+	Enable bool
+
+	// WebhookURL is the URL for the Lark custom bot webhook.
+	WebhookURL string
+
+	// Secret is the secret for the Lark custom bot webhook.
+	// Optional, if set, the secret will be used to sign the request body.
+	Secret string
+
+	// AtUserIds is the list of users to @ in the Lark custom bot message.
+	// The user IDs are unique identifiers for users in the Lark system.
+	// The format is "ou_id1,ou_id2", 'all' can be used to @ all users.
+	// Optional, if set, the users will be @ in the message.
+	AtUserIds []string
+
+	// Footer is the footer for the Lark custom bot message.
+	// lark markdown is supported.
+	// Optional, if set, the footer will be added to the message.
+	Footer string
 }
 
 type JournalConfig struct {

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -407,23 +407,53 @@ description: The default curio configuration
 
 
 [Alerting]
-  # PagerDutyEventURL is URL for PagerDuty.com Events API v2 URL. Events sent to this API URL are ultimately
-  # routed to a PagerDuty.com service and processed.
-  # The default is sufficient for integration with the stock commercial PagerDuty.com company's service.
-  #
-  # type: string
-  #PagerDutyEventURL = "https://events.pagerduty.com/v2/enqueue"
-
-  # PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
-  # identifier in the integration page for the service.
-  #
-  # type: string
-  #PageDutyIntegrationKey = ""
-
   # MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
   # alerts will be triggered for the wallet
   #
   # type: types.FIL
   #MinimumWalletBalance = "5 FIL"
+
+  [Alerting.PagerDuty]
+    # Enable is a flag to enable or disable the PagerDuty integration.
+    #
+    # type: bool
+    #Enable = true
+
+    # PagerDutyEventURL is URL for PagerDuty.com Events API v2 URL. Events sent to this API URL are ultimately
+    # routed to a PagerDuty.com service and processed.
+    # The default is sufficient for integration with the stock commercial PagerDuty.com company's service.
+    #
+    # type: string
+    #PagerDutyEventURL = "https://events.pagerduty.com/v2/enqueue"
+
+    # PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
+    # identifier in the integration page for the service.
+    #
+    # type: string
+    #PageDutyIntegrationKey = ""
+
+  [Alerting.LarkBot]
+    # Enable is a flag to enable or disable the Lark custom bot integration.
+    #
+    # type: bool
+    #Enable = false
+
+    # WebhookURL is the URL for the Lark custom bot webhook.
+    #
+    # type: string
+    #WebhookURL = ""
+
+    # Secret is the secret for the Lark custom bot webhook.
+    # Optional, if set, the secret will be used to sign the request body.
+    #
+    # type: string
+    #Secret = ""
+
+    # Footer is the footer for the Lark custom bot message.
+    # lark markdown is supported.
+    # Optional, if set, the footer will be added to the message.
+    #
+    # type: string
+    #Footer = ""
 
 ```


### PR DESCRIPTION
https://github.com/filecoin-project/curio/discussions/83

Design Alerting as a plugin mode, and add a new Lark bot plugin. 
The Alerting configuration has changed and is no longer compatible with previous versions.

Before:
```go
type CurioAlerting struct {
	PagerDutyEventURL string
	PageDutyIntegrationKey string
	MinimumWalletBalance types.FIL
}
```

Now:
```go
type CurioAlertingConfig struct {
	MinimumWalletBalance types.FIL
	// PagerDuty is the configuration for the PagerDuty integration.
	PagerDuty PagerDutyConfig
	// LarkBot is the configuration for the Lark custom bot integration.
	LarkBot LarkBotConfig

        // Add more alerting integrations here
}
```

Here is an example of a Lark bot:

configuration:

```go
config.LarkCustomBotConfig{
    Enable: true,
    WebhookURL: "https://open.larksuite.com/open-apis/bot/v2/hook/xxxx",
    Footer:     "📝 For more information, please visit the [Curio Alerting System](https://github.com/filecoin-project/curio)", // Optional
    Secret: "",  // Optional
    AtUserIds:  []string{"ou_myid", "all"} // Optional
}
```
the effect looks like:

![image](https://github.com/filecoin-project/curio/assets/7932644/162503f1-8e9f-4dda-8234-cc607ec453a6)
