### PR TITLE
feat: Add support for Prometheus AlertManager

### DIFF
--- a/alertmanager/doc.go
+++ b/alertmanager/doc.go
@@ -1,0 +1,41 @@
+/*
+Package alertmanager provides a framework for monitoring and alerting within the Curio project. It supports dynamic plugin integration for alert notifications, allowing for flexible and extensible alerting mechanisms.
+
+Implementing a New Plugin:
+
+1. Define a struct that implements the Plugin interface, which includes the SendAlert method for dispatching alerts.
+2. Implement the SendAlert method to handle the alert logic specific to your plugin.
+3. Provide a constructor function for your plugin to facilitate its configuration and initialization.
+4. Register your plugin in the LoadAlertPlugins function, which dynamically loads plugins based on the CurioAlertingConfig.
+
+Plugin Configuration:
+
+Plugins are configured through the config.CurioAlertingConfig struct. Each plugin can have its own configuration section within this struct, enabling or disabling the plugin and setting plugin-specific parameters.
+
+Example:
+
+```go
+type MyPlugin struct{}
+
+	func (p *MyPlugin) SendAlert(data *plugin.AlertPayload) error {
+		// Plugin-specific alert sending logic
+		return nil
+	}
+
+	func NewMyPlugin() *MyPlugin {
+		return &MyPlugin{}
+	}
+
+	func LoadAlertPlugins(cfg config.CurioAlertingConfig) []plugin.Plugin {
+		var plugins []plugin.Plugin
+		if cfg.MyPlugin.Enabled {
+			plugins = append(plugins, NewMyPlugin())
+		}
+		return plugins
+	}
+
+```
+This package leverages the CurioAlertingConfig for plugin configuration,
+enabling a modular approach to adding or removing alerting capabilities as required.
+*/
+package alertmanager

