### PR TITLE
fix: read-any-spid

### DIFF
--- a/alertmanager/task_alert.go
+++ b/alertmanager/task_alert.go
@@ -160,3 +160,4 @@ func (a *AlertTask) TypeDetails() harmonytask.TaskTypeDetails {
 func (a *AlertTask) Adder(taskFunc harmonytask.AddTaskFunc) {}
 
 var _ harmonytask.TaskInterface = &AlertTask{}
+var _ = harmonytask.Reg(&AlertTask{})

--- a/cmd/curio/rpc/rpc.go
+++ b/cmd/curio/rpc/rpc.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/filecoin-project/curio/api/client"
 	"github.com/filecoin-project/curio/deps"
-	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/lib/paths"
 	"github.com/filecoin-project/curio/market"
 	"github.com/filecoin-project/curio/web"
@@ -245,7 +244,7 @@ func (p *CurioAPI) LogSetLevel(ctx context.Context, subsystem, level string) err
 	return logging.SetLogLevel(subsystem, level)
 }
 
-func ListenAndServe(ctx context.Context, dependencies *deps.Deps, activeTasks []harmonytask.TaskInterface, shutdownChan chan struct{}) error {
+func ListenAndServe(ctx context.Context, dependencies *deps.Deps, shutdownChan chan struct{}) error {
 	fh := &paths.FetchHandler{Local: dependencies.LocalStore, PfHandler: &paths.DefaultPartialFileHandler{}}
 	remoteHandler := func(w http.ResponseWriter, r *http.Request) {
 		if !auth.HasPerm(r.Context(), nil, api.PermAdmin) {
@@ -292,7 +291,7 @@ func ListenAndServe(ctx context.Context, dependencies *deps.Deps, activeTasks []
 	eg.Go(srv.ListenAndServe)
 
 	if dependencies.Cfg.Subsystems.EnableWebGui {
-		web, err := web.GetSrv(ctx, dependencies, activeTasks)
+		web, err := web.GetSrv(ctx, dependencies)
 		if err != nil {
 			return err
 		}

--- a/cmd/curio/run.go
+++ b/cmd/curio/run.go
@@ -142,7 +142,7 @@ var runCmd = &cli.Command{
 
 		go ffiSelfTest() // Panics on failure
 
-		taskEngine, activeTasks, err := tasks.StartTasks(ctx, dependencies)
+		taskEngine, err := tasks.StartTasks(ctx, dependencies)
 
 		if err != nil {
 			return nil
@@ -153,7 +153,7 @@ var runCmd = &cli.Command{
 			return xerrors.Errorf("starting market RPCs: %w", err)
 		}
 
-		err = rpc.ListenAndServe(ctx, dependencies, activeTasks, shutdownChan) // Monitor for shutdown.
+		err = rpc.ListenAndServe(ctx, dependencies, shutdownChan) // Monitor for shutdown.
 		if err != nil {
 			return err
 		}

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -70,7 +70,7 @@ func WindowPostScheduler(ctx context.Context, fc config.CurioFees, pc config.Cur
 	return computeTask, submitTask, recoverTask, nil
 }
 
-func StartTasks(ctx context.Context, dependencies *deps.Deps) (*harmonytask.TaskEngine, []harmonytask.TaskInterface, error) {
+func StartTasks(ctx context.Context, dependencies *deps.Deps) (*harmonytask.TaskEngine, error) {
 	cfg := dependencies.Cfg
 	db := dependencies.DB
 	full := dependencies.Chain
@@ -132,7 +132,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps) (*harmonytask.Task
 				as, maddrs, db, stor, si, cfg.Subsystems.WindowPostMaxTasks)
 
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			activeTasks = append(activeTasks, wdPostTask, wdPoStSubmitTask, derlareRecoverTask)
 		}
@@ -154,7 +154,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps) (*harmonytask.Task
 		if cfg.Subsystems.EnableParkPiece {
 			parkPieceTask, err := piece2.NewParkPieceTask(db, must.One(slrLazy.Val()), cfg.Subsystems.ParkPieceMaxTasks)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			cleanupPieceTask := piece2.NewCleanupPieceTask(db, must.One(slrLazy.Val()), 0)
 			activeTasks = append(activeTasks, parkPieceTask, cleanupPieceTask)
@@ -170,7 +170,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps) (*harmonytask.Task
 	if hasAnySealingTask {
 		sealingTasks, err := addSealingTasks(ctx, hasAnySealingTask, db, full, sender, as, cfg, slrLazy, asyncParams, si, stor, bstore)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		activeTasks = append(activeTasks, sealingTasks...)
 	}
@@ -193,14 +193,14 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps) (*harmonytask.Task
 
 	ht, err := harmonytask.New(db, activeTasks, dependencies.ListenAddr)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	go machineDetails(dependencies, activeTasks, ht.ResourcesAvailable().MachineID, dependencies.Name)
 
 	if hasAnySealingTask {
 		watcher, err := message.NewMessageWatcher(db, ht, chainSched, full)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		_ = watcher
 	}
@@ -209,7 +209,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps) (*harmonytask.Task
 		go chainSched.Run(ctx)
 	}
 
-	return ht, activeTasks, nil
+	return ht, nil
 }
 
 func addSealingTasks(

--- a/harmony/harmonytask/harmonytask.go
+++ b/harmony/harmonytask/harmonytask.go
@@ -157,6 +157,9 @@ func New(
 			TaskTypeDetails: c.TypeDetails(),
 			TaskEngine:      e,
 		}
+		if Registry[h.TaskTypeDetails.Name] == nil {
+			return nil, fmt.Errorf("task %s not registered", h.TaskTypeDetails.Name)
+		}
 
 		if len(h.Name) > 16 {
 			return nil, fmt.Errorf("task name too long: %s, max 16 characters", h.Name)
@@ -384,4 +387,13 @@ func (e *TaskEngine) ResourcesAvailable() resources.Resources {
 // Resources returns the resources available in the TaskEngine's registry.
 func (e *TaskEngine) Resources() resources.Resources {
 	return e.reg.Resources
+}
+
+// Reg is a task registry full of nil implementations.
+// Even if NOT running, a nil task should be registered here.
+var Registry = map[string]TaskInterface{}
+
+func Reg(t TaskInterface) bool {
+	Registry[t.TypeDetails().Name] = t
+	return true
 }

--- a/harmony/harmonytask/harmonytask.go
+++ b/harmony/harmonytask/harmonytask.go
@@ -389,6 +389,13 @@ func (e *TaskEngine) Resources() resources.Resources {
 	return e.reg.Resources
 }
 
+// About the Registry
+// This registry exists for the benefit of "static methods" of TaskInterface extensions.
+// For example, GetSPID(db, taskID) (int, err) is a static method that can be called
+//
+//	from any task that has a GetSPID method. This is useful for the web UI to
+//	be able to indicate the SpID for a task.
+//
 // Reg is a task registry full of nil implementations.
 // Even if NOT running, a nil task should be registered here.
 var Registry = map[string]TaskInterface{}

--- a/itests/curio_test.go
+++ b/itests/curio_test.go
@@ -348,7 +348,7 @@ func ConstructCurioTest(ctx context.Context, t *testing.T, dir string, db *harmo
 	err = dependencies.PopulateRemainingDeps(ctx, cctx, false)
 	require.NoError(t, err)
 
-	taskEngine, activeTasks, err := tasks.StartTasks(ctx, dependencies)
+	taskEngine, err := tasks.StartTasks(ctx, dependencies)
 	require.NoError(t, err)
 
 	dependencies.Cfg.Subsystems.BoostAdapters = []string{fmt.Sprintf("%s:127.0.0.1:32000", maddr)}
@@ -356,7 +356,7 @@ func ConstructCurioTest(ctx context.Context, t *testing.T, dir string, db *harmo
 	require.NoError(t, err)
 
 	go func() {
-		err = rpc.ListenAndServe(ctx, dependencies, activeTasks, shutdownChan) // Monitor for shutdown.
+		err = rpc.ListenAndServe(ctx, dependencies, shutdownChan) // Monitor for shutdown.
 		require.NoError(t, err)
 	}()
 

--- a/tasks/gc/sdr_pipeline_meta_gc.go
+++ b/tasks/gc/sdr_pipeline_meta_gc.go
@@ -104,3 +104,4 @@ func (s *SDRPipelineGC) cleanupSealed() error {
 }
 
 var _ harmonytask.TaskInterface = &SDRPipelineGC{}
+var _ = harmonytask.Reg(&SDRPipelineGC{})

--- a/tasks/gc/storage_endpoint_gc.go
+++ b/tasks/gc/storage_endpoint_gc.go
@@ -286,3 +286,4 @@ func (s *StorageEndpointGC) Adder(taskFunc harmonytask.AddTaskFunc) {
 }
 
 var _ harmonytask.TaskInterface = &StorageEndpointGC{}
+var _ = harmonytask.Reg(&StorageEndpointGC{})

--- a/tasks/gc/storage_gc_mark.go
+++ b/tasks/gc/storage_gc_mark.go
@@ -268,3 +268,4 @@ func (s *StorageGCMark) Adder(taskFunc harmonytask.AddTaskFunc) {
 }
 
 var _ harmonytask.TaskInterface = &StorageGCMark{}
+var _ = harmonytask.Reg(&StorageGCMark{})

--- a/tasks/gc/storage_gc_sweep.go
+++ b/tasks/gc/storage_gc_sweep.go
@@ -125,3 +125,4 @@ func (s *StorageGCSweep) Adder(taskFunc harmonytask.AddTaskFunc) {
 }
 
 var _ harmonytask.TaskInterface = &StorageGCSweep{}
+var _ = harmonytask.Reg(&StorageGCSweep{})

--- a/tasks/message/sender.go
+++ b/tasks/message/sender.go
@@ -253,6 +253,7 @@ func (s *SendTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 }
 
 var _ harmonytask.TaskInterface = &SendTask{}
+var _ = harmonytask.Reg(&SendTask{})
 
 // NewSender creates a new Sender.
 func NewSender(api SenderAPI, signer SignerAPI, db *harmonydb.DB) (*Sender, *SendTask) {

--- a/tasks/piece/task_cleanup_piece.go
+++ b/tasks/piece/task_cleanup_piece.go
@@ -134,3 +134,4 @@ func (c *CleanupPieceTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 }
 
 var _ harmonytask.TaskInterface = &CleanupPieceTask{}
+var _ = harmonytask.Reg(&CleanupPieceTask{})

--- a/tasks/piece/task_park_piece.go
+++ b/tasks/piece/task_park_piece.go
@@ -238,3 +238,4 @@ func (p *ParkPieceTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 }
 
 var _ harmonytask.TaskInterface = &ParkPieceTask{}
+var _ = harmonytask.Reg(&ParkPieceTask{})

--- a/tasks/seal/task_finalize.go
+++ b/tasks/seal/task_finalize.go
@@ -31,16 +31,17 @@ func NewFinalizeTask(max int, sp *SealPoller, sc *ffi.SealCalls, db *harmonydb.D
 	}
 }
 
-func (f *FinalizeTask) GetSpid(taskID int64) string {
+func (f *FinalizeTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
-	err := f.db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_finalize = $1`, taskID).Scan(&spid)
+	err := db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_finalize = $1`, taskID).Scan(&spid)
 	if err != nil {
 		log.Errorf("getting spid: %v", err)
 		return ""
 	}
 	return spid
-
 }
+
+var _ = harmonytask.Reg(&FinalizeTask{})
 
 func (f *FinalizeTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
 	var tasks []struct {

--- a/tasks/seal/task_movestorage.go
+++ b/tasks/seal/task_movestorage.go
@@ -156,15 +156,17 @@ func (m *MoveStorageTask) TypeDetails() harmonytask.TaskTypeDetails {
 	}
 }
 
-func (m *MoveStorageTask) GetSpid(taskID int64) string {
+func (m *MoveStorageTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
-	err := m.db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_move_storage = $1`, taskID).Scan(&spid)
+	err := db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_move_storage = $1`, taskID).Scan(&spid)
 	if err != nil {
 		log.Errorf("getting spid: %s", err)
 		return ""
 	}
 	return spid
 }
+
+var _ = harmonytask.Reg(&MoveStorageTask{})
 
 func (m *MoveStorageTask) taskToSector(id harmonytask.TaskID) (ffi2.SectorRef, error) {
 	var refs []ffi2.SectorRef

--- a/tasks/seal/task_porep.go
+++ b/tasks/seal/task_porep.go
@@ -181,15 +181,17 @@ func (p *PoRepTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return res
 }
 
-func (p *PoRepTask) GetSpid(taskID int64) string {
+func (p *PoRepTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
-	err := p.db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_porep = $1`, taskID).Scan(&spid)
+	err := db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_porep = $1`, taskID).Scan(&spid)
 	if err != nil {
 		log.Errorf("getting spid: %s", err)
 		return ""
 	}
 	return spid
 }
+
+var _ = harmonytask.Reg(&PoRepTask{})
 
 func (p *PoRepTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 	p.sp.pollers[pollerPoRep].Set(taskFunc)

--- a/tasks/seal/task_sdr.go
+++ b/tasks/seal/task_sdr.go
@@ -259,7 +259,7 @@ func (s *SDRTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 	s.sp.pollers[pollerSDR].Set(taskFunc)
 }
 
-func (s *SDRTask) GetSpid(taskID int64) string {
+func (s *SDRTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
 	err := s.db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_sdr = $1`, taskID).Scan(&spid)
 	if err != nil {
@@ -268,6 +268,8 @@ func (s *SDRTask) GetSpid(taskID int64) string {
 	}
 	return spid
 }
+
+var _ = harmonytask.Reg(&SDRTask{})
 
 func (s *SDRTask) taskToSector(id harmonytask.TaskID) (ffi2.SectorRef, error) {
 	var refs []ffi2.SectorRef

--- a/tasks/seal/task_submit_commit.go
+++ b/tasks/seal/task_submit_commit.go
@@ -80,15 +80,17 @@ func NewSubmitCommitTask(sp *SealPoller, db *harmonydb.DB, api SubmitCommitAPI, 
 	}
 }
 
-func (s *SubmitCommitTask) GetSpid(taskID int64) string {
+func (s *SubmitCommitTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
-	err := s.db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_commit_msg = $1`, taskID).Scan(&spid)
+	err := db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_commit_msg = $1`, taskID).Scan(&spid)
 	if err != nil {
 		log.Errorf("getting spid: %v", err)
 		return ""
 	}
 	return spid
 }
+
+var _ = harmonytask.Reg(&SubmitCommitTask{})
 
 func (s *SubmitCommitTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
 	ctx := context.Background()

--- a/tasks/seal/task_submit_precommit.go
+++ b/tasks/seal/task_submit_precommit.go
@@ -63,15 +63,17 @@ func NewSubmitPrecommitTask(sp *SealPoller, db *harmonydb.DB, api SubmitPrecommi
 	}
 }
 
-func (s *SubmitPrecommitTask) GetSpid(taskID int64) string {
+func (s *SubmitPrecommitTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
-	err := s.db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_precommit_msg = $1`, taskID).Scan(&spid)
+	err := db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_precommit_msg = $1`, taskID).Scan(&spid)
 	if err != nil {
 		log.Errorf("getting spid: %v", err)
 		return ""
 	}
 	return spid
 }
+
+var _ = harmonytask.Reg(&SubmitPrecommitTask{})
 
 func (s *SubmitPrecommitTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
 	ctx := context.Background()

--- a/tasks/seal/task_treed.go
+++ b/tasks/seal/task_treed.go
@@ -64,15 +64,17 @@ func (t *TreeDTask) TypeDetails() harmonytask.TaskTypeDetails {
 	}
 }
 
-func (t *TreeDTask) GetSpid(taskID int64) string {
+func (t *TreeDTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
-	err := t.db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_tree_d = $1`, taskID).Scan(&spid)
+	err := db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_tree_d = $1`, taskID).Scan(&spid)
 	if err != nil {
 		log.Errorf("getting spid: %v", err)
 		return ""
 	}
 	return spid
 }
+
+var _ = harmonytask.Reg(&TreeDTask{})
 
 func (t *TreeDTask) taskToSector(id harmonytask.TaskID) (ffi2.SectorRef, error) {
 	var refs []ffi2.SectorRef

--- a/tasks/seal/task_treerc.go
+++ b/tasks/seal/task_treerc.go
@@ -179,15 +179,17 @@ func (t *TreeRCTask) TypeDetails() harmonytask.TaskTypeDetails {
 	}
 }
 
-func (t *TreeRCTask) GetSpid(taskID int64) string {
+func (t *TreeRCTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
-	err := t.db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_tree_r = $1`, taskID).Scan(&spid)
+	err := db.QueryRow(context.Background(), `SELECT sp_id FROM sectors_sdr_pipeline WHERE task_id_tree_r = $1`, taskID).Scan(&spid)
 	if err != nil {
 		log.Errorf("getting spid: %s", err)
 		return ""
 	}
 	return spid
 }
+
+var _ = harmonytask.Reg(&TreeRCTask{})
 
 func (t *TreeRCTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 	t.sp.pollers[pollerTreeRC].Set(taskFunc)

--- a/tasks/window/compute_task.go
+++ b/tasks/window/compute_task.go
@@ -389,15 +389,17 @@ func (t *WdPostTask) TypeDetails() harmonytask.TaskTypeDetails {
 	}
 }
 
-func (t *WdPostTask) GetSpid(taskID int64) string {
+func (t *WdPostTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
-	err := t.db.QueryRow(context.Background(), `SELECT sp_id FROM wdpost_partition_tasks WHERE task_id = $1`, taskID).Scan(&spid)
+	err := db.QueryRow(context.Background(), `SELECT sp_id FROM wdpost_partition_tasks WHERE task_id = $1`, taskID).Scan(&spid)
 	if err != nil {
 		log.Errorf("getting spid: %s", err)
 		return ""
 	}
 	return spid
 }
+
+var _ = harmonytask.Reg(&WdPostTask{})
 
 func (t *WdPostTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 	t.windowPoStTF.Set(taskFunc)

--- a/tasks/window/recover_task.go
+++ b/tasks/window/recover_task.go
@@ -230,15 +230,17 @@ func (w *WdPostRecoverDeclareTask) TypeDetails() harmonytask.TaskTypeDetails {
 	}
 }
 
-func (w *WdPostRecoverDeclareTask) GetSpid(taskID int64) string {
+func (w *WdPostRecoverDeclareTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
-	err := w.db.QueryRow(context.Background(), `SELECT sp_id FROM wdpost_recovery_tasks WHERE task_id = $1`, taskID).Scan(&spid)
+	err := db.QueryRow(context.Background(), `SELECT sp_id FROM wdpost_recovery_tasks WHERE task_id = $1`, taskID).Scan(&spid)
 	if err != nil {
 		log.Errorf("getting spid: %s", err)
 		return ""
 	}
 	return spid
 }
+
+var _ = harmonytask.Reg(&WdPostRecoverDeclareTask{})
 
 func (w *WdPostRecoverDeclareTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 	w.startCheckTF.Set(taskFunc)

--- a/tasks/window/submit_task.go
+++ b/tasks/window/submit_task.go
@@ -195,15 +195,17 @@ func (w *WdPostSubmitTask) TypeDetails() harmonytask.TaskTypeDetails {
 	}
 }
 
-func (w *WdPostSubmitTask) GetSpid(taskID int64) string {
+func (w *WdPostSubmitTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
-	err := w.db.QueryRow(context.Background(), `SELECT sp_id FROM wdpost_proofs WHERE submit_task_id = $1`, taskID).Scan(&spid)
+	err := db.QueryRow(context.Background(), `SELECT sp_id FROM wdpost_proofs WHERE submit_task_id = $1`, taskID).Scan(&spid)
 	if err != nil {
 		log.Errorf("getting spid: %s", err)
 		return ""
 	}
 	return spid
 }
+
+var _ = harmonytask.Reg(&WdPostSubmitTask{})
 
 func (w *WdPostSubmitTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 	w.submitPoStTF.Set(taskFunc)

--- a/tasks/winning/inclusion_check_task.go
+++ b/tasks/winning/inclusion_check_task.go
@@ -103,3 +103,4 @@ func (i *InclusionCheckTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 }
 
 var _ harmonytask.TaskInterface = &InclusionCheckTask{}
+var _ = harmonytask.Reg(&InclusionCheckTask{})

--- a/tasks/winning/winning_task.go
+++ b/tasks/winning/winning_task.go
@@ -525,15 +525,17 @@ func (t *WinPostTask) TypeDetails() harmonytask.TaskTypeDetails {
 	}
 }
 
-func (t *WinPostTask) GetSpid(taskID int64) string {
+func (t *WinPostTask) GetSpid(db *harmonydb.DB, taskID int64) string {
 	var spid string
-	err := t.db.QueryRow(context.Background(), `SELECT sp_id FROM mining_tasks WHERE task_id = $1`, taskID).Scan(&spid)
+	err := db.QueryRow(context.Background(), `SELECT sp_id FROM mining_tasks WHERE task_id = $1`, taskID).Scan(&spid)
 	if err != nil {
 		log.Errorf("getting spid: %s", err)
 		return ""
 	}
 	return spid
 }
+
+var _ = harmonytask.Reg(&WinPostTask{})
 
 func (t *WinPostTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 	t.mineTF.Set(taskFunc)

--- a/web/api/routes.go
+++ b/web/api/routes.go
@@ -5,14 +5,13 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/filecoin-project/curio/deps"
-	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/web/api/config"
 	"github.com/filecoin-project/curio/web/api/sector"
 	"github.com/filecoin-project/curio/web/api/webrpc"
 )
 
-func Routes(r *mux.Router, deps *deps.Deps, activeTasks []harmonytask.TaskInterface) {
-	webrpc.Routes(r.PathPrefix("/webrpc").Subrouter(), deps, activeTasks)
+func Routes(r *mux.Router, deps *deps.Deps) {
+	webrpc.Routes(r.PathPrefix("/webrpc").Subrouter(), deps)
 	config.Routes(r.PathPrefix("/config").Subrouter(), deps)
 	sector.Routes(r.PathPrefix("/sector").Subrouter(), deps)
 }

--- a/web/api/webrpc/routes.go
+++ b/web/api/webrpc/routes.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/filecoin-project/curio/build"
 	"github.com/filecoin-project/curio/deps"
-	"github.com/filecoin-project/curio/harmony/harmonytask"
 
 	lbuild "github.com/filecoin-project/lotus/build"
 )
@@ -30,10 +29,10 @@ func (a *WebRPC) BlockDelaySecs(context.Context) (uint64, error) {
 	return lbuild.BlockDelaySecs, nil
 }
 
-func Routes(r *mux.Router, deps *deps.Deps, activeTasks []harmonytask.TaskInterface) {
+func Routes(r *mux.Router, deps *deps.Deps) {
 	handler := &WebRPC{
 		deps:      deps,
-		taskSPIDs: makeTaskSPIDs(activeTasks),
+		taskSPIDs: makeTaskSPIDs(),
 	}
 
 	rpcSrv := jsonrpc.NewServer()

--- a/web/api/webrpc/tasks.go
+++ b/web/api/webrpc/tasks.go
@@ -50,8 +50,8 @@ type SpidGetter interface {
 	GetSpid(db *harmonydb.DB, taskID int64) string
 }
 
-func makeTaskSPIDs(tasks []harmonytask.TaskInterface) map[string]SpidGetter {
-	spidGetters := lo.Filter(tasks, func(t harmonytask.TaskInterface, _ int) bool {
+func makeTaskSPIDs() map[string]SpidGetter {
+	spidGetters := lo.Filter(lo.Values(harmonytask.Registry), func(t harmonytask.TaskInterface, _ int) bool {
 		_, ok := t.(SpidGetter)
 		return ok
 	})

--- a/web/api/webrpc/tasks.go
+++ b/web/api/webrpc/tasks.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"
 )
 
@@ -37,7 +38,7 @@ func (a *WebRPC) ClusterTaskSummary(ctx context.Context) ([]TaskSummary, error) 
 	for _, g := range grouped {
 		if v, ok := a.taskSPIDs[g[0].Name]; ok {
 			for i, t := range g {
-				g[i].MinerID = v.GetSpid(t.ID)
+				g[i].MinerID = v.GetSpid(a.deps.DB, t.ID)
 			}
 		}
 	}
@@ -46,7 +47,7 @@ func (a *WebRPC) ClusterTaskSummary(ctx context.Context) ([]TaskSummary, error) 
 }
 
 type SpidGetter interface {
-	GetSpid(taskID int64) string
+	GetSpid(db *harmonydb.DB, taskID int64) string
 }
 
 func makeTaskSPIDs(tasks []harmonytask.TaskInterface) map[string]SpidGetter {

--- a/web/srv.go
+++ b/web/srv.go
@@ -17,7 +17,6 @@ import (
 	"go.opencensus.io/tag"
 
 	"github.com/filecoin-project/curio/deps"
-	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/web/api"
 	"github.com/filecoin-project/curio/web/hapi"
 
@@ -33,13 +32,13 @@ var basePath = "/static/"
 // You still need to recomplie the binary for changes to go code.
 var webDev = os.Getenv("CURIO_WEB_DEV") == "1"
 
-func GetSrv(ctx context.Context, deps *deps.Deps, activeTasks []harmonytask.TaskInterface) (*http.Server, error) {
+func GetSrv(ctx context.Context, deps *deps.Deps) (*http.Server, error) {
 	mx := mux.NewRouter()
 	err := hapi.Routes(mx.PathPrefix("/hapi").Subrouter(), deps)
 	if err != nil {
 		return nil, err
 	}
-	api.Routes(mx.PathPrefix("/api").Subrouter(), deps, activeTasks)
+	api.Routes(mx.PathPrefix("/api").Subrouter(), deps)
 
 	var static fs.FS = static
 	if webDev {

--- a/web/static/cluster-tasks.mjs
+++ b/web/static/cluster-tasks.mjs
@@ -25,7 +25,7 @@ class ClusterTasks extends LitElement {
             <table class="table table-dark">
                 <thead>
                 <tr>
-                    <th>Miner ID</th>
+                    <th>SpID</th>
                     <th style="min-width: 128px">Task</th>
                     <th>ID</th>
                     <th>Posted</th>

--- a/web/static/sector/index.html
+++ b/web/static/sector/index.html
@@ -45,7 +45,7 @@
       ajax: '/api/sector/all',
       columns: [
         {title: "", data: null},
-        {title: "Miner", data:'MinerID'},
+        {title: "SpID", data:'MinerID'},
         {title: "Sector", data:'SectorNum'},
         {title: "Expiry", data:'ExpiresAt'},
         {title: "🔗", data:'IsOnChain'},
@@ -77,7 +77,7 @@
                 return {MinerID: row.MinerID, Sector: row.SectorNum};
               });
               console.log(res);
-              var confirmMessage = res.map(obj => `MinerID: ${obj.MinerID}, Sector: ${obj.Sector}`).join(", ");
+              var confirmMessage = res.map(obj => `SpID: ${obj.MinerID}, Sector: ${obj.Sector}`).join(", ");
 
               if (confirm("Terminate & Delete: "+confirmMessage)) {
                 axios.post('/api/sector/terminate', res)


### PR DESCRIPTION
The current implementation of the SPID reader is unable to show SPIDs for tasks that are not active on that web server (which is probably few). 
This should allow the UI to show the related SPID for all SPID-type tasks.
This Generic change requires ALL tasks to register into a global registry in init(). Then, various future TaskInterface implementations can provide ad-hoc support for extended Interfaces, the first being GetSPID()