### PR TITLE
doc: versions

### DIFF
--- a/documentation/en/SUMMARY.md
+++ b/documentation/en/SUMMARY.md
@@ -5,6 +5,7 @@
   * [Sealing](design/sealing.md)
   * [Harmony Tasks](design/harmony-tasks.md)
 * [Getting Started](getting-started.md)
+* [Versions](versions.md)
 * [Installation](installation.md)
 * [Setup](setup.md)
 * [Curio Service](curio-service.md)

--- a/documentation/en/getting-started.md
+++ b/documentation/en/getting-started.md
@@ -4,15 +4,6 @@ description: This is a step by step guide for new users to get onboarded with Cu
 
 # Getting Started
 
-## Compatibility
-
-This is the Curio and Lotus compatibility matrix.
-
-| Curio Version | Lotus Version | Go Version |
-| ------------- | ------------- | ---------- |
-| 1.22.0        | v1.27.0       | 1.21.7     |
-| 1.22.1        | v1.27.x       | 1.22.3     |
-
 ## Curio Database and Distributed Architecture
 
 ### Familiarizing Yourself with Curio

--- a/documentation/en/versions.md
+++ b/documentation/en/versions.md
@@ -1,0 +1,20 @@
+
+# Version Compatibility
+
+This is the compatibility matrix for the latest free Curio releases.
+
+| Curio Version | Lotus Version | Go Version   | Boost       | Yugabyte |
+| ------------- | ------------- | ------------ | ----------- | -------- |
+| 1.22.1        | v1.27.X       | 1.22.3 & DEB | Coming soon | 2.20.X   |
+| 1.23.0        | v1.28.0-rcX   | 1.22.3       | Coming soon | 2.20.X   |
+
+No preference is denoted by "X".
+
+## Notes
+
+- Different machines should be running Lotus Client, Curio, Yugabyte, and (optionally) Boost.
+- Forest 0.19+ is a light alternative to Lotus Client. It meets Curio's needs, but Boost compatability is in development.
+- The available branches are named as release/vVERSION like: release/v1.23.4
+- DEB: Curio offers pre-built AMD64 Ubuntu packages for nvidia & ATI.
+- CalibrationNet may be a network version ahead of MainNet.
+  - DEBs are only for MainNet releases and will be available early so MainNet upgrades cause no interruption.

--- a/documentation/en/versions.md
+++ b/documentation/en/versions.md
@@ -5,7 +5,7 @@ This is the compatibility matrix for the latest free Curio releases.
 
 | Curio Version       | Lotus Version | Boost       | Yugabyte           | Forest           |
 | ------------------- | ------------- | ----------- | ------------------ | ---------------- |
-| 1.22.1 / Automatic  | v1.27.X       | Coming soon | 2.20.X / Automatic | 0.19 / Automatic |
+| 1.22.1 / Automatic  | v1.27.X       | v2.3.0-rc2 | 2.20.X / Automatic | 0.19 / Automatic |
 | 1.23.0              | v1.28.0-rcX   | Coming soon | 2.20.X / Automatic | 0.19 / Automatic |
 
 No preference is denoted by "X".

--- a/documentation/en/versions.md
+++ b/documentation/en/versions.md
@@ -3,18 +3,33 @@
 
 This is the compatibility matrix for the latest free Curio releases.
 
-| Curio Version | Lotus Version | Go Version   | Boost       | Yugabyte |
-| ------------- | ------------- | ------------ | ----------- | -------- |
-| 1.22.1        | v1.27.X       | 1.22.3 & DEB | Coming soon | 2.20.X   |
-| 1.23.0        | v1.28.0-rcX   | 1.22.3       | Coming soon | 2.20.X   |
+| Curio Version       | Lotus Version | Boost       | Yugabyte           | Forest           |
+| ------------------- | ------------- | ----------- | ------------------ | ---------------- |
+| 1.22.1 / Automatic  | v1.27.X       | Coming soon | 2.20.X / Automatic | 0.19 / Automatic |
+| 1.23.0              | v1.28.0-rcX   | Coming soon | 2.20.X / Automatic | 0.19 / Automatic |
 
 No preference is denoted by "X".
 
+Configurations and the number of machines needed:
+ A: Lotus, Curio (numerous), Yugabyte (1 or 3), (optional Boost)
+ B: Forest, Curio (numerous), Yugabyte (1 or 3)
+
+## Automatic Updates
+
+- Docker has Watchtower which offers automatic updates which work for Yugabyte and Forest.
+- Curio can automatically be updated on MainNet through the Debian update process on Ubuntu.
+- Today, only Lotus & Boost lacks automatic updates and must be built and deployed.
+- Curio's DEBs include curio-cuda (for Nvidia) and curio-opencl (others like ATI).
+  - These can be mixed in a Curio cluster as they only relate to the hardware on the box.
+  
 ## Notes
 
-- Different machines should be running Lotus Client, Curio, Yugabyte, and (optionally) Boost.
-- Forest 0.19+ is a light alternative to Lotus Client. It meets Curio's needs, but Boost compatability is in development.
-- The available branches are named as release/vVERSION like: release/v1.23.4
-- DEB: Curio offers pre-built AMD64 Ubuntu packages for nvidia & ATI.
-- CalibrationNet may be a network version ahead of MainNet.
+- Forest (0.19+ & Docker Watchtower) is a light alternative to Lotus Client. It meets Curio's needs, but Boost compatability is in development.
+
+## Building for CalibrationNet
+
+- Required for CalibrationNet participation
+- Use the Go version specified in curio/GO_VERSION_MIN
+- The available Curio branches are named as release/vVERSION like: release/v1.23.4
+- CalibrationNet may be a network-version ahead of MainNet.
   - DEBs are only for MainNet releases and will be available early so MainNet upgrades cause no interruption.


### PR DESCRIPTION
Curio docs should include the expected versions of other related systems. 
![image](https://github.com/user-attachments/assets/eef16404-e771-4e8a-8d75-44c7f39c6520)
