### PR TITLE
Feat: Add api proxy dev server

### DIFF
--- a/cmd/curio/rpc/rpc.go
+++ b/cmd/curio/rpc/rpc.go
@@ -296,7 +296,7 @@ func ListenAndServe(ctx context.Context, dependencies *deps.Deps, shutdownChan c
 	eg.Go(srv.ListenAndServe)
 
 	if dependencies.Cfg.Subsystems.EnableWebGui {
-		web, err := web.GetSrv(ctx, dependencies)
+		web, err := web.GetSrv(ctx, dependencies, false)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/icza/backscanner v0.0.0-20210726202459-ac2ffc679f94
@@ -158,7 +159,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20240509144519-723abb6459b7 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026 // indirect
 	github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/web/devsrv/main.go
+++ b/web/devsrv/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/filecoin-project/curio/deps"
+	"github.com/filecoin-project/curio/deps/config"
+	"github.com/filecoin-project/curio/web"
+)
+
+func main() {
+	srv, err := web.GetSrv(context.Background(),
+		&deps.Deps{
+			Cfg: &config.CurioConfig{
+				Subsystems: config.CurioSubsystemsConfig{GuiAddress: ":4701"},
+			}},
+		true)
+
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Running on: ", srv.Addr)
+	if err := srv.ListenAndServe(); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Added an API proxy to make it possible to develop web UI without running a local Curio node.

To run:
- set the `CURIO_API_SRV` env variable to a node web UI address
- `go run ./web/devsrv/main.go`