--- a/alertmanager/plugin/pager_duty.go
+++ b/alertmanager/plugin/pager_duty.go
@@ -1,0 +1,111 @@
+package plugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/curio/deps/config"
+	"github.com/samber/lo"
+)
+
+type PagerDuty struct {
+	cfg config.PagerDutyConfig
+}
+
+func NewPagerDuty(cfg config.PagerDutyConfig) Plugin {
+	return &PagerDuty{
+		cfg: cfg,
+	}
+}
+
+// SendAlert sends an alert to PagerDuty with the provided payload data.
+// It creates a PDData struct with the provided routing key, event action and payload.
+// It creates an HTTP POST request with the PagerDuty event URL as the endpoint and the marshaled JSON data as the request body.
+// It sends the request using an HTTP client with a maximum of 5 retries for network errors with exponential backoff before each retry.
+// It handles different HTTP response status codes and returns an error based on the status code().
+// If all retries fail, it returns an error indicating the last network error encountered.
+func (p *PagerDuty) SendAlert(data *AlertPayload) error {
+
+	type pdPayload struct {
+		Summary       string      `json:"summary"`
+		Severity      string      `json:"severity"`
+		Source        string      `json:"source"`
+		Component     string      `json:"component,omitempty"`
+		Group         string      `json:"group,omitempty"`
+		Class         string      `json:"class,omitempty"`
+		CustomDetails interface{} `json:"custom_details,omitempty"`
+	}
+
+	type pdData struct {
+		RoutingKey  string     `json:"routing_key"`
+		EventAction string     `json:"event_action"`
+		Payload     *pdPayload `json:"payload"`
+	}
+
+	payload := &pdData{
+		RoutingKey:  p.cfg.PageDutyIntegrationKey,
+		EventAction: "trigger",
+		Payload: &pdPayload{
+			Summary:       data.Summary,
+			Severity:      data.Severity,
+			Source:        data.Source,
+			CustomDetails: data.Details,
+		},
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("error marshaling JSON: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", p.cfg.PagerDutyEventURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Timeout: time.Second * 15,
+	}
+	iter, _, err := lo.AttemptWithDelay(5, time.Second,
+		func(index int, duration time.Duration) error {
+			resp, err := client.Do(req)
+			if err != nil {
+				time.Sleep(time.Duration(2*index) * duration) // Exponential backoff
+				return err
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			switch resp.StatusCode {
+			case 202:
+				log.Debug("Accepted: The event has been accepted by PagerDuty.")
+				return nil
+			case 400:
+				bd, rerr := io.ReadAll(resp.Body)
+				if rerr != nil {
+					return xerrors.Errorf("Bad request: payload JSON is invalid. Failed to read the body: %w", err)
+				}
+				return xerrors.Errorf("Bad request: payload JSON is invalid %s", string(bd))
+			case 429:
+				log.Debug("Too many API calls, retrying after backoff...")
+				time.Sleep(time.Duration(5*index) * time.Second) // Exponential backoff
+			case 500, 501, 502, 503, 504:
+				log.Debug("Server error, retrying after backoff...")
+				time.Sleep(time.Duration(5*index) * time.Second) // Exponential backoff
+			default:
+				log.Errorw("Response status:", resp.Status)
+				return xerrors.Errorf("Unexpected HTTP response: %s", resp.Status)
+			}
+			return nil
+		})
+	if err != nil {
+		return fmt.Errorf("after %d retries,last error: %w", iter, err)
+	}
+	return nil
+}

--- a/alertmanager/plugin/plugin.go
+++ b/alertmanager/plugin/plugin.go
@@ -1,0 +1,34 @@
+package plugin
+
+import (
+	"time"
+
+	"github.com/filecoin-project/curio/deps/config"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+var log = logging.Logger("curio/alertplugins")
+
+type Plugin interface {
+	SendAlert(data *AlertPayload) error
+}
+
+type AlertPayload struct {
+	Summary  string
+	Severity string
+	Source   string
+	Details  map[string]interface{}
+	Time     time.Time
+}
+
+func LoadAlertPlugins(cfg config.CurioAlertingConfig) []Plugin {
+	var plugins []Plugin
+	if cfg.PagerDuty.Enable {
+		plugins = append(plugins, NewPagerDuty(cfg.PagerDuty))
+	}
+	if cfg.PrometheusAlertManager.Enable {
+		plugins = append(plugins, NewPrometheusAlertManager(cfg.PrometheusAlertManager))
+	}
+	return plugins
+}

--- a/alertmanager/plugin/prometheus_alertmanager.go
+++ b/alertmanager/plugin/prometheus_alertmanager.go
@@ -44,12 +44,13 @@ func (p *PrometheusAlertManager) SendAlert(data *AlertPayload) error {
 		alerts = append(alerts, &amPayload{
 			StartsAt: data.Time,
 			Labels: map[string]string{
-				"Summary":  data.Summary,
-				"Severity": data.Severity,
-				"Name":     k,
+				"alertName": k,
+				"severity":  data.Severity,
+				"instance":  data.Source,
 			},
 			Annotations: map[string]interface{}{
-				"Details": v,
+				"summary": data.Summary,
+				"details": v,
 			},
 		})
 	}

--- a/alertmanager/plugin/prometheus_alertmanager.go
+++ b/alertmanager/plugin/prometheus_alertmanager.go
@@ -1,0 +1,98 @@
+package plugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/filecoin-project/curio/deps/config"
+	"github.com/samber/lo"
+)
+
+type PrometheusAlertManager struct {
+	cfg config.PrometheusAlertManagerConfig
+}
+
+func NewPrometheusAlertManager(cfg config.PrometheusAlertManagerConfig) Plugin {
+	return &PrometheusAlertManager{
+		cfg: cfg,
+	}
+}
+
+// SendAlert sends an alert to Prometheus AlertManager with the provided payload data.
+// API reference: https://raw.githubusercontent.com/prometheus/alertmanager/main/api/v2/openapi.yaml
+func (p *PrometheusAlertManager) SendAlert(data *AlertPayload) error {
+	if len(data.Details) == 0 {
+		return nil
+	}
+
+	type amPayload struct {
+		StartsAt    time.Time              `json:"startsAt"`
+		EndsAt      *time.Time             `json:"EndsAt,omitempty"`
+		Annotations map[string]interface{} `json:"annotations"`
+		Labels      map[string]string      `json:"labels"`
+
+		// is a unique back-link which identifies the causing entity of this alert
+		//GeneratorURL string            `json:"generatorURL"`
+	}
+
+	var alerts []*amPayload
+	for k, v := range data.Details {
+		alerts = append(alerts, &amPayload{
+			StartsAt: data.Time,
+			Labels: map[string]string{
+				"Summary":  data.Summary,
+				"Severity": data.Severity,
+				"Name":     k,
+			},
+			Annotations: map[string]interface{}{
+				"Details": v,
+			},
+		})
+	}
+
+	jsonData, err := json.Marshal(alerts)
+	if err != nil {
+		return fmt.Errorf("error marshaling JSON: %w", err)
+	}
+	req, err := http.NewRequest("POST", p.cfg.AlertManagerURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Timeout: time.Second * 15,
+	}
+	iter, _, err := lo.AttemptWithDelay(5, time.Second,
+		func(index int, duration time.Duration) error {
+			resp, err := client.Do(req)
+			if err != nil {
+				time.Sleep(time.Duration(2*index) * duration) // Exponential backoff
+				return err
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			switch resp.StatusCode {
+			case http.StatusOK:
+				return nil
+			case http.StatusBadRequest, http.StatusInternalServerError:
+				errBody, err := io.ReadAll(resp.Body)
+				if err != nil {
+					time.Sleep(time.Duration(2*index) * duration) // Exponential backoff
+					return err
+				}
+				return fmt.Errorf("error: %s", string(errBody))
+			default:
+				time.Sleep(time.Duration(2*index) * duration) // Exponential backoff
+				return fmt.Errorf("unexpected HTTP response: %s", resp.Status)
+			}
+		})
+	if err != nil {
+		return fmt.Errorf("after %d retries,last error: %w", iter, err)
+	}
+	return nil
+}

--- a/alertmanager/task_alert.go
+++ b/alertmanager/task_alert.go
@@ -119,6 +119,7 @@ func (a *AlertTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 			Severity: "critical", // This can be critical, error, warning or info.
 			Source:   "Curio Cluster",
 			Details:  details,
+			Time:     time.Now(),
 		}
 
 		var errs []error

--- a/alertmanager/task_alert.go
+++ b/alertmanager/task_alert.go
@@ -4,19 +4,15 @@
 package alertmanager
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"time"
 
-	logging "github.com/ipfs/go-log/v2"
-	"golang.org/x/xerrors"
+	"github.com/filecoin-project/curio/alertmanager/plugin"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/dline"
+	logging "github.com/ipfs/go-log/v2"
 
 	"github.com/filecoin-project/curio/deps/config"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
@@ -42,9 +38,10 @@ type AlertAPI interface {
 }
 
 type AlertTask struct {
-	api AlertAPI
-	cfg config.CurioAlerting
-	db  *harmonydb.DB
+	api     AlertAPI
+	cfg     config.CurioAlertingConfig
+	db      *harmonydb.DB
+	plugins []plugin.Plugin
 }
 
 type alertOut struct {
@@ -56,18 +53,8 @@ type alerts struct {
 	ctx      context.Context
 	api      AlertAPI
 	db       *harmonydb.DB
-	cfg      config.CurioAlerting
+	cfg      config.CurioAlertingConfig
 	alertMap map[string]*alertOut
-}
-
-type pdPayload struct {
-	Summary       string      `json:"summary"`
-	Severity      string      `json:"severity"`
-	Source        string      `json:"source"`
-	Component     string      `json:"component,omitempty"`
-	Group         string      `json:"group,omitempty"`
-	Class         string      `json:"class,omitempty"`
-	CustomDetails interface{} `json:"custom_details,omitempty"`
 }
 
 type alertFunc func(al *alerts)
@@ -80,17 +67,18 @@ var alertFuncs = []alertFunc{
 	wnPostCheck,
 }
 
-func NewAlertTask(api AlertAPI, db *harmonydb.DB, alertingCfg config.CurioAlerting) *AlertTask {
+func NewAlertTask(api AlertAPI, db *harmonydb.DB, alertingCfg config.CurioAlertingConfig) *AlertTask {
 	return &AlertTask{
-		api: api,
-		db:  db,
-		cfg: alertingCfg,
+		api:     api,
+		db:      db,
+		cfg:     alertingCfg,
+		plugins: plugin.LoadAlertPlugins(alertingCfg),
 	}
 }
 
 func (a *AlertTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
-	if a.cfg.PageDutyIntegrationKey == "" {
-		log.Warnf("PageDutyIntegrationKey is empty, not sending an alert")
+	if len(a.plugins) == 0 {
+		log.Warnf("No alert plugins enabled, not sending an alert")
 		return true, nil
 	}
 
@@ -126,17 +114,23 @@ func (a *AlertTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 
 	// Alert only if required
 	if len(details) > 0 {
-		payloadData := &pdPayload{
-			Summary:       "Curio Alert",
-			Severity:      "critical",
-			CustomDetails: details,
-			Source:        "Curio Cluster",
+		payloadData := &plugin.AlertPayload{
+			Summary:  "Curio Alert",
+			Severity: "critical", // This can be critical, error, warning or info.
+			Source:   "Curio Cluster",
+			Details:  details,
 		}
 
-		err = a.sendAlert(payloadData)
-
-		if err != nil {
-			return false, err
+		var errs []error
+		for _, ap := range a.plugins {
+			err = ap.SendAlert(payloadData)
+			if err != nil {
+				log.Errorf("Error sending alert: %s", err)
+				errs = append(errs, err)
+			}
+		}
+		if len(errs) != 0 {
+			return false, fmt.Errorf("errors sending alerts: %v", errs)
 		}
 	}
 
@@ -165,69 +159,3 @@ func (a *AlertTask) TypeDetails() harmonytask.TaskTypeDetails {
 func (a *AlertTask) Adder(taskFunc harmonytask.AddTaskFunc) {}
 
 var _ harmonytask.TaskInterface = &AlertTask{}
-
-// sendAlert sends an alert to PagerDuty with the provided payload data.
-// It creates a PDData struct with the provided routing key, event action and payload.
-// It creates an HTTP POST request with the PagerDuty event URL as the endpoint and the marshaled JSON data as the request body.
-// It sends the request using an HTTP client with a maximum of 5 retries for network errors with exponential backoff before each retry.
-// It handles different HTTP response status codes and returns an error based on the status code().
-// If all retries fail, it returns an error indicating the last network error encountered.
-func (a *AlertTask) sendAlert(data *pdPayload) error {
-
-	type pdData struct {
-		RoutingKey  string     `json:"routing_key"`
-		EventAction string     `json:"event_action"`
-		Payload     *pdPayload `json:"payload"`
-	}
-
-	payload := &pdData{
-		RoutingKey:  a.cfg.PageDutyIntegrationKey,
-		EventAction: "trigger",
-		Payload:     data,
-	}
-
-	jsonData, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("error marshaling JSON: %w", err)
-	}
-
-	req, err := http.NewRequest("POST", a.cfg.PagerDutyEventURL, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return fmt.Errorf("error creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	client := &http.Client{}
-	var resp *http.Response
-
-	for i := 0; i < 5; i++ { // Maximum of 5 retries
-		resp, err = client.Do(req)
-		if err != nil {
-			time.Sleep(time.Duration(2*i) * time.Second) // Exponential backoff
-			continue
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		switch resp.StatusCode {
-		case 202:
-			log.Debug("Accepted: The event has been accepted by PagerDuty.")
-			return nil
-		case 400:
-			bd, rerr := io.ReadAll(resp.Body)
-			if rerr != nil {
-				return xerrors.Errorf("Bad request: payload JSON is invalid. Failed to read the body: %w", err)
-			}
-			return xerrors.Errorf("Bad request: payload JSON is invalid %s", string(bd))
-		case 429:
-			log.Debug("Too many API calls, retrying after backoff...")
-			time.Sleep(time.Duration(5*i) * time.Second) // Exponential backoff
-		case 500, 501, 502, 503, 504:
-			log.Debug("Server error, retrying after backoff...")
-			time.Sleep(time.Duration(5*i) * time.Second) // Exponential backoff
-		default:
-			log.Errorw("Response status:", resp.Status)
-			return xerrors.Errorf("Unexpected HTTP response: %s", resp.Status)
-		}
-	}
-	return fmt.Errorf("after retries, last error: %w", err)
-}

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -81,28 +81,25 @@ over the worker address if this flag is set.`,
 			Comment: `MinerAddresses are the addresses of the miner actors to use for sending messages`,
 		},
 	},
-	"CurioAlerting": {
-		{
-			Name: "PagerDutyEventURL",
-			Type: "string",
-
-			Comment: `PagerDutyEventURL is URL for PagerDuty.com Events API v2 URL. Events sent to this API URL are ultimately
-routed to a PagerDuty.com service and processed.
-The default is sufficient for integration with the stock commercial PagerDuty.com company's service.`,
-		},
-		{
-			Name: "PageDutyIntegrationKey",
-			Type: "string",
-
-			Comment: `PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
-identifier in the integration page for the service.`,
-		},
+	"CurioAlertingConfig": {
 		{
 			Name: "MinimumWalletBalance",
 			Type: "types.FIL",
 
 			Comment: `MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
 alerts will be triggered for the wallet`,
+		},
+		{
+			Name: "PagerDuty",
+			Type: "PagerDutyConfig",
+
+			Comment: `PagerDutyConfig is the configuration for the PagerDuty alerting integration.`,
+		},
+		{
+			Name: "PrometheusAlertManager",
+			Type: "PrometheusAlertManagerConfig",
+
+			Comment: `PrometheusAlertManagerConfig is the configuration for the Prometheus AlertManager alerting integration.`,
 		},
 	},
 	"CurioConfig": {
@@ -150,7 +147,7 @@ alerts will be triggered for the wallet`,
 		},
 		{
 			Name: "Alerting",
-			Type: "CurioAlerting",
+			Type: "CurioAlertingConfig",
 
 			Comment: ``,
 		},
@@ -608,6 +605,43 @@ only need to be run on a single machine in the cluster.`,
 			Type: "string",
 
 			Comment: `Events of the form: "system1:event1,system1:event2[,...]"`,
+		},
+	},
+	"PagerDutyConfig": {
+		{
+			Name: "Enable",
+			Type: "bool",
+
+			Comment: `Enable is a flag to enable or disable the PagerDuty integration.`,
+		},
+		{
+			Name: "PagerDutyEventURL",
+			Type: "string",
+
+			Comment: `PagerDutyEventURL is URL for PagerDuty.com Events API v2 URL. Events sent to this API URL are ultimately
+routed to a PagerDuty.com service and processed.
+The default is sufficient for integration with the stock commercial PagerDuty.com company's service.`,
+		},
+		{
+			Name: "PageDutyIntegrationKey",
+			Type: "string",
+
+			Comment: `PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
+identifier in the integration page for the service.`,
+		},
+	},
+	"PrometheusAlertManagerConfig": {
+		{
+			Name: "Enable",
+			Type: "bool",
+
+			Comment: `Enable is a flag to enable or disable the Prometheus AlertManager integration.`,
+		},
+		{
+			Name: "AlertManagerURL",
+			Type: "string",
+
+			Comment: `AlertManagerURL is the URL for the Prometheus AlertManager API v2 URL.`,
 		},
 	},
 }

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -54,6 +54,12 @@ func DefaultCurioConfig() *CurioConfig {
 		},
 		Alerting: CurioAlertingConfig{
 			MinimumWalletBalance: types.MustParseFIL("5"),
+			PagerDuty: PagerDutyConfig{
+				PagerDutyEventURL: "https://events.pagerduty.com/v2/enqueue",
+			},
+			PrometheusAlertManager: PrometheusAlertManagerConfig{
+				AlertManagerURL: "http://localhost:9093/api/v2/alerts",
+			},
 		},
 	}
 }

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -52,10 +52,8 @@ func DefaultCurioConfig() *CurioConfig {
 			MaxQueuePoRep:      0, // default don't use this limit
 			MaxDealWaitTime:    Duration(1 * time.Hour),
 		},
-		Alerting: CurioAlerting{
-			PagerDutyEventURL:      "https://events.pagerduty.com/v2/enqueue",
-			PageDutyIntegrationKey: "",
-			MinimumWalletBalance:   types.MustParseFIL("5"),
+		Alerting: CurioAlertingConfig{
+			MinimumWalletBalance: types.MustParseFIL("5"),
 		},
 	}
 }
@@ -71,7 +69,7 @@ type CurioConfig struct {
 	Ingest    CurioIngestConfig
 	Journal   JournalConfig
 	Apis      ApisConfig
-	Alerting  CurioAlerting
+	Alerting  CurioAlertingConfig
 }
 
 func DefaultDefaultMaxFee() types.FIL {
@@ -398,7 +396,22 @@ type CurioIngestConfig struct {
 	MaxDealWaitTime Duration
 }
 
-type CurioAlerting struct {
+type CurioAlertingConfig struct {
+	// MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
+	// alerts will be triggered for the wallet
+	MinimumWalletBalance types.FIL
+
+	// PagerDutyConfig is the configuration for the PagerDuty alerting integration.
+	PagerDuty PagerDutyConfig
+
+	// PrometheusAlertManagerConfig is the configuration for the Prometheus AlertManager alerting integration.
+	PrometheusAlertManager PrometheusAlertManagerConfig
+}
+
+type PagerDutyConfig struct {
+	// Enable is a flag to enable or disable the PagerDuty integration.
+	Enable bool
+
 	// PagerDutyEventURL is URL for PagerDuty.com Events API v2 URL. Events sent to this API URL are ultimately
 	// routed to a PagerDuty.com service and processed.
 	// The default is sufficient for integration with the stock commercial PagerDuty.com company's service.
@@ -407,10 +420,14 @@ type CurioAlerting struct {
 	// PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
 	// identifier in the integration page for the service.
 	PageDutyIntegrationKey string
+}
 
-	// MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
-	// alerts will be triggered for the wallet
-	MinimumWalletBalance types.FIL
+type PrometheusAlertManagerConfig struct {
+	// Enable is a flag to enable or disable the Prometheus AlertManager integration.
+	Enable bool
+
+	// AlertManagerURL is the URL for the Prometheus AlertManager API v2 URL.
+	AlertManagerURL string
 }
 
 type JournalConfig struct {

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -424,7 +424,7 @@ description: The default curio configuration
     # The default is sufficient for integration with the stock commercial PagerDuty.com company's service.
     #
     # type: string
-    #PagerDutyEventURL = ""
+    #PagerDutyEventURL = "https://events.pagerduty.com/v2/enqueue"
 
     # PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
     # identifier in the integration page for the service.
@@ -441,6 +441,6 @@ description: The default curio configuration
     # AlertManagerURL is the URL for the Prometheus AlertManager API v2 URL.
     #
     # type: string
-    #AlertManagerURL = ""
+    #AlertManagerURL = "http://localhost:9093/api/v2/alerts"
 
 ```

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -407,23 +407,40 @@ description: The default curio configuration
 
 
 [Alerting]
-  # PagerDutyEventURL is URL for PagerDuty.com Events API v2 URL. Events sent to this API URL are ultimately
-  # routed to a PagerDuty.com service and processed.
-  # The default is sufficient for integration with the stock commercial PagerDuty.com company's service.
-  #
-  # type: string
-  #PagerDutyEventURL = "https://events.pagerduty.com/v2/enqueue"
-
-  # PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
-  # identifier in the integration page for the service.
-  #
-  # type: string
-  #PageDutyIntegrationKey = ""
-
   # MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
   # alerts will be triggered for the wallet
   #
   # type: types.FIL
   #MinimumWalletBalance = "5 FIL"
+
+  [Alerting.PagerDuty]
+    # Enable is a flag to enable or disable the PagerDuty integration.
+    #
+    # type: bool
+    #Enable = false
+
+    # PagerDutyEventURL is URL for PagerDuty.com Events API v2 URL. Events sent to this API URL are ultimately
+    # routed to a PagerDuty.com service and processed.
+    # The default is sufficient for integration with the stock commercial PagerDuty.com company's service.
+    #
+    # type: string
+    #PagerDutyEventURL = ""
+
+    # PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
+    # identifier in the integration page for the service.
+    #
+    # type: string
+    #PageDutyIntegrationKey = ""
+
+  [Alerting.PrometheusAlertManager]
+    # Enable is a flag to enable or disable the Prometheus AlertManager integration.
+    #
+    # type: bool
+    #Enable = false
+
+    # AlertManagerURL is the URL for the Prometheus AlertManager API v2 URL.
+    #
+    # type: string
+    #AlertManagerURL = ""
 
 ```


### PR DESCRIPTION
https://github.com/filecoin-project/curio/discussions/83

Added support for the [Prometheus AlertManager](https://github.com/prometheus/alertmanager), resulting in a change to the configuration file format:

Previously:
```go
type CurioAlerting struct {
    // PagerDutyEventURL is the URL for PagerDuty.com Events API v2. Events sent to this API URL are ultimately
    // routed to a PagerDuty.com service and processed.
    // The default is sufficient for integration with the stock commercial PagerDuty.com company's service.
    PagerDutyEventURL string

    // PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
    // identifier on the integration page for the service.
    PageDutyIntegrationKey string

    // MinimumWalletBalance is the minimum balance for all active wallets. If the balance is below this value, an
    // alert will be triggered for the wallet.
    MinimumWalletBalance types.FIL
}
```
Now:
```go
type CurioAlertingConfig struct {
    // MinimumWalletBalance is the minimum balance for all active wallets. If the balance is below this value, an
    // alert will be triggered for the wallet.
    MinimumWalletBalance types.FIL

    // PagerDutyConfig is the configuration for the PagerDuty alerting integration.
    PagerDuty PagerDutyConfig

    // PrometheusAlertManagerConfig is the configuration for the Prometheus AlertManager alerting integration.
    PrometheusAlertManager PrometheusAlertManagerConfig
}

type PagerDutyConfig struct {
	// Enable is a flag to enable or disable the PagerDuty integration.
	Enable bool

	// PagerDutyEventURL is URL for PagerDuty.com Events API v2 URL. Events sent to this API URL are ultimately
	// routed to a PagerDuty.com service and processed.
	// The default is sufficient for integration with the stock commercial PagerDuty.com company's service.
	PagerDutyEventURL string

	// PageDutyIntegrationKey is the integration key for a PagerDuty.com service. You can find this unique service
	// identifier in the integration page for the service.
	PageDutyIntegrationKey string
}

type PrometheusAlertManagerConfig struct {
	// Enable is a flag to enable or disable the Prometheus AlertManager integration.
	Enable bool

	// AlertManagerURL is the URL for the Prometheus AlertManager API v2 URL.
	AlertManagerURL string
}
```
