### PR TITLE
lmrpc: Decode DDO in SectorsStatus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/snadrus/must v0.0.0-20240605044437-98cedd57f8eb
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.25.5
+	github.com/whyrusleeping/cbor-gen v0.1.1
 	github.com/yugabyte/pgx/v5 v5.5.3-yb-2
 	go.opencensus.io v0.24.0
 	go.uber.org/multierr v1.11.0
@@ -285,7 +286,6 @@ require (
 	github.com/valyala/fasttemplate v1.0.1 // indirect
 	github.com/whyrusleeping/bencher v0.0.0-20190829221104-bb6607aa8bba // indirect
 	github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 // indirect
-	github.com/whyrusleeping/cbor-gen v0.1.1 // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/market/fakelm/lmimpl.go
+++ b/market/fakelm/lmimpl.go
@@ -5,14 +5,13 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	market2 "github.com/filecoin-project/lotus/chain/actors/builtin/market"
-	logging "github.com/ipfs/go-log/v2"
-	typegen "github.com/whyrusleeping/cbor-gen"
 	"net/http"
 	"net/url"
 
 	"github.com/gbrlsnchs/jwt/v3"
 	"github.com/google/uuid"
+	logging "github.com/ipfs/go-log/v2"
+	typegen "github.com/whyrusleeping/cbor-gen"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
@@ -28,6 +27,7 @@ import (
 	"github.com/filecoin-project/curio/market"
 
 	lapi "github.com/filecoin-project/lotus/api"
+	market2 "github.com/filecoin-project/lotus/chain/actors/builtin/market"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	sealing "github.com/filecoin-project/lotus/storage/pipeline"
 	lpiece "github.com/filecoin-project/lotus/storage/pipeline/piece"


### PR DESCRIPTION
Boost calls SectorsStatus to check if deals are in the sector, and it really likes to see the DealID there

Unfortunately Snap converts all deals to DDO, so to fix this the rpc adapter decodes the dealID back from the PAM