### PR TITLE
no amd build opmz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ deps: $(BUILD_DEPS)
 
 curio: $(BUILD_DEPS)
 	rm -f curio
-	$(GOCC) build $(GOFLAGS) -o curio -ldflags " -s -w \
+	GOAMD64=v3 $(GOCC) build $(GOFLAGS) -o curio -ldflags " -s -w \
 	-X github.com/filecoin-project/curio/build.IsOpencl=$(FFI_USE_OPENCL) \
 	-X github.com/filecoin-project/curio/build.CurrentCommit=+git_`git log -1 --format=%h_%cI`" \
 	./cmd/curio

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ deps: $(BUILD_DEPS)
 
 curio: $(BUILD_DEPS)
 	rm -f curio
-	GOAMD64=v4 $(GOCC) build $(GOFLAGS) -o curio -ldflags " -s -w \
+	$(GOCC) build $(GOFLAGS) -o curio -ldflags " -s -w \
 	-X github.com/filecoin-project/curio/build.IsOpencl=$(FFI_USE_OPENCL) \
 	-X github.com/filecoin-project/curio/build.CurrentCommit=+git_`git log -1 --format=%h_%cI`" \
 	./cmd/curio


### PR DESCRIPTION
Lets support as old has Haswell from 2013. 
This still unnecessarily blocks 2008-2012 chips like Via Nano, Bulldozer, etc, but those are likely more expensive to run & maintain than to replace. 
And v3 we get AVX & AVX2 which are often used in compiler optimizations. I know Go uses AVX to zero large ram allocations.