### PR TITLE
Add indexes to mining and message waits tables

### DIFF
--- a/harmony/harmonydb/sql/20240824-longterm-indexes.sql
+++ b/harmony/harmonydb/sql/20240824-longterm-indexes.sql
@@ -1,0 +1,8 @@
+create index mining_base_block_task_id_id_index
+    on mining_base_block (task_id, id);
+
+create index message_waits_waiter_machine_id_index
+    on message_waits (waiter_machine_id);
+
+create index message_sends_signed_cid_index
+    on message_sends (signed_cid);


### PR DESCRIPTION
* Mining base lookups were the 3rd most time-consuming query in my stats, due to the winnnigPoSt task looking up the mining base by task_id which wasn't indexed
* Message waits are updated by joining waits with non-null waiter machine to message sends on signed cid. Because neither column had an index each invocation would trigger an insanely expensive sequential of both tables on every epoch, making it the second most expensive query.

Most time-consuming is
```
SELECT id 
			FROM harmony_task
			WHERE owner_id IS NULL AND name=$1
			ORDER BY update_time
```
But this one is expensive purely because it's executed very frequently, the execution itself seems to be very cheap with avg time at ~8ms on my cluster; Also does basically no IO since it's all going to be in memory due to that table being tiny