### PR TITLE
feat: add service-setup subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ docker/curio:
 		--build-arg BUILD_VERSION=dev .
 .PHONY: docker/curio
 
-docker/devnet: $(lotus_build_cmd) docker/curio-all-in-one docker/lotus docker/lotus-miner docker/curio docker/yugabyte
+docker/devnet: $(lotus_build_cmd) docker/curio-all-in-one docker/lotus docker/lotus-miner docker/curio
 .PHONY: docker/devnet
 
 devnet/up:

--- a/apt/make_debs.go
+++ b/apt/make_debs.go
@@ -111,7 +111,7 @@ func part2(base, product, extra string) {
 		OrPanic(os.MkdirAll(base, 0755))
 		OrPanic(copyFile("curio", path.Join(base, "curio")))
 		OrPanic(copyFile("sptool", path.Join(base, "sptool")))
-		base = path.Join(dir, "lib", "systemd", "system")
+		base = path.Join(dir, "etc", "systemd", "system")
 		OrPanic(os.MkdirAll(base, 0755))
 		OrPanic(copyFile("apt/curio.service", path.Join(base, "curio.service")))
 		base = path.Join(dir, "usr", "share", "bash-completion", "completions")

--- a/cmd/curio/guidedsetup/servicesetup.go
+++ b/cmd/curio/guidedsetup/servicesetup.go
@@ -1,0 +1,200 @@
+package guidedsetup
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+	"github.com/urfave/cli/v2"
+)
+
+// This should always match apt/curio.service
+var serviceContent = `
+[Unit]
+Description=Curio
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/curio run
+Environment=GOLOG_FILE="/var/log/curio/curio.log"
+Environment=GOLOG_LOG_FMT="json"
+LimitNOFILE=1000000
+Restart=always
+RestartSec=10
+EnvironmentFile=/etc/curio.env
+
+[Install]
+WantedBy=multi-user.target
+`
+
+var ServicesetupCmd = &cli.Command{
+	Name:  "service-setup",
+	Usage: "Run the service setup for a new Curio node. This command will take input from user and create/modify the service files",
+	Action: func(cctx *cli.Context) (err error) {
+		T, say := SetupLanguage()
+		setupCtrlC(say)
+
+		// Run the migration steps
+		migrationData := MigrationData{
+			T:   T,
+			say: say,
+			selectTemplates: &promptui.SelectTemplates{
+				Help: T("Use the arrow keys to navigate: ↓ ↑ → ← "),
+			},
+			cctx: cctx,
+			ctx:  cctx.Context,
+		}
+
+		say(header, "This interactive tool creates/replace Curio service file and creates the basic env file for it.")
+		for _, step := range newServiceSteps {
+			step(&migrationData)
+		}
+
+		return nil
+	},
+}
+
+type newServiceStep func(data *MigrationData)
+
+var newServiceSteps = []newServiceStep{
+	getDBDetails,
+	createServiceFile,
+	createEnvFile,
+}
+
+func createServiceFile(d *MigrationData) {
+	// Define the service file name
+	serviceName := "curio.service"
+
+	// Service file paths to check
+	servicePaths := []string{
+		filepath.Join("/etc/systemd/system/", serviceName),
+		filepath.Join("/usr/lib/systemd/system/", serviceName),
+	}
+
+	// Check if the service file already exists in any of the standard locations
+	for _, servicePath := range servicePaths {
+		if _, err := os.Stat(servicePath); err == nil {
+			d.say(notice, "Service file %s already exists at %s, no changes made.", serviceName, servicePath)
+			return //early return
+		} else if !os.IsNotExist(err) {
+			d.say(notice, "Error checking for service file at %s: %s", servicePath, err)
+			os.Exit(1)
+		}
+	}
+
+	// If the service file doesn't exist, create it in /etc/systemd/system/
+	targetServicePath := filepath.Join("/etc/systemd/system/", serviceName)
+	err := os.WriteFile(targetServicePath, []byte(serviceContent), 0644)
+	if err != nil {
+		d.say(notice, "Error writing service file: %s", err)
+		os.Exit(1)
+	}
+
+	d.say(notice, "Service file %s created successfully at %s", serviceName, targetServicePath)
+
+	// Reload systemd to recognize the new service
+	cmd := exec.Command("systemctl", "daemon-reload")
+	if err := cmd.Run(); err != nil {
+		d.say(notice, "Error reloading systemd: %s", err)
+		os.Exit(1)
+	}
+
+	// Enable the service to start on boot
+	cmd = exec.Command("systemctl", "enable", serviceName)
+	if err := cmd.Run(); err != nil {
+		d.say(notice, "Error enabling service: %s", err)
+		os.Exit(1)
+	}
+	d.say(notice, "Service %s enabled.\n", serviceName)
+}
+
+func createEnvFile(d *MigrationData) {
+	// Define the path to the environment file
+	envFilePath := "/etc/curio.env"
+
+	var layers []string
+	var repoPath, nodeName string
+
+	// Take user input to remaining env vars
+	for {
+		i, _, err := (&promptui.Select{
+			Label: d.T("Enter the info to configure your Curio node"),
+			Items: []string{
+				d.T("CURIO_LAYERS: %s", ""),
+				d.T("CURIO_REPO_PATH: %s", "~/.curio"),
+				d.T("CURIO_NODE_NAME: %s", ""),
+				d.T("Continue update the env file.")},
+			Size:      6,
+			Templates: d.selectTemplates,
+		}).Run()
+		if err != nil {
+			d.say(notice, "Env config error occurred, abandoning: %s ", err.Error())
+			os.Exit(1)
+		}
+		switch i {
+		case 0:
+			host, err := (&promptui.Prompt{
+				Label: d.T("Enter the config layer name to use for this node. Base is already included by default"),
+			}).Run()
+			if err != nil {
+				d.say(notice, "No layer provided")
+				continue
+			}
+			layers = strings.Split(host, ",")
+		case 1, 2:
+			val, err := (&promptui.Prompt{
+				Label: d.T("Enter the %s", []string{"repo path", "node name"}[i-1]),
+			}).Run()
+			if err != nil {
+				d.say(notice, "No value provided")
+				continue
+			}
+			switch i {
+			case 1:
+				repoPath = val
+			case 2:
+				nodeName = val
+			}
+			continue
+		case 3:
+			// Define the environment variables to be added or updated
+			envVars := map[string]string{
+				"CURIO_LAYERS": fmt.Sprintf("export CURIO_LAYERS=%s", strings.Join(layers, ",")),
+				"CURIO_ALL_REMAINING_FIELDS_ARE_OPTIONAL": "true",
+				"CURIO_DB_HOST":                fmt.Sprintf("export CURIO_DB_HOST=%s", strings.Join(d.HarmonyCfg.Hosts, ",")),
+				"CURIO_DB_PORT":                fmt.Sprintf("export CURIO_DB_PORT=%s", d.HarmonyCfg.Port),
+				"CURIO_DB_NAME":                fmt.Sprintf("export CURIO_DB_HOST=%s", d.HarmonyCfg.Database),
+				"CURIO_DB_USER":                fmt.Sprintf("export CURIO_DB_HOST=%s", d.HarmonyCfg.Username),
+				"CURIO_DB_PASSWORD":            fmt.Sprintf("export CURIO_DB_HOST=%s", d.HarmonyCfg.Password),
+				"CURIO_REPO_PATH":              repoPath,
+				"CURIO_NODE_NAME":              nodeName,
+				"FIL_PROOFS_USE_MULTICORE_SDR": "1",
+			}
+
+			// Open the file with truncation (this clears the file if it exists)
+			file, err := os.OpenFile(envFilePath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+			if err != nil {
+				d.say(notice, "Error opening or creating file %s: %s", envFilePath, err)
+				os.Exit(1)
+			}
+			defer func() {
+				_ = file.Close()
+			}()
+
+			// Write the new environment variables to the file
+			for key, value := range envVars {
+				line := fmt.Sprintf("%s=%s\n", key, value)
+				if _, err := file.WriteString(line); err != nil {
+					d.say(notice, "Error writing to file %s: %s", envFilePath, err)
+					os.Exit(1)
+				}
+			}
+			d.say(notice, "Service env file /etc/curio.env created successfully.")
+			return
+		}
+	}
+}

--- a/cmd/curio/internal/translations/catalog.go
+++ b/cmd/curio/internal/translations/catalog.go
@@ -40,157 +40,190 @@ func init() {
 }
 
 var messageKeyToIndex = map[string]int{
-	"2 KiB":                     74,
-	"32 GiB":                    72,
-	"64 GiB":                    71,
-	"8 MiB":                     73,
-	"Aborting migration.":       12,
+	"2 KiB":                     80,
+	"32 GiB":                    78,
+	"64 GiB":                    77,
+	"8 MiB":                     79,
+	"Aborting migration.":       31,
 	"Aborting remaining steps.": 9,
-	"Additional info is at http://docs.curiostorage.org":                    17,
-	"Aggregate-Anonymous: version, chain, and Miner power (bucketed).":      30,
-	"Cannot reach the DB: %s":                                               79,
-	"Cannot read the config.toml file in the provided directory, Error: %s": 53,
-	"Compare the configurations %s to %s. Changes between the miner IDs other than wallet addreses should be a new, minimal layer for runners that need it.": 107,
-	"Configuration 'base' was created to resemble this lotus-miner's config.toml .":                                                                          108,
-	"Configuration 'base' was updated to include this miner's address":                                                                                       88,
-	"Configuration 'base' was updated to include this miner's address (%s) and its wallet setup.":                                                            106,
-	"Connected to Yugabyte":                                                          47,
-	"Connected to Yugabyte. Schema is current.":                                      46,
-	"Continue to connect and update schema.":                                         98,
-	"Continue to verify the addresses and create a new miner actor.":                 64,
-	"Could not create repo from directory: %s. Aborting migration":                   54,
-	"Could not lock miner repo. Your miner must be stopped: %s\n Aborting migration": 55,
+	"Additional info is at http://docs.curiostorage.org":               22,
+	"Aggregate-Anonymous: version, chain, and Miner power (bucketed).": 36,
+	"CURIO_LAYERS: %s":        120,
+	"CURIO_NODE_NAME: %s":     122,
+	"CURIO_REPO_PATH: %s":     121,
+	"Cannot reach the DB: %s": 85,
+	"Cannot read the config.toml file in the provided directory, Error: %s":                                                                                  59,
+	"Compare the configurations %s to %s. Changes between the miner IDs other than wallet addreses should be a new, minimal layer for runners that need it.": 133,
+	"Configuration 'base' was created to resemble this lotus-miner's config.toml .":                                                                          134,
+	"Configuration 'base' was updated to include this miner's address":                                                                                       94,
+	"Configuration 'base' was updated to include this miner's address (%s) and its wallet setup.":                                                            132,
+	"Connected to Yugabyte":                                                          53,
+	"Connected to Yugabyte. Schema is current.":                                      52,
+	"Continue to connect and update schema.":                                         104,
+	"Continue to verify the addresses and create a new miner actor.":                 70,
+	"Continue update the env file.":                                                  123,
+	"Could not create repo from directory: %s. Aborting migration":                   60,
+	"Could not lock miner repo. Your miner must be stopped: %s\n Aborting migration": 61,
 	"Create a new miner":                                                             8,
 	"Ctrl+C pressed in Terminal":                                                     5,
-	"Database config error occurred, abandoning migration: %s ":                      99,
-	"Database: %s":    97,
-	"Documentation: ": 40,
+	"Database config error occurred, abandoning migration: %s ":                      105,
+	"Database: %s":    103,
+	"Documentation: ": 46,
 	"Each step needs your confirmation and can be reversed. Press Ctrl+C to exit at any time.": 4,
-	"Enter %s address":                    69,
-	"Enter the Yugabyte database %s":      102,
-	"Enter the Yugabyte database host(s)": 100,
-	"Enter the info to connect to your Yugabyte database installation (https://download.yugabyte.com/)": 92,
-	"Enter the info to create a new miner":                     59,
-	"Enter the owner address":                                  66,
-	"Enter the path to the configuration directory used by %s": 51,
-	"Error connecting to Yugabyte database: %s":                104,
-	"Error connecting to full node API: %s":                    80,
-	"Error getting API: %s":                                    20,
-	"Error getting miner info: %s":                             35,
-	"Error getting miner power: %s":                            33,
-	"Error getting token: %s":                                  22,
-	"Error marshalling message: %s":                            34,
-	"Error saving config to layer: %s. Aborting Migration":     26,
-	"Error sending message: %s":                                37,
-	"Error sending message: Status %s, Message: ":              38,
-	"Error signing message: %s":                                36,
-	"Error writing file: %s":                                   13,
-	"Failed to create the miner actor: %s":                     77,
-	"Failed to generate default config: %s":                    86,
-	"Failed to generate random bytes for secret: %s":           82,
-	"Failed to get API info for FullNode: %w":                  84,
-	"Failed to insert 'base' config layer in database: %s":     87,
-	"Failed to load base config from database: %s":             89,
-	"Failed to parse base config: %s":                          90,
-	"Failed to parse sector size: %s":                          76,
-	"Failed to parse the address: %s":                          68,
-	"Failed to regenerate base config: %s":                     91,
-	"Failed to verify the auth token from daemon node: %s":     85,
-	"Filecoin %s channels: %s and %s":                          43,
-	"For more servers, make /etc/curio.env with the curio.env database env and add the CURIO_LAYERS env to assign purposes.": 15,
-	"Hint: I am someone running Curio on whichever chain.":                                                                   31,
-	"Host: %s":   93,
+	"Enter %s address":                    75,
+	"Enter the %s":                        127,
+	"Enter the Yugabyte database %s":      108,
+	"Enter the Yugabyte database host(s)": 106,
+	"Enter the config layer name to use for this node. Base is already included by default":             125,
+	"Enter the info to configure your Curio node":                                                       119,
+	"Enter the info to connect to your Yugabyte database installation (https://download.yugabyte.com/)": 98,
+	"Enter the info to create a new miner":                                                              65,
+	"Enter the owner address":                                                                           72,
+	"Enter the path to the configuration directory used by %s":                                          57,
+	"Env config error occurred, abandoning: %s ":                                                        124,
+	"Error checking for service file at %s: %s":                                                         113,
+	"Error connecting to Yugabyte database: %s":                                                         110,
+	"Error connecting to full node API: %s":                                                             86,
+	"Error enabling service: %s":                                                                        117,
+	"Error getting API: %s":                                                                             25,
+	"Error getting miner info: %s":                                                                      41,
+	"Error getting miner power: %s":                                                                     39,
+	"Error getting token: %s":                                                                           27,
+	"Error getting user home directory:":                                                                12,
+	"Error marshalling message: %s":                                                                     40,
+	"Error opening %s file in write mode:":                                                              15,
+	"Error opening %s file: %s":                                                                         13,
+	"Error opening or creating file %s: %s":                                                             128,
+	"Error reading %s file: %s":                                                                         14,
+	"Error reloading systemd: %s":                                                                       116,
+	"Error saving config to layer: %s. Aborting Migration":                                              32,
+	"Error sending message: %s":                                                                         43,
+	"Error sending message: Status %s, Message: ":                                                       44,
+	"Error signing message: %s":                                                                         42,
+	"Error writing service file: %s":                                                                    114,
+	"Error writing to %s file: %s":                                                                      16,
+	"Error writing to file %s: %s":                                                                      129,
+	"Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes": 20,
+	"Failed to create the miner actor: %s":                 83,
+	"Failed to flush thw writes to file %s: %s":            17,
+	"Failed to generate default config: %s":                92,
+	"Failed to generate random bytes for secret: %s":       88,
+	"Failed to get API info for FullNode: %w":              90,
+	"Failed to insert 'base' config layer in database: %s": 93,
+	"Failed to load base config from database: %s":         95,
+	"Failed to parse base config: %s":                      96,
+	"Failed to parse sector size: %s":                      82,
+	"Failed to parse the address: %s":                      74,
+	"Failed to regenerate base config: %s":                 97,
+	"Failed to verify the auth token from daemon node: %s": 91,
+	"Filecoin %s channels: %s and %s":                      49,
+	"Hint: I am someone running Curio on whichever chain.": 37,
+	"Host: %s":   99,
 	"I want to:": 6,
-	"Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'": 44,
-	"Individual Data: Miner ID, Curio version, chain (%s or %s). Signed.":                                                    29,
-	"Initializing a new miner actor.":   58,
-	"Layer %s created. ":                109,
+	"Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'": 50,
+	"Individual Data: Miner ID, Curio version, chain (%s or %s). Signed.":                                                    35,
+	"Initializing a new miner actor.":   64,
+	"Layer %s created. ":                135,
 	"Lotus-Miner to Curio Migration.":   10,
-	"Message sent.":                     39,
+	"Message sent.":                     45,
 	"Migrate from existing Lotus-Miner": 7,
-	"Migrating lotus-miner config.toml to Curio in-database configuration.": 19,
-	"Migrating metadata for %d sectors.":                                    105,
-	"Miner %s created successfully":                                         78,
-	"Miner creation error occurred: %s ":                                    65,
-	"New Miner initialization complete.":                                    18,
-	"No address provided":                                                   67,
-	"No host provided":                                                      101,
-	"No path provided, abandoning migration ":                               52,
-	"No value provided":                                                     103,
-	"No, abort":                                                             25,
-	"Nothing.":                                                              32,
-	"One database can serve multiple miner IDs: Run a migration for each lotus-miner.": 45,
-	"Other":            50,
-	"Owner Wallet: %s": 60,
-	"Password: %s":     96,
-	"Please do not run guided-setup again as miner creation is not idempotent. You need to run 'curio config new-cluster %s' to finish the configuration": 83,
-	"Port: %s":                          94,
-	"Pre-initialization steps complete": 81,
-	"Read Miner Config":                 56,
-	"Sector Size: %s":                   63,
-	"Sector selection failed: %s ":      75,
-	"Select the Sector Size":            70,
-	"Select the location of your lotus-miner config directory?": 49,
-	"Select what you want to share with the Curio team.":        28,
-	"Sender Wallet: %s":   62,
-	"Step Complete: %s\n": 57,
-	"The '%s' layer stores common configuration. All curio instances can include it in their %s argument.":                                                                                               41,
-	"The Curio team wants to improve the software you use. Tell the team you're using `%s`.":                                                                                                             27,
-	"This interactive tool creates a new miner actor and creates the basic configuration layer for it.":                                                                                                  1,
-	"This interactive tool migrates lotus-miner to Curio in 5 minutes.":                                                                                                                                  3,
+	"Migrating lotus-miner config.toml to Curio in-database configuration.": 24,
+	"Migrating metadata for %d sectors.":                                    131,
+	"Miner %s created successfully":                                         84,
+	"Miner creation error occurred: %s ":                                    71,
+	"New Miner initialization complete.":                                    23,
+	"No address provided":                                                   73,
+	"No host provided":                                                      107,
+	"No layer provided":                                                     126,
+	"No path provided, abandoning migration ":                               58,
+	"No value provided":                                                     109,
+	"No, abort":                                                             30,
+	"Not adding DB variables to RC file as shell %s is not BASH or ZSH.":    11,
+	"Nothing.": 38,
+	"One database can serve multiple miner IDs: Run a migration for each lotus-miner.": 51,
+	"Other":            56,
+	"Owner Wallet: %s": 66,
+	"Password: %s":     102,
+	"Please do not run guided-setup again as miner creation is not idempotent. You need to run 'curio config new-cluster %s' to finish the configuration": 89,
+	"Port: %s":                          100,
+	"Pre-initialization steps complete": 87,
+	"Read Miner Config":                 62,
+	"Retrying.......(%d/5)":             18,
+	"Sector Size: %s":                   69,
+	"Sector selection failed: %s ":      81,
+	"Select the Sector Size":            76,
+	"Select the location of your lotus-miner config directory?": 55,
+	"Select what you want to share with the Curio team.":        34,
+	"Sender Wallet: %s":     68,
+	"Service %s enabled.\n": 118,
+	"Service env file /etc/curio.env created successfully.":                                                130,
+	"Service file %s already exists at %s, no changes made.":                                               112,
+	"Service file %s created successfully at %s":                                                           115,
+	"Step Complete: %s\n":                                                                                  63,
+	"The '%s' layer stores common configuration. All curio instances can include it in their %s argument.": 47,
+	"The Curio team wants to improve the software you use. Tell the team you're using `%s`.":               33,
+	"This interactive tool creates a new miner actor and creates the basic configuration layer for it.":    1,
+	"This interactive tool creates/replace Curio service file and creates the basic env file for it.":      111,
+	"This interactive tool migrates lotus-miner to Curio in 5 minutes.":                                    3,
 	"This process is partially idempotent. Once a new miner actor has been created and subsequent steps fail, the user need to run 'curio config new-cluster < miner ID >' to finish the configuration.": 2,
-	"To run Curio: With machine or cgroup isolation, use the command (with example layer selection):":                                                                                                    111,
-	"To start, ensure your sealing pipeline is drained and shut-down lotus-miner.":                                                                                                                       48,
-	"To work with the config: ":                            110,
-	"Try the web interface with %s ":                       14,
-	"Unmigratable sectors found. Do you want to continue?": 23,
+	"To run Curio: With machine or cgroup isolation, use the command (with example layer selection):":                                                                                                    137,
+	"To start, ensure your sealing pipeline is drained and shut-down lotus-miner.":                                                                                                                       54,
+	"To work with the config: ":                            136,
+	"Try the web interface with %s ":                       19,
+	"Unmigratable sectors found. Do you want to continue?": 28,
 	"Use the arrow keys to navigate: ↓ ↑ → ← ":             0,
-	"Username: %s": 95,
-	"Where should we save your database config file?": 11,
-	"Worker Wallet: %s": 61,
-	"Yes, continue":     24,
-	"You can add other layers for per-machine configuration changes.": 42,
-	"You can now migrate your market node (%s), if applicable.":       16,
-	"could not get API info for FullNode: %w":                         21,
+	"Username: %s":      101,
+	"Worker Wallet: %s": 67,
+	"Yes, continue":     29,
+	"You can add other layers for per-machine configuration changes.": 48,
+	"You can now migrate your market node (%s), if applicable.":       21,
+	"could not get API info for FullNode: %w":                         26,
 }
 
-var enIndex = []uint32{ // 113 elements
+var enIndex = []uint32{ // 139 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000035, 0x00000097, 0x0000015a,
 	0x0000019c, 0x000001f5, 0x00000210, 0x0000021b,
 	0x0000023d, 0x00000250, 0x0000026a, 0x0000028a,
-	0x000002ba, 0x000002ce, 0x000002e8, 0x0000030e,
-	0x00000385, 0x000003c2, 0x000003f5, 0x00000418,
-	0x0000045e, 0x00000477, 0x000004a2, 0x000004bd,
-	0x000004f2, 0x00000500, 0x0000050a, 0x00000542,
-	0x0000059c, 0x000005cf, 0x00000619, 0x0000065a,
+	0x000002d0, 0x000002f3, 0x00000313, 0x00000333,
+	0x0000035b, 0x0000037e, 0x000003ae, 0x000003c7,
+	0x000003ed, 0x00000461, 0x0000049e, 0x000004d1,
+	0x000004f4, 0x0000053a, 0x00000553, 0x0000057e,
+	0x00000599, 0x000005ce, 0x000005dc, 0x000005e6,
 	// Entry 20 - 3F
-	0x0000068f, 0x00000698, 0x000006b9, 0x000006da,
-	0x000006fa, 0x00000717, 0x00000734, 0x00000767,
-	0x00000775, 0x00000789, 0x000007f4, 0x00000834,
-	0x0000085d, 0x000008d4, 0x00000925, 0x0000094f,
-	0x00000965, 0x000009b2, 0x000009ec, 0x000009f2,
-	0x00000a2e, 0x00000a5a, 0x00000aa3, 0x00000ae3,
-	0x00000b34, 0x00000b46, 0x00000b60, 0x00000b80,
-	0x00000ba5, 0x00000bb9, 0x00000bce, 0x00000be3,
+	0x000005fa, 0x00000632, 0x0000068c, 0x000006bf,
+	0x00000709, 0x0000074a, 0x0000077f, 0x00000788,
+	0x000007a9, 0x000007ca, 0x000007ea, 0x00000807,
+	0x00000824, 0x00000857, 0x00000865, 0x00000879,
+	0x000008e4, 0x00000924, 0x0000094d, 0x000009c4,
+	0x00000a15, 0x00000a3f, 0x00000a55, 0x00000aa2,
+	0x00000adc, 0x00000ae2, 0x00000b1e, 0x00000b4a,
+	0x00000b93, 0x00000bd3, 0x00000c24, 0x00000c36,
 	// Entry 40 - 5F
-	0x00000bf6, 0x00000c35, 0x00000c5f, 0x00000c77,
-	0x00000c8b, 0x00000cae, 0x00000cc2, 0x00000cd9,
-	0x00000ce0, 0x00000ce7, 0x00000ced, 0x00000cf3,
-	0x00000d17, 0x00000d3a, 0x00000d62, 0x00000d83,
-	0x00000d9e, 0x00000dc7, 0x00000de9, 0x00000e1b,
-	0x00000eb2, 0x00000edd, 0x00000f15, 0x00000f3e,
-	0x00000f76, 0x00000fb7, 0x00000fe7, 0x0000100a,
-	0x00001032, 0x00001094, 0x000010a0, 0x000010ac,
+	0x00000c50, 0x00000c70, 0x00000c95, 0x00000ca9,
+	0x00000cbe, 0x00000cd3, 0x00000ce6, 0x00000d25,
+	0x00000d4f, 0x00000d67, 0x00000d7b, 0x00000d9e,
+	0x00000db2, 0x00000dc9, 0x00000dd0, 0x00000dd7,
+	0x00000ddd, 0x00000de3, 0x00000e07, 0x00000e2a,
+	0x00000e52, 0x00000e73, 0x00000e8e, 0x00000eb7,
+	0x00000ed9, 0x00000f0b, 0x00000fa2, 0x00000fcd,
+	0x00001005, 0x0000102e, 0x00001066, 0x000010a7,
 	// Entry 60 - 7F
-	0x000010bc, 0x000010cc, 0x000010dc, 0x00001103,
-	0x00001144, 0x00001168, 0x00001179, 0x0000119b,
-	0x000011ad, 0x000011da, 0x00001200, 0x0000125f,
-	0x000012fc, 0x0000134a, 0x00001364, 0x00001382,
-	0x000013e2,
-} // Size: 476 bytes
+	0x000010d7, 0x000010fa, 0x00001122, 0x00001184,
+	0x00001190, 0x0000119c, 0x000011ac, 0x000011bc,
+	0x000011cc, 0x000011f3, 0x00001234, 0x00001258,
+	0x00001269, 0x0000128b, 0x0000129d, 0x000012ca,
+	0x0000132a, 0x00001367, 0x00001397, 0x000013b9,
+	0x000013ea, 0x00001409, 0x00001427, 0x00001443,
+	0x0000146f, 0x00001483, 0x0000149a, 0x000014b1,
+	0x000014cf, 0x00001501, 0x00001557, 0x00001569,
+	// Entry 80 - 9F
+	0x00001579, 0x000015a5, 0x000015c8, 0x000015fe,
+	0x00001624, 0x00001683, 0x00001720, 0x0000176e,
+	0x00001788, 0x000017a6, 0x00001806,
+} // Size: 580 bytes
 
-const enData string = "" + // Size: 5090 bytes
+const enData string = "" + // Size: 6150 bytes
 	"\x04\x00\x01 0\x02Use the arrow keys to navigate: ↓ ↑ → ←\x02This intera" +
 	"ctive tool creates a new miner actor and creates the basic configuration" +
 	" layer for it.\x02This process is partially idempotent. Once a new miner" +
@@ -200,245 +233,297 @@ const enData string = "" + // Size: 5090 bytes
 	"h step needs your confirmation and can be reversed. Press Ctrl+C to exit" +
 	" at any time.\x02Ctrl+C pressed in Terminal\x02I want to:\x02Migrate fro" +
 	"m existing Lotus-Miner\x02Create a new miner\x02Aborting remaining steps" +
-	".\x02Lotus-Miner to Curio Migration.\x02Where should we save your databa" +
-	"se config file?\x02Aborting migration.\x02Error writing file: %[1]s\x04" +
-	"\x00\x01 !\x02Try the web interface with %[1]s\x02For more servers, make" +
-	" /etc/curio.env with the curio.env database env and add the CURIO_LAYERS" +
-	" env to assign purposes.\x02You can now migrate your market node (%[1]s)" +
-	", if applicable.\x02Additional info is at http://docs.curiostorage.org" +
-	"\x02New Miner initialization complete.\x02Migrating lotus-miner config.t" +
-	"oml to Curio in-database configuration.\x02Error getting API: %[1]s\x02c" +
-	"ould not get API info for FullNode: %[1]w\x02Error getting token: %[1]s" +
-	"\x02Unmigratable sectors found. Do you want to continue?\x02Yes, continu" +
-	"e\x02No, abort\x02Error saving config to layer: %[1]s. Aborting Migratio" +
-	"n\x02The Curio team wants to improve the software you use. Tell the team" +
-	" you're using `%[1]s`.\x02Select what you want to share with the Curio t" +
-	"eam.\x02Individual Data: Miner ID, Curio version, chain (%[1]s or %[2]s)" +
-	". Signed.\x02Aggregate-Anonymous: version, chain, and Miner power (bucke" +
-	"ted).\x02Hint: I am someone running Curio on whichever chain.\x02Nothing" +
-	".\x02Error getting miner power: %[1]s\x02Error marshalling message: %[1]" +
-	"s\x02Error getting miner info: %[1]s\x02Error signing message: %[1]s\x02" +
-	"Error sending message: %[1]s\x04\x00\x01 .\x02Error sending message: Sta" +
-	"tus %[1]s, Message:\x02Message sent.\x04\x00\x01 \x0f\x02Documentation:" +
-	"\x02The '%[1]s' layer stores common configuration. All curio instances c" +
-	"an include it in their %[2]s argument.\x02You can add other layers for p" +
-	"er-machine configuration changes.\x02Filecoin %[1]s channels: %[2]s and " +
-	"%[3]s\x02Increase reliability using redundancy: start multiple machines " +
-	"with at-least the post layer: 'curio run --layers=post'\x02One database " +
-	"can serve multiple miner IDs: Run a migration for each lotus-miner.\x02C" +
-	"onnected to Yugabyte. Schema is current.\x02Connected to Yugabyte\x02To " +
-	"start, ensure your sealing pipeline is drained and shut-down lotus-miner" +
-	".\x02Select the location of your lotus-miner config directory?\x02Other" +
-	"\x02Enter the path to the configuration directory used by %[1]s\x04\x00" +
-	"\x01 '\x02No path provided, abandoning migration\x02Cannot read the conf" +
-	"ig.toml file in the provided directory, Error: %[1]s\x02Could not create" +
-	" repo from directory: %[1]s. Aborting migration\x02Could not lock miner " +
-	"repo. Your miner must be stopped: %[1]s\x0a Aborting migration\x02Read M" +
-	"iner Config\x04\x00\x01\x0a\x15\x02Step Complete: %[1]s\x02Initializing " +
-	"a new miner actor.\x02Enter the info to create a new miner\x02Owner Wall" +
-	"et: %[1]s\x02Worker Wallet: %[1]s\x02Sender Wallet: %[1]s\x02Sector Size" +
-	": %[1]s\x02Continue to verify the addresses and create a new miner actor" +
-	".\x04\x00\x01 %\x02Miner creation error occurred: %[1]s\x02Enter the own" +
-	"er address\x02No address provided\x02Failed to parse the address: %[1]s" +
-	"\x02Enter %[1]s address\x02Select the Sector Size\x0264 GiB\x0232 GiB" +
-	"\x028 MiB\x022 KiB\x04\x00\x01 \x1f\x02Sector selection failed: %[1]s" +
-	"\x02Failed to parse sector size: %[1]s\x02Failed to create the miner act" +
-	"or: %[1]s\x02Miner %[1]s created successfully\x02Cannot reach the DB: %[" +
-	"1]s\x02Error connecting to full node API: %[1]s\x02Pre-initialization st" +
-	"eps complete\x02Failed to generate random bytes for secret: %[1]s\x02Ple" +
-	"ase do not run guided-setup again as miner creation is not idempotent. Y" +
-	"ou need to run 'curio config new-cluster %[1]s' to finish the configurat" +
-	"ion\x02Failed to get API info for FullNode: %[1]w\x02Failed to verify th" +
-	"e auth token from daemon node: %[1]s\x02Failed to generate default confi" +
-	"g: %[1]s\x02Failed to insert 'base' config layer in database: %[1]s\x02C" +
-	"onfiguration 'base' was updated to include this miner's address\x02Faile" +
-	"d to load base config from database: %[1]s\x02Failed to parse base confi" +
-	"g: %[1]s\x02Failed to regenerate base config: %[1]s\x02Enter the info to" +
-	" connect to your Yugabyte database installation (https://download.yugaby" +
-	"te.com/)\x02Host: %[1]s\x02Port: %[1]s\x02Username: %[1]s\x02Password: %" +
-	"[1]s\x02Database: %[1]s\x02Continue to connect and update schema.\x04" +
-	"\x00\x01 <\x02Database config error occurred, abandoning migration: %[1]" +
-	"s\x02Enter the Yugabyte database host(s)\x02No host provided\x02Enter th" +
-	"e Yugabyte database %[1]s\x02No value provided\x02Error connecting to Yu" +
-	"gabyte database: %[1]s\x02Migrating metadata for %[1]d sectors.\x02Confi" +
-	"guration 'base' was updated to include this miner's address (%[1]s) and " +
-	"its wallet setup.\x02Compare the configurations %[1]s to %[2]s. Changes " +
-	"between the miner IDs other than wallet addreses should be a new, minima" +
-	"l layer for runners that need it.\x02Configuration 'base' was created to" +
-	" resemble this lotus-miner's config.toml .\x04\x00\x01 \x15\x02Layer %[1" +
-	"]s created.\x04\x00\x01 \x19\x02To work with the config:\x02To run Curio" +
-	": With machine or cgroup isolation, use the command (with example layer " +
-	"selection):"
+	".\x02Lotus-Miner to Curio Migration.\x02Not adding DB variables to RC fi" +
+	"le as shell %[1]s is not BASH or ZSH.\x02Error getting user home directo" +
+	"ry:\x02Error opening %[1]s file: %[2]s\x02Error reading %[1]s file: %[2]" +
+	"s\x02Error opening %[1]s file in write mode:\x02Error writing to %[1]s f" +
+	"ile: %[2]s\x02Failed to flush thw writes to file %[1]s: %[2]s\x02Retryin" +
+	"g.......(%[1]d/5)\x04\x00\x01 !\x02Try the web interface with %[1]s\x02E" +
+	"xecute 'curio service-setup' to setup the Curio service on this node and" +
+	" proceed to do the same on the other nodes\x02You can now migrate your m" +
+	"arket node (%[1]s), if applicable.\x02Additional info is at http://docs." +
+	"curiostorage.org\x02New Miner initialization complete.\x02Migrating lotu" +
+	"s-miner config.toml to Curio in-database configuration.\x02Error getting" +
+	" API: %[1]s\x02could not get API info for FullNode: %[1]w\x02Error getti" +
+	"ng token: %[1]s\x02Unmigratable sectors found. Do you want to continue?" +
+	"\x02Yes, continue\x02No, abort\x02Aborting migration.\x02Error saving co" +
+	"nfig to layer: %[1]s. Aborting Migration\x02The Curio team wants to impr" +
+	"ove the software you use. Tell the team you're using `%[1]s`.\x02Select " +
+	"what you want to share with the Curio team.\x02Individual Data: Miner ID" +
+	", Curio version, chain (%[1]s or %[2]s). Signed.\x02Aggregate-Anonymous:" +
+	" version, chain, and Miner power (bucketed).\x02Hint: I am someone runni" +
+	"ng Curio on whichever chain.\x02Nothing.\x02Error getting miner power: %" +
+	"[1]s\x02Error marshalling message: %[1]s\x02Error getting miner info: %[" +
+	"1]s\x02Error signing message: %[1]s\x02Error sending message: %[1]s\x04" +
+	"\x00\x01 .\x02Error sending message: Status %[1]s, Message:\x02Message s" +
+	"ent.\x04\x00\x01 \x0f\x02Documentation:\x02The '%[1]s' layer stores comm" +
+	"on configuration. All curio instances can include it in their %[2]s argu" +
+	"ment.\x02You can add other layers for per-machine configuration changes." +
+	"\x02Filecoin %[1]s channels: %[2]s and %[3]s\x02Increase reliability usi" +
+	"ng redundancy: start multiple machines with at-least the post layer: 'cu" +
+	"rio run --layers=post'\x02One database can serve multiple miner IDs: Run" +
+	" a migration for each lotus-miner.\x02Connected to Yugabyte. Schema is c" +
+	"urrent.\x02Connected to Yugabyte\x02To start, ensure your sealing pipeli" +
+	"ne is drained and shut-down lotus-miner.\x02Select the location of your " +
+	"lotus-miner config directory?\x02Other\x02Enter the path to the configur" +
+	"ation directory used by %[1]s\x04\x00\x01 '\x02No path provided, abandon" +
+	"ing migration\x02Cannot read the config.toml file in the provided direct" +
+	"ory, Error: %[1]s\x02Could not create repo from directory: %[1]s. Aborti" +
+	"ng migration\x02Could not lock miner repo. Your miner must be stopped: %" +
+	"[1]s\x0a Aborting migration\x02Read Miner Config\x04\x00\x01\x0a\x15\x02" +
+	"Step Complete: %[1]s\x02Initializing a new miner actor.\x02Enter the inf" +
+	"o to create a new miner\x02Owner Wallet: %[1]s\x02Worker Wallet: %[1]s" +
+	"\x02Sender Wallet: %[1]s\x02Sector Size: %[1]s\x02Continue to verify the" +
+	" addresses and create a new miner actor.\x04\x00\x01 %\x02Miner creation" +
+	" error occurred: %[1]s\x02Enter the owner address\x02No address provided" +
+	"\x02Failed to parse the address: %[1]s\x02Enter %[1]s address\x02Select " +
+	"the Sector Size\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1f" +
+	"\x02Sector selection failed: %[1]s\x02Failed to parse sector size: %[1]s" +
+	"\x02Failed to create the miner actor: %[1]s\x02Miner %[1]s created succe" +
+	"ssfully\x02Cannot reach the DB: %[1]s\x02Error connecting to full node A" +
+	"PI: %[1]s\x02Pre-initialization steps complete\x02Failed to generate ran" +
+	"dom bytes for secret: %[1]s\x02Please do not run guided-setup again as m" +
+	"iner creation is not idempotent. You need to run 'curio config new-clust" +
+	"er %[1]s' to finish the configuration\x02Failed to get API info for Full" +
+	"Node: %[1]w\x02Failed to verify the auth token from daemon node: %[1]s" +
+	"\x02Failed to generate default config: %[1]s\x02Failed to insert 'base' " +
+	"config layer in database: %[1]s\x02Configuration 'base' was updated to i" +
+	"nclude this miner's address\x02Failed to load base config from database:" +
+	" %[1]s\x02Failed to parse base config: %[1]s\x02Failed to regenerate bas" +
+	"e config: %[1]s\x02Enter the info to connect to your Yugabyte database i" +
+	"nstallation (https://download.yugabyte.com/)\x02Host: %[1]s\x02Port: %[1" +
+	"]s\x02Username: %[1]s\x02Password: %[1]s\x02Database: %[1]s\x02Continue " +
+	"to connect and update schema.\x04\x00\x01 <\x02Database config error occ" +
+	"urred, abandoning migration: %[1]s\x02Enter the Yugabyte database host(s" +
+	")\x02No host provided\x02Enter the Yugabyte database %[1]s\x02No value p" +
+	"rovided\x02Error connecting to Yugabyte database: %[1]s\x02This interact" +
+	"ive tool creates/replace Curio service file and creates the basic env fi" +
+	"le for it.\x02Service file %[1]s already exists at %[2]s, no changes mad" +
+	"e.\x02Error checking for service file at %[1]s: %[2]s\x02Error writing s" +
+	"ervice file: %[1]s\x02Service file %[1]s created successfully at %[2]s" +
+	"\x02Error reloading systemd: %[1]s\x02Error enabling service: %[1]s\x04" +
+	"\x00\x01\x0a\x17\x02Service %[1]s enabled.\x02Enter the info to configur" +
+	"e your Curio node\x02CURIO_LAYERS: %[1]s\x02CURIO_REPO_PATH: %[1]s\x02CU" +
+	"RIO_NODE_NAME: %[1]s\x02Continue update the env file.\x04\x00\x01 -\x02E" +
+	"nv config error occurred, abandoning: %[1]s\x02Enter the config layer na" +
+	"me to use for this node. Base is already included by default\x02No layer" +
+	" provided\x02Enter the %[1]s\x02Error opening or creating file %[1]s: %[" +
+	"2]s\x02Error writing to file %[1]s: %[2]s\x02Service env file /etc/curio" +
+	".env created successfully.\x02Migrating metadata for %[1]d sectors.\x02C" +
+	"onfiguration 'base' was updated to include this miner's address (%[1]s) " +
+	"and its wallet setup.\x02Compare the configurations %[1]s to %[2]s. Chan" +
+	"ges between the miner IDs other than wallet addreses should be a new, mi" +
+	"nimal layer for runners that need it.\x02Configuration 'base' was create" +
+	"d to resemble this lotus-miner's config.toml .\x04\x00\x01 \x15\x02Layer" +
+	" %[1]s created.\x04\x00\x01 \x19\x02To work with the config:\x02To run C" +
+	"urio: With machine or cgroup isolation, use the command (with example la" +
+	"yer selection):"
 
-var koIndex = []uint32{ // 113 elements
+var koIndex = []uint32{ // 139 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000044, 0x000000c1, 0x000001c1,
 	0x0000020e, 0x00000289, 0x000002aa, 0x000002bc,
 	0x000002e5, 0x00000300, 0x00000325, 0x00000348,
-	0x0000038e, 0x000003a9, 0x000003c5, 0x00000404,
-	0x000004ba, 0x0000050a, 0x0000054a, 0x00000570,
-	0x000005c9, 0x000005e8, 0x00000624, 0x00000654,
-	0x000006a4, 0x000006b0, 0x000006c2, 0x0000071a,
-	0x000007a6, 0x000007df, 0x00000835, 0x00000873,
+	0x000003aa, 0x000003e8, 0x00000418, 0x00000448,
+	0x00000483, 0x000004b3, 0x00000502, 0x00000524,
+	0x00000563, 0x000005f5, 0x00000645, 0x00000685,
+	0x000006ab, 0x00000704, 0x00000723, 0x0000075f,
+	0x0000078f, 0x000007df, 0x000007eb, 0x000007fd,
 	// Entry 20 - 3F
-	0x000008c1, 0x000008dc, 0x00000916, 0x00000949,
-	0x00000983, 0x000009ad, 0x000009d7, 0x00000a19,
-	0x00000a3d, 0x00000a4a, 0x00000ad0, 0x00000b22,
-	0x00000b49, 0x00000be5, 0x00000c77, 0x00000cb8,
-	0x00000cce, 0x00000d39, 0x00000d88, 0x00000d8f,
-	0x00000dd7, 0x00000e29, 0x00000e83, 0x00000eed,
-	0x00000f7e, 0x00000f96, 0x00000fb0, 0x00000fd4,
-	0x00001007, 0x0000101f, 0x00001037, 0x0000104f,
+	0x00000818, 0x00000870, 0x000008fc, 0x00000935,
+	0x0000098b, 0x000009c9, 0x00000a17, 0x00000a32,
+	0x00000a6c, 0x00000a9f, 0x00000ad9, 0x00000b03,
+	0x00000b2d, 0x00000b6f, 0x00000b93, 0x00000ba0,
+	0x00000c26, 0x00000c78, 0x00000c9f, 0x00000d3b,
+	0x00000dcd, 0x00000e0e, 0x00000e24, 0x00000e8f,
+	0x00000ede, 0x00000ee5, 0x00000f2d, 0x00000f7f,
+	0x00000fd9, 0x00001043, 0x000010d4, 0x000010ec,
 	// Entry 40 - 5F
-	0x00001064, 0x000010bb, 0x000010e6, 0x000010fe,
-	0x00001125, 0x00001148, 0x0000115c, 0x00001171,
-	0x00001178, 0x0000117f, 0x00001185, 0x0000118b,
-	0x000011ac, 0x000011d6, 0x000011fc, 0x00001235,
-	0x0000126d, 0x000012a5, 0x000012c4, 0x00001310,
-	0x000013ce, 0x0000141a, 0x00001468, 0x0000148b,
-	0x000014e7, 0x00001537, 0x0000158c, 0x000015cf,
-	0x0000160e, 0x0000167c, 0x0000168d, 0x0000169b,
+	0x00001106, 0x0000112a, 0x0000115d, 0x00001175,
+	0x0000118d, 0x000011a5, 0x000011ba, 0x00001211,
+	0x0000123c, 0x00001254, 0x0000127b, 0x0000129e,
+	0x000012b2, 0x000012c7, 0x000012ce, 0x000012d5,
+	0x000012db, 0x000012e1, 0x00001302, 0x0000132c,
+	0x00001352, 0x0000138b, 0x000013c3, 0x000013fb,
+	0x0000141a, 0x00001466, 0x00001524, 0x00001570,
+	0x000015be, 0x000015e1, 0x0000163d, 0x0000168d,
 	// Entry 60 - 7F
-	0x000016b3, 0x000016c7, 0x000016e1, 0x0000170b,
-	0x0000176e, 0x000017aa, 0x000017d4, 0x0000180c,
-	0x00001830, 0x00001884, 0x000018bc, 0x00001935,
-	0x000019ef, 0x00001a46, 0x00001a75, 0x00001a9c,
-	0x00001b28,
-} // Size: 476 bytes
+	0x000016e2, 0x00001725, 0x00001764, 0x000017d2,
+	0x000017e3, 0x000017f1, 0x00001809, 0x0000181d,
+	0x00001837, 0x00001861, 0x000018c4, 0x00001900,
+	0x0000192a, 0x00001962, 0x00001986, 0x000019da,
+	0x00001a46, 0x00001a97, 0x00001add, 0x00001b11,
+	0x00001b5b, 0x00001b93, 0x00001bc9, 0x00001bfb,
+	0x00001c32, 0x00001c46, 0x00001c5d, 0x00001c74,
+	0x00001ca3, 0x00001cd7, 0x00001d57, 0x00001d81,
+	// Entry 80 - 9F
+	0x00001da2, 0x00001de7, 0x00001e17, 0x00001e6d,
+	0x00001ea5, 0x00001f1e, 0x00001fd8, 0x0000202f,
+	0x0000205e, 0x00002085, 0x00002111,
+} // Size: 580 bytes
 
-const koData string = "" + // Size: 6952 bytes
+const koData string = "" + // Size: 8465 bytes
 	"\x04\x00\x01 ?\x02화살표 키를 사용하여 이동하세요: ↓ ↑ → ←\x02이 대화형 도구는 새로운 채굴자 액터를 생성" +
 	"하고 그에 대한 기본 구성 레이어를 생성합니다.\x02이 프로세스는 부분적으로 항등원적입니다. 새로운 채굴자 액터가 생성되었고" +
 	" 후속 단계가 실패하는 경우 사용자는 구성을 완료하기 위해 'curio config new-cluster < 채굴자 ID >'를 " +
 	"실행해야 합니다.\x02이 대화형 도구는 5분 안에 lotus-miner를 Curio로 이주합니다.\x02각 단계는 확인이 필" +
 	"요하며 되돌릴 수 있습니다. 언제든지 Ctrl+C를 눌러 종료할 수 있습니다.\x02터미널에서 Ctrl+C가 눌림\x02나는 " +
 	"원한다:\x02기존의 Lotus-Miner에서 이전하기\x02새로운 채굴자 생성\x02나머지 단계를 중단합니다.\x02Lotu" +
-	"s-Miner에서 Curio로 이주.\x02데이터베이스 구성 파일을 어디에 저장해야 하나요?\x02마이그레이션 중단.\x02파일 " +
-	"쓰기 오류: %[1]s\x04\x00\x01 :\x02%[1]s와 함께 웹 인터페이스를 시도해보세요\x02더 많은 서버를 위해" +
-	" /etc/curio.env 파일을 curio.env 데이터베이스 환경으로 만들고 목적을 할당하기 위해 CURIO_LAYERS 환" +
-	"경 변수를 추가하세요.\x02해당하는 경우 이제 시장 노드를 이주할 수 있습니다 (%[1]s).\x02추가 정보는 http:/" +
-	"/docs.curiostorage.org 에 있습니다.\x02새로운 채굴자 초기화 완료.\x02lotus-miner config." +
-	"toml을 Curio의 데이터베이스 구성으로 이전 중입니다.\x02API 가져오기 오류: %[1]s\x02FullNode의 API" +
-	" 정보를 가져올 수 없습니다: %[1]w\x02토큰을 가져오는 중 오류 발생: %[1]s\x02이동할 수 없는 섹터가 발견되었습니" +
-	"다. 계속하시겠습니까?\x02예, 계속\x02아니오, 중단\x02레이어에 구성을 저장하는 중 오류 발생: %[1]s. 마이그레" +
-	"이션 중단\x02Curio 팀은 당신이 사용하는 소프트웨어를 개선하고자 합니다. 팀에게 `%[1]s`를 사용 중이라고 알려주세" +
-	"요.\x02Curio 팀과 공유하고 싶은 것을 선택하세요.\x02개별 데이터: 채굴자 ID, Curio 버전, 체인 (%[1]" +
-	"s 또는 %[2]s). 서명됨.\x02집계-익명: 버전, 체인, 및 채굴자 파워 (버킷).\x02힌트: 나는 어떤 체인에서든 Cu" +
-	"rio를 실행 중인 사람입니다.\x02아무것도 없습니다.\x02마이너 파워를 가져오는 중 오류 발생: %[1]s\x02메시지를 마" +
-	"샬하는 중 오류 발생: %[1]s\x02마이너 정보를 가져오는 중 오류 발생: %[1]s\x02메시지 서명 중 오류 발생: %" +
-	"[1]s\x02메시지 전송 중 오류 발생: %[1]s\x04\x00\x01 =\x02메시지 전송 중 오류 발생: 상태 %[1]s," +
-	" 메시지:\x02메시지가 전송되었습니다.\x04\x00\x01 \x08\x02문서:\x02'%[1]s' 레이어에는 공통 구성이 저" +
-	"장됩니다. 모든 Curio 인스턴스는 %[2]s 인수에 포함시킬 수 있습니다.\x02기계별 구성 변경을 위해 다른 레이어를 추" +
-	"가할 수 있습니다.\x02Filecoin %[1]s 채널: %[2]s 및 %[3]s\x02신뢰성 향상을 위한 중복성 사용: 적" +
-	"어도 post 레이어를 사용하여 여러 대의 기계를 시작하십시오: 'curio run --layers=post'\x02한 개의 " +
-	"데이터베이스는 여러 광부 ID를 제공할 수 있습니다: 각 lotus-miner에 대해 마이그레이션을 실행하세요.\x02Yuga" +
-	"byte에 연결되었습니다. 스키마가 현재입니다.\x02Yugabyte에 연결됨\x02시작하려면 밀봉 파이프라인이 비어 있고 lot" +
-	"us-miner가 종료되었는지 확인하세요.\x02로터스 마이너 구성 디렉토리의 위치를 선택하시겠습니까?\x02기타\x02%[1]s" +
-	"에서 사용하는 구성 디렉터리 경로를 입력하세요.\x04\x00\x01 M\x02경로가 제공되지 않았으므로 마이그레이션을 포기합" +
-	"니다\x02제공된 디렉토리에서 config.toml 파일을 읽을 수 없습니다. 오류: %[1]s\x02디렉토리에서 저장소를 생" +
-	"성할 수 없습니다: %[1]s. 마이그레이션을 중단합니다.\x02광부 저장소를 잠금 해제할 수 없습니다. 귀하의 광부를 중지해" +
-	"야 합니다: %[1]s\x0a 마이그레이션을 중단합니다.\x02마이너 구성 읽기\x04\x00\x01\x0a\x15\x02단계" +
-	" 완료: %[1]s\x02새 채굴자 액터 초기화 중.\x02새 채굴자를 생성하기 위한 정보 입력\x02소유자 지갑: %[1]s" +
-	"\x02작업자 지갑: %[1]s\x02발송자 지갑: %[1]s\x02섹터 크기: %[1]s\x02주소를 확인하고 새 채굴자 액터를" +
-	" 생성하려면 계속 진행하세요.\x04\x00\x01 &\x02채굴자 생성 오류 발생: %[1]s\x02소유자 주소 입력\x02주소" +
-	"가 제공되지 않았습니다\x02주소 구문 분석 실패: %[1]s\x02%[1]s 주소 입력\x02섹터 크기 선택\x0264 Gi" +
-	"B\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1c\x02섹터 선택 실패: %[1]s\x02섹터 " +
-	"크기 구문 분석 실패: %[1]s\x02채굴자 액터 생성 실패: %[1]s\x02%[1]s 채굴자가 성공적으로 생성되었습니다" +
-	"\x02데이터베이스에 연결할 수 없습니다: %[1]s\x02풀 노드 API에 연결하는 중 오류 발생: %[1]s\x02사전 초기화" +
-	" 단계 완료\x02비밀번호를 위한 랜덤 바이트 생성에 실패했습니다: %[1]s\x02마이너 생성은 idempotent하지 않으므로" +
-	" 가이드 설정을 다시 실행하지 마십시오. 구성을 완료하려면 'curio config new-cluster %[1]s'를 실행해야 " +
-	"합니다.\x02FullNode에 대한 API 정보를 가져오는 데 실패했습니다: %[1]w\x02데몬 노드로부터 인증 토큰을 확" +
-	"인하는 중 오류 발생: %[1]s\x02기본 구성 생성 실패: %[1]s\x02데이터베이스에 'base' 구성 레이어를 삽입하" +
-	"는 데 실패했습니다: %[1]s\x02이 마이너 주소를 포함한 구성 'base'가 업데이트되었습니다.\x02데이터베이스에서 기" +
-	"본 구성을 로드하는 데 실패했습니다: %[1]s\x02기본 구성을 구문 분석하는 데 실패했습니다: %[1]s\x02기본 구성을" +
-	" 재생성하는 데 실패했습니다: %[1]s\x02Yugabyte 데이터베이스 설치에 연결할 정보를 입력하십시오 (https://do" +
-	"wnload.yugabyte.com/)\x02호스트: %[1]s\x02포트: %[1]s\x02사용자 이름: %[1]s\x02비밀번" +
-	"호: %[1]s\x02데이터베이스: %[1]s\x02계속 연결 및 스키마 업데이트.\x04\x00\x01 ^\x02데이터베이스" +
-	" 구성 오류가 발생하여 마이그레이션을 포기합니다: %[1]s\x02Yugabyte 데이터베이스 호스트를 입력하십시오\x02호스트가" +
-	" 제공되지 않았습니다\x02Yugabyte 데이터베이스 %[1]s을 입력하십시오\x02값이 제공되지 않았습니다\x02Yugabyt" +
-	"e 데이터베이스에 연결하는 중 오류가 발생했습니다: %[1]s\x02%[1]d 섹터의 메타데이터를 이동 중입니다.\x02기본 설정" +
-	" 'base'가 이 마이너의 주소(%[1]s) 및 지갑 설정을 포함하도록 업데이트되었습니다.\x02구성 %[1]s를 %[2]s과 " +
-	"비교하세요. 지갑 주소 이외의 마이너 ID 사이의 변경 사항은 필요한 실행자를 위한 새로운 최소한의 레이어여야 합니다.\x02" +
-	"'base' 설정이 이 lotus-miner의 config.toml과 유사하게 만들어졌습니다.\x04\x00\x01 *\x02레이" +
-	"어 %[1]s가 생성되었습니다.\x04\x00\x01 \x22\x02구성 파일을 사용하려면:\x02Curio를 실행하려면: 기" +
-	"계 또는 cgroup 격리를 사용하여 다음 명령을 사용하세요 (예제 레이어 선택과 함께):"
+	"s-Miner에서 Curio로 이주.\x02셸 %[1]s이 BASH 또는 ZSH가 아니므로 RC 파일에 DB 변수를 추가하지 않습" +
+	"니다.\x02사용자 홈 디렉토리를 가져오는 중 오류 발생:\x02%[1]s 파일을 여는 중 오류 발생: %[2]s\x02%[1" +
+	"]s 파일을 읽는 중 오류 발생: %[2]s\x02%[1]s 파일을 쓰기 모드로 여는 중 오류 발생:\x02%[1]s 파일에 쓰는" +
+	" 중 오류 발생: %[2]s\x02%[1]s 파일에 쓰기 내용을 플러시하는 데 실패했습니다: %[2]s\x02다시 시도 중...." +
+	"...(%[1]d/5)\x04\x00\x01 :\x02%[1]s와 함께 웹 인터페이스를 시도해보세요\x02이 노드에서 Curio " +
+	"서비스를 설정하려면 'curio service-setup'을 실행하고 다른 노드에서도 동일하게 진행하십시오.\x02해당하는 경" +
+	"우 이제 시장 노드를 이주할 수 있습니다 (%[1]s).\x02추가 정보는 http://docs.curiostorage.org" +
+	" 에 있습니다.\x02새로운 채굴자 초기화 완료.\x02lotus-miner config.toml을 Curio의 데이터베이스 구성" +
+	"으로 이전 중입니다.\x02API 가져오기 오류: %[1]s\x02FullNode의 API 정보를 가져올 수 없습니다: %[1" +
+	"]w\x02토큰을 가져오는 중 오류 발생: %[1]s\x02이동할 수 없는 섹터가 발견되었습니다. 계속하시겠습니까?\x02예, 계" +
+	"속\x02아니오, 중단\x02마이그레이션 중단.\x02레이어에 구성을 저장하는 중 오류 발생: %[1]s. 마이그레이션 중단" +
+	"\x02Curio 팀은 당신이 사용하는 소프트웨어를 개선하고자 합니다. 팀에게 `%[1]s`를 사용 중이라고 알려주세요.\x02C" +
+	"urio 팀과 공유하고 싶은 것을 선택하세요.\x02개별 데이터: 채굴자 ID, Curio 버전, 체인 (%[1]s 또는 %[2]" +
+	"s). 서명됨.\x02집계-익명: 버전, 체인, 및 채굴자 파워 (버킷).\x02힌트: 나는 어떤 체인에서든 Curio를 실행 중" +
+	"인 사람입니다.\x02아무것도 없습니다.\x02마이너 파워를 가져오는 중 오류 발생: %[1]s\x02메시지를 마샬하는 중 오" +
+	"류 발생: %[1]s\x02마이너 정보를 가져오는 중 오류 발생: %[1]s\x02메시지 서명 중 오류 발생: %[1]s" +
+	"\x02메시지 전송 중 오류 발생: %[1]s\x04\x00\x01 =\x02메시지 전송 중 오류 발생: 상태 %[1]s, 메시지" +
+	":\x02메시지가 전송되었습니다.\x04\x00\x01 \x08\x02문서:\x02'%[1]s' 레이어에는 공통 구성이 저장됩니다" +
+	". 모든 Curio 인스턴스는 %[2]s 인수에 포함시킬 수 있습니다.\x02기계별 구성 변경을 위해 다른 레이어를 추가할 수 있" +
+	"습니다.\x02Filecoin %[1]s 채널: %[2]s 및 %[3]s\x02신뢰성 향상을 위한 중복성 사용: 적어도 pos" +
+	"t 레이어를 사용하여 여러 대의 기계를 시작하십시오: 'curio run --layers=post'\x02한 개의 데이터베이스는 " +
+	"여러 광부 ID를 제공할 수 있습니다: 각 lotus-miner에 대해 마이그레이션을 실행하세요.\x02Yugabyte에 연결" +
+	"되었습니다. 스키마가 현재입니다.\x02Yugabyte에 연결됨\x02시작하려면 밀봉 파이프라인이 비어 있고 lotus-min" +
+	"er가 종료되었는지 확인하세요.\x02로터스 마이너 구성 디렉토리의 위치를 선택하시겠습니까?\x02기타\x02%[1]s에서 사용하" +
+	"는 구성 디렉터리 경로를 입력하세요.\x04\x00\x01 M\x02경로가 제공되지 않았으므로 마이그레이션을 포기합니다\x02" +
+	"제공된 디렉토리에서 config.toml 파일을 읽을 수 없습니다. 오류: %[1]s\x02디렉토리에서 저장소를 생성할 수 없" +
+	"습니다: %[1]s. 마이그레이션을 중단합니다.\x02광부 저장소를 잠금 해제할 수 없습니다. 귀하의 광부를 중지해야 합니다:" +
+	" %[1]s\x0a 마이그레이션을 중단합니다.\x02마이너 구성 읽기\x04\x00\x01\x0a\x15\x02단계 완료: %[1" +
+	"]s\x02새 채굴자 액터 초기화 중.\x02새 채굴자를 생성하기 위한 정보 입력\x02소유자 지갑: %[1]s\x02작업자 지갑" +
+	": %[1]s\x02발송자 지갑: %[1]s\x02섹터 크기: %[1]s\x02주소를 확인하고 새 채굴자 액터를 생성하려면 계속 " +
+	"진행하세요.\x04\x00\x01 &\x02채굴자 생성 오류 발생: %[1]s\x02소유자 주소 입력\x02주소가 제공되지 않" +
+	"았습니다\x02주소 구문 분석 실패: %[1]s\x02%[1]s 주소 입력\x02섹터 크기 선택\x0264 GiB\x0232 " +
+	"GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1c\x02섹터 선택 실패: %[1]s\x02섹터 크기 구문 분석" +
+	" 실패: %[1]s\x02채굴자 액터 생성 실패: %[1]s\x02%[1]s 채굴자가 성공적으로 생성되었습니다\x02데이터베이스에" +
+	" 연결할 수 없습니다: %[1]s\x02풀 노드 API에 연결하는 중 오류 발생: %[1]s\x02사전 초기화 단계 완료\x02비" +
+	"밀번호를 위한 랜덤 바이트 생성에 실패했습니다: %[1]s\x02마이너 생성은 idempotent하지 않으므로 가이드 설정을 " +
+	"다시 실행하지 마십시오. 구성을 완료하려면 'curio config new-cluster %[1]s'를 실행해야 합니다." +
+	"\x02FullNode에 대한 API 정보를 가져오는 데 실패했습니다: %[1]w\x02데몬 노드로부터 인증 토큰을 확인하는 중 " +
+	"오류 발생: %[1]s\x02기본 구성 생성 실패: %[1]s\x02데이터베이스에 'base' 구성 레이어를 삽입하는 데 실패" +
+	"했습니다: %[1]s\x02이 마이너 주소를 포함한 구성 'base'가 업데이트되었습니다.\x02데이터베이스에서 기본 구성을 " +
+	"로드하는 데 실패했습니다: %[1]s\x02기본 구성을 구문 분석하는 데 실패했습니다: %[1]s\x02기본 구성을 재생성하는" +
+	" 데 실패했습니다: %[1]s\x02Yugabyte 데이터베이스 설치에 연결할 정보를 입력하십시오 (https://download" +
+	".yugabyte.com/)\x02호스트: %[1]s\x02포트: %[1]s\x02사용자 이름: %[1]s\x02비밀번호: %[1" +
+	"]s\x02데이터베이스: %[1]s\x02계속 연결 및 스키마 업데이트.\x04\x00\x01 ^\x02데이터베이스 구성 오류가 " +
+	"발생하여 마이그레이션을 포기합니다: %[1]s\x02Yugabyte 데이터베이스 호스트를 입력하십시오\x02호스트가 제공되지 " +
+	"않았습니다\x02Yugabyte 데이터베이스 %[1]s을 입력하십시오\x02값이 제공되지 않았습니다\x02Yugabyte 데이" +
+	"터베이스에 연결하는 중 오류가 발생했습니다: %[1]s\x02이 대화형 도구는 Curio 서비스 파일을 생성/교체하고 기본 e" +
+	"nv 파일을 생성합니다.\x02서비스 파일 %[1]s이 %[2]s에 이미 존재합니다. 변경 사항 없음.\x02%[1]s에서 서비스" +
+	" 파일을 확인하는 중 오류 발생: %[2]s\x02서비스 파일을 쓰는 중 오류 발생: %[1]s\x02서비스 파일 %[1]s이 %" +
+	"[2]s에 성공적으로 생성되었습니다.\x02systemd를 다시 로드하는 중 오류 발생: %[1]s\x02서비스를 활성화하는 중 " +
+	"오류 발생: %[1]s\x04\x00\x01\x0a-\x02서비스 %[1]s이 활성화되었습니다.\x02Curio 노드를 구성할" +
+	" 정보를 입력하십시오\x02CURIO_LAYERS: %[1]s\x02CURIO_REPO_PATH: %[1]s\x02CURIO_NO" +
+	"DE_NAME: %[1]s\x02env 파일 업데이트를 계속하십시오.\x04\x00\x01 /\x02환경 설정 오류 발생, 중단 " +
+	"중: %[1]s\x02이 노드에 사용할 구성 레이어 이름을 입력하십시오. 기본값으로 Base가 이미 포함되어 있습니다\x02레" +
+	"이어가 제공되지 않았습니다\x02%[1]s을(를) 입력하십시오\x02파일 %[1]s을(를) 열거나 생성하는 중 오류 발생: %" +
+	"[2]s\x02파일 %[1]s에 쓰는 중 오류 발생: %[2]s\x02서비스 환경 파일 /etc/curio.env이(가) 성공적으" +
+	"로 생성되었습니다.\x02%[1]d 섹터의 메타데이터를 이동 중입니다.\x02기본 설정 'base'가 이 마이너의 주소(%[1" +
+	"]s) 및 지갑 설정을 포함하도록 업데이트되었습니다.\x02구성 %[1]s를 %[2]s과 비교하세요. 지갑 주소 이외의 마이너 I" +
+	"D 사이의 변경 사항은 필요한 실행자를 위한 새로운 최소한의 레이어여야 합니다.\x02'base' 설정이 이 lotus-miner" +
+	"의 config.toml과 유사하게 만들어졌습니다.\x04\x00\x01 *\x02레이어 %[1]s가 생성되었습니다.\x04" +
+	"\x00\x01 \x22\x02구성 파일을 사용하려면:\x02Curio를 실행하려면: 기계 또는 cgroup 격리를 사용하여 다음" +
+	" 명령을 사용하세요 (예제 레이어 선택과 함께):"
 
-var zhIndex = []uint32{ // 113 elements
+var zhIndex = []uint32{ // 139 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000033, 0x0000008b, 0x00000134,
 	0x0000017c, 0x000001cb, 0x000001e4, 0x000001f1,
 	0x00000211, 0x0000022a, 0x00000240, 0x0000025d,
-	0x0000029a, 0x000002aa, 0x000002c4, 0x000002ea,
-	0x00000371, 0x000003b2, 0x000003e5, 0x00000401,
-	0x00000446, 0x00000463, 0x0000048c, 0x000004aa,
-	0x000004de, 0x000004ee, 0x000004fb, 0x00000534,
-	0x00000588, 0x000005b5, 0x00000604, 0x0000063f,
+	0x000002bb, 0x000002db, 0x000002ff, 0x00000323,
+	0x00000350, 0x00000374, 0x000003a6, 0x000003c0,
+	0x000003e6, 0x00000453, 0x00000494, 0x000004c7,
+	0x000004e3, 0x00000528, 0x00000545, 0x0000056e,
+	0x0000058c, 0x000005c0, 0x000005d0, 0x000005dd,
 	// Entry 20 - 3F
-	0x00000674, 0x0000067e, 0x000006a2, 0x000006c0,
-	0x000006e4, 0x00000702, 0x00000720, 0x00000755,
-	0x00000768, 0x00000777, 0x000007d1, 0x0000080e,
-	0x00000836, 0x00000895, 0x000008e5, 0x00000912,
-	0x00000927, 0x00000972, 0x000009a2, 0x000009a9,
-	0x000009d3, 0x000009f7, 0x00000a3b, 0x00000a6d,
-	0x00000ab6, 0x00000ac9, 0x00000ae3, 0x00000b02,
-	0x00000b27, 0x00000b3e, 0x00000b52, 0x00000b69,
+	0x000005ed, 0x00000626, 0x0000067a, 0x000006a7,
+	0x000006f6, 0x00000731, 0x00000766, 0x00000770,
+	0x00000794, 0x000007b2, 0x000007d6, 0x000007f4,
+	0x00000812, 0x00000847, 0x0000085a, 0x00000869,
+	0x000008c3, 0x00000900, 0x00000928, 0x00000987,
+	0x000009d7, 0x00000a04, 0x00000a19, 0x00000a64,
+	0x00000a94, 0x00000a9b, 0x00000ac5, 0x00000ae9,
+	0x00000b2d, 0x00000b5f, 0x00000ba8, 0x00000bbb,
 	// Entry 40 - 5F
-	0x00000b7d, 0x00000bae, 0x00000bd3, 0x00000be9,
-	0x00000bf9, 0x00000c13, 0x00000c27, 0x00000c3a,
-	0x00000c41, 0x00000c48, 0x00000c4e, 0x00000c54,
-	0x00000c73, 0x00000c93, 0x00000cb3, 0x00000ccd,
-	0x00000cea, 0x00000d1b, 0x00000d34, 0x00000d5d,
-	0x00000dea, 0x00000e16, 0x00000e51, 0x00000e71,
-	0x00000ea2, 0x00000ed5, 0x00000f02, 0x00000f23,
-	0x00000f49, 0x00000fa3, 0x00000fb2, 0x00000fc1,
+	0x00000bd5, 0x00000bf4, 0x00000c19, 0x00000c30,
+	0x00000c44, 0x00000c5b, 0x00000c6f, 0x00000ca0,
+	0x00000cc5, 0x00000cdb, 0x00000ceb, 0x00000d05,
+	0x00000d19, 0x00000d2c, 0x00000d33, 0x00000d3a,
+	0x00000d40, 0x00000d46, 0x00000d65, 0x00000d85,
+	0x00000da5, 0x00000dbf, 0x00000ddc, 0x00000e0d,
+	0x00000e26, 0x00000e4f, 0x00000edc, 0x00000f08,
+	0x00000f43, 0x00000f63, 0x00000f94, 0x00000fc7,
 	// Entry 60 - 7F
-	0x00000fd3, 0x00000fe2, 0x00000ff4, 0x00001013,
-	0x0000104b, 0x00001070, 0x00001080, 0x0000109e,
-	0x000010ab, 0x000010d7, 0x00001101, 0x00001152,
-	0x000011d4, 0x0000121b, 0x00001235, 0x0000124d,
-	0x000012a4,
-} // Size: 476 bytes
+	0x00000ff4, 0x00001015, 0x0000103b, 0x00001095,
+	0x000010a4, 0x000010b3, 0x000010c5, 0x000010d4,
+	0x000010e6, 0x00001105, 0x0000113d, 0x00001162,
+	0x00001172, 0x00001190, 0x0000119d, 0x000011c9,
+	0x00001222, 0x00001260, 0x0000128d, 0x000012b0,
+	0x000012dc, 0x00001302, 0x0000131f, 0x0000133e,
+	0x00001367, 0x0000137b, 0x00001392, 0x000013a9,
+	0x000013c4, 0x000013f5, 0x00001440, 0x0000144d,
+	// Entry 80 - 9F
+	0x0000145a, 0x00001487, 0x000014ab, 0x000014e0,
+	0x0000150a, 0x0000155b, 0x000015dd, 0x00001624,
+	0x0000163e, 0x00001656, 0x000016ad,
+} // Size: 580 bytes
 
-const zhData string = "" + // Size: 4772 bytes
+const zhData string = "" + // Size: 5805 bytes
 	"\x04\x00\x01 .\x02使用箭头键进行导航：↓ ↑ → ←\x02此交互式工具将创建一个新的矿工角色，并为其创建基本配置层。\x02" +
 	"该过程部分幂等。一旦创建了新的矿工角色，并且随后的步骤失败，用户需要运行 'curio config new-cluster < 矿工 ID" +
 	" >' 来完成配置。\x02这个交互式工具可以在5分钟内将lotus-miner迁移到Curio。\x02每一步都需要您的确认，并且可以撤销。随" +
 	"时按Ctrl+C退出。\x02在终端中按下Ctrl+C\x02我想要：\x02从现有的 Lotus-Miner 迁移\x02创建一个新的矿工" +
-	"\x02中止剩余步骤。\x02Lotus-Miner到Curio迁移。\x02我们应该把你的数据库配置文件保存在哪里？\x02中止迁移。\x02" +
-	"写入文件错误: %[1]s\x04\x00\x01 !\x02尝试使用%[1]s的网页界面\x02对于更多服务器，请使用 curio.env" +
-	" 数据库环境创建 /etc/curio.env 并添加 CURIO_LAYERS 环境变量以分配用途。\x02如果适用，您现在可以迁移您的市场节" +
-	"点(%[1]s)。\x02更多信息请访问 http://docs.curiostorage.org\x02新矿工初始化完成。\x02将 lo" +
-	"tus-miner config.toml 迁移到 Curio 的数据库配置中。\x02获取 API 时出错：%[1]s\x02无法获取Full" +
-	"Node的API信息：%[1]w\x02获取令牌时出错：%[1]s\x02发现无法迁移的扇区。您想要继续吗？\x02是的，继续\x02不，中止" +
-	"\x02保存配置到层时出错：%[1]s。正在中止迁移\x02Curio 团队希望改进您使用的软件。告诉团队您正在使用 `%[1]s`。\x02选" +
-	"择您想与Curio团队分享的内容。\x02个人数据：矿工 ID，Curio 版本，链（%[1]s 或 %[2]s）。签名。\x02聚合-匿名" +
-	"：版本，链和矿工算力（分桶）。\x02提示：我是在任何链上运行 Curio 的人。\x02没有。\x02获取矿工功率时出错：%[1]s" +
-	"\x02整理消息时出错：%[1]s\x02获取矿工信息时出错：%[1]s\x02签署消息时出错：%[1]s\x02发送消息时出错：%[1]s" +
-	"\x04\x00\x01 0\x02发送消息时出错：状态%[1]s，消息：\x02消息已发送。\x04\x00\x01 \x0a\x02文档：" +
-	"\x02'%[1]s'层存储通用配置。所有Curio实例都可以在其%[2]s参数中包含它。\x02您可以添加其他层进行每台机器的配置更改。" +
-	"\x02Filecoin %[1]s 频道：%[2]s 和 %[3]s\x02通过冗余增加可靠性：使用至少后层启动多台机器：'curio run" +
-	" --layers=post'\x02一个数据库可以服务多个矿工ID：为每个lotus-miner运行迁移。\x02已连接到Yugabyte。模" +
-	"式是当前的。\x02已连接到Yugabyte\x02开始之前，请确保您的密封管道已排空并关闭lotus-miner。\x02选择您的lotu" +
-	"s-miner配置目录的位置？\x02其他\x02输入%[1]s使用的配置目录的路径\x04\x00\x01 \x1f\x02未提供路径，放弃迁" +
-	"移\x02无法读取提供的目录中的config.toml文件，错误：%[1]s\x02无法从目录创建repo：%[1]s。 中止迁移\x02无" +
-	"法锁定矿工repo。 您的矿工必须停止：%[1]s\x0a 中止迁移\x02读取矿工配置\x04\x00\x01\x0a\x15\x02步骤" +
-	"完成：%[1]s\x02初始化新的矿工角色。\x02输入创建新矿工所需的信息\x02所有者钱包: %[1]s\x02工人钱包: %[1]s" +
-	"\x02发送者钱包: %[1]s\x02扇区大小: %[1]s\x02继续验证地址并创建新的矿工角色。\x04\x00\x01  \x02矿工创" +
-	"建错误发生: %[1]s\x02输入所有者地址\x02未提供地址\x02解析地址失败: %[1]s\x02输入 %[1]s 地址\x02选择" +
-	"扇区大小\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1a\x02扇区选择失败:" +
-	" %[1]s\x02解析扇区大小失败: %[1]s\x02创建矿工角色失败: %[1]s\x02矿工 %[1]s 创建成功\x02无法访问数据库" +
-	": %[1]s\x02连接到完整节点 API 时发生错误: %[1]s\x02预初始化步骤完成\x02生成密码的随机字节失败: %[1]s" +
-	"\x02请不要再次运行引导设置，因为矿工创建不是幂等的。 您需要运行 'curio config new-cluster %[1]s' 来完成配" +
-	"置。\x02无法获取 FullNode 的 API 信息: %[1]w\x02无法验证来自守护进程节点的授权令牌: %[1]s\x02无法生" +
-	"成默认配置: %[1]s\x02无法将 'base' 配置层插入数据库: %[1]s\x02配置 'base' 已更新以包含此矿工的地址" +
-	"\x02从数据库加载基本配置失败：%[1]s\x02解析基本配置失败：%[1]s\x02重新生成基本配置失败: %[1]s\x02输入连接到您的" +
-	"Yugabyte数据库安装的信息（https://download.yugabyte.com/）\x02主机：%[1]s\x02端口：%[1]s" +
-	"\x02用户名：%[1]s\x02密码：%[1]s\x02数据库：%[1]s\x02继续连接和更新架构。\x04\x00\x01 3\x02发生" +
-	"数据库配置错误，放弃迁移：%[1]s\x02输入Yugabyte数据库主机（S）\x02未提供主机\x02输入Yugabyte数据库 %[1" +
-	"]s\x02未提供值\x02连接到Yugabyte数据库时出错：%[1]s\x02正在迁移%[1]d个扇区的元数据。\x02'base'配置已更" +
-	"新，包括该矿工的地址（%[1]s）及其钱包设置。\x02比较配置%[1]s和%[2]s。矿工ID之间除了钱包地址的变化应该是需要的运行者的一" +
-	"个新的、最小的层。\x02'base'配置已创建，以类似于这个lotus-miner的config.toml。\x04\x00\x01 " +
-	"\x15\x02层%[1]s已创建。\x04\x00\x01 \x13\x02要使用配置：\x02运行Curio：使用机器或cgroup隔离，使" +
-	"用命令（附带示例层选择）："
+	"\x02中止剩余步骤。\x02Lotus-Miner到Curio迁移。\x02由于 shell %[1]s 不是 BASH 或 ZSH，因此未将" +
+	"数据库变量添加到 RC 文件中。\x02获取用户主目录时出错:\x02打开文件 %[1]s 时出错: %[2]s\x02读取文件 %[1]s" +
+	" 时出错: %[2]s\x02以写入模式打开文件 %[1]s 时出错:\x02写入文件 %[1]s 时出错: %[2]s\x02无法将写入内容刷" +
+	"新到文件 %[1]s: %[2]s\x02重试中.......(%[1]d/5)\x04\x00\x01 !\x02尝试使用%[1]s的网页" +
+	"界面\x02执行 'curio service-setup' 以在此节点上设置 Curio 服务，并在其他节点上执行相同操作\x02如果适用" +
+	"，您现在可以迁移您的市场节点(%[1]s)。\x02更多信息请访问 http://docs.curiostorage.org\x02新矿工初" +
+	"始化完成。\x02将 lotus-miner config.toml 迁移到 Curio 的数据库配置中。\x02获取 API 时出错：%[" +
+	"1]s\x02无法获取FullNode的API信息：%[1]w\x02获取令牌时出错：%[1]s\x02发现无法迁移的扇区。您想要继续吗？" +
+	"\x02是的，继续\x02不，中止\x02中止迁移。\x02保存配置到层时出错：%[1]s。正在中止迁移\x02Curio 团队希望改进您使用的" +
+	"软件。告诉团队您正在使用 `%[1]s`。\x02选择您想与Curio团队分享的内容。\x02个人数据：矿工 ID，Curio 版本，链（%" +
+	"[1]s 或 %[2]s）。签名。\x02聚合-匿名：版本，链和矿工算力（分桶）。\x02提示：我是在任何链上运行 Curio 的人。\x02没" +
+	"有。\x02获取矿工功率时出错：%[1]s\x02整理消息时出错：%[1]s\x02获取矿工信息时出错：%[1]s\x02签署消息时出错：%" +
+	"[1]s\x02发送消息时出错：%[1]s\x04\x00\x01 0\x02发送消息时出错：状态%[1]s，消息：\x02消息已发送。\x04" +
+	"\x00\x01 \x0a\x02文档：\x02'%[1]s'层存储通用配置。所有Curio实例都可以在其%[2]s参数中包含它。\x02您可以" +
+	"添加其他层进行每台机器的配置更改。\x02Filecoin %[1]s 频道：%[2]s 和 %[3]s\x02通过冗余增加可靠性：使用至少" +
+	"后层启动多台机器：'curio run --layers=post'\x02一个数据库可以服务多个矿工ID：为每个lotus-miner运行" +
+	"迁移。\x02已连接到Yugabyte。模式是当前的。\x02已连接到Yugabyte\x02开始之前，请确保您的密封管道已排空并关闭lot" +
+	"us-miner。\x02选择您的lotus-miner配置目录的位置？\x02其他\x02输入%[1]s使用的配置目录的路径\x04\x00" +
+	"\x01 \x1f\x02未提供路径，放弃迁移\x02无法读取提供的目录中的config.toml文件，错误：%[1]s\x02无法从目录创建r" +
+	"epo：%[1]s。 中止迁移\x02无法锁定矿工repo。 您的矿工必须停止：%[1]s\x0a 中止迁移\x02读取矿工配置\x04\x00" +
+	"\x01\x0a\x15\x02步骤完成：%[1]s\x02初始化新的矿工角色。\x02输入创建新矿工所需的信息\x02所有者钱包: %[1]s" +
+	"\x02工人钱包: %[1]s\x02发送者钱包: %[1]s\x02扇区大小: %[1]s\x02继续验证地址并创建新的矿工角色。\x04" +
+	"\x00\x01  \x02矿工创建错误发生: %[1]s\x02输入所有者地址\x02未提供地址\x02解析地址失败: %[1]s\x02输入" +
+	" %[1]s 地址\x02选择扇区大小\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 " +
+	"\x1a\x02扇区选择失败: %[1]s\x02解析扇区大小失败: %[1]s\x02创建矿工角色失败: %[1]s\x02矿工 %[1]s " +
+	"创建成功\x02无法访问数据库: %[1]s\x02连接到完整节点 API 时发生错误: %[1]s\x02预初始化步骤完成\x02生成密码" +
+	"的随机字节失败: %[1]s\x02请不要再次运行引导设置，因为矿工创建不是幂等的。 您需要运行 'curio config new-clu" +
+	"ster %[1]s' 来完成配置。\x02无法获取 FullNode 的 API 信息: %[1]w\x02无法验证来自守护进程节点的授权令牌" +
+	": %[1]s\x02无法生成默认配置: %[1]s\x02无法将 'base' 配置层插入数据库: %[1]s\x02配置 'base' 已更" +
+	"新以包含此矿工的地址\x02从数据库加载基本配置失败：%[1]s\x02解析基本配置失败：%[1]s\x02重新生成基本配置失败: %[1]" +
+	"s\x02输入连接到您的Yugabyte数据库安装的信息（https://download.yugabyte.com/）\x02主机：%[1]s" +
+	"\x02端口：%[1]s\x02用户名：%[1]s\x02密码：%[1]s\x02数据库：%[1]s\x02继续连接和更新架构。\x04\x00" +
+	"\x01 3\x02发生数据库配置错误，放弃迁移：%[1]s\x02输入Yugabyte数据库主机（S）\x02未提供主机\x02输入Yugab" +
+	"yte数据库 %[1]s\x02未提供值\x02连接到Yugabyte数据库时出错：%[1]s\x02此交互式工具创建/替换 Curio 服务文" +
+	"件并为其创建基本的 env 文件。\x02服务文件 %[1]s 已存在于 %[2]s，未做任何更改。\x02检查 %[1]s 的服务文件时出" +
+	"错: %[2]s\x02写入服务文件时出错: %[1]s\x02服务文件 %[1]s 已成功创建于 %[2]s\x02重新加载 system" +
+	"d 时出错: %[1]s\x02启用服务时出错: %[1]s\x04\x00\x01\x0a\x1a\x02服务 %[1]s 已启用。\x02输" +
+	"入信息以配置您的 Curio 节点\x02CURIO_LAYERS: %[1]s\x02CURIO_REPO_PATH: %[1]s\x02" +
+	"CURIO_NODE_NAME: %[1]s\x02继续更新 env 文件。\x04\x00\x01 ,\x02发生环境配置错误，放弃中: %[" +
+	"1]s\x02输入此节点要使用的配置层名称。默认情况下已包含 Base\x02未提供层\x02输入 %[1]s\x02打开或创建文件 %[1]s" +
+	" 时出错: %[2]s\x02写入文件 %[1]s 时出错: %[2]s\x02服务环境文件 /etc/curio.env 已成功创建。\x02" +
+	"正在迁移%[1]d个扇区的元数据。\x02'base'配置已更新，包括该矿工的地址（%[1]s）及其钱包设置。\x02比较配置%[1]s和%" +
+	"[2]s。矿工ID之间除了钱包地址的变化应该是需要的运行者的一个新的、最小的层。\x02'base'配置已创建，以类似于这个lotus-mine" +
+	"r的config.toml。\x04\x00\x01 \x15\x02层%[1]s已创建。\x04\x00\x01 \x13\x02要使用配置：" +
+	"\x02运行Curio：使用机器或cgroup隔离，使用命令（附带示例层选择）："
 
-	// Total table size 18242 bytes (17KiB); checksum: 1CC76A35
+	// Total table size 22160 bytes (21KiB); checksum: 7C0037F2

--- a/cmd/curio/internal/translations/catalog.go
+++ b/cmd/curio/internal/translations/catalog.go
@@ -40,190 +40,203 @@ func init() {
 }
 
 var messageKeyToIndex = map[string]int{
-	"2 KiB":                     80,
-	"32 GiB":                    78,
-	"64 GiB":                    77,
-	"8 MiB":                     79,
-	"Aborting migration.":       31,
+	"2 KiB":                     84,
+	"32 GiB":                    82,
+	"64 GiB":                    81,
+	"8 MiB":                     83,
+	"Aborting migration.":       35,
 	"Aborting remaining steps.": 9,
-	"Additional info is at http://docs.curiostorage.org":               22,
-	"Aggregate-Anonymous: version, chain, and Miner power (bucketed).": 36,
-	"CURIO_LAYERS: %s":        120,
-	"CURIO_NODE_NAME: %s":     122,
-	"CURIO_REPO_PATH: %s":     121,
-	"Cannot reach the DB: %s": 85,
-	"Cannot read the config.toml file in the provided directory, Error: %s":                                                                                  59,
-	"Compare the configurations %s to %s. Changes between the miner IDs other than wallet addreses should be a new, minimal layer for runners that need it.": 133,
-	"Configuration 'base' was created to resemble this lotus-miner's config.toml .":                                                                          134,
-	"Configuration 'base' was updated to include this miner's address":                                                                                       94,
-	"Configuration 'base' was updated to include this miner's address (%s) and its wallet setup.":                                                            132,
-	"Connected to Yugabyte":                                                          53,
-	"Connected to Yugabyte. Schema is current.":                                      52,
-	"Continue to connect and update schema.":                                         104,
-	"Continue to verify the addresses and create a new miner actor.":                 70,
-	"Continue update the env file.":                                                  123,
-	"Could not create repo from directory: %s. Aborting migration":                   60,
-	"Could not lock miner repo. Your miner must be stopped: %s\n Aborting migration": 61,
+	"Add additional variables like FIL_PROOFS_PARAMETER_CACHE.":        127,
+	"Additional info is at http://docs.curiostorage.org":               26,
+	"Aggregate-Anonymous: version, chain, and Miner power (bucketed).": 40,
+	"CURIO_LAYERS: %s":        124,
+	"CURIO_NODE_NAME: %s":     126,
+	"CURIO_REPO_PATH: %s":     125,
+	"Cannot reach the DB: %s": 89,
+	"Cannot read the config.toml file in the provided directory, Error: %s":                                                                                  63,
+	"Compare the configurations %s to %s. Changes between the miner IDs other than wallet addreses should be a new, minimal layer for runners that need it.": 143,
+	"Configuration 'base' was created to resemble this lotus-miner's config.toml .":                                                                          144,
+	"Configuration 'base' was updated to include this miner's address":                                                                                       98,
+	"Configuration 'base' was updated to include this miner's address (%s) and its wallet setup.":                                                            142,
+	"Connected to Yugabyte":                                                          57,
+	"Connected to Yugabyte. Schema is current.":                                      56,
+	"Continue to connect and update schema.":                                         108,
+	"Continue to verify the addresses and create a new miner actor.":                 74,
+	"Continue update the env file.":                                                  128,
+	"Could not create repo from directory: %s. Aborting migration":                   64,
+	"Could not lock miner repo. Your miner must be stopped: %s\n Aborting migration": 65,
 	"Create a new miner":                                                             8,
 	"Ctrl+C pressed in Terminal":                                                     5,
-	"Database config error occurred, abandoning migration: %s ":                      105,
-	"Database: %s":    103,
-	"Documentation: ": 46,
+	"Database config error occurred, abandoning migration: %s ":                      109,
+	"Database: %s": 107,
+	"Do you want to add additional variables like FIL_PROOFS_PARAMETER_CACHE? (y/n)": 133,
+	"Do you wish to add Harmony DB credentials to your ~/.bashrc or ~/.zshrc file?":  11,
+	"Documentation: ": 50,
 	"Each step needs your confirmation and can be reversed. Press Ctrl+C to exit at any time.": 4,
-	"Enter %s address":                    75,
-	"Enter the %s":                        127,
-	"Enter the Yugabyte database %s":      108,
-	"Enter the Yugabyte database host(s)": 106,
-	"Enter the config layer name to use for this node. Base is already included by default":             125,
-	"Enter the info to configure your Curio node":                                                       119,
-	"Enter the info to connect to your Yugabyte database installation (https://download.yugabyte.com/)": 98,
-	"Enter the info to create a new miner":                                                              65,
-	"Enter the owner address":                                                                           72,
-	"Enter the path to the configuration directory used by %s":                                          57,
-	"Env config error occurred, abandoning: %s ":                                                        124,
-	"Error checking for service file at %s: %s":                                                         113,
-	"Error connecting to Yugabyte database: %s":                                                         110,
-	"Error connecting to full node API: %s":                                                             86,
-	"Error enabling service: %s":                                                                        117,
-	"Error getting API: %s":                                                                             25,
-	"Error getting miner info: %s":                                                                      41,
-	"Error getting miner power: %s":                                                                     39,
-	"Error getting token: %s":                                                                           27,
-	"Error getting user home directory:":                                                                12,
-	"Error marshalling message: %s":                                                                     40,
-	"Error opening %s file in write mode:":                                                              15,
-	"Error opening %s file: %s":                                                                         13,
-	"Error opening or creating file %s: %s":                                                             128,
-	"Error reading %s file: %s":                                                                         14,
-	"Error reloading systemd: %s":                                                                       116,
-	"Error saving config to layer: %s. Aborting Migration":                                              32,
-	"Error sending message: %s":                                                                         43,
-	"Error sending message: Status %s, Message: ":                                                       44,
-	"Error signing message: %s":                                                                         42,
-	"Error writing service file: %s":                                                                    114,
-	"Error writing to %s file: %s":                                                                      16,
-	"Error writing to file %s: %s":                                                                      129,
-	"Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes": 20,
-	"Failed to create the miner actor: %s":                 83,
-	"Failed to flush thw writes to file %s: %s":            17,
-	"Failed to generate default config: %s":                92,
-	"Failed to generate random bytes for secret: %s":       88,
-	"Failed to get API info for FullNode: %w":              90,
-	"Failed to insert 'base' config layer in database: %s": 93,
-	"Failed to load base config from database: %s":         95,
-	"Failed to parse base config: %s":                      96,
-	"Failed to parse sector size: %s":                      82,
-	"Failed to parse the address: %s":                      74,
-	"Failed to regenerate base config: %s":                 97,
-	"Failed to verify the auth token from daemon node: %s": 91,
-	"Filecoin %s channels: %s and %s":                      49,
-	"Hint: I am someone running Curio on whichever chain.": 37,
-	"Host: %s":   99,
+	"Enter %s address":                    79,
+	"Enter the %s":                        132,
+	"Enter the Yugabyte database %s":      112,
+	"Enter the Yugabyte database host(s)": 110,
+	"Enter the config layer name to use for this node. Base is already included by default":             130,
+	"Enter the info to configure your Curio node":                                                       123,
+	"Enter the info to connect to your Yugabyte database installation (https://download.yugabyte.com/)": 102,
+	"Enter the info to create a new miner":                                                              69,
+	"Enter the owner address":                                                                           76,
+	"Enter the path to the configuration directory used by %s":                                          61,
+	"Env config error occurred, abandoning: %s ":                                                        129,
+	"Error checking for service file at %s: %s":                                                         117,
+	"Error closing %s file: %s":                                                                         18,
+	"Error connecting to Yugabyte database: %s":                                                         114,
+	"Error connecting to full node API: %s":                                                             90,
+	"Error enabling service: %s":                                                                        121,
+	"Error getting API: %s":                                                                             29,
+	"Error getting miner info: %s":                                                                      45,
+	"Error getting miner power: %s":                                                                     43,
+	"Error getting token: %s":                                                                           31,
+	"Error getting user home directory:":                                                                15,
+	"Error marshalling message: %s":                                                                     44,
+	"Error opening %s file in write mode:":                                                              19,
+	"Error opening %s file: %s":                                                                         16,
+	"Error opening or creating file %s: %s":                                                             138,
+	"Error reading %s file: %s":                                                                         17,
+	"Error reading input: %s":                                                                           136,
+	"Error reloading systemd: %s":                                                                       120,
+	"Error saving config to layer: %s. Aborting Migration":                                              36,
+	"Error sending message: %s":                                                                         47,
+	"Error sending message: Status %s, Message: ":                                                       48,
+	"Error signing message: %s":                                                                         46,
+	"Error writing service file: %s":                                                                    118,
+	"Error writing to %s file: %s":                                                                      20,
+	"Error writing to file %s: %s":                                                                      139,
+	"Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes": 24,
+	"Failed to create the miner actor: %s":                 87,
+	"Failed to flush thw writes to file %s: %s":            21,
+	"Failed to generate default config: %s":                96,
+	"Failed to generate random bytes for secret: %s":       92,
+	"Failed to get API info for FullNode: %w":              94,
+	"Failed to insert 'base' config layer in database: %s": 97,
+	"Failed to load base config from database: %s":         99,
+	"Failed to parse base config: %s":                      100,
+	"Failed to parse sector size: %s":                      86,
+	"Failed to parse the address: %s":                      78,
+	"Failed to regenerate base config: %s":                 101,
+	"Failed to verify the auth token from daemon node: %s": 95,
+	"Filecoin %s channels: %s and %s":                      53,
+	"Hint: I am someone running Curio on whichever chain.": 41,
+	"Host: %s":   103,
 	"I want to:": 6,
-	"Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'": 50,
-	"Individual Data: Miner ID, Curio version, chain (%s or %s). Signed.":                                                    35,
-	"Initializing a new miner actor.":   64,
-	"Layer %s created. ":                135,
+	"Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'": 54,
+	"Individual Data: Miner ID, Curio version, chain (%s or %s). Signed.":                                                    39,
+	"Initializing a new miner actor.":   68,
+	"Layer %s created. ":                145,
 	"Lotus-Miner to Curio Migration.":   10,
-	"Message sent.":                     45,
+	"Message sent.":                     49,
 	"Migrate from existing Lotus-Miner": 7,
-	"Migrating lotus-miner config.toml to Curio in-database configuration.": 24,
-	"Migrating metadata for %d sectors.":                                    131,
-	"Miner %s created successfully":                                         84,
-	"Miner creation error occurred: %s ":                                    71,
-	"New Miner initialization complete.":                                    23,
-	"No address provided":                                                   73,
-	"No host provided":                                                      107,
-	"No layer provided":                                                     126,
-	"No path provided, abandoning migration ":                               58,
-	"No value provided":                                                     109,
-	"No, abort":                                                             30,
-	"Not adding DB variables to RC file as shell %s is not BASH or ZSH.":    11,
-	"Nothing.": 38,
-	"One database can serve multiple miner IDs: Run a migration for each lotus-miner.": 51,
-	"Other":            56,
-	"Owner Wallet: %s": 66,
-	"Password: %s":     102,
-	"Please do not run guided-setup again as miner creation is not idempotent. You need to run 'curio config new-cluster %s' to finish the configuration": 89,
-	"Port: %s":                          100,
-	"Pre-initialization steps complete": 87,
-	"Read Miner Config":                 62,
-	"Retrying.......(%d/5)":             18,
-	"Sector Size: %s":                   69,
-	"Sector selection failed: %s ":      81,
-	"Select the Sector Size":            76,
-	"Select the location of your lotus-miner config directory?": 55,
-	"Select what you want to share with the Curio team.":        34,
-	"Sender Wallet: %s":     68,
-	"Service %s enabled.\n": 118,
-	"Service env file /etc/curio.env created successfully.":                                                130,
-	"Service file %s already exists at %s, no changes made.":                                               112,
-	"Service file %s created successfully at %s":                                                           115,
-	"Step Complete: %s\n":                                                                                  63,
-	"The '%s' layer stores common configuration. All curio instances can include it in their %s argument.": 47,
-	"The Curio team wants to improve the software you use. Tell the team you're using `%s`.":               33,
+	"Migrating lotus-miner config.toml to Curio in-database configuration.": 28,
+	"Migrating metadata for %d sectors.":                                    141,
+	"Miner %s created successfully":                                         88,
+	"Miner creation error occurred: %s ":                                    75,
+	"New Miner initialization complete.":                                    27,
+	"No":                                                                    13,
+	"No additional variables added":                                         134,
+	"No address provided":                                                   77,
+	"No host provided":                                                      111,
+	"No layer provided":                                                     131,
+	"No path provided, abandoning migration ":                               62,
+	"No value provided":                                                     113,
+	"No, abort":                                                             34,
+	"Not adding DB variables to RC file as shell %s is not BASH or ZSH.": 14,
+	"Nothing.": 42,
+	"One database can serve multiple miner IDs: Run a migration for each lotus-miner.": 55,
+	"Other":            60,
+	"Owner Wallet: %s": 70,
+	"Password: %s":     106,
+	"Please do not run guided-setup again as miner creation is not idempotent. You need to run 'curio config new-cluster %s' to finish the configuration": 93,
+	"Port: %s":                          104,
+	"Pre-initialization steps complete": 91,
+	"Read Miner Config":                 66,
+	"Retrying.......(%d/5)":             22,
+	"Sector Size: %s":                   73,
+	"Sector selection failed: %s ":      85,
+	"Select the Sector Size":            80,
+	"Select the location of your lotus-miner config directory?": 59,
+	"Select what you want to share with the Curio team.":        38,
+	"Sender Wallet: %s":     72,
+	"Service %s enabled.\n": 122,
+	"Service env file /etc/curio.env created successfully.":                                                140,
+	"Service file %s already exists at %s, no changes made.":                                               116,
+	"Service file %s created successfully at %s":                                                           119,
+	"Skipping invalid input: %s":                                                                           137,
+	"Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:":      135,
+	"Step Complete: %s\n":                                                                                  67,
+	"The '%s' layer stores common configuration. All curio instances can include it in their %s argument.": 51,
+	"The Curio team wants to improve the software you use. Tell the team you're using `%s`.":               37,
 	"This interactive tool creates a new miner actor and creates the basic configuration layer for it.":    1,
-	"This interactive tool creates/replace Curio service file and creates the basic env file for it.":      111,
+	"This interactive tool creates/replace Curio service file and creates the basic env file for it.":      115,
 	"This interactive tool migrates lotus-miner to Curio in 5 minutes.":                                    3,
 	"This process is partially idempotent. Once a new miner actor has been created and subsequent steps fail, the user need to run 'curio config new-cluster < miner ID >' to finish the configuration.": 2,
-	"To run Curio: With machine or cgroup isolation, use the command (with example layer selection):":                                                                                                    137,
-	"To start, ensure your sealing pipeline is drained and shut-down lotus-miner.":                                                                                                                       54,
-	"To work with the config: ":                            136,
-	"Try the web interface with %s ":                       19,
-	"Unmigratable sectors found. Do you want to continue?": 28,
+	"To run Curio: With machine or cgroup isolation, use the command (with example layer selection):":                                                                                                    147,
+	"To start, ensure your sealing pipeline is drained and shut-down lotus-miner.":                                                                                                                       58,
+	"To work with the config: ":                            146,
+	"Try the web interface with %s ":                       23,
+	"Unmigratable sectors found. Do you want to continue?": 32,
 	"Use the arrow keys to navigate: ↓ ↑ → ← ":             0,
-	"Username: %s":      101,
-	"Worker Wallet: %s": 67,
-	"Yes, continue":     29,
-	"You can add other layers for per-machine configuration changes.": 48,
-	"You can now migrate your market node (%s), if applicable.":       21,
-	"could not get API info for FullNode: %w":                         26,
+	"Username: %s":      105,
+	"Worker Wallet: %s": 71,
+	"Yes":               12,
+	"Yes, continue":     33,
+	"You can add other layers for per-machine configuration changes.": 52,
+	"You can now migrate your market node (%s), if applicable.":       25,
+	"could not get API info for FullNode: %w":                         30,
 }
 
-var enIndex = []uint32{ // 139 elements
+var enIndex = []uint32{ // 149 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000035, 0x00000097, 0x0000015a,
 	0x0000019c, 0x000001f5, 0x00000210, 0x0000021b,
 	0x0000023d, 0x00000250, 0x0000026a, 0x0000028a,
-	0x000002d0, 0x000002f3, 0x00000313, 0x00000333,
-	0x0000035b, 0x0000037e, 0x000003ae, 0x000003c7,
-	0x000003ed, 0x00000461, 0x0000049e, 0x000004d1,
-	0x000004f4, 0x0000053a, 0x00000553, 0x0000057e,
-	0x00000599, 0x000005ce, 0x000005dc, 0x000005e6,
+	0x000002d8, 0x000002dc, 0x000002df, 0x00000325,
+	0x00000348, 0x00000368, 0x00000388, 0x000003a8,
+	0x000003d0, 0x000003f3, 0x00000423, 0x0000043c,
+	0x00000462, 0x000004d6, 0x00000513, 0x00000546,
+	0x00000569, 0x000005af, 0x000005c8, 0x000005f3,
 	// Entry 20 - 3F
-	0x000005fa, 0x00000632, 0x0000068c, 0x000006bf,
-	0x00000709, 0x0000074a, 0x0000077f, 0x00000788,
-	0x000007a9, 0x000007ca, 0x000007ea, 0x00000807,
-	0x00000824, 0x00000857, 0x00000865, 0x00000879,
-	0x000008e4, 0x00000924, 0x0000094d, 0x000009c4,
-	0x00000a15, 0x00000a3f, 0x00000a55, 0x00000aa2,
-	0x00000adc, 0x00000ae2, 0x00000b1e, 0x00000b4a,
-	0x00000b93, 0x00000bd3, 0x00000c24, 0x00000c36,
+	0x0000060e, 0x00000643, 0x00000651, 0x0000065b,
+	0x0000066f, 0x000006a7, 0x00000701, 0x00000734,
+	0x0000077e, 0x000007bf, 0x000007f4, 0x000007fd,
+	0x0000081e, 0x0000083f, 0x0000085f, 0x0000087c,
+	0x00000899, 0x000008cc, 0x000008da, 0x000008ee,
+	0x00000959, 0x00000999, 0x000009c2, 0x00000a39,
+	0x00000a8a, 0x00000ab4, 0x00000aca, 0x00000b17,
+	0x00000b51, 0x00000b57, 0x00000b93, 0x00000bbf,
 	// Entry 40 - 5F
-	0x00000c50, 0x00000c70, 0x00000c95, 0x00000ca9,
-	0x00000cbe, 0x00000cd3, 0x00000ce6, 0x00000d25,
-	0x00000d4f, 0x00000d67, 0x00000d7b, 0x00000d9e,
-	0x00000db2, 0x00000dc9, 0x00000dd0, 0x00000dd7,
-	0x00000ddd, 0x00000de3, 0x00000e07, 0x00000e2a,
-	0x00000e52, 0x00000e73, 0x00000e8e, 0x00000eb7,
-	0x00000ed9, 0x00000f0b, 0x00000fa2, 0x00000fcd,
-	0x00001005, 0x0000102e, 0x00001066, 0x000010a7,
+	0x00000c08, 0x00000c48, 0x00000c99, 0x00000cab,
+	0x00000cc5, 0x00000ce5, 0x00000d0a, 0x00000d1e,
+	0x00000d33, 0x00000d48, 0x00000d5b, 0x00000d9a,
+	0x00000dc4, 0x00000ddc, 0x00000df0, 0x00000e13,
+	0x00000e27, 0x00000e3e, 0x00000e45, 0x00000e4c,
+	0x00000e52, 0x00000e58, 0x00000e7c, 0x00000e9f,
+	0x00000ec7, 0x00000ee8, 0x00000f03, 0x00000f2c,
+	0x00000f4e, 0x00000f80, 0x00001017, 0x00001042,
 	// Entry 60 - 7F
-	0x000010d7, 0x000010fa, 0x00001122, 0x00001184,
-	0x00001190, 0x0000119c, 0x000011ac, 0x000011bc,
-	0x000011cc, 0x000011f3, 0x00001234, 0x00001258,
-	0x00001269, 0x0000128b, 0x0000129d, 0x000012ca,
-	0x0000132a, 0x00001367, 0x00001397, 0x000013b9,
-	0x000013ea, 0x00001409, 0x00001427, 0x00001443,
-	0x0000146f, 0x00001483, 0x0000149a, 0x000014b1,
-	0x000014cf, 0x00001501, 0x00001557, 0x00001569,
+	0x0000107a, 0x000010a3, 0x000010db, 0x0000111c,
+	0x0000114c, 0x0000116f, 0x00001197, 0x000011f9,
+	0x00001205, 0x00001211, 0x00001221, 0x00001231,
+	0x00001241, 0x00001268, 0x000012a9, 0x000012cd,
+	0x000012de, 0x00001300, 0x00001312, 0x0000133f,
+	0x0000139f, 0x000013dc, 0x0000140c, 0x0000142e,
+	0x0000145f, 0x0000147e, 0x0000149c, 0x000014b8,
+	0x000014e4, 0x000014f8, 0x0000150f, 0x00001526,
 	// Entry 80 - 9F
-	0x00001579, 0x000015a5, 0x000015c8, 0x000015fe,
-	0x00001624, 0x00001683, 0x00001720, 0x0000176e,
-	0x00001788, 0x000017a6, 0x00001806,
-} // Size: 580 bytes
+	0x00001560, 0x0000157e, 0x000015b0, 0x00001606,
+	0x00001618, 0x00001628, 0x00001677, 0x00001695,
+	0x000016f5, 0x00001710, 0x0000172e, 0x0000175a,
+	0x0000177d, 0x000017b3, 0x000017d9, 0x00001838,
+	0x000018d5, 0x00001923, 0x0000193d, 0x0000195b,
+	0x000019bb,
+} // Size: 620 bytes
 
-const enData string = "" + // Size: 6150 bytes
+const enData string = "" + // Size: 6587 bytes
 	"\x04\x00\x01 0\x02Use the arrow keys to navigate: ↓ ↑ → ←\x02This intera" +
 	"ctive tool creates a new miner actor and creates the basic configuration" +
 	" layer for it.\x02This process is partially idempotent. Once a new miner" +
@@ -233,297 +246,317 @@ const enData string = "" + // Size: 6150 bytes
 	"h step needs your confirmation and can be reversed. Press Ctrl+C to exit" +
 	" at any time.\x02Ctrl+C pressed in Terminal\x02I want to:\x02Migrate fro" +
 	"m existing Lotus-Miner\x02Create a new miner\x02Aborting remaining steps" +
-	".\x02Lotus-Miner to Curio Migration.\x02Not adding DB variables to RC fi" +
-	"le as shell %[1]s is not BASH or ZSH.\x02Error getting user home directo" +
-	"ry:\x02Error opening %[1]s file: %[2]s\x02Error reading %[1]s file: %[2]" +
-	"s\x02Error opening %[1]s file in write mode:\x02Error writing to %[1]s f" +
-	"ile: %[2]s\x02Failed to flush thw writes to file %[1]s: %[2]s\x02Retryin" +
-	"g.......(%[1]d/5)\x04\x00\x01 !\x02Try the web interface with %[1]s\x02E" +
-	"xecute 'curio service-setup' to setup the Curio service on this node and" +
-	" proceed to do the same on the other nodes\x02You can now migrate your m" +
-	"arket node (%[1]s), if applicable.\x02Additional info is at http://docs." +
-	"curiostorage.org\x02New Miner initialization complete.\x02Migrating lotu" +
-	"s-miner config.toml to Curio in-database configuration.\x02Error getting" +
-	" API: %[1]s\x02could not get API info for FullNode: %[1]w\x02Error getti" +
-	"ng token: %[1]s\x02Unmigratable sectors found. Do you want to continue?" +
-	"\x02Yes, continue\x02No, abort\x02Aborting migration.\x02Error saving co" +
-	"nfig to layer: %[1]s. Aborting Migration\x02The Curio team wants to impr" +
-	"ove the software you use. Tell the team you're using `%[1]s`.\x02Select " +
-	"what you want to share with the Curio team.\x02Individual Data: Miner ID" +
-	", Curio version, chain (%[1]s or %[2]s). Signed.\x02Aggregate-Anonymous:" +
-	" version, chain, and Miner power (bucketed).\x02Hint: I am someone runni" +
-	"ng Curio on whichever chain.\x02Nothing.\x02Error getting miner power: %" +
-	"[1]s\x02Error marshalling message: %[1]s\x02Error getting miner info: %[" +
-	"1]s\x02Error signing message: %[1]s\x02Error sending message: %[1]s\x04" +
-	"\x00\x01 .\x02Error sending message: Status %[1]s, Message:\x02Message s" +
-	"ent.\x04\x00\x01 \x0f\x02Documentation:\x02The '%[1]s' layer stores comm" +
-	"on configuration. All curio instances can include it in their %[2]s argu" +
-	"ment.\x02You can add other layers for per-machine configuration changes." +
-	"\x02Filecoin %[1]s channels: %[2]s and %[3]s\x02Increase reliability usi" +
-	"ng redundancy: start multiple machines with at-least the post layer: 'cu" +
-	"rio run --layers=post'\x02One database can serve multiple miner IDs: Run" +
-	" a migration for each lotus-miner.\x02Connected to Yugabyte. Schema is c" +
-	"urrent.\x02Connected to Yugabyte\x02To start, ensure your sealing pipeli" +
-	"ne is drained and shut-down lotus-miner.\x02Select the location of your " +
-	"lotus-miner config directory?\x02Other\x02Enter the path to the configur" +
-	"ation directory used by %[1]s\x04\x00\x01 '\x02No path provided, abandon" +
-	"ing migration\x02Cannot read the config.toml file in the provided direct" +
-	"ory, Error: %[1]s\x02Could not create repo from directory: %[1]s. Aborti" +
-	"ng migration\x02Could not lock miner repo. Your miner must be stopped: %" +
-	"[1]s\x0a Aborting migration\x02Read Miner Config\x04\x00\x01\x0a\x15\x02" +
-	"Step Complete: %[1]s\x02Initializing a new miner actor.\x02Enter the inf" +
-	"o to create a new miner\x02Owner Wallet: %[1]s\x02Worker Wallet: %[1]s" +
-	"\x02Sender Wallet: %[1]s\x02Sector Size: %[1]s\x02Continue to verify the" +
-	" addresses and create a new miner actor.\x04\x00\x01 %\x02Miner creation" +
-	" error occurred: %[1]s\x02Enter the owner address\x02No address provided" +
-	"\x02Failed to parse the address: %[1]s\x02Enter %[1]s address\x02Select " +
-	"the Sector Size\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1f" +
-	"\x02Sector selection failed: %[1]s\x02Failed to parse sector size: %[1]s" +
-	"\x02Failed to create the miner actor: %[1]s\x02Miner %[1]s created succe" +
-	"ssfully\x02Cannot reach the DB: %[1]s\x02Error connecting to full node A" +
-	"PI: %[1]s\x02Pre-initialization steps complete\x02Failed to generate ran" +
-	"dom bytes for secret: %[1]s\x02Please do not run guided-setup again as m" +
-	"iner creation is not idempotent. You need to run 'curio config new-clust" +
-	"er %[1]s' to finish the configuration\x02Failed to get API info for Full" +
-	"Node: %[1]w\x02Failed to verify the auth token from daemon node: %[1]s" +
-	"\x02Failed to generate default config: %[1]s\x02Failed to insert 'base' " +
-	"config layer in database: %[1]s\x02Configuration 'base' was updated to i" +
-	"nclude this miner's address\x02Failed to load base config from database:" +
-	" %[1]s\x02Failed to parse base config: %[1]s\x02Failed to regenerate bas" +
-	"e config: %[1]s\x02Enter the info to connect to your Yugabyte database i" +
-	"nstallation (https://download.yugabyte.com/)\x02Host: %[1]s\x02Port: %[1" +
-	"]s\x02Username: %[1]s\x02Password: %[1]s\x02Database: %[1]s\x02Continue " +
-	"to connect and update schema.\x04\x00\x01 <\x02Database config error occ" +
-	"urred, abandoning migration: %[1]s\x02Enter the Yugabyte database host(s" +
-	")\x02No host provided\x02Enter the Yugabyte database %[1]s\x02No value p" +
-	"rovided\x02Error connecting to Yugabyte database: %[1]s\x02This interact" +
-	"ive tool creates/replace Curio service file and creates the basic env fi" +
-	"le for it.\x02Service file %[1]s already exists at %[2]s, no changes mad" +
-	"e.\x02Error checking for service file at %[1]s: %[2]s\x02Error writing s" +
-	"ervice file: %[1]s\x02Service file %[1]s created successfully at %[2]s" +
-	"\x02Error reloading systemd: %[1]s\x02Error enabling service: %[1]s\x04" +
-	"\x00\x01\x0a\x17\x02Service %[1]s enabled.\x02Enter the info to configur" +
-	"e your Curio node\x02CURIO_LAYERS: %[1]s\x02CURIO_REPO_PATH: %[1]s\x02CU" +
-	"RIO_NODE_NAME: %[1]s\x02Continue update the env file.\x04\x00\x01 -\x02E" +
-	"nv config error occurred, abandoning: %[1]s\x02Enter the config layer na" +
-	"me to use for this node. Base is already included by default\x02No layer" +
-	" provided\x02Enter the %[1]s\x02Error opening or creating file %[1]s: %[" +
-	"2]s\x02Error writing to file %[1]s: %[2]s\x02Service env file /etc/curio" +
-	".env created successfully.\x02Migrating metadata for %[1]d sectors.\x02C" +
-	"onfiguration 'base' was updated to include this miner's address (%[1]s) " +
-	"and its wallet setup.\x02Compare the configurations %[1]s to %[2]s. Chan" +
-	"ges between the miner IDs other than wallet addreses should be a new, mi" +
-	"nimal layer for runners that need it.\x02Configuration 'base' was create" +
-	"d to resemble this lotus-miner's config.toml .\x04\x00\x01 \x15\x02Layer" +
-	" %[1]s created.\x04\x00\x01 \x19\x02To work with the config:\x02To run C" +
-	"urio: With machine or cgroup isolation, use the command (with example la" +
-	"yer selection):"
+	".\x02Lotus-Miner to Curio Migration.\x02Do you wish to add Harmony DB cr" +
+	"edentials to your ~/.bashrc or ~/.zshrc file?\x02Yes\x02No\x02Not adding" +
+	" DB variables to RC file as shell %[1]s is not BASH or ZSH.\x02Error get" +
+	"ting user home directory:\x02Error opening %[1]s file: %[2]s\x02Error re" +
+	"ading %[1]s file: %[2]s\x02Error closing %[1]s file: %[2]s\x02Error open" +
+	"ing %[1]s file in write mode:\x02Error writing to %[1]s file: %[2]s\x02F" +
+	"ailed to flush thw writes to file %[1]s: %[2]s\x02Retrying.......(%[1]d/" +
+	"5)\x04\x00\x01 !\x02Try the web interface with %[1]s\x02Execute 'curio s" +
+	"ervice-setup' to setup the Curio service on this node and proceed to do " +
+	"the same on the other nodes\x02You can now migrate your market node (%[1" +
+	"]s), if applicable.\x02Additional info is at http://docs.curiostorage.or" +
+	"g\x02New Miner initialization complete.\x02Migrating lotus-miner config." +
+	"toml to Curio in-database configuration.\x02Error getting API: %[1]s\x02" +
+	"could not get API info for FullNode: %[1]w\x02Error getting token: %[1]s" +
+	"\x02Unmigratable sectors found. Do you want to continue?\x02Yes, continu" +
+	"e\x02No, abort\x02Aborting migration.\x02Error saving config to layer: %" +
+	"[1]s. Aborting Migration\x02The Curio team wants to improve the software" +
+	" you use. Tell the team you're using `%[1]s`.\x02Select what you want to" +
+	" share with the Curio team.\x02Individual Data: Miner ID, Curio version," +
+	" chain (%[1]s or %[2]s). Signed.\x02Aggregate-Anonymous: version, chain," +
+	" and Miner power (bucketed).\x02Hint: I am someone running Curio on whic" +
+	"hever chain.\x02Nothing.\x02Error getting miner power: %[1]s\x02Error ma" +
+	"rshalling message: %[1]s\x02Error getting miner info: %[1]s\x02Error sig" +
+	"ning message: %[1]s\x02Error sending message: %[1]s\x04\x00\x01 .\x02Err" +
+	"or sending message: Status %[1]s, Message:\x02Message sent.\x04\x00\x01 " +
+	"\x0f\x02Documentation:\x02The '%[1]s' layer stores common configuration." +
+	" All curio instances can include it in their %[2]s argument.\x02You can " +
+	"add other layers for per-machine configuration changes.\x02Filecoin %[1]" +
+	"s channels: %[2]s and %[3]s\x02Increase reliability using redundancy: st" +
+	"art multiple machines with at-least the post layer: 'curio run --layers=" +
+	"post'\x02One database can serve multiple miner IDs: Run a migration for " +
+	"each lotus-miner.\x02Connected to Yugabyte. Schema is current.\x02Connec" +
+	"ted to Yugabyte\x02To start, ensure your sealing pipeline is drained and" +
+	" shut-down lotus-miner.\x02Select the location of your lotus-miner confi" +
+	"g directory?\x02Other\x02Enter the path to the configuration directory u" +
+	"sed by %[1]s\x04\x00\x01 '\x02No path provided, abandoning migration\x02" +
+	"Cannot read the config.toml file in the provided directory, Error: %[1]s" +
+	"\x02Could not create repo from directory: %[1]s. Aborting migration\x02C" +
+	"ould not lock miner repo. Your miner must be stopped: %[1]s\x0a Aborting" +
+	" migration\x02Read Miner Config\x04\x00\x01\x0a\x15\x02Step Complete: %[" +
+	"1]s\x02Initializing a new miner actor.\x02Enter the info to create a new" +
+	" miner\x02Owner Wallet: %[1]s\x02Worker Wallet: %[1]s\x02Sender Wallet: " +
+	"%[1]s\x02Sector Size: %[1]s\x02Continue to verify the addresses and crea" +
+	"te a new miner actor.\x04\x00\x01 %\x02Miner creation error occurred: %[" +
+	"1]s\x02Enter the owner address\x02No address provided\x02Failed to parse" +
+	" the address: %[1]s\x02Enter %[1]s address\x02Select the Sector Size\x02" +
+	"64 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1f\x02Sector selection " +
+	"failed: %[1]s\x02Failed to parse sector size: %[1]s\x02Failed to create " +
+	"the miner actor: %[1]s\x02Miner %[1]s created successfully\x02Cannot rea" +
+	"ch the DB: %[1]s\x02Error connecting to full node API: %[1]s\x02Pre-init" +
+	"ialization steps complete\x02Failed to generate random bytes for secret:" +
+	" %[1]s\x02Please do not run guided-setup again as miner creation is not " +
+	"idempotent. You need to run 'curio config new-cluster %[1]s' to finish t" +
+	"he configuration\x02Failed to get API info for FullNode: %[1]w\x02Failed" +
+	" to verify the auth token from daemon node: %[1]s\x02Failed to generate " +
+	"default config: %[1]s\x02Failed to insert 'base' config layer in databas" +
+	"e: %[1]s\x02Configuration 'base' was updated to include this miner's add" +
+	"ress\x02Failed to load base config from database: %[1]s\x02Failed to par" +
+	"se base config: %[1]s\x02Failed to regenerate base config: %[1]s\x02Ente" +
+	"r the info to connect to your Yugabyte database installation (https://do" +
+	"wnload.yugabyte.com/)\x02Host: %[1]s\x02Port: %[1]s\x02Username: %[1]s" +
+	"\x02Password: %[1]s\x02Database: %[1]s\x02Continue to connect and update" +
+	" schema.\x04\x00\x01 <\x02Database config error occurred, abandoning mig" +
+	"ration: %[1]s\x02Enter the Yugabyte database host(s)\x02No host provided" +
+	"\x02Enter the Yugabyte database %[1]s\x02No value provided\x02Error conn" +
+	"ecting to Yugabyte database: %[1]s\x02This interactive tool creates/repl" +
+	"ace Curio service file and creates the basic env file for it.\x02Service" +
+	" file %[1]s already exists at %[2]s, no changes made.\x02Error checking " +
+	"for service file at %[1]s: %[2]s\x02Error writing service file: %[1]s" +
+	"\x02Service file %[1]s created successfully at %[2]s\x02Error reloading " +
+	"systemd: %[1]s\x02Error enabling service: %[1]s\x04\x00\x01\x0a\x17\x02S" +
+	"ervice %[1]s enabled.\x02Enter the info to configure your Curio node\x02" +
+	"CURIO_LAYERS: %[1]s\x02CURIO_REPO_PATH: %[1]s\x02CURIO_NODE_NAME: %[1]s" +
+	"\x02Add additional variables like FIL_PROOFS_PARAMETER_CACHE.\x02Continu" +
+	"e update the env file.\x04\x00\x01 -\x02Env config error occurred, aband" +
+	"oning: %[1]s\x02Enter the config layer name to use for this node. Base i" +
+	"s already included by default\x02No layer provided\x02Enter the %[1]s" +
+	"\x02Do you want to add additional variables like FIL_PROOFS_PARAMETER_CA" +
+	"CHE? (y/n)\x02No additional variables added\x02Start typing your additio" +
+	"nal environment variables one variable per line. Use Ctrl+D to finish:" +
+	"\x02Error reading input: %[1]s\x02Skipping invalid input: %[1]s\x02Error" +
+	" opening or creating file %[1]s: %[2]s\x02Error writing to file %[1]s: %" +
+	"[2]s\x02Service env file /etc/curio.env created successfully.\x02Migrati" +
+	"ng metadata for %[1]d sectors.\x02Configuration 'base' was updated to in" +
+	"clude this miner's address (%[1]s) and its wallet setup.\x02Compare the " +
+	"configurations %[1]s to %[2]s. Changes between the miner IDs other than " +
+	"wallet addreses should be a new, minimal layer for runners that need it." +
+	"\x02Configuration 'base' was created to resemble this lotus-miner's conf" +
+	"ig.toml .\x04\x00\x01 \x15\x02Layer %[1]s created.\x04\x00\x01 \x19\x02T" +
+	"o work with the config:\x02To run Curio: With machine or cgroup isolatio" +
+	"n, use the command (with example layer selection):"
 
-var koIndex = []uint32{ // 139 elements
+var koIndex = []uint32{ // 149 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000044, 0x000000c1, 0x000001c1,
 	0x0000020e, 0x00000289, 0x000002aa, 0x000002bc,
 	0x000002e5, 0x00000300, 0x00000325, 0x00000348,
-	0x000003aa, 0x000003e8, 0x00000418, 0x00000448,
-	0x00000483, 0x000004b3, 0x00000502, 0x00000524,
-	0x00000563, 0x000005f5, 0x00000645, 0x00000685,
-	0x000006ab, 0x00000704, 0x00000723, 0x0000075f,
-	0x0000078f, 0x000007df, 0x000007eb, 0x000007fd,
+	0x000003a2, 0x000003a6, 0x000003b0, 0x00000412,
+	0x00000450, 0x00000480, 0x000004b0, 0x000004e0,
+	0x0000051b, 0x0000054b, 0x0000059a, 0x000005bc,
+	0x000005fb, 0x0000068d, 0x000006dd, 0x0000071d,
+	0x00000743, 0x0000079c, 0x000007bb, 0x000007f7,
 	// Entry 20 - 3F
-	0x00000818, 0x00000870, 0x000008fc, 0x00000935,
-	0x0000098b, 0x000009c9, 0x00000a17, 0x00000a32,
-	0x00000a6c, 0x00000a9f, 0x00000ad9, 0x00000b03,
-	0x00000b2d, 0x00000b6f, 0x00000b93, 0x00000ba0,
-	0x00000c26, 0x00000c78, 0x00000c9f, 0x00000d3b,
-	0x00000dcd, 0x00000e0e, 0x00000e24, 0x00000e8f,
-	0x00000ede, 0x00000ee5, 0x00000f2d, 0x00000f7f,
-	0x00000fd9, 0x00001043, 0x000010d4, 0x000010ec,
+	0x00000827, 0x00000877, 0x00000883, 0x00000895,
+	0x000008b0, 0x00000908, 0x00000994, 0x000009cd,
+	0x00000a23, 0x00000a61, 0x00000aaf, 0x00000aca,
+	0x00000b04, 0x00000b37, 0x00000b71, 0x00000b9b,
+	0x00000bc5, 0x00000c07, 0x00000c2b, 0x00000c38,
+	0x00000cbe, 0x00000d10, 0x00000d37, 0x00000dd3,
+	0x00000e65, 0x00000ea6, 0x00000ebc, 0x00000f27,
+	0x00000f76, 0x00000f7d, 0x00000fc5, 0x00001017,
 	// Entry 40 - 5F
-	0x00001106, 0x0000112a, 0x0000115d, 0x00001175,
-	0x0000118d, 0x000011a5, 0x000011ba, 0x00001211,
-	0x0000123c, 0x00001254, 0x0000127b, 0x0000129e,
-	0x000012b2, 0x000012c7, 0x000012ce, 0x000012d5,
-	0x000012db, 0x000012e1, 0x00001302, 0x0000132c,
-	0x00001352, 0x0000138b, 0x000013c3, 0x000013fb,
-	0x0000141a, 0x00001466, 0x00001524, 0x00001570,
-	0x000015be, 0x000015e1, 0x0000163d, 0x0000168d,
+	0x00001071, 0x000010db, 0x0000116c, 0x00001184,
+	0x0000119e, 0x000011c2, 0x000011f5, 0x0000120d,
+	0x00001225, 0x0000123d, 0x00001252, 0x000012a9,
+	0x000012d4, 0x000012ec, 0x00001313, 0x00001336,
+	0x0000134a, 0x0000135f, 0x00001366, 0x0000136d,
+	0x00001373, 0x00001379, 0x0000139a, 0x000013c4,
+	0x000013ea, 0x00001423, 0x0000145b, 0x00001493,
+	0x000014b2, 0x000014fe, 0x000015bc, 0x00001608,
 	// Entry 60 - 7F
-	0x000016e2, 0x00001725, 0x00001764, 0x000017d2,
-	0x000017e3, 0x000017f1, 0x00001809, 0x0000181d,
-	0x00001837, 0x00001861, 0x000018c4, 0x00001900,
-	0x0000192a, 0x00001962, 0x00001986, 0x000019da,
-	0x00001a46, 0x00001a97, 0x00001add, 0x00001b11,
-	0x00001b5b, 0x00001b93, 0x00001bc9, 0x00001bfb,
-	0x00001c32, 0x00001c46, 0x00001c5d, 0x00001c74,
-	0x00001ca3, 0x00001cd7, 0x00001d57, 0x00001d81,
+	0x00001656, 0x00001679, 0x000016d5, 0x00001725,
+	0x0000177a, 0x000017bd, 0x000017fc, 0x0000186a,
+	0x0000187b, 0x00001889, 0x000018a1, 0x000018b5,
+	0x000018cf, 0x000018f9, 0x0000195c, 0x00001998,
+	0x000019c2, 0x000019fa, 0x00001a1e, 0x00001a72,
+	0x00001ade, 0x00001b2f, 0x00001b75, 0x00001ba9,
+	0x00001bf3, 0x00001c2b, 0x00001c61, 0x00001c93,
+	0x00001cca, 0x00001cde, 0x00001cf5, 0x00001d0c,
 	// Entry 80 - 9F
-	0x00001da2, 0x00001de7, 0x00001e17, 0x00001e6d,
-	0x00001ea5, 0x00001f1e, 0x00001fd8, 0x0000202f,
-	0x0000205e, 0x00002085, 0x00002111,
-} // Size: 580 bytes
+	0x00001d53, 0x00001d82, 0x00001db6, 0x00001e36,
+	0x00001e60, 0x00001e81, 0x00001ed7, 0x00001f05,
+	0x00001f6e, 0x00001f98, 0x00001fba, 0x00001fff,
+	0x0000202f, 0x00002085, 0x000020bd, 0x00002136,
+	0x000021f0, 0x00002247, 0x00002276, 0x0000229d,
+	0x00002329,
+} // Size: 620 bytes
 
-const koData string = "" + // Size: 8465 bytes
+const koData string = "" + // Size: 9001 bytes
 	"\x04\x00\x01 ?\x02화살표 키를 사용하여 이동하세요: ↓ ↑ → ←\x02이 대화형 도구는 새로운 채굴자 액터를 생성" +
 	"하고 그에 대한 기본 구성 레이어를 생성합니다.\x02이 프로세스는 부분적으로 항등원적입니다. 새로운 채굴자 액터가 생성되었고" +
 	" 후속 단계가 실패하는 경우 사용자는 구성을 완료하기 위해 'curio config new-cluster < 채굴자 ID >'를 " +
 	"실행해야 합니다.\x02이 대화형 도구는 5분 안에 lotus-miner를 Curio로 이주합니다.\x02각 단계는 확인이 필" +
 	"요하며 되돌릴 수 있습니다. 언제든지 Ctrl+C를 눌러 종료할 수 있습니다.\x02터미널에서 Ctrl+C가 눌림\x02나는 " +
 	"원한다:\x02기존의 Lotus-Miner에서 이전하기\x02새로운 채굴자 생성\x02나머지 단계를 중단합니다.\x02Lotu" +
-	"s-Miner에서 Curio로 이주.\x02셸 %[1]s이 BASH 또는 ZSH가 아니므로 RC 파일에 DB 변수를 추가하지 않습" +
-	"니다.\x02사용자 홈 디렉토리를 가져오는 중 오류 발생:\x02%[1]s 파일을 여는 중 오류 발생: %[2]s\x02%[1" +
-	"]s 파일을 읽는 중 오류 발생: %[2]s\x02%[1]s 파일을 쓰기 모드로 여는 중 오류 발생:\x02%[1]s 파일에 쓰는" +
-	" 중 오류 발생: %[2]s\x02%[1]s 파일에 쓰기 내용을 플러시하는 데 실패했습니다: %[2]s\x02다시 시도 중...." +
-	"...(%[1]d/5)\x04\x00\x01 :\x02%[1]s와 함께 웹 인터페이스를 시도해보세요\x02이 노드에서 Curio " +
-	"서비스를 설정하려면 'curio service-setup'을 실행하고 다른 노드에서도 동일하게 진행하십시오.\x02해당하는 경" +
-	"우 이제 시장 노드를 이주할 수 있습니다 (%[1]s).\x02추가 정보는 http://docs.curiostorage.org" +
-	" 에 있습니다.\x02새로운 채굴자 초기화 완료.\x02lotus-miner config.toml을 Curio의 데이터베이스 구성" +
-	"으로 이전 중입니다.\x02API 가져오기 오류: %[1]s\x02FullNode의 API 정보를 가져올 수 없습니다: %[1" +
-	"]w\x02토큰을 가져오는 중 오류 발생: %[1]s\x02이동할 수 없는 섹터가 발견되었습니다. 계속하시겠습니까?\x02예, 계" +
-	"속\x02아니오, 중단\x02마이그레이션 중단.\x02레이어에 구성을 저장하는 중 오류 발생: %[1]s. 마이그레이션 중단" +
-	"\x02Curio 팀은 당신이 사용하는 소프트웨어를 개선하고자 합니다. 팀에게 `%[1]s`를 사용 중이라고 알려주세요.\x02C" +
-	"urio 팀과 공유하고 싶은 것을 선택하세요.\x02개별 데이터: 채굴자 ID, Curio 버전, 체인 (%[1]s 또는 %[2]" +
-	"s). 서명됨.\x02집계-익명: 버전, 체인, 및 채굴자 파워 (버킷).\x02힌트: 나는 어떤 체인에서든 Curio를 실행 중" +
-	"인 사람입니다.\x02아무것도 없습니다.\x02마이너 파워를 가져오는 중 오류 발생: %[1]s\x02메시지를 마샬하는 중 오" +
-	"류 발생: %[1]s\x02마이너 정보를 가져오는 중 오류 발생: %[1]s\x02메시지 서명 중 오류 발생: %[1]s" +
-	"\x02메시지 전송 중 오류 발생: %[1]s\x04\x00\x01 =\x02메시지 전송 중 오류 발생: 상태 %[1]s, 메시지" +
-	":\x02메시지가 전송되었습니다.\x04\x00\x01 \x08\x02문서:\x02'%[1]s' 레이어에는 공통 구성이 저장됩니다" +
-	". 모든 Curio 인스턴스는 %[2]s 인수에 포함시킬 수 있습니다.\x02기계별 구성 변경을 위해 다른 레이어를 추가할 수 있" +
-	"습니다.\x02Filecoin %[1]s 채널: %[2]s 및 %[3]s\x02신뢰성 향상을 위한 중복성 사용: 적어도 pos" +
-	"t 레이어를 사용하여 여러 대의 기계를 시작하십시오: 'curio run --layers=post'\x02한 개의 데이터베이스는 " +
-	"여러 광부 ID를 제공할 수 있습니다: 각 lotus-miner에 대해 마이그레이션을 실행하세요.\x02Yugabyte에 연결" +
-	"되었습니다. 스키마가 현재입니다.\x02Yugabyte에 연결됨\x02시작하려면 밀봉 파이프라인이 비어 있고 lotus-min" +
-	"er가 종료되었는지 확인하세요.\x02로터스 마이너 구성 디렉토리의 위치를 선택하시겠습니까?\x02기타\x02%[1]s에서 사용하" +
-	"는 구성 디렉터리 경로를 입력하세요.\x04\x00\x01 M\x02경로가 제공되지 않았으므로 마이그레이션을 포기합니다\x02" +
-	"제공된 디렉토리에서 config.toml 파일을 읽을 수 없습니다. 오류: %[1]s\x02디렉토리에서 저장소를 생성할 수 없" +
-	"습니다: %[1]s. 마이그레이션을 중단합니다.\x02광부 저장소를 잠금 해제할 수 없습니다. 귀하의 광부를 중지해야 합니다:" +
-	" %[1]s\x0a 마이그레이션을 중단합니다.\x02마이너 구성 읽기\x04\x00\x01\x0a\x15\x02단계 완료: %[1" +
-	"]s\x02새 채굴자 액터 초기화 중.\x02새 채굴자를 생성하기 위한 정보 입력\x02소유자 지갑: %[1]s\x02작업자 지갑" +
-	": %[1]s\x02발송자 지갑: %[1]s\x02섹터 크기: %[1]s\x02주소를 확인하고 새 채굴자 액터를 생성하려면 계속 " +
-	"진행하세요.\x04\x00\x01 &\x02채굴자 생성 오류 발생: %[1]s\x02소유자 주소 입력\x02주소가 제공되지 않" +
-	"았습니다\x02주소 구문 분석 실패: %[1]s\x02%[1]s 주소 입력\x02섹터 크기 선택\x0264 GiB\x0232 " +
-	"GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1c\x02섹터 선택 실패: %[1]s\x02섹터 크기 구문 분석" +
-	" 실패: %[1]s\x02채굴자 액터 생성 실패: %[1]s\x02%[1]s 채굴자가 성공적으로 생성되었습니다\x02데이터베이스에" +
-	" 연결할 수 없습니다: %[1]s\x02풀 노드 API에 연결하는 중 오류 발생: %[1]s\x02사전 초기화 단계 완료\x02비" +
-	"밀번호를 위한 랜덤 바이트 생성에 실패했습니다: %[1]s\x02마이너 생성은 idempotent하지 않으므로 가이드 설정을 " +
-	"다시 실행하지 마십시오. 구성을 완료하려면 'curio config new-cluster %[1]s'를 실행해야 합니다." +
-	"\x02FullNode에 대한 API 정보를 가져오는 데 실패했습니다: %[1]w\x02데몬 노드로부터 인증 토큰을 확인하는 중 " +
-	"오류 발생: %[1]s\x02기본 구성 생성 실패: %[1]s\x02데이터베이스에 'base' 구성 레이어를 삽입하는 데 실패" +
-	"했습니다: %[1]s\x02이 마이너 주소를 포함한 구성 'base'가 업데이트되었습니다.\x02데이터베이스에서 기본 구성을 " +
-	"로드하는 데 실패했습니다: %[1]s\x02기본 구성을 구문 분석하는 데 실패했습니다: %[1]s\x02기본 구성을 재생성하는" +
-	" 데 실패했습니다: %[1]s\x02Yugabyte 데이터베이스 설치에 연결할 정보를 입력하십시오 (https://download" +
-	".yugabyte.com/)\x02호스트: %[1]s\x02포트: %[1]s\x02사용자 이름: %[1]s\x02비밀번호: %[1" +
-	"]s\x02데이터베이스: %[1]s\x02계속 연결 및 스키마 업데이트.\x04\x00\x01 ^\x02데이터베이스 구성 오류가 " +
-	"발생하여 마이그레이션을 포기합니다: %[1]s\x02Yugabyte 데이터베이스 호스트를 입력하십시오\x02호스트가 제공되지 " +
-	"않았습니다\x02Yugabyte 데이터베이스 %[1]s을 입력하십시오\x02값이 제공되지 않았습니다\x02Yugabyte 데이" +
-	"터베이스에 연결하는 중 오류가 발생했습니다: %[1]s\x02이 대화형 도구는 Curio 서비스 파일을 생성/교체하고 기본 e" +
-	"nv 파일을 생성합니다.\x02서비스 파일 %[1]s이 %[2]s에 이미 존재합니다. 변경 사항 없음.\x02%[1]s에서 서비스" +
-	" 파일을 확인하는 중 오류 발생: %[2]s\x02서비스 파일을 쓰는 중 오류 발생: %[1]s\x02서비스 파일 %[1]s이 %" +
-	"[2]s에 성공적으로 생성되었습니다.\x02systemd를 다시 로드하는 중 오류 발생: %[1]s\x02서비스를 활성화하는 중 " +
-	"오류 발생: %[1]s\x04\x00\x01\x0a-\x02서비스 %[1]s이 활성화되었습니다.\x02Curio 노드를 구성할" +
-	" 정보를 입력하십시오\x02CURIO_LAYERS: %[1]s\x02CURIO_REPO_PATH: %[1]s\x02CURIO_NO" +
-	"DE_NAME: %[1]s\x02env 파일 업데이트를 계속하십시오.\x04\x00\x01 /\x02환경 설정 오류 발생, 중단 " +
-	"중: %[1]s\x02이 노드에 사용할 구성 레이어 이름을 입력하십시오. 기본값으로 Base가 이미 포함되어 있습니다\x02레" +
-	"이어가 제공되지 않았습니다\x02%[1]s을(를) 입력하십시오\x02파일 %[1]s을(를) 열거나 생성하는 중 오류 발생: %" +
-	"[2]s\x02파일 %[1]s에 쓰는 중 오류 발생: %[2]s\x02서비스 환경 파일 /etc/curio.env이(가) 성공적으" +
-	"로 생성되었습니다.\x02%[1]d 섹터의 메타데이터를 이동 중입니다.\x02기본 설정 'base'가 이 마이너의 주소(%[1" +
-	"]s) 및 지갑 설정을 포함하도록 업데이트되었습니다.\x02구성 %[1]s를 %[2]s과 비교하세요. 지갑 주소 이외의 마이너 I" +
-	"D 사이의 변경 사항은 필요한 실행자를 위한 새로운 최소한의 레이어여야 합니다.\x02'base' 설정이 이 lotus-miner" +
-	"의 config.toml과 유사하게 만들어졌습니다.\x04\x00\x01 *\x02레이어 %[1]s가 생성되었습니다.\x04" +
-	"\x00\x01 \x22\x02구성 파일을 사용하려면:\x02Curio를 실행하려면: 기계 또는 cgroup 격리를 사용하여 다음" +
-	" 명령을 사용하세요 (예제 레이어 선택과 함께):"
+	"s-Miner에서 Curio로 이주.\x02Harmony DB 자격 증명을 ~/.bashrc 또는 ~/.zshrc 파일에 추가하시" +
+	"겠습니까?\x02예\x02아니요\x02셸 %[1]s이 BASH 또는 ZSH가 아니므로 RC 파일에 DB 변수를 추가하지 않습니" +
+	"다.\x02사용자 홈 디렉토리를 가져오는 중 오류 발생:\x02%[1]s 파일을 여는 중 오류 발생: %[2]s\x02%[1]" +
+	"s 파일을 읽는 중 오류 발생: %[2]s\x02%[1]s 파일을 닫는 중 오류 발생: %[2]s\x02%[1]s 파일을 쓰기 모" +
+	"드로 여는 중 오류 발생:\x02%[1]s 파일에 쓰는 중 오류 발생: %[2]s\x02%[1]s 파일에 쓰기 내용을 플러시하" +
+	"는 데 실패했습니다: %[2]s\x02다시 시도 중.......(%[1]d/5)\x04\x00\x01 :\x02%[1]s와 함" +
+	"께 웹 인터페이스를 시도해보세요\x02이 노드에서 Curio 서비스를 설정하려면 'curio service-setup'을 실행" +
+	"하고 다른 노드에서도 동일하게 진행하십시오.\x02해당하는 경우 이제 시장 노드를 이주할 수 있습니다 (%[1]s).\x02추" +
+	"가 정보는 http://docs.curiostorage.org 에 있습니다.\x02새로운 채굴자 초기화 완료.\x02lotus" +
+	"-miner config.toml을 Curio의 데이터베이스 구성으로 이전 중입니다.\x02API 가져오기 오류: %[1]s" +
+	"\x02FullNode의 API 정보를 가져올 수 없습니다: %[1]w\x02토큰을 가져오는 중 오류 발생: %[1]s\x02이동" +
+	"할 수 없는 섹터가 발견되었습니다. 계속하시겠습니까?\x02예, 계속\x02아니오, 중단\x02마이그레이션 중단.\x02레이어" +
+	"에 구성을 저장하는 중 오류 발생: %[1]s. 마이그레이션 중단\x02Curio 팀은 당신이 사용하는 소프트웨어를 개선하고자" +
+	" 합니다. 팀에게 `%[1]s`를 사용 중이라고 알려주세요.\x02Curio 팀과 공유하고 싶은 것을 선택하세요.\x02개별 데이" +
+	"터: 채굴자 ID, Curio 버전, 체인 (%[1]s 또는 %[2]s). 서명됨.\x02집계-익명: 버전, 체인, 및 채굴자" +
+	" 파워 (버킷).\x02힌트: 나는 어떤 체인에서든 Curio를 실행 중인 사람입니다.\x02아무것도 없습니다.\x02마이너 파워" +
+	"를 가져오는 중 오류 발생: %[1]s\x02메시지를 마샬하는 중 오류 발생: %[1]s\x02마이너 정보를 가져오는 중 오류" +
+	" 발생: %[1]s\x02메시지 서명 중 오류 발생: %[1]s\x02메시지 전송 중 오류 발생: %[1]s\x04\x00\x01" +
+	" =\x02메시지 전송 중 오류 발생: 상태 %[1]s, 메시지:\x02메시지가 전송되었습니다.\x04\x00\x01 \x08" +
+	"\x02문서:\x02'%[1]s' 레이어에는 공통 구성이 저장됩니다. 모든 Curio 인스턴스는 %[2]s 인수에 포함시킬 수 있" +
+	"습니다.\x02기계별 구성 변경을 위해 다른 레이어를 추가할 수 있습니다.\x02Filecoin %[1]s 채널: %[2]s " +
+	"및 %[3]s\x02신뢰성 향상을 위한 중복성 사용: 적어도 post 레이어를 사용하여 여러 대의 기계를 시작하십시오: 'cu" +
+	"rio run --layers=post'\x02한 개의 데이터베이스는 여러 광부 ID를 제공할 수 있습니다: 각 lotus-min" +
+	"er에 대해 마이그레이션을 실행하세요.\x02Yugabyte에 연결되었습니다. 스키마가 현재입니다.\x02Yugabyte에 연결됨" +
+	"\x02시작하려면 밀봉 파이프라인이 비어 있고 lotus-miner가 종료되었는지 확인하세요.\x02로터스 마이너 구성 디렉토리의" +
+	" 위치를 선택하시겠습니까?\x02기타\x02%[1]s에서 사용하는 구성 디렉터리 경로를 입력하세요.\x04\x00\x01 M" +
+	"\x02경로가 제공되지 않았으므로 마이그레이션을 포기합니다\x02제공된 디렉토리에서 config.toml 파일을 읽을 수 없습니다" +
+	". 오류: %[1]s\x02디렉토리에서 저장소를 생성할 수 없습니다: %[1]s. 마이그레이션을 중단합니다.\x02광부 저장소를 " +
+	"잠금 해제할 수 없습니다. 귀하의 광부를 중지해야 합니다: %[1]s\x0a 마이그레이션을 중단합니다.\x02마이너 구성 읽기" +
+	"\x04\x00\x01\x0a\x15\x02단계 완료: %[1]s\x02새 채굴자 액터 초기화 중.\x02새 채굴자를 생성하기 위" +
+	"한 정보 입력\x02소유자 지갑: %[1]s\x02작업자 지갑: %[1]s\x02발송자 지갑: %[1]s\x02섹터 크기: %" +
+	"[1]s\x02주소를 확인하고 새 채굴자 액터를 생성하려면 계속 진행하세요.\x04\x00\x01 &\x02채굴자 생성 오류 발생" +
+	": %[1]s\x02소유자 주소 입력\x02주소가 제공되지 않았습니다\x02주소 구문 분석 실패: %[1]s\x02%[1]s 주소" +
+	" 입력\x02섹터 크기 선택\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1c" +
+	"\x02섹터 선택 실패: %[1]s\x02섹터 크기 구문 분석 실패: %[1]s\x02채굴자 액터 생성 실패: %[1]s\x02%" +
+	"[1]s 채굴자가 성공적으로 생성되었습니다\x02데이터베이스에 연결할 수 없습니다: %[1]s\x02풀 노드 API에 연결하는 중" +
+	" 오류 발생: %[1]s\x02사전 초기화 단계 완료\x02비밀번호를 위한 랜덤 바이트 생성에 실패했습니다: %[1]s\x02마이" +
+	"너 생성은 idempotent하지 않으므로 가이드 설정을 다시 실행하지 마십시오. 구성을 완료하려면 'curio config " +
+	"new-cluster %[1]s'를 실행해야 합니다.\x02FullNode에 대한 API 정보를 가져오는 데 실패했습니다: %[1" +
+	"]w\x02데몬 노드로부터 인증 토큰을 확인하는 중 오류 발생: %[1]s\x02기본 구성 생성 실패: %[1]s\x02데이터베이" +
+	"스에 'base' 구성 레이어를 삽입하는 데 실패했습니다: %[1]s\x02이 마이너 주소를 포함한 구성 'base'가 업데이" +
+	"트되었습니다.\x02데이터베이스에서 기본 구성을 로드하는 데 실패했습니다: %[1]s\x02기본 구성을 구문 분석하는 데 실패" +
+	"했습니다: %[1]s\x02기본 구성을 재생성하는 데 실패했습니다: %[1]s\x02Yugabyte 데이터베이스 설치에 연결할" +
+	" 정보를 입력하십시오 (https://download.yugabyte.com/)\x02호스트: %[1]s\x02포트: %[1]s" +
+	"\x02사용자 이름: %[1]s\x02비밀번호: %[1]s\x02데이터베이스: %[1]s\x02계속 연결 및 스키마 업데이트." +
+	"\x04\x00\x01 ^\x02데이터베이스 구성 오류가 발생하여 마이그레이션을 포기합니다: %[1]s\x02Yugabyte 데이" +
+	"터베이스 호스트를 입력하십시오\x02호스트가 제공되지 않았습니다\x02Yugabyte 데이터베이스 %[1]s을 입력하십시오" +
+	"\x02값이 제공되지 않았습니다\x02Yugabyte 데이터베이스에 연결하는 중 오류가 발생했습니다: %[1]s\x02이 대화형 " +
+	"도구는 Curio 서비스 파일을 생성/교체하고 기본 env 파일을 생성합니다.\x02서비스 파일 %[1]s이 %[2]s에 이미" +
+	" 존재합니다. 변경 사항 없음.\x02%[1]s에서 서비스 파일을 확인하는 중 오류 발생: %[2]s\x02서비스 파일을 쓰는 중" +
+	" 오류 발생: %[1]s\x02서비스 파일 %[1]s이 %[2]s에 성공적으로 생성되었습니다.\x02systemd를 다시 로드하는" +
+	" 중 오류 발생: %[1]s\x02서비스를 활성화하는 중 오류 발생: %[1]s\x04\x00\x01\x0a-\x02서비스 %[1" +
+	"]s이 활성화되었습니다.\x02Curio 노드를 구성할 정보를 입력하십시오\x02CURIO_LAYERS: %[1]s\x02CURI" +
+	"O_REPO_PATH: %[1]s\x02CURIO_NODE_NAME: %[1]s\x02FIL_PROOFS_PARAMETER_CAC" +
+	"HE와 같은 추가 변수를 추가하세요.\x02env 파일 업데이트를 계속하십시오.\x04\x00\x01 /\x02환경 설정 오류 발" +
+	"생, 중단 중: %[1]s\x02이 노드에 사용할 구성 레이어 이름을 입력하십시오. 기본값으로 Base가 이미 포함되어 있습니" +
+	"다\x02레이어가 제공되지 않았습니다\x02%[1]s을(를) 입력하십시오\x02FIL_PROOFS_PARAMETER_CACHE" +
+	"와 같은 추가 변수를 추가하시겠습니까? (y/n)\x02추가 변수가 추가되지 않았습니다\x02추가 환경 변수를 한 줄에 하나씩" +
+	" 입력하세요. 완료하려면 Ctrl+D를 사용하세요:\x02입력을 읽는 중 오류 발생: %[1]s\x02잘못된 입력 건너뜀: %[1" +
+	"]s\x02파일 %[1]s을(를) 열거나 생성하는 중 오류 발생: %[2]s\x02파일 %[1]s에 쓰는 중 오류 발생: %[2]" +
+	"s\x02서비스 환경 파일 /etc/curio.env이(가) 성공적으로 생성되었습니다.\x02%[1]d 섹터의 메타데이터를 이동 " +
+	"중입니다.\x02기본 설정 'base'가 이 마이너의 주소(%[1]s) 및 지갑 설정을 포함하도록 업데이트되었습니다.\x02구" +
+	"성 %[1]s를 %[2]s과 비교하세요. 지갑 주소 이외의 마이너 ID 사이의 변경 사항은 필요한 실행자를 위한 새로운 최소한" +
+	"의 레이어여야 합니다.\x02'base' 설정이 이 lotus-miner의 config.toml과 유사하게 만들어졌습니다." +
+	"\x04\x00\x01 *\x02레이어 %[1]s가 생성되었습니다.\x04\x00\x01 \x22\x02구성 파일을 사용하려면:" +
+	"\x02Curio를 실행하려면: 기계 또는 cgroup 격리를 사용하여 다음 명령을 사용하세요 (예제 레이어 선택과 함께):"
 
-var zhIndex = []uint32{ // 139 elements
+var zhIndex = []uint32{ // 149 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000033, 0x0000008b, 0x00000134,
 	0x0000017c, 0x000001cb, 0x000001e4, 0x000001f1,
 	0x00000211, 0x0000022a, 0x00000240, 0x0000025d,
-	0x000002bb, 0x000002db, 0x000002ff, 0x00000323,
-	0x00000350, 0x00000374, 0x000003a6, 0x000003c0,
-	0x000003e6, 0x00000453, 0x00000494, 0x000004c7,
-	0x000004e3, 0x00000528, 0x00000545, 0x0000056e,
-	0x0000058c, 0x000005c0, 0x000005d0, 0x000005dd,
+	0x000002af, 0x000002b3, 0x000002b7, 0x00000315,
+	0x00000335, 0x00000359, 0x0000037d, 0x000003a1,
+	0x000003ce, 0x000003f2, 0x00000424, 0x0000043e,
+	0x00000464, 0x000004d1, 0x00000512, 0x00000545,
+	0x00000561, 0x000005a6, 0x000005c3, 0x000005ec,
 	// Entry 20 - 3F
-	0x000005ed, 0x00000626, 0x0000067a, 0x000006a7,
-	0x000006f6, 0x00000731, 0x00000766, 0x00000770,
-	0x00000794, 0x000007b2, 0x000007d6, 0x000007f4,
-	0x00000812, 0x00000847, 0x0000085a, 0x00000869,
-	0x000008c3, 0x00000900, 0x00000928, 0x00000987,
-	0x000009d7, 0x00000a04, 0x00000a19, 0x00000a64,
-	0x00000a94, 0x00000a9b, 0x00000ac5, 0x00000ae9,
-	0x00000b2d, 0x00000b5f, 0x00000ba8, 0x00000bbb,
+	0x0000060a, 0x0000063e, 0x0000064e, 0x0000065b,
+	0x0000066b, 0x000006a4, 0x000006f8, 0x00000725,
+	0x00000774, 0x000007af, 0x000007e4, 0x000007ee,
+	0x00000812, 0x00000830, 0x00000854, 0x00000872,
+	0x00000890, 0x000008c5, 0x000008d8, 0x000008e7,
+	0x00000941, 0x0000097e, 0x000009a6, 0x00000a05,
+	0x00000a55, 0x00000a82, 0x00000a97, 0x00000ae2,
+	0x00000b12, 0x00000b19, 0x00000b43, 0x00000b67,
 	// Entry 40 - 5F
-	0x00000bd5, 0x00000bf4, 0x00000c19, 0x00000c30,
-	0x00000c44, 0x00000c5b, 0x00000c6f, 0x00000ca0,
-	0x00000cc5, 0x00000cdb, 0x00000ceb, 0x00000d05,
-	0x00000d19, 0x00000d2c, 0x00000d33, 0x00000d3a,
-	0x00000d40, 0x00000d46, 0x00000d65, 0x00000d85,
-	0x00000da5, 0x00000dbf, 0x00000ddc, 0x00000e0d,
-	0x00000e26, 0x00000e4f, 0x00000edc, 0x00000f08,
-	0x00000f43, 0x00000f63, 0x00000f94, 0x00000fc7,
+	0x00000bab, 0x00000bdd, 0x00000c26, 0x00000c39,
+	0x00000c53, 0x00000c72, 0x00000c97, 0x00000cae,
+	0x00000cc2, 0x00000cd9, 0x00000ced, 0x00000d1e,
+	0x00000d43, 0x00000d59, 0x00000d69, 0x00000d83,
+	0x00000d97, 0x00000daa, 0x00000db1, 0x00000db8,
+	0x00000dbe, 0x00000dc4, 0x00000de3, 0x00000e03,
+	0x00000e23, 0x00000e3d, 0x00000e5a, 0x00000e8b,
+	0x00000ea4, 0x00000ecd, 0x00000f5a, 0x00000f86,
 	// Entry 60 - 7F
-	0x00000ff4, 0x00001015, 0x0000103b, 0x00001095,
-	0x000010a4, 0x000010b3, 0x000010c5, 0x000010d4,
-	0x000010e6, 0x00001105, 0x0000113d, 0x00001162,
-	0x00001172, 0x00001190, 0x0000119d, 0x000011c9,
-	0x00001222, 0x00001260, 0x0000128d, 0x000012b0,
-	0x000012dc, 0x00001302, 0x0000131f, 0x0000133e,
-	0x00001367, 0x0000137b, 0x00001392, 0x000013a9,
-	0x000013c4, 0x000013f5, 0x00001440, 0x0000144d,
+	0x00000fc1, 0x00000fe1, 0x00001012, 0x00001045,
+	0x00001072, 0x00001093, 0x000010b9, 0x00001113,
+	0x00001122, 0x00001131, 0x00001143, 0x00001152,
+	0x00001164, 0x00001183, 0x000011bb, 0x000011e0,
+	0x000011f0, 0x0000120e, 0x0000121b, 0x00001247,
+	0x000012a0, 0x000012de, 0x0000130b, 0x0000132e,
+	0x0000135a, 0x00001380, 0x0000139d, 0x000013bc,
+	0x000013e5, 0x000013f9, 0x00001410, 0x00001427,
 	// Entry 80 - 9F
-	0x0000145a, 0x00001487, 0x000014ab, 0x000014e0,
-	0x0000150a, 0x0000155b, 0x000015dd, 0x00001624,
-	0x0000163e, 0x00001656, 0x000016ad,
-} // Size: 580 bytes
+	0x0000145c, 0x00001477, 0x000014a8, 0x000014f3,
+	0x00001500, 0x0000150d, 0x00001556, 0x0000156c,
+	0x000015c4, 0x000015e1, 0x000015fb, 0x00001628,
+	0x0000164c, 0x00001681, 0x000016ab, 0x000016fc,
+	0x0000177e, 0x000017c5, 0x000017df, 0x000017f7,
+	0x0000184e,
+} // Size: 620 bytes
 
-const zhData string = "" + // Size: 5805 bytes
+const zhData string = "" + // Size: 6222 bytes
 	"\x04\x00\x01 .\x02使用箭头键进行导航：↓ ↑ → ←\x02此交互式工具将创建一个新的矿工角色，并为其创建基本配置层。\x02" +
 	"该过程部分幂等。一旦创建了新的矿工角色，并且随后的步骤失败，用户需要运行 'curio config new-cluster < 矿工 ID" +
 	" >' 来完成配置。\x02这个交互式工具可以在5分钟内将lotus-miner迁移到Curio。\x02每一步都需要您的确认，并且可以撤销。随" +
 	"时按Ctrl+C退出。\x02在终端中按下Ctrl+C\x02我想要：\x02从现有的 Lotus-Miner 迁移\x02创建一个新的矿工" +
-	"\x02中止剩余步骤。\x02Lotus-Miner到Curio迁移。\x02由于 shell %[1]s 不是 BASH 或 ZSH，因此未将" +
-	"数据库变量添加到 RC 文件中。\x02获取用户主目录时出错:\x02打开文件 %[1]s 时出错: %[2]s\x02读取文件 %[1]s" +
-	" 时出错: %[2]s\x02以写入模式打开文件 %[1]s 时出错:\x02写入文件 %[1]s 时出错: %[2]s\x02无法将写入内容刷" +
-	"新到文件 %[1]s: %[2]s\x02重试中.......(%[1]d/5)\x04\x00\x01 !\x02尝试使用%[1]s的网页" +
-	"界面\x02执行 'curio service-setup' 以在此节点上设置 Curio 服务，并在其他节点上执行相同操作\x02如果适用" +
-	"，您现在可以迁移您的市场节点(%[1]s)。\x02更多信息请访问 http://docs.curiostorage.org\x02新矿工初" +
-	"始化完成。\x02将 lotus-miner config.toml 迁移到 Curio 的数据库配置中。\x02获取 API 时出错：%[" +
-	"1]s\x02无法获取FullNode的API信息：%[1]w\x02获取令牌时出错：%[1]s\x02发现无法迁移的扇区。您想要继续吗？" +
-	"\x02是的，继续\x02不，中止\x02中止迁移。\x02保存配置到层时出错：%[1]s。正在中止迁移\x02Curio 团队希望改进您使用的" +
-	"软件。告诉团队您正在使用 `%[1]s`。\x02选择您想与Curio团队分享的内容。\x02个人数据：矿工 ID，Curio 版本，链（%" +
-	"[1]s 或 %[2]s）。签名。\x02聚合-匿名：版本，链和矿工算力（分桶）。\x02提示：我是在任何链上运行 Curio 的人。\x02没" +
-	"有。\x02获取矿工功率时出错：%[1]s\x02整理消息时出错：%[1]s\x02获取矿工信息时出错：%[1]s\x02签署消息时出错：%" +
-	"[1]s\x02发送消息时出错：%[1]s\x04\x00\x01 0\x02发送消息时出错：状态%[1]s，消息：\x02消息已发送。\x04" +
-	"\x00\x01 \x0a\x02文档：\x02'%[1]s'层存储通用配置。所有Curio实例都可以在其%[2]s参数中包含它。\x02您可以" +
-	"添加其他层进行每台机器的配置更改。\x02Filecoin %[1]s 频道：%[2]s 和 %[3]s\x02通过冗余增加可靠性：使用至少" +
-	"后层启动多台机器：'curio run --layers=post'\x02一个数据库可以服务多个矿工ID：为每个lotus-miner运行" +
-	"迁移。\x02已连接到Yugabyte。模式是当前的。\x02已连接到Yugabyte\x02开始之前，请确保您的密封管道已排空并关闭lot" +
-	"us-miner。\x02选择您的lotus-miner配置目录的位置？\x02其他\x02输入%[1]s使用的配置目录的路径\x04\x00" +
-	"\x01 \x1f\x02未提供路径，放弃迁移\x02无法读取提供的目录中的config.toml文件，错误：%[1]s\x02无法从目录创建r" +
-	"epo：%[1]s。 中止迁移\x02无法锁定矿工repo。 您的矿工必须停止：%[1]s\x0a 中止迁移\x02读取矿工配置\x04\x00" +
-	"\x01\x0a\x15\x02步骤完成：%[1]s\x02初始化新的矿工角色。\x02输入创建新矿工所需的信息\x02所有者钱包: %[1]s" +
-	"\x02工人钱包: %[1]s\x02发送者钱包: %[1]s\x02扇区大小: %[1]s\x02继续验证地址并创建新的矿工角色。\x04" +
-	"\x00\x01  \x02矿工创建错误发生: %[1]s\x02输入所有者地址\x02未提供地址\x02解析地址失败: %[1]s\x02输入" +
-	" %[1]s 地址\x02选择扇区大小\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 " +
-	"\x1a\x02扇区选择失败: %[1]s\x02解析扇区大小失败: %[1]s\x02创建矿工角色失败: %[1]s\x02矿工 %[1]s " +
-	"创建成功\x02无法访问数据库: %[1]s\x02连接到完整节点 API 时发生错误: %[1]s\x02预初始化步骤完成\x02生成密码" +
-	"的随机字节失败: %[1]s\x02请不要再次运行引导设置，因为矿工创建不是幂等的。 您需要运行 'curio config new-clu" +
-	"ster %[1]s' 来完成配置。\x02无法获取 FullNode 的 API 信息: %[1]w\x02无法验证来自守护进程节点的授权令牌" +
-	": %[1]s\x02无法生成默认配置: %[1]s\x02无法将 'base' 配置层插入数据库: %[1]s\x02配置 'base' 已更" +
-	"新以包含此矿工的地址\x02从数据库加载基本配置失败：%[1]s\x02解析基本配置失败：%[1]s\x02重新生成基本配置失败: %[1]" +
-	"s\x02输入连接到您的Yugabyte数据库安装的信息（https://download.yugabyte.com/）\x02主机：%[1]s" +
-	"\x02端口：%[1]s\x02用户名：%[1]s\x02密码：%[1]s\x02数据库：%[1]s\x02继续连接和更新架构。\x04\x00" +
-	"\x01 3\x02发生数据库配置错误，放弃迁移：%[1]s\x02输入Yugabyte数据库主机（S）\x02未提供主机\x02输入Yugab" +
-	"yte数据库 %[1]s\x02未提供值\x02连接到Yugabyte数据库时出错：%[1]s\x02此交互式工具创建/替换 Curio 服务文" +
-	"件并为其创建基本的 env 文件。\x02服务文件 %[1]s 已存在于 %[2]s，未做任何更改。\x02检查 %[1]s 的服务文件时出" +
-	"错: %[2]s\x02写入服务文件时出错: %[1]s\x02服务文件 %[1]s 已成功创建于 %[2]s\x02重新加载 system" +
-	"d 时出错: %[1]s\x02启用服务时出错: %[1]s\x04\x00\x01\x0a\x1a\x02服务 %[1]s 已启用。\x02输" +
-	"入信息以配置您的 Curio 节点\x02CURIO_LAYERS: %[1]s\x02CURIO_REPO_PATH: %[1]s\x02" +
-	"CURIO_NODE_NAME: %[1]s\x02继续更新 env 文件。\x04\x00\x01 ,\x02发生环境配置错误，放弃中: %[" +
-	"1]s\x02输入此节点要使用的配置层名称。默认情况下已包含 Base\x02未提供层\x02输入 %[1]s\x02打开或创建文件 %[1]s" +
-	" 时出错: %[2]s\x02写入文件 %[1]s 时出错: %[2]s\x02服务环境文件 /etc/curio.env 已成功创建。\x02" +
-	"正在迁移%[1]d个扇区的元数据。\x02'base'配置已更新，包括该矿工的地址（%[1]s）及其钱包设置。\x02比较配置%[1]s和%" +
-	"[2]s。矿工ID之间除了钱包地址的变化应该是需要的运行者的一个新的、最小的层。\x02'base'配置已创建，以类似于这个lotus-mine" +
-	"r的config.toml。\x04\x00\x01 \x15\x02层%[1]s已创建。\x04\x00\x01 \x13\x02要使用配置：" +
-	"\x02运行Curio：使用机器或cgroup隔离，使用命令（附带示例层选择）："
+	"\x02中止剩余步骤。\x02Lotus-Miner到Curio迁移。\x02您是否希望将 Harmony DB 凭据添加到 ~/.bashrc" +
+	" 或 ~/.zshrc 文件中？\x02是\x02否\x02由于 shell %[1]s 不是 BASH 或 ZSH，因此未将数据库变量添加到 " +
+	"RC 文件中。\x02获取用户主目录时出错:\x02打开文件 %[1]s 时出错: %[2]s\x02读取文件 %[1]s 时出错: %[2]s" +
+	"\x02关闭 %[1]s 文件时出错: %[2]s\x02以写入模式打开文件 %[1]s 时出错:\x02写入文件 %[1]s 时出错: %[2" +
+	"]s\x02无法将写入内容刷新到文件 %[1]s: %[2]s\x02重试中.......(%[1]d/5)\x04\x00\x01 !\x02" +
+	"尝试使用%[1]s的网页界面\x02执行 'curio service-setup' 以在此节点上设置 Curio 服务，并在其他节点上执行" +
+	"相同操作\x02如果适用，您现在可以迁移您的市场节点(%[1]s)。\x02更多信息请访问 http://docs.curiostorage" +
+	".org\x02新矿工初始化完成。\x02将 lotus-miner config.toml 迁移到 Curio 的数据库配置中。\x02获取 " +
+	"API 时出错：%[1]s\x02无法获取FullNode的API信息：%[1]w\x02获取令牌时出错：%[1]s\x02发现无法迁移的扇区。" +
+	"您想要继续吗？\x02是的，继续\x02不，中止\x02中止迁移。\x02保存配置到层时出错：%[1]s。正在中止迁移\x02Curio 团" +
+	"队希望改进您使用的软件。告诉团队您正在使用 `%[1]s`。\x02选择您想与Curio团队分享的内容。\x02个人数据：矿工 ID，Cur" +
+	"io 版本，链（%[1]s 或 %[2]s）。签名。\x02聚合-匿名：版本，链和矿工算力（分桶）。\x02提示：我是在任何链上运行 Curio" +
+	" 的人。\x02没有。\x02获取矿工功率时出错：%[1]s\x02整理消息时出错：%[1]s\x02获取矿工信息时出错：%[1]s\x02签署" +
+	"消息时出错：%[1]s\x02发送消息时出错：%[1]s\x04\x00\x01 0\x02发送消息时出错：状态%[1]s，消息：\x02消" +
+	"息已发送。\x04\x00\x01 \x0a\x02文档：\x02'%[1]s'层存储通用配置。所有Curio实例都可以在其%[2]s参数中" +
+	"包含它。\x02您可以添加其他层进行每台机器的配置更改。\x02Filecoin %[1]s 频道：%[2]s 和 %[3]s\x02通过冗" +
+	"余增加可靠性：使用至少后层启动多台机器：'curio run --layers=post'\x02一个数据库可以服务多个矿工ID：为每个lo" +
+	"tus-miner运行迁移。\x02已连接到Yugabyte。模式是当前的。\x02已连接到Yugabyte\x02开始之前，请确保您的密封管道" +
+	"已排空并关闭lotus-miner。\x02选择您的lotus-miner配置目录的位置？\x02其他\x02输入%[1]s使用的配置目录的" +
+	"路径\x04\x00\x01 \x1f\x02未提供路径，放弃迁移\x02无法读取提供的目录中的config.toml文件，错误：%[1]s" +
+	"\x02无法从目录创建repo：%[1]s。 中止迁移\x02无法锁定矿工repo。 您的矿工必须停止：%[1]s\x0a 中止迁移\x02读取" +
+	"矿工配置\x04\x00\x01\x0a\x15\x02步骤完成：%[1]s\x02初始化新的矿工角色。\x02输入创建新矿工所需的信息" +
+	"\x02所有者钱包: %[1]s\x02工人钱包: %[1]s\x02发送者钱包: %[1]s\x02扇区大小: %[1]s\x02继续验证地址" +
+	"并创建新的矿工角色。\x04\x00\x01  \x02矿工创建错误发生: %[1]s\x02输入所有者地址\x02未提供地址\x02解析地" +
+	"址失败: %[1]s\x02输入 %[1]s 地址\x02选择扇区大小\x0264 GiB\x0232 GiB\x028 MiB\x022 " +
+	"KiB\x04\x00\x01 \x1a\x02扇区选择失败: %[1]s\x02解析扇区大小失败: %[1]s\x02创建矿工角色失败: %[" +
+	"1]s\x02矿工 %[1]s 创建成功\x02无法访问数据库: %[1]s\x02连接到完整节点 API 时发生错误: %[1]s\x02预初" +
+	"始化步骤完成\x02生成密码的随机字节失败: %[1]s\x02请不要再次运行引导设置，因为矿工创建不是幂等的。 您需要运行 'curio " +
+	"config new-cluster %[1]s' 来完成配置。\x02无法获取 FullNode 的 API 信息: %[1]w\x02无法验" +
+	"证来自守护进程节点的授权令牌: %[1]s\x02无法生成默认配置: %[1]s\x02无法将 'base' 配置层插入数据库: %[1]s" +
+	"\x02配置 'base' 已更新以包含此矿工的地址\x02从数据库加载基本配置失败：%[1]s\x02解析基本配置失败：%[1]s\x02重新" +
+	"生成基本配置失败: %[1]s\x02输入连接到您的Yugabyte数据库安装的信息（https://download.yugabyte.c" +
+	"om/）\x02主机：%[1]s\x02端口：%[1]s\x02用户名：%[1]s\x02密码：%[1]s\x02数据库：%[1]s\x02继续" +
+	"连接和更新架构。\x04\x00\x01 3\x02发生数据库配置错误，放弃迁移：%[1]s\x02输入Yugabyte数据库主机（S）" +
+	"\x02未提供主机\x02输入Yugabyte数据库 %[1]s\x02未提供值\x02连接到Yugabyte数据库时出错：%[1]s\x02此" +
+	"交互式工具创建/替换 Curio 服务文件并为其创建基本的 env 文件。\x02服务文件 %[1]s 已存在于 %[2]s，未做任何更改。" +
+	"\x02检查 %[1]s 的服务文件时出错: %[2]s\x02写入服务文件时出错: %[1]s\x02服务文件 %[1]s 已成功创建于 %[" +
+	"2]s\x02重新加载 systemd 时出错: %[1]s\x02启用服务时出错: %[1]s\x04\x00\x01\x0a\x1a\x02" +
+	"服务 %[1]s 已启用。\x02输入信息以配置您的 Curio 节点\x02CURIO_LAYERS: %[1]s\x02CURIO_RE" +
+	"PO_PATH: %[1]s\x02CURIO_NODE_NAME: %[1]s\x02添加 FIL_PROOFS_PARAMETER_CACH" +
+	"E 等其他变量。\x02继续更新 env 文件。\x04\x00\x01 ,\x02发生环境配置错误，放弃中: %[1]s\x02输入此节点要使" +
+	"用的配置层名称。默认情况下已包含 Base\x02未提供层\x02输入 %[1]s\x02您是否希望添加 FIL_PROOFS_PARAME" +
+	"TER_CACHE 等其他变量？(y/n)\x02未添加其他变量\x02开始输入您的附加环境变量，每行一个变量。使用 Ctrl+D 完成输入:" +
+	"\x02读取输入时出错: %[1]s\x02跳过无效输入: %[1]s\x02打开或创建文件 %[1]s 时出错: %[2]s\x02写入文件 " +
+	"%[1]s 时出错: %[2]s\x02服务环境文件 /etc/curio.env 已成功创建。\x02正在迁移%[1]d个扇区的元数据。" +
+	"\x02'base'配置已更新，包括该矿工的地址（%[1]s）及其钱包设置。\x02比较配置%[1]s和%[2]s。矿工ID之间除了钱包地址的变" +
+	"化应该是需要的运行者的一个新的、最小的层。\x02'base'配置已创建，以类似于这个lotus-miner的config.toml。" +
+	"\x04\x00\x01 \x15\x02层%[1]s已创建。\x04\x00\x01 \x13\x02要使用配置：\x02运行Curio：使用" +
+	"机器或cgroup隔离，使用命令（附带示例层选择）："
 
-	// Total table size 22160 bytes (21KiB); checksum: 7C0037F2
+	// Total table size 23670 bytes (23KiB); checksum: D742C53

--- a/cmd/curio/internal/translations/catalog.go
+++ b/cmd/curio/internal/translations/catalog.go
@@ -40,203 +40,199 @@ func init() {
 }
 
 var messageKeyToIndex = map[string]int{
-	"2 KiB":                     84,
-	"32 GiB":                    82,
-	"64 GiB":                    81,
-	"8 MiB":                     83,
-	"Aborting migration.":       35,
+	"2 KiB":                     82,
+	"32 GiB":                    80,
+	"64 GiB":                    79,
+	"8 MiB":                     81,
+	"Aborting migration.":       33,
 	"Aborting remaining steps.": 9,
-	"Add additional variables like FIL_PROOFS_PARAMETER_CACHE.":        127,
-	"Additional info is at http://docs.curiostorage.org":               26,
-	"Aggregate-Anonymous: version, chain, and Miner power (bucketed).": 40,
-	"CURIO_LAYERS: %s":        124,
-	"CURIO_NODE_NAME: %s":     126,
-	"CURIO_REPO_PATH: %s":     125,
-	"Cannot reach the DB: %s": 89,
-	"Cannot read the config.toml file in the provided directory, Error: %s":                                                                                  63,
-	"Compare the configurations %s to %s. Changes between the miner IDs other than wallet addreses should be a new, minimal layer for runners that need it.": 143,
-	"Configuration 'base' was created to resemble this lotus-miner's config.toml .":                                                                          144,
-	"Configuration 'base' was updated to include this miner's address":                                                                                       98,
-	"Configuration 'base' was updated to include this miner's address (%s) and its wallet setup.":                                                            142,
-	"Connected to Yugabyte":                                                          57,
-	"Connected to Yugabyte. Schema is current.":                                      56,
-	"Continue to connect and update schema.":                                         108,
-	"Continue to verify the addresses and create a new miner actor.":                 74,
-	"Continue update the env file.":                                                  128,
-	"Could not create repo from directory: %s. Aborting migration":                   64,
-	"Could not lock miner repo. Your miner must be stopped: %s\n Aborting migration": 65,
+	"Add additional variables like FIL_PROOFS_PARAMETER_CACHE: %s":     125,
+	"Additional info is at http://docs.curiostorage.org":               24,
+	"Aggregate-Anonymous: version, chain, and Miner power (bucketed).": 38,
+	"CURIO_LAYERS: %s":        122,
+	"CURIO_NODE_NAME: %s":     124,
+	"CURIO_REPO_PATH: %s":     123,
+	"Cannot reach the DB: %s": 87,
+	"Cannot read the config.toml file in the provided directory, Error: %s":                                                                                  61,
+	"Compare the configurations %s to %s. Changes between the miner IDs other than wallet addreses should be a new, minimal layer for runners that need it.": 140,
+	"Configuration 'base' was created to resemble this lotus-miner's config.toml .":                                                                          141,
+	"Configuration 'base' was updated to include this miner's address":                                                                                       96,
+	"Configuration 'base' was updated to include this miner's address (%s) and its wallet setup.":                                                            139,
+	"Connected to Yugabyte":                                                          55,
+	"Connected to Yugabyte. Schema is current.":                                      54,
+	"Continue to connect and update schema.":                                         106,
+	"Continue to verify the addresses and create a new miner actor.":                 72,
+	"Continue update the env file.":                                                  126,
+	"Could not create repo from directory: %s. Aborting migration":                   62,
+	"Could not lock miner repo. Your miner must be stopped: %s\n Aborting migration": 63,
 	"Create a new miner":                                                             8,
 	"Ctrl+C pressed in Terminal":                                                     5,
-	"Database config error occurred, abandoning migration: %s ":                      109,
-	"Database: %s": 107,
-	"Do you want to add additional variables like FIL_PROOFS_PARAMETER_CACHE? (y/n)": 133,
+	"Database config error occurred, abandoning migration: %s ":                      107,
+	"Database: %s": 105,
+	"Do you want to add additional variables like FIL_PROOFS_PARAMETER_CACHE? (y/n)": 131,
 	"Do you wish to add Harmony DB credentials to your ~/.bashrc or ~/.zshrc file?":  11,
-	"Documentation: ": 50,
+	"Documentation: ": 48,
 	"Each step needs your confirmation and can be reversed. Press Ctrl+C to exit at any time.": 4,
-	"Enter %s address":                    79,
-	"Enter the %s":                        132,
-	"Enter the Yugabyte database %s":      112,
-	"Enter the Yugabyte database host(s)": 110,
-	"Enter the config layer name to use for this node. Base is already included by default":             130,
-	"Enter the info to configure your Curio node":                                                       123,
-	"Enter the info to connect to your Yugabyte database installation (https://download.yugabyte.com/)": 102,
-	"Enter the info to create a new miner":                                                              69,
-	"Enter the owner address":                                                                           76,
-	"Enter the path to the configuration directory used by %s":                                          61,
-	"Env config error occurred, abandoning: %s ":                                                        129,
-	"Error checking for service file at %s: %s":                                                         117,
-	"Error closing %s file: %s":                                                                         18,
-	"Error connecting to Yugabyte database: %s":                                                         114,
-	"Error connecting to full node API: %s":                                                             90,
-	"Error enabling service: %s":                                                                        121,
-	"Error getting API: %s":                                                                             29,
-	"Error getting miner info: %s":                                                                      45,
-	"Error getting miner power: %s":                                                                     43,
-	"Error getting token: %s":                                                                           31,
+	"Enter %s address":                    77,
+	"Enter the %s":                        130,
+	"Enter the Yugabyte database %s":      110,
+	"Enter the Yugabyte database host(s)": 108,
+	"Enter the config layer name to use for this node. Base is already included by default":             128,
+	"Enter the info to configure your Curio node":                                                       121,
+	"Enter the info to connect to your Yugabyte database installation (https://download.yugabyte.com/)": 100,
+	"Enter the info to create a new miner":                                                              67,
+	"Enter the owner address":                                                                           74,
+	"Enter the path to the configuration directory used by %s":                                          59,
+	"Env config error occurred, abandoning: %s ":                                                        127,
+	"Error checking for service file at %s: %s":                                                         115,
+	"Error connecting to Yugabyte database: %s":                                                         112,
+	"Error connecting to full node API: %s":                                                             88,
+	"Error enabling service: %s":                                                                        119,
+	"Error getting API: %s":                                                                             27,
+	"Error getting miner info: %s":                                                                      43,
+	"Error getting miner power: %s":                                                                     41,
+	"Error getting token: %s":                                                                           29,
 	"Error getting user home directory:":                                                                15,
-	"Error marshalling message: %s":                                                                     44,
-	"Error opening %s file in write mode:":                                                              19,
-	"Error opening %s file: %s":                                                                         16,
-	"Error opening or creating file %s: %s":                                                             138,
-	"Error reading %s file: %s":                                                                         17,
-	"Error reading input: %s":                                                                           136,
-	"Error reloading systemd: %s":                                                                       120,
-	"Error saving config to layer: %s. Aborting Migration":                                              36,
-	"Error sending message: %s":                                                                         47,
-	"Error sending message: Status %s, Message: ":                                                       48,
-	"Error signing message: %s":                                                                         46,
-	"Error writing service file: %s":                                                                    118,
-	"Error writing to %s file: %s":                                                                      20,
-	"Error writing to file %s: %s":                                                                      139,
-	"Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes": 24,
-	"Failed to create the miner actor: %s":                 87,
-	"Failed to flush thw writes to file %s: %s":            21,
-	"Failed to generate default config: %s":                96,
-	"Failed to generate random bytes for secret: %s":       92,
-	"Failed to get API info for FullNode: %w":              94,
-	"Failed to insert 'base' config layer in database: %s": 97,
-	"Failed to load base config from database: %s":         99,
-	"Failed to parse base config: %s":                      100,
-	"Failed to parse sector size: %s":                      86,
-	"Failed to parse the address: %s":                      78,
-	"Failed to regenerate base config: %s":                 101,
-	"Failed to verify the auth token from daemon node: %s": 95,
-	"Filecoin %s channels: %s and %s":                      53,
-	"Hint: I am someone running Curio on whichever chain.": 41,
-	"Host: %s":   103,
+	"Error marshalling message: %s":                                                                     42,
+	"Error opening %s file in write mode:":                                                              16,
+	"Error reading input: %s":                                                                           134,
+	"Error reloading systemd: %s":                                                                       118,
+	"Error saving config to layer: %s. Aborting Migration":                                              34,
+	"Error sending message: %s":                                                                         45,
+	"Error sending message: Status %s, Message: ":                                                       46,
+	"Error signing message: %s":                                                                         44,
+	"Error writing service file: %s":                                                                    116,
+	"Error writing to %s file: %s":                                                                      17,
+	"Error writing to file %s: %s":                                                                      136,
+	"Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes": 22,
+	"Failed to create the miner actor: %s":                 85,
+	"Failed to flush the writes to file %s: %s":            18,
+	"Failed to generate default config: %s":                94,
+	"Failed to generate random bytes for secret: %s":       90,
+	"Failed to get API info for FullNode: %w":              92,
+	"Failed to insert 'base' config layer in database: %s": 95,
+	"Failed to load base config from database: %s":         97,
+	"Failed to parse base config: %s":                      98,
+	"Failed to parse sector size: %s":                      84,
+	"Failed to parse the address: %s":                      76,
+	"Failed to regenerate base config: %s":                 99,
+	"Failed to verify the auth token from daemon node: %s": 93,
+	"Filecoin %s channels: %s and %s":                      51,
+	"Finished updating the %s file":                        20,
+	"Hint: I am someone running Curio on whichever chain.": 39,
+	"Host: %s":   101,
 	"I want to:": 6,
-	"Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'": 54,
-	"Individual Data: Miner ID, Curio version, chain (%s or %s). Signed.":                                                    39,
-	"Initializing a new miner actor.":   68,
-	"Layer %s created. ":                145,
+	"Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'": 52,
+	"Individual Data: Miner ID, Curio version, chain (%s or %s). Signed.":                                                    37,
+	"Initializing a new miner actor.":   66,
+	"Layer %s created. ":                142,
 	"Lotus-Miner to Curio Migration.":   10,
-	"Message sent.":                     49,
+	"Message sent.":                     47,
 	"Migrate from existing Lotus-Miner": 7,
-	"Migrating lotus-miner config.toml to Curio in-database configuration.": 28,
-	"Migrating metadata for %d sectors.":                                    141,
-	"Miner %s created successfully":                                         88,
-	"Miner creation error occurred: %s ":                                    75,
-	"New Miner initialization complete.":                                    27,
+	"Migrating lotus-miner config.toml to Curio in-database configuration.": 26,
+	"Migrating metadata for %d sectors.":                                    138,
+	"Miner %s created successfully":                                         86,
+	"Miner creation error occurred: %s ":                                    73,
+	"New Miner initialization complete.":                                    25,
 	"No":                                                                    13,
-	"No additional variables added":                                         134,
-	"No address provided":                                                   77,
-	"No host provided":                                                      111,
-	"No layer provided":                                                     131,
-	"No path provided, abandoning migration ":                               62,
-	"No value provided":                                                     113,
-	"No, abort":                                                             34,
+	"No additional variables added":                                         132,
+	"No address provided":                                                   75,
+	"No host provided":                                                      109,
+	"No layer provided":                                                     129,
+	"No path provided, abandoning migration ":                               60,
+	"No value provided":                                                     111,
+	"No, abort":                                                             32,
 	"Not adding DB variables to RC file as shell %s is not BASH or ZSH.": 14,
-	"Nothing.": 42,
-	"One database can serve multiple miner IDs: Run a migration for each lotus-miner.": 55,
-	"Other":            60,
-	"Owner Wallet: %s": 70,
-	"Password: %s":     106,
-	"Please do not run guided-setup again as miner creation is not idempotent. You need to run 'curio config new-cluster %s' to finish the configuration": 93,
-	"Port: %s":                          104,
-	"Pre-initialization steps complete": 91,
-	"Read Miner Config":                 66,
-	"Retrying.......(%d/5)":             22,
-	"Sector Size: %s":                   73,
-	"Sector selection failed: %s ":      85,
-	"Select the Sector Size":            80,
-	"Select the location of your lotus-miner config directory?": 59,
-	"Select what you want to share with the Curio team.":        38,
-	"Sender Wallet: %s":     72,
-	"Service %s enabled.\n": 122,
-	"Service env file /etc/curio.env created successfully.":                                                140,
-	"Service file %s already exists at %s, no changes made.":                                               116,
-	"Service file %s created successfully at %s":                                                           119,
-	"Skipping invalid input: %s":                                                                           137,
-	"Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:":      135,
-	"Step Complete: %s\n":                                                                                  67,
-	"The '%s' layer stores common configuration. All curio instances can include it in their %s argument.": 51,
-	"The Curio team wants to improve the software you use. Tell the team you're using `%s`.":               37,
+	"Nothing.": 40,
+	"One database can serve multiple miner IDs: Run a migration for each lotus-miner.": 53,
+	"Other":            58,
+	"Owner Wallet: %s": 68,
+	"Password: %s":     104,
+	"Please do not run guided-setup again as miner creation is not idempotent. You need to run 'curio config new-cluster %s' to finish the configuration": 91,
+	"Port: %s":                          102,
+	"Pre-initialization steps complete": 89,
+	"Read Miner Config":                 64,
+	"Retrying.......(%d/5)":             19,
+	"Sector Size: %s":                   71,
+	"Sector selection failed: %s ":      83,
+	"Select the Sector Size":            78,
+	"Select the location of your lotus-miner config directory?": 57,
+	"Select what you want to share with the Curio team.":        36,
+	"Sender Wallet: %s":     70,
+	"Service %s enabled.\n": 120,
+	"Service env file /etc/curio.env created successfully.":                                                137,
+	"Service file %s already exists at %s, no changes made.":                                               114,
+	"Service file %s created successfully at %s":                                                           117,
+	"Skipping invalid input: %s":                                                                           135,
+	"Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:":      133,
+	"Step Complete: %s\n":                                                                                  65,
+	"The '%s' layer stores common configuration. All curio instances can include it in their %s argument.": 49,
+	"The Curio team wants to improve the software you use. Tell the team you're using `%s`.":               35,
 	"This interactive tool creates a new miner actor and creates the basic configuration layer for it.":    1,
-	"This interactive tool creates/replace Curio service file and creates the basic env file for it.":      115,
+	"This interactive tool creates/replace Curio service file and creates the basic env file for it.":      113,
 	"This interactive tool migrates lotus-miner to Curio in 5 minutes.":                                    3,
 	"This process is partially idempotent. Once a new miner actor has been created and subsequent steps fail, the user need to run 'curio config new-cluster < miner ID >' to finish the configuration.": 2,
-	"To run Curio: With machine or cgroup isolation, use the command (with example layer selection):":                                                                                                    147,
-	"To start, ensure your sealing pipeline is drained and shut-down lotus-miner.":                                                                                                                       58,
-	"To work with the config: ":                            146,
-	"Try the web interface with %s ":                       23,
-	"Unmigratable sectors found. Do you want to continue?": 32,
+	"To run Curio: With machine or cgroup isolation, use the command (with example layer selection):":                                                                                                    144,
+	"To start, ensure your sealing pipeline is drained and shut-down lotus-miner.":                                                                                                                       56,
+	"To work with the config: ":                            143,
+	"Try the web interface with %s ":                       21,
+	"Unmigratable sectors found. Do you want to continue?": 30,
 	"Use the arrow keys to navigate: ↓ ↑ → ← ":             0,
-	"Username: %s":      105,
-	"Worker Wallet: %s": 71,
+	"Username: %s":      103,
+	"Worker Wallet: %s": 69,
 	"Yes":               12,
-	"Yes, continue":     33,
-	"You can add other layers for per-machine configuration changes.": 52,
-	"You can now migrate your market node (%s), if applicable.":       25,
-	"could not get API info for FullNode: %w":                         30,
+	"Yes, continue":     31,
+	"You can add other layers for per-machine configuration changes.": 50,
+	"You can now migrate your market node (%s), if applicable.":       23,
+	"could not get API info for FullNode: %w":                         28,
 }
 
-var enIndex = []uint32{ // 149 elements
+var enIndex = []uint32{ // 146 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000035, 0x00000097, 0x0000015a,
 	0x0000019c, 0x000001f5, 0x00000210, 0x0000021b,
 	0x0000023d, 0x00000250, 0x0000026a, 0x0000028a,
 	0x000002d8, 0x000002dc, 0x000002df, 0x00000325,
-	0x00000348, 0x00000368, 0x00000388, 0x000003a8,
-	0x000003d0, 0x000003f3, 0x00000423, 0x0000043c,
-	0x00000462, 0x000004d6, 0x00000513, 0x00000546,
-	0x00000569, 0x000005af, 0x000005c8, 0x000005f3,
+	0x00000348, 0x00000370, 0x00000393, 0x000003c3,
+	0x000003dc, 0x000003fd, 0x00000423, 0x00000497,
+	0x000004d4, 0x00000507, 0x0000052a, 0x00000570,
+	0x00000589, 0x000005b4, 0x000005cf, 0x00000604,
 	// Entry 20 - 3F
-	0x0000060e, 0x00000643, 0x00000651, 0x0000065b,
-	0x0000066f, 0x000006a7, 0x00000701, 0x00000734,
-	0x0000077e, 0x000007bf, 0x000007f4, 0x000007fd,
-	0x0000081e, 0x0000083f, 0x0000085f, 0x0000087c,
-	0x00000899, 0x000008cc, 0x000008da, 0x000008ee,
-	0x00000959, 0x00000999, 0x000009c2, 0x00000a39,
-	0x00000a8a, 0x00000ab4, 0x00000aca, 0x00000b17,
-	0x00000b51, 0x00000b57, 0x00000b93, 0x00000bbf,
+	0x00000612, 0x0000061c, 0x00000630, 0x00000668,
+	0x000006c2, 0x000006f5, 0x0000073f, 0x00000780,
+	0x000007b5, 0x000007be, 0x000007df, 0x00000800,
+	0x00000820, 0x0000083d, 0x0000085a, 0x0000088d,
+	0x0000089b, 0x000008af, 0x0000091a, 0x0000095a,
+	0x00000983, 0x000009fa, 0x00000a4b, 0x00000a75,
+	0x00000a8b, 0x00000ad8, 0x00000b12, 0x00000b18,
+	0x00000b54, 0x00000b80, 0x00000bc9, 0x00000c09,
 	// Entry 40 - 5F
-	0x00000c08, 0x00000c48, 0x00000c99, 0x00000cab,
-	0x00000cc5, 0x00000ce5, 0x00000d0a, 0x00000d1e,
-	0x00000d33, 0x00000d48, 0x00000d5b, 0x00000d9a,
-	0x00000dc4, 0x00000ddc, 0x00000df0, 0x00000e13,
-	0x00000e27, 0x00000e3e, 0x00000e45, 0x00000e4c,
-	0x00000e52, 0x00000e58, 0x00000e7c, 0x00000e9f,
-	0x00000ec7, 0x00000ee8, 0x00000f03, 0x00000f2c,
-	0x00000f4e, 0x00000f80, 0x00001017, 0x00001042,
+	0x00000c5a, 0x00000c6c, 0x00000c86, 0x00000ca6,
+	0x00000ccb, 0x00000cdf, 0x00000cf4, 0x00000d09,
+	0x00000d1c, 0x00000d5b, 0x00000d85, 0x00000d9d,
+	0x00000db1, 0x00000dd4, 0x00000de8, 0x00000dff,
+	0x00000e06, 0x00000e0d, 0x00000e13, 0x00000e19,
+	0x00000e3d, 0x00000e60, 0x00000e88, 0x00000ea9,
+	0x00000ec4, 0x00000eed, 0x00000f0f, 0x00000f41,
+	0x00000fd8, 0x00001003, 0x0000103b, 0x00001064,
 	// Entry 60 - 7F
-	0x0000107a, 0x000010a3, 0x000010db, 0x0000111c,
-	0x0000114c, 0x0000116f, 0x00001197, 0x000011f9,
-	0x00001205, 0x00001211, 0x00001221, 0x00001231,
-	0x00001241, 0x00001268, 0x000012a9, 0x000012cd,
-	0x000012de, 0x00001300, 0x00001312, 0x0000133f,
-	0x0000139f, 0x000013dc, 0x0000140c, 0x0000142e,
-	0x0000145f, 0x0000147e, 0x0000149c, 0x000014b8,
-	0x000014e4, 0x000014f8, 0x0000150f, 0x00001526,
+	0x0000109c, 0x000010dd, 0x0000110d, 0x00001130,
+	0x00001158, 0x000011ba, 0x000011c6, 0x000011d2,
+	0x000011e2, 0x000011f2, 0x00001202, 0x00001229,
+	0x0000126a, 0x0000128e, 0x0000129f, 0x000012c1,
+	0x000012d3, 0x00001300, 0x00001360, 0x0000139d,
+	0x000013cd, 0x000013ef, 0x00001420, 0x0000143f,
+	0x0000145d, 0x00001479, 0x000014a5, 0x000014b9,
+	0x000014d0, 0x000014e7, 0x00001527, 0x00001545,
 	// Entry 80 - 9F
-	0x00001560, 0x0000157e, 0x000015b0, 0x00001606,
-	0x00001618, 0x00001628, 0x00001677, 0x00001695,
-	0x000016f5, 0x00001710, 0x0000172e, 0x0000175a,
-	0x0000177d, 0x000017b3, 0x000017d9, 0x00001838,
-	0x000018d5, 0x00001923, 0x0000193d, 0x0000195b,
-	0x000019bb,
-} // Size: 620 bytes
+	0x00001577, 0x000015cd, 0x000015df, 0x000015ef,
+	0x0000163e, 0x0000165c, 0x000016bc, 0x000016d7,
+	0x000016f5, 0x00001718, 0x0000174e, 0x00001774,
+	0x000017d3, 0x00001870, 0x000018be, 0x000018d8,
+	0x000018f6, 0x00001956,
+} // Size: 608 bytes
 
-const enData string = "" + // Size: 6587 bytes
+const enData string = "" + // Size: 6486 bytes
 	"\x04\x00\x01 0\x02Use the arrow keys to navigate: ↓ ↑ → ←\x02This intera" +
 	"ctive tool creates a new miner actor and creates the basic configuration" +
 	" layer for it.\x02This process is partially idempotent. Once a new miner" +
@@ -249,142 +245,140 @@ const enData string = "" + // Size: 6587 bytes
 	".\x02Lotus-Miner to Curio Migration.\x02Do you wish to add Harmony DB cr" +
 	"edentials to your ~/.bashrc or ~/.zshrc file?\x02Yes\x02No\x02Not adding" +
 	" DB variables to RC file as shell %[1]s is not BASH or ZSH.\x02Error get" +
-	"ting user home directory:\x02Error opening %[1]s file: %[2]s\x02Error re" +
-	"ading %[1]s file: %[2]s\x02Error closing %[1]s file: %[2]s\x02Error open" +
-	"ing %[1]s file in write mode:\x02Error writing to %[1]s file: %[2]s\x02F" +
-	"ailed to flush thw writes to file %[1]s: %[2]s\x02Retrying.......(%[1]d/" +
-	"5)\x04\x00\x01 !\x02Try the web interface with %[1]s\x02Execute 'curio s" +
-	"ervice-setup' to setup the Curio service on this node and proceed to do " +
-	"the same on the other nodes\x02You can now migrate your market node (%[1" +
-	"]s), if applicable.\x02Additional info is at http://docs.curiostorage.or" +
-	"g\x02New Miner initialization complete.\x02Migrating lotus-miner config." +
-	"toml to Curio in-database configuration.\x02Error getting API: %[1]s\x02" +
-	"could not get API info for FullNode: %[1]w\x02Error getting token: %[1]s" +
-	"\x02Unmigratable sectors found. Do you want to continue?\x02Yes, continu" +
-	"e\x02No, abort\x02Aborting migration.\x02Error saving config to layer: %" +
-	"[1]s. Aborting Migration\x02The Curio team wants to improve the software" +
-	" you use. Tell the team you're using `%[1]s`.\x02Select what you want to" +
-	" share with the Curio team.\x02Individual Data: Miner ID, Curio version," +
-	" chain (%[1]s or %[2]s). Signed.\x02Aggregate-Anonymous: version, chain," +
-	" and Miner power (bucketed).\x02Hint: I am someone running Curio on whic" +
-	"hever chain.\x02Nothing.\x02Error getting miner power: %[1]s\x02Error ma" +
-	"rshalling message: %[1]s\x02Error getting miner info: %[1]s\x02Error sig" +
-	"ning message: %[1]s\x02Error sending message: %[1]s\x04\x00\x01 .\x02Err" +
-	"or sending message: Status %[1]s, Message:\x02Message sent.\x04\x00\x01 " +
-	"\x0f\x02Documentation:\x02The '%[1]s' layer stores common configuration." +
-	" All curio instances can include it in their %[2]s argument.\x02You can " +
-	"add other layers for per-machine configuration changes.\x02Filecoin %[1]" +
-	"s channels: %[2]s and %[3]s\x02Increase reliability using redundancy: st" +
-	"art multiple machines with at-least the post layer: 'curio run --layers=" +
-	"post'\x02One database can serve multiple miner IDs: Run a migration for " +
-	"each lotus-miner.\x02Connected to Yugabyte. Schema is current.\x02Connec" +
-	"ted to Yugabyte\x02To start, ensure your sealing pipeline is drained and" +
-	" shut-down lotus-miner.\x02Select the location of your lotus-miner confi" +
-	"g directory?\x02Other\x02Enter the path to the configuration directory u" +
-	"sed by %[1]s\x04\x00\x01 '\x02No path provided, abandoning migration\x02" +
-	"Cannot read the config.toml file in the provided directory, Error: %[1]s" +
-	"\x02Could not create repo from directory: %[1]s. Aborting migration\x02C" +
-	"ould not lock miner repo. Your miner must be stopped: %[1]s\x0a Aborting" +
-	" migration\x02Read Miner Config\x04\x00\x01\x0a\x15\x02Step Complete: %[" +
-	"1]s\x02Initializing a new miner actor.\x02Enter the info to create a new" +
-	" miner\x02Owner Wallet: %[1]s\x02Worker Wallet: %[1]s\x02Sender Wallet: " +
-	"%[1]s\x02Sector Size: %[1]s\x02Continue to verify the addresses and crea" +
-	"te a new miner actor.\x04\x00\x01 %\x02Miner creation error occurred: %[" +
-	"1]s\x02Enter the owner address\x02No address provided\x02Failed to parse" +
-	" the address: %[1]s\x02Enter %[1]s address\x02Select the Sector Size\x02" +
-	"64 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1f\x02Sector selection " +
-	"failed: %[1]s\x02Failed to parse sector size: %[1]s\x02Failed to create " +
-	"the miner actor: %[1]s\x02Miner %[1]s created successfully\x02Cannot rea" +
-	"ch the DB: %[1]s\x02Error connecting to full node API: %[1]s\x02Pre-init" +
-	"ialization steps complete\x02Failed to generate random bytes for secret:" +
-	" %[1]s\x02Please do not run guided-setup again as miner creation is not " +
-	"idempotent. You need to run 'curio config new-cluster %[1]s' to finish t" +
-	"he configuration\x02Failed to get API info for FullNode: %[1]w\x02Failed" +
-	" to verify the auth token from daemon node: %[1]s\x02Failed to generate " +
-	"default config: %[1]s\x02Failed to insert 'base' config layer in databas" +
-	"e: %[1]s\x02Configuration 'base' was updated to include this miner's add" +
-	"ress\x02Failed to load base config from database: %[1]s\x02Failed to par" +
-	"se base config: %[1]s\x02Failed to regenerate base config: %[1]s\x02Ente" +
-	"r the info to connect to your Yugabyte database installation (https://do" +
-	"wnload.yugabyte.com/)\x02Host: %[1]s\x02Port: %[1]s\x02Username: %[1]s" +
-	"\x02Password: %[1]s\x02Database: %[1]s\x02Continue to connect and update" +
-	" schema.\x04\x00\x01 <\x02Database config error occurred, abandoning mig" +
-	"ration: %[1]s\x02Enter the Yugabyte database host(s)\x02No host provided" +
-	"\x02Enter the Yugabyte database %[1]s\x02No value provided\x02Error conn" +
-	"ecting to Yugabyte database: %[1]s\x02This interactive tool creates/repl" +
-	"ace Curio service file and creates the basic env file for it.\x02Service" +
-	" file %[1]s already exists at %[2]s, no changes made.\x02Error checking " +
-	"for service file at %[1]s: %[2]s\x02Error writing service file: %[1]s" +
-	"\x02Service file %[1]s created successfully at %[2]s\x02Error reloading " +
-	"systemd: %[1]s\x02Error enabling service: %[1]s\x04\x00\x01\x0a\x17\x02S" +
-	"ervice %[1]s enabled.\x02Enter the info to configure your Curio node\x02" +
-	"CURIO_LAYERS: %[1]s\x02CURIO_REPO_PATH: %[1]s\x02CURIO_NODE_NAME: %[1]s" +
-	"\x02Add additional variables like FIL_PROOFS_PARAMETER_CACHE.\x02Continu" +
-	"e update the env file.\x04\x00\x01 -\x02Env config error occurred, aband" +
-	"oning: %[1]s\x02Enter the config layer name to use for this node. Base i" +
-	"s already included by default\x02No layer provided\x02Enter the %[1]s" +
-	"\x02Do you want to add additional variables like FIL_PROOFS_PARAMETER_CA" +
-	"CHE? (y/n)\x02No additional variables added\x02Start typing your additio" +
-	"nal environment variables one variable per line. Use Ctrl+D to finish:" +
-	"\x02Error reading input: %[1]s\x02Skipping invalid input: %[1]s\x02Error" +
-	" opening or creating file %[1]s: %[2]s\x02Error writing to file %[1]s: %" +
-	"[2]s\x02Service env file /etc/curio.env created successfully.\x02Migrati" +
-	"ng metadata for %[1]d sectors.\x02Configuration 'base' was updated to in" +
-	"clude this miner's address (%[1]s) and its wallet setup.\x02Compare the " +
-	"configurations %[1]s to %[2]s. Changes between the miner IDs other than " +
-	"wallet addreses should be a new, minimal layer for runners that need it." +
-	"\x02Configuration 'base' was created to resemble this lotus-miner's conf" +
-	"ig.toml .\x04\x00\x01 \x15\x02Layer %[1]s created.\x04\x00\x01 \x19\x02T" +
-	"o work with the config:\x02To run Curio: With machine or cgroup isolatio" +
-	"n, use the command (with example layer selection):"
+	"ting user home directory:\x02Error opening %[1]s file in write mode:\x02" +
+	"Error writing to %[1]s file: %[2]s\x02Failed to flush the writes to file" +
+	" %[1]s: %[2]s\x02Retrying.......(%[1]d/5)\x02Finished updating the %[1]s" +
+	" file\x04\x00\x01 !\x02Try the web interface with %[1]s\x02Execute 'curi" +
+	"o service-setup' to setup the Curio service on this node and proceed to " +
+	"do the same on the other nodes\x02You can now migrate your market node (" +
+	"%[1]s), if applicable.\x02Additional info is at http://docs.curiostorage" +
+	".org\x02New Miner initialization complete.\x02Migrating lotus-miner conf" +
+	"ig.toml to Curio in-database configuration.\x02Error getting API: %[1]s" +
+	"\x02could not get API info for FullNode: %[1]w\x02Error getting token: %" +
+	"[1]s\x02Unmigratable sectors found. Do you want to continue?\x02Yes, con" +
+	"tinue\x02No, abort\x02Aborting migration.\x02Error saving config to laye" +
+	"r: %[1]s. Aborting Migration\x02The Curio team wants to improve the soft" +
+	"ware you use. Tell the team you're using `%[1]s`.\x02Select what you wan" +
+	"t to share with the Curio team.\x02Individual Data: Miner ID, Curio vers" +
+	"ion, chain (%[1]s or %[2]s). Signed.\x02Aggregate-Anonymous: version, ch" +
+	"ain, and Miner power (bucketed).\x02Hint: I am someone running Curio on " +
+	"whichever chain.\x02Nothing.\x02Error getting miner power: %[1]s\x02Erro" +
+	"r marshalling message: %[1]s\x02Error getting miner info: %[1]s\x02Error" +
+	" signing message: %[1]s\x02Error sending message: %[1]s\x04\x00\x01 ." +
+	"\x02Error sending message: Status %[1]s, Message:\x02Message sent.\x04" +
+	"\x00\x01 \x0f\x02Documentation:\x02The '%[1]s' layer stores common confi" +
+	"guration. All curio instances can include it in their %[2]s argument." +
+	"\x02You can add other layers for per-machine configuration changes.\x02F" +
+	"ilecoin %[1]s channels: %[2]s and %[3]s\x02Increase reliability using re" +
+	"dundancy: start multiple machines with at-least the post layer: 'curio r" +
+	"un --layers=post'\x02One database can serve multiple miner IDs: Run a mi" +
+	"gration for each lotus-miner.\x02Connected to Yugabyte. Schema is curren" +
+	"t.\x02Connected to Yugabyte\x02To start, ensure your sealing pipeline is" +
+	" drained and shut-down lotus-miner.\x02Select the location of your lotus" +
+	"-miner config directory?\x02Other\x02Enter the path to the configuration" +
+	" directory used by %[1]s\x04\x00\x01 '\x02No path provided, abandoning m" +
+	"igration\x02Cannot read the config.toml file in the provided directory, " +
+	"Error: %[1]s\x02Could not create repo from directory: %[1]s. Aborting mi" +
+	"gration\x02Could not lock miner repo. Your miner must be stopped: %[1]s" +
+	"\x0a Aborting migration\x02Read Miner Config\x04\x00\x01\x0a\x15\x02Step" +
+	" Complete: %[1]s\x02Initializing a new miner actor.\x02Enter the info to" +
+	" create a new miner\x02Owner Wallet: %[1]s\x02Worker Wallet: %[1]s\x02Se" +
+	"nder Wallet: %[1]s\x02Sector Size: %[1]s\x02Continue to verify the addre" +
+	"sses and create a new miner actor.\x04\x00\x01 %\x02Miner creation error" +
+	" occurred: %[1]s\x02Enter the owner address\x02No address provided\x02Fa" +
+	"iled to parse the address: %[1]s\x02Enter %[1]s address\x02Select the Se" +
+	"ctor Size\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1f\x02Sect" +
+	"or selection failed: %[1]s\x02Failed to parse sector size: %[1]s\x02Fail" +
+	"ed to create the miner actor: %[1]s\x02Miner %[1]s created successfully" +
+	"\x02Cannot reach the DB: %[1]s\x02Error connecting to full node API: %[1" +
+	"]s\x02Pre-initialization steps complete\x02Failed to generate random byt" +
+	"es for secret: %[1]s\x02Please do not run guided-setup again as miner cr" +
+	"eation is not idempotent. You need to run 'curio config new-cluster %[1]" +
+	"s' to finish the configuration\x02Failed to get API info for FullNode: %" +
+	"[1]w\x02Failed to verify the auth token from daemon node: %[1]s\x02Faile" +
+	"d to generate default config: %[1]s\x02Failed to insert 'base' config la" +
+	"yer in database: %[1]s\x02Configuration 'base' was updated to include th" +
+	"is miner's address\x02Failed to load base config from database: %[1]s" +
+	"\x02Failed to parse base config: %[1]s\x02Failed to regenerate base conf" +
+	"ig: %[1]s\x02Enter the info to connect to your Yugabyte database install" +
+	"ation (https://download.yugabyte.com/)\x02Host: %[1]s\x02Port: %[1]s\x02" +
+	"Username: %[1]s\x02Password: %[1]s\x02Database: %[1]s\x02Continue to con" +
+	"nect and update schema.\x04\x00\x01 <\x02Database config error occurred," +
+	" abandoning migration: %[1]s\x02Enter the Yugabyte database host(s)\x02N" +
+	"o host provided\x02Enter the Yugabyte database %[1]s\x02No value provide" +
+	"d\x02Error connecting to Yugabyte database: %[1]s\x02This interactive to" +
+	"ol creates/replace Curio service file and creates the basic env file for" +
+	" it.\x02Service file %[1]s already exists at %[2]s, no changes made.\x02" +
+	"Error checking for service file at %[1]s: %[2]s\x02Error writing service" +
+	" file: %[1]s\x02Service file %[1]s created successfully at %[2]s\x02Erro" +
+	"r reloading systemd: %[1]s\x02Error enabling service: %[1]s\x04\x00\x01" +
+	"\x0a\x17\x02Service %[1]s enabled.\x02Enter the info to configure your C" +
+	"urio node\x02CURIO_LAYERS: %[1]s\x02CURIO_REPO_PATH: %[1]s\x02CURIO_NODE" +
+	"_NAME: %[1]s\x02Add additional variables like FIL_PROOFS_PARAMETER_CACHE" +
+	": %[1]s\x02Continue update the env file.\x04\x00\x01 -\x02Env config err" +
+	"or occurred, abandoning: %[1]s\x02Enter the config layer name to use for" +
+	" this node. Base is already included by default\x02No layer provided\x02" +
+	"Enter the %[1]s\x02Do you want to add additional variables like FIL_PROO" +
+	"FS_PARAMETER_CACHE? (y/n)\x02No additional variables added\x02Start typi" +
+	"ng your additional environment variables one variable per line. Use Ctrl" +
+	"+D to finish:\x02Error reading input: %[1]s\x02Skipping invalid input: %" +
+	"[1]s\x02Error writing to file %[1]s: %[2]s\x02Service env file /etc/curi" +
+	"o.env created successfully.\x02Migrating metadata for %[1]d sectors.\x02" +
+	"Configuration 'base' was updated to include this miner's address (%[1]s)" +
+	" and its wallet setup.\x02Compare the configurations %[1]s to %[2]s. Cha" +
+	"nges between the miner IDs other than wallet addreses should be a new, m" +
+	"inimal layer for runners that need it.\x02Configuration 'base' was creat" +
+	"ed to resemble this lotus-miner's config.toml .\x04\x00\x01 \x15\x02Laye" +
+	"r %[1]s created.\x04\x00\x01 \x19\x02To work with the config:\x02To run " +
+	"Curio: With machine or cgroup isolation, use the command (with example l" +
+	"ayer selection):"
 
-var koIndex = []uint32{ // 149 elements
+var koIndex = []uint32{ // 146 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000044, 0x000000c1, 0x000001c1,
 	0x0000020e, 0x00000289, 0x000002aa, 0x000002bc,
 	0x000002e5, 0x00000300, 0x00000325, 0x00000348,
 	0x000003a2, 0x000003a6, 0x000003b0, 0x00000412,
-	0x00000450, 0x00000480, 0x000004b0, 0x000004e0,
-	0x0000051b, 0x0000054b, 0x0000059a, 0x000005bc,
-	0x000005fb, 0x0000068d, 0x000006dd, 0x0000071d,
-	0x00000743, 0x0000079c, 0x000007bb, 0x000007f7,
+	0x00000450, 0x0000048b, 0x000004bb, 0x000004fc,
+	0x0000051e, 0x0000054e, 0x0000058d, 0x0000061f,
+	0x0000066f, 0x000006af, 0x000006d5, 0x0000072e,
+	0x0000074d, 0x00000789, 0x000007b9, 0x00000809,
 	// Entry 20 - 3F
-	0x00000827, 0x00000877, 0x00000883, 0x00000895,
-	0x000008b0, 0x00000908, 0x00000994, 0x000009cd,
-	0x00000a23, 0x00000a61, 0x00000aaf, 0x00000aca,
-	0x00000b04, 0x00000b37, 0x00000b71, 0x00000b9b,
-	0x00000bc5, 0x00000c07, 0x00000c2b, 0x00000c38,
-	0x00000cbe, 0x00000d10, 0x00000d37, 0x00000dd3,
-	0x00000e65, 0x00000ea6, 0x00000ebc, 0x00000f27,
-	0x00000f76, 0x00000f7d, 0x00000fc5, 0x00001017,
+	0x00000815, 0x00000827, 0x00000842, 0x0000089a,
+	0x00000926, 0x0000095f, 0x000009b5, 0x000009f3,
+	0x00000a41, 0x00000a5c, 0x00000a96, 0x00000ac9,
+	0x00000b03, 0x00000b2d, 0x00000b57, 0x00000b99,
+	0x00000bbd, 0x00000bca, 0x00000c50, 0x00000ca2,
+	0x00000cc9, 0x00000d65, 0x00000df7, 0x00000e38,
+	0x00000e4e, 0x00000eb9, 0x00000f08, 0x00000f0f,
+	0x00000f57, 0x00000fa9, 0x00001003, 0x0000106d,
 	// Entry 40 - 5F
-	0x00001071, 0x000010db, 0x0000116c, 0x00001184,
-	0x0000119e, 0x000011c2, 0x000011f5, 0x0000120d,
-	0x00001225, 0x0000123d, 0x00001252, 0x000012a9,
-	0x000012d4, 0x000012ec, 0x00001313, 0x00001336,
-	0x0000134a, 0x0000135f, 0x00001366, 0x0000136d,
-	0x00001373, 0x00001379, 0x0000139a, 0x000013c4,
-	0x000013ea, 0x00001423, 0x0000145b, 0x00001493,
-	0x000014b2, 0x000014fe, 0x000015bc, 0x00001608,
+	0x000010fe, 0x00001116, 0x00001130, 0x00001154,
+	0x00001187, 0x0000119f, 0x000011b7, 0x000011cf,
+	0x000011e4, 0x0000123b, 0x00001266, 0x0000127e,
+	0x000012a5, 0x000012c8, 0x000012dc, 0x000012f1,
+	0x000012f8, 0x000012ff, 0x00001305, 0x0000130b,
+	0x0000132c, 0x00001356, 0x0000137c, 0x000013b5,
+	0x000013ed, 0x00001425, 0x00001444, 0x00001490,
+	0x0000154e, 0x0000159a, 0x000015e8, 0x0000160b,
 	// Entry 60 - 7F
-	0x00001656, 0x00001679, 0x000016d5, 0x00001725,
-	0x0000177a, 0x000017bd, 0x000017fc, 0x0000186a,
-	0x0000187b, 0x00001889, 0x000018a1, 0x000018b5,
-	0x000018cf, 0x000018f9, 0x0000195c, 0x00001998,
-	0x000019c2, 0x000019fa, 0x00001a1e, 0x00001a72,
-	0x00001ade, 0x00001b2f, 0x00001b75, 0x00001ba9,
-	0x00001bf3, 0x00001c2b, 0x00001c61, 0x00001c93,
-	0x00001cca, 0x00001cde, 0x00001cf5, 0x00001d0c,
+	0x00001667, 0x000016b7, 0x0000170c, 0x0000174f,
+	0x0000178e, 0x000017fc, 0x0000180d, 0x0000181b,
+	0x00001833, 0x00001847, 0x00001861, 0x0000188b,
+	0x000018ee, 0x0000192a, 0x00001954, 0x0000198c,
+	0x000019b0, 0x00001a04, 0x00001a70, 0x00001ac1,
+	0x00001b07, 0x00001b3b, 0x00001b85, 0x00001bbd,
+	0x00001bf3, 0x00001c25, 0x00001c5c, 0x00001c70,
+	0x00001c87, 0x00001c9e, 0x00001ceb, 0x00001d1a,
 	// Entry 80 - 9F
-	0x00001d53, 0x00001d82, 0x00001db6, 0x00001e36,
-	0x00001e60, 0x00001e81, 0x00001ed7, 0x00001f05,
-	0x00001f6e, 0x00001f98, 0x00001fba, 0x00001fff,
-	0x0000202f, 0x00002085, 0x000020bd, 0x00002136,
-	0x000021f0, 0x00002247, 0x00002276, 0x0000229d,
-	0x00002329,
-} // Size: 620 bytes
+	0x00001d4e, 0x00001dce, 0x00001df8, 0x00001e19,
+	0x00001e6f, 0x00001e9d, 0x00001f06, 0x00001f30,
+	0x00001f52, 0x00001f82, 0x00001fd8, 0x00002010,
+	0x00002089, 0x00002143, 0x0000219a, 0x000021c9,
+	0x000021f0, 0x0000227c,
+} // Size: 608 bytes
 
-const koData string = "" + // Size: 9001 bytes
+const koData string = "" + // Size: 8828 bytes
 	"\x04\x00\x01 ?\x02화살표 키를 사용하여 이동하세요: ↓ ↑ → ←\x02이 대화형 도구는 새로운 채굴자 액터를 생성" +
 	"하고 그에 대한 기본 구성 레이어를 생성합니다.\x02이 프로세스는 부분적으로 항등원적입니다. 새로운 채굴자 액터가 생성되었고" +
 	" 후속 단계가 실패하는 경우 사용자는 구성을 완료하기 위해 'curio config new-cluster < 채굴자 ID >'를 " +
@@ -393,170 +387,167 @@ const koData string = "" + // Size: 9001 bytes
 	"원한다:\x02기존의 Lotus-Miner에서 이전하기\x02새로운 채굴자 생성\x02나머지 단계를 중단합니다.\x02Lotu" +
 	"s-Miner에서 Curio로 이주.\x02Harmony DB 자격 증명을 ~/.bashrc 또는 ~/.zshrc 파일에 추가하시" +
 	"겠습니까?\x02예\x02아니요\x02셸 %[1]s이 BASH 또는 ZSH가 아니므로 RC 파일에 DB 변수를 추가하지 않습니" +
-	"다.\x02사용자 홈 디렉토리를 가져오는 중 오류 발생:\x02%[1]s 파일을 여는 중 오류 발생: %[2]s\x02%[1]" +
-	"s 파일을 읽는 중 오류 발생: %[2]s\x02%[1]s 파일을 닫는 중 오류 발생: %[2]s\x02%[1]s 파일을 쓰기 모" +
-	"드로 여는 중 오류 발생:\x02%[1]s 파일에 쓰는 중 오류 발생: %[2]s\x02%[1]s 파일에 쓰기 내용을 플러시하" +
-	"는 데 실패했습니다: %[2]s\x02다시 시도 중.......(%[1]d/5)\x04\x00\x01 :\x02%[1]s와 함" +
-	"께 웹 인터페이스를 시도해보세요\x02이 노드에서 Curio 서비스를 설정하려면 'curio service-setup'을 실행" +
-	"하고 다른 노드에서도 동일하게 진행하십시오.\x02해당하는 경우 이제 시장 노드를 이주할 수 있습니다 (%[1]s).\x02추" +
-	"가 정보는 http://docs.curiostorage.org 에 있습니다.\x02새로운 채굴자 초기화 완료.\x02lotus" +
-	"-miner config.toml을 Curio의 데이터베이스 구성으로 이전 중입니다.\x02API 가져오기 오류: %[1]s" +
-	"\x02FullNode의 API 정보를 가져올 수 없습니다: %[1]w\x02토큰을 가져오는 중 오류 발생: %[1]s\x02이동" +
-	"할 수 없는 섹터가 발견되었습니다. 계속하시겠습니까?\x02예, 계속\x02아니오, 중단\x02마이그레이션 중단.\x02레이어" +
-	"에 구성을 저장하는 중 오류 발생: %[1]s. 마이그레이션 중단\x02Curio 팀은 당신이 사용하는 소프트웨어를 개선하고자" +
-	" 합니다. 팀에게 `%[1]s`를 사용 중이라고 알려주세요.\x02Curio 팀과 공유하고 싶은 것을 선택하세요.\x02개별 데이" +
-	"터: 채굴자 ID, Curio 버전, 체인 (%[1]s 또는 %[2]s). 서명됨.\x02집계-익명: 버전, 체인, 및 채굴자" +
-	" 파워 (버킷).\x02힌트: 나는 어떤 체인에서든 Curio를 실행 중인 사람입니다.\x02아무것도 없습니다.\x02마이너 파워" +
-	"를 가져오는 중 오류 발생: %[1]s\x02메시지를 마샬하는 중 오류 발생: %[1]s\x02마이너 정보를 가져오는 중 오류" +
-	" 발생: %[1]s\x02메시지 서명 중 오류 발생: %[1]s\x02메시지 전송 중 오류 발생: %[1]s\x04\x00\x01" +
-	" =\x02메시지 전송 중 오류 발생: 상태 %[1]s, 메시지:\x02메시지가 전송되었습니다.\x04\x00\x01 \x08" +
-	"\x02문서:\x02'%[1]s' 레이어에는 공통 구성이 저장됩니다. 모든 Curio 인스턴스는 %[2]s 인수에 포함시킬 수 있" +
-	"습니다.\x02기계별 구성 변경을 위해 다른 레이어를 추가할 수 있습니다.\x02Filecoin %[1]s 채널: %[2]s " +
-	"및 %[3]s\x02신뢰성 향상을 위한 중복성 사용: 적어도 post 레이어를 사용하여 여러 대의 기계를 시작하십시오: 'cu" +
-	"rio run --layers=post'\x02한 개의 데이터베이스는 여러 광부 ID를 제공할 수 있습니다: 각 lotus-min" +
-	"er에 대해 마이그레이션을 실행하세요.\x02Yugabyte에 연결되었습니다. 스키마가 현재입니다.\x02Yugabyte에 연결됨" +
-	"\x02시작하려면 밀봉 파이프라인이 비어 있고 lotus-miner가 종료되었는지 확인하세요.\x02로터스 마이너 구성 디렉토리의" +
-	" 위치를 선택하시겠습니까?\x02기타\x02%[1]s에서 사용하는 구성 디렉터리 경로를 입력하세요.\x04\x00\x01 M" +
-	"\x02경로가 제공되지 않았으므로 마이그레이션을 포기합니다\x02제공된 디렉토리에서 config.toml 파일을 읽을 수 없습니다" +
-	". 오류: %[1]s\x02디렉토리에서 저장소를 생성할 수 없습니다: %[1]s. 마이그레이션을 중단합니다.\x02광부 저장소를 " +
-	"잠금 해제할 수 없습니다. 귀하의 광부를 중지해야 합니다: %[1]s\x0a 마이그레이션을 중단합니다.\x02마이너 구성 읽기" +
-	"\x04\x00\x01\x0a\x15\x02단계 완료: %[1]s\x02새 채굴자 액터 초기화 중.\x02새 채굴자를 생성하기 위" +
-	"한 정보 입력\x02소유자 지갑: %[1]s\x02작업자 지갑: %[1]s\x02발송자 지갑: %[1]s\x02섹터 크기: %" +
-	"[1]s\x02주소를 확인하고 새 채굴자 액터를 생성하려면 계속 진행하세요.\x04\x00\x01 &\x02채굴자 생성 오류 발생" +
-	": %[1]s\x02소유자 주소 입력\x02주소가 제공되지 않았습니다\x02주소 구문 분석 실패: %[1]s\x02%[1]s 주소" +
-	" 입력\x02섹터 크기 선택\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1c" +
-	"\x02섹터 선택 실패: %[1]s\x02섹터 크기 구문 분석 실패: %[1]s\x02채굴자 액터 생성 실패: %[1]s\x02%" +
-	"[1]s 채굴자가 성공적으로 생성되었습니다\x02데이터베이스에 연결할 수 없습니다: %[1]s\x02풀 노드 API에 연결하는 중" +
-	" 오류 발생: %[1]s\x02사전 초기화 단계 완료\x02비밀번호를 위한 랜덤 바이트 생성에 실패했습니다: %[1]s\x02마이" +
-	"너 생성은 idempotent하지 않으므로 가이드 설정을 다시 실행하지 마십시오. 구성을 완료하려면 'curio config " +
-	"new-cluster %[1]s'를 실행해야 합니다.\x02FullNode에 대한 API 정보를 가져오는 데 실패했습니다: %[1" +
-	"]w\x02데몬 노드로부터 인증 토큰을 확인하는 중 오류 발생: %[1]s\x02기본 구성 생성 실패: %[1]s\x02데이터베이" +
-	"스에 'base' 구성 레이어를 삽입하는 데 실패했습니다: %[1]s\x02이 마이너 주소를 포함한 구성 'base'가 업데이" +
-	"트되었습니다.\x02데이터베이스에서 기본 구성을 로드하는 데 실패했습니다: %[1]s\x02기본 구성을 구문 분석하는 데 실패" +
-	"했습니다: %[1]s\x02기본 구성을 재생성하는 데 실패했습니다: %[1]s\x02Yugabyte 데이터베이스 설치에 연결할" +
-	" 정보를 입력하십시오 (https://download.yugabyte.com/)\x02호스트: %[1]s\x02포트: %[1]s" +
-	"\x02사용자 이름: %[1]s\x02비밀번호: %[1]s\x02데이터베이스: %[1]s\x02계속 연결 및 스키마 업데이트." +
-	"\x04\x00\x01 ^\x02데이터베이스 구성 오류가 발생하여 마이그레이션을 포기합니다: %[1]s\x02Yugabyte 데이" +
-	"터베이스 호스트를 입력하십시오\x02호스트가 제공되지 않았습니다\x02Yugabyte 데이터베이스 %[1]s을 입력하십시오" +
-	"\x02값이 제공되지 않았습니다\x02Yugabyte 데이터베이스에 연결하는 중 오류가 발생했습니다: %[1]s\x02이 대화형 " +
-	"도구는 Curio 서비스 파일을 생성/교체하고 기본 env 파일을 생성합니다.\x02서비스 파일 %[1]s이 %[2]s에 이미" +
-	" 존재합니다. 변경 사항 없음.\x02%[1]s에서 서비스 파일을 확인하는 중 오류 발생: %[2]s\x02서비스 파일을 쓰는 중" +
-	" 오류 발생: %[1]s\x02서비스 파일 %[1]s이 %[2]s에 성공적으로 생성되었습니다.\x02systemd를 다시 로드하는" +
-	" 중 오류 발생: %[1]s\x02서비스를 활성화하는 중 오류 발생: %[1]s\x04\x00\x01\x0a-\x02서비스 %[1" +
-	"]s이 활성화되었습니다.\x02Curio 노드를 구성할 정보를 입력하십시오\x02CURIO_LAYERS: %[1]s\x02CURI" +
-	"O_REPO_PATH: %[1]s\x02CURIO_NODE_NAME: %[1]s\x02FIL_PROOFS_PARAMETER_CAC" +
-	"HE와 같은 추가 변수를 추가하세요.\x02env 파일 업데이트를 계속하십시오.\x04\x00\x01 /\x02환경 설정 오류 발" +
-	"생, 중단 중: %[1]s\x02이 노드에 사용할 구성 레이어 이름을 입력하십시오. 기본값으로 Base가 이미 포함되어 있습니" +
-	"다\x02레이어가 제공되지 않았습니다\x02%[1]s을(를) 입력하십시오\x02FIL_PROOFS_PARAMETER_CACHE" +
-	"와 같은 추가 변수를 추가하시겠습니까? (y/n)\x02추가 변수가 추가되지 않았습니다\x02추가 환경 변수를 한 줄에 하나씩" +
-	" 입력하세요. 완료하려면 Ctrl+D를 사용하세요:\x02입력을 읽는 중 오류 발생: %[1]s\x02잘못된 입력 건너뜀: %[1" +
-	"]s\x02파일 %[1]s을(를) 열거나 생성하는 중 오류 발생: %[2]s\x02파일 %[1]s에 쓰는 중 오류 발생: %[2]" +
-	"s\x02서비스 환경 파일 /etc/curio.env이(가) 성공적으로 생성되었습니다.\x02%[1]d 섹터의 메타데이터를 이동 " +
-	"중입니다.\x02기본 설정 'base'가 이 마이너의 주소(%[1]s) 및 지갑 설정을 포함하도록 업데이트되었습니다.\x02구" +
-	"성 %[1]s를 %[2]s과 비교하세요. 지갑 주소 이외의 마이너 ID 사이의 변경 사항은 필요한 실행자를 위한 새로운 최소한" +
-	"의 레이어여야 합니다.\x02'base' 설정이 이 lotus-miner의 config.toml과 유사하게 만들어졌습니다." +
-	"\x04\x00\x01 *\x02레이어 %[1]s가 생성되었습니다.\x04\x00\x01 \x22\x02구성 파일을 사용하려면:" +
-	"\x02Curio를 실행하려면: 기계 또는 cgroup 격리를 사용하여 다음 명령을 사용하세요 (예제 레이어 선택과 함께):"
+	"다.\x02사용자 홈 디렉토리를 가져오는 중 오류 발생:\x02%[1]s 파일을 쓰기 모드로 여는 중 오류 발생:\x02%[1" +
+	"]s 파일에 쓰는 중 오류 발생: %[2]s\x02파일 %[1]s에 쓰기를 플러시하지 못했습니다: %[2]s\x02다시 시도 중." +
+	"......(%[1]d/5)\x02%[1]s 파일 업데이트를 완료했습니다\x04\x00\x01 :\x02%[1]s와 함께 웹 인터" +
+	"페이스를 시도해보세요\x02이 노드에서 Curio 서비스를 설정하려면 'curio service-setup'을 실행하고 다른 " +
+	"노드에서도 동일하게 진행하십시오.\x02해당하는 경우 이제 시장 노드를 이주할 수 있습니다 (%[1]s).\x02추가 정보는 " +
+	"http://docs.curiostorage.org 에 있습니다.\x02새로운 채굴자 초기화 완료.\x02lotus-miner c" +
+	"onfig.toml을 Curio의 데이터베이스 구성으로 이전 중입니다.\x02API 가져오기 오류: %[1]s\x02FullNod" +
+	"e의 API 정보를 가져올 수 없습니다: %[1]w\x02토큰을 가져오는 중 오류 발생: %[1]s\x02이동할 수 없는 섹터가 " +
+	"발견되었습니다. 계속하시겠습니까?\x02예, 계속\x02아니오, 중단\x02마이그레이션 중단.\x02레이어에 구성을 저장하는 " +
+	"중 오류 발생: %[1]s. 마이그레이션 중단\x02Curio 팀은 당신이 사용하는 소프트웨어를 개선하고자 합니다. 팀에게 `" +
+	"%[1]s`를 사용 중이라고 알려주세요.\x02Curio 팀과 공유하고 싶은 것을 선택하세요.\x02개별 데이터: 채굴자 ID, " +
+	"Curio 버전, 체인 (%[1]s 또는 %[2]s). 서명됨.\x02집계-익명: 버전, 체인, 및 채굴자 파워 (버킷).\x02" +
+	"힌트: 나는 어떤 체인에서든 Curio를 실행 중인 사람입니다.\x02아무것도 없습니다.\x02마이너 파워를 가져오는 중 오류" +
+	" 발생: %[1]s\x02메시지를 마샬하는 중 오류 발생: %[1]s\x02마이너 정보를 가져오는 중 오류 발생: %[1]s" +
+	"\x02메시지 서명 중 오류 발생: %[1]s\x02메시지 전송 중 오류 발생: %[1]s\x04\x00\x01 =\x02메시지 " +
+	"전송 중 오류 발생: 상태 %[1]s, 메시지:\x02메시지가 전송되었습니다.\x04\x00\x01 \x08\x02문서:" +
+	"\x02'%[1]s' 레이어에는 공통 구성이 저장됩니다. 모든 Curio 인스턴스는 %[2]s 인수에 포함시킬 수 있습니다." +
+	"\x02기계별 구성 변경을 위해 다른 레이어를 추가할 수 있습니다.\x02Filecoin %[1]s 채널: %[2]s 및 %[3]" +
+	"s\x02신뢰성 향상을 위한 중복성 사용: 적어도 post 레이어를 사용하여 여러 대의 기계를 시작하십시오: 'curio run " +
+	"--layers=post'\x02한 개의 데이터베이스는 여러 광부 ID를 제공할 수 있습니다: 각 lotus-miner에 대해 마" +
+	"이그레이션을 실행하세요.\x02Yugabyte에 연결되었습니다. 스키마가 현재입니다.\x02Yugabyte에 연결됨\x02시작" +
+	"하려면 밀봉 파이프라인이 비어 있고 lotus-miner가 종료되었는지 확인하세요.\x02로터스 마이너 구성 디렉토리의 위치를" +
+	" 선택하시겠습니까?\x02기타\x02%[1]s에서 사용하는 구성 디렉터리 경로를 입력하세요.\x04\x00\x01 M\x02경로가" +
+	" 제공되지 않았으므로 마이그레이션을 포기합니다\x02제공된 디렉토리에서 config.toml 파일을 읽을 수 없습니다. 오류: %" +
+	"[1]s\x02디렉토리에서 저장소를 생성할 수 없습니다: %[1]s. 마이그레이션을 중단합니다.\x02광부 저장소를 잠금 해제할 " +
+	"수 없습니다. 귀하의 광부를 중지해야 합니다: %[1]s\x0a 마이그레이션을 중단합니다.\x02마이너 구성 읽기\x04" +
+	"\x00\x01\x0a\x15\x02단계 완료: %[1]s\x02새 채굴자 액터 초기화 중.\x02새 채굴자를 생성하기 위한 정보" +
+	" 입력\x02소유자 지갑: %[1]s\x02작업자 지갑: %[1]s\x02발송자 지갑: %[1]s\x02섹터 크기: %[1]s" +
+	"\x02주소를 확인하고 새 채굴자 액터를 생성하려면 계속 진행하세요.\x04\x00\x01 &\x02채굴자 생성 오류 발생: %[" +
+	"1]s\x02소유자 주소 입력\x02주소가 제공되지 않았습니다\x02주소 구문 분석 실패: %[1]s\x02%[1]s 주소 입력" +
+	"\x02섹터 크기 선택\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1c\x02섹" +
+	"터 선택 실패: %[1]s\x02섹터 크기 구문 분석 실패: %[1]s\x02채굴자 액터 생성 실패: %[1]s\x02%[1]" +
+	"s 채굴자가 성공적으로 생성되었습니다\x02데이터베이스에 연결할 수 없습니다: %[1]s\x02풀 노드 API에 연결하는 중 오류" +
+	" 발생: %[1]s\x02사전 초기화 단계 완료\x02비밀번호를 위한 랜덤 바이트 생성에 실패했습니다: %[1]s\x02마이너 생" +
+	"성은 idempotent하지 않으므로 가이드 설정을 다시 실행하지 마십시오. 구성을 완료하려면 'curio config new" +
+	"-cluster %[1]s'를 실행해야 합니다.\x02FullNode에 대한 API 정보를 가져오는 데 실패했습니다: %[1]w" +
+	"\x02데몬 노드로부터 인증 토큰을 확인하는 중 오류 발생: %[1]s\x02기본 구성 생성 실패: %[1]s\x02데이터베이스에" +
+	" 'base' 구성 레이어를 삽입하는 데 실패했습니다: %[1]s\x02이 마이너 주소를 포함한 구성 'base'가 업데이트되었습" +
+	"니다.\x02데이터베이스에서 기본 구성을 로드하는 데 실패했습니다: %[1]s\x02기본 구성을 구문 분석하는 데 실패했습니다" +
+	": %[1]s\x02기본 구성을 재생성하는 데 실패했습니다: %[1]s\x02Yugabyte 데이터베이스 설치에 연결할 정보를 입" +
+	"력하십시오 (https://download.yugabyte.com/)\x02호스트: %[1]s\x02포트: %[1]s\x02사" +
+	"용자 이름: %[1]s\x02비밀번호: %[1]s\x02데이터베이스: %[1]s\x02계속 연결 및 스키마 업데이트.\x04" +
+	"\x00\x01 ^\x02데이터베이스 구성 오류가 발생하여 마이그레이션을 포기합니다: %[1]s\x02Yugabyte 데이터베이스" +
+	" 호스트를 입력하십시오\x02호스트가 제공되지 않았습니다\x02Yugabyte 데이터베이스 %[1]s을 입력하십시오\x02값이 제" +
+	"공되지 않았습니다\x02Yugabyte 데이터베이스에 연결하는 중 오류가 발생했습니다: %[1]s\x02이 대화형 도구는 Cu" +
+	"rio 서비스 파일을 생성/교체하고 기본 env 파일을 생성합니다.\x02서비스 파일 %[1]s이 %[2]s에 이미 존재합니다. " +
+	"변경 사항 없음.\x02%[1]s에서 서비스 파일을 확인하는 중 오류 발생: %[2]s\x02서비스 파일을 쓰는 중 오류 발생" +
+	": %[1]s\x02서비스 파일 %[1]s이 %[2]s에 성공적으로 생성되었습니다.\x02systemd를 다시 로드하는 중 오류 " +
+	"발생: %[1]s\x02서비스를 활성화하는 중 오류 발생: %[1]s\x04\x00\x01\x0a-\x02서비스 %[1]s이 " +
+	"활성화되었습니다.\x02Curio 노드를 구성할 정보를 입력하십시오\x02CURIO_LAYERS: %[1]s\x02CURIO_" +
+	"REPO_PATH: %[1]s\x02CURIO_NODE_NAME: %[1]s\x02FIL_PROOFS_PARAMETER_CACHE" +
+	"와 같은 추가 변수를 추가하세요: %[1]s\x02env 파일 업데이트를 계속하십시오.\x04\x00\x01 /\x02환경 설" +
+	"정 오류 발생, 중단 중: %[1]s\x02이 노드에 사용할 구성 레이어 이름을 입력하십시오. 기본값으로 Base가 이미 포함" +
+	"되어 있습니다\x02레이어가 제공되지 않았습니다\x02%[1]s을(를) 입력하십시오\x02FIL_PROOFS_PARAMETER" +
+	"_CACHE와 같은 추가 변수를 추가하시겠습니까? (y/n)\x02추가 변수가 추가되지 않았습니다\x02추가 환경 변수를 한 줄에" +
+	" 하나씩 입력하세요. 완료하려면 Ctrl+D를 사용하세요:\x02입력을 읽는 중 오류 발생: %[1]s\x02잘못된 입력 건너뜀:" +
+	" %[1]s\x02파일 %[1]s에 쓰는 중 오류 발생: %[2]s\x02서비스 환경 파일 /etc/curio.env이(가) 성공" +
+	"적으로 생성되었습니다.\x02%[1]d 섹터의 메타데이터를 이동 중입니다.\x02기본 설정 'base'가 이 마이너의 주소(%" +
+	"[1]s) 및 지갑 설정을 포함하도록 업데이트되었습니다.\x02구성 %[1]s를 %[2]s과 비교하세요. 지갑 주소 이외의 마이너" +
+	" ID 사이의 변경 사항은 필요한 실행자를 위한 새로운 최소한의 레이어여야 합니다.\x02'base' 설정이 이 lotus-min" +
+	"er의 config.toml과 유사하게 만들어졌습니다.\x04\x00\x01 *\x02레이어 %[1]s가 생성되었습니다.\x04" +
+	"\x00\x01 \x22\x02구성 파일을 사용하려면:\x02Curio를 실행하려면: 기계 또는 cgroup 격리를 사용하여 다음" +
+	" 명령을 사용하세요 (예제 레이어 선택과 함께):"
 
-var zhIndex = []uint32{ // 149 elements
+var zhIndex = []uint32{ // 146 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000033, 0x0000008b, 0x00000134,
 	0x0000017c, 0x000001cb, 0x000001e4, 0x000001f1,
 	0x00000211, 0x0000022a, 0x00000240, 0x0000025d,
 	0x000002af, 0x000002b3, 0x000002b7, 0x00000315,
-	0x00000335, 0x00000359, 0x0000037d, 0x000003a1,
-	0x000003ce, 0x000003f2, 0x00000424, 0x0000043e,
-	0x00000464, 0x000004d1, 0x00000512, 0x00000545,
-	0x00000561, 0x000005a6, 0x000005c3, 0x000005ec,
+	0x00000335, 0x00000362, 0x00000386, 0x000003b9,
+	0x000003d3, 0x000003f3, 0x00000419, 0x00000486,
+	0x000004c7, 0x000004fa, 0x00000516, 0x0000055b,
+	0x00000578, 0x000005a1, 0x000005bf, 0x000005f3,
 	// Entry 20 - 3F
-	0x0000060a, 0x0000063e, 0x0000064e, 0x0000065b,
-	0x0000066b, 0x000006a4, 0x000006f8, 0x00000725,
-	0x00000774, 0x000007af, 0x000007e4, 0x000007ee,
-	0x00000812, 0x00000830, 0x00000854, 0x00000872,
-	0x00000890, 0x000008c5, 0x000008d8, 0x000008e7,
-	0x00000941, 0x0000097e, 0x000009a6, 0x00000a05,
-	0x00000a55, 0x00000a82, 0x00000a97, 0x00000ae2,
-	0x00000b12, 0x00000b19, 0x00000b43, 0x00000b67,
+	0x00000603, 0x00000610, 0x00000620, 0x00000659,
+	0x000006ad, 0x000006da, 0x00000729, 0x00000764,
+	0x00000799, 0x000007a3, 0x000007c7, 0x000007e5,
+	0x00000809, 0x00000827, 0x00000845, 0x0000087a,
+	0x0000088d, 0x0000089c, 0x000008f6, 0x00000933,
+	0x0000095b, 0x000009ba, 0x00000a0a, 0x00000a37,
+	0x00000a4c, 0x00000a97, 0x00000ac7, 0x00000ace,
+	0x00000af8, 0x00000b1c, 0x00000b60, 0x00000b92,
 	// Entry 40 - 5F
-	0x00000bab, 0x00000bdd, 0x00000c26, 0x00000c39,
-	0x00000c53, 0x00000c72, 0x00000c97, 0x00000cae,
-	0x00000cc2, 0x00000cd9, 0x00000ced, 0x00000d1e,
-	0x00000d43, 0x00000d59, 0x00000d69, 0x00000d83,
-	0x00000d97, 0x00000daa, 0x00000db1, 0x00000db8,
-	0x00000dbe, 0x00000dc4, 0x00000de3, 0x00000e03,
-	0x00000e23, 0x00000e3d, 0x00000e5a, 0x00000e8b,
-	0x00000ea4, 0x00000ecd, 0x00000f5a, 0x00000f86,
+	0x00000bdb, 0x00000bee, 0x00000c08, 0x00000c27,
+	0x00000c4c, 0x00000c63, 0x00000c77, 0x00000c8e,
+	0x00000ca2, 0x00000cd3, 0x00000cf8, 0x00000d0e,
+	0x00000d1e, 0x00000d38, 0x00000d4c, 0x00000d5f,
+	0x00000d66, 0x00000d6d, 0x00000d73, 0x00000d79,
+	0x00000d98, 0x00000db8, 0x00000dd8, 0x00000df2,
+	0x00000e0f, 0x00000e40, 0x00000e59, 0x00000e82,
+	0x00000f0f, 0x00000f3b, 0x00000f76, 0x00000f96,
 	// Entry 60 - 7F
-	0x00000fc1, 0x00000fe1, 0x00001012, 0x00001045,
-	0x00001072, 0x00001093, 0x000010b9, 0x00001113,
-	0x00001122, 0x00001131, 0x00001143, 0x00001152,
-	0x00001164, 0x00001183, 0x000011bb, 0x000011e0,
-	0x000011f0, 0x0000120e, 0x0000121b, 0x00001247,
-	0x000012a0, 0x000012de, 0x0000130b, 0x0000132e,
-	0x0000135a, 0x00001380, 0x0000139d, 0x000013bc,
-	0x000013e5, 0x000013f9, 0x00001410, 0x00001427,
+	0x00000fc7, 0x00000ffa, 0x00001027, 0x00001048,
+	0x0000106e, 0x000010c8, 0x000010d7, 0x000010e6,
+	0x000010f8, 0x00001107, 0x00001119, 0x00001138,
+	0x00001170, 0x00001195, 0x000011a5, 0x000011c3,
+	0x000011d0, 0x000011fc, 0x00001255, 0x00001293,
+	0x000012c0, 0x000012e3, 0x0000130f, 0x00001335,
+	0x00001352, 0x00001371, 0x0000139a, 0x000013ae,
+	0x000013c5, 0x000013dc, 0x0000141a, 0x00001435,
 	// Entry 80 - 9F
-	0x0000145c, 0x00001477, 0x000014a8, 0x000014f3,
-	0x00001500, 0x0000150d, 0x00001556, 0x0000156c,
-	0x000015c4, 0x000015e1, 0x000015fb, 0x00001628,
-	0x0000164c, 0x00001681, 0x000016ab, 0x000016fc,
-	0x0000177e, 0x000017c5, 0x000017df, 0x000017f7,
-	0x0000184e,
-} // Size: 620 bytes
+	0x00001466, 0x000014b1, 0x000014be, 0x000014cb,
+	0x00001514, 0x0000152a, 0x00001582, 0x0000159f,
+	0x000015b9, 0x000015dd, 0x00001612, 0x0000163c,
+	0x0000168d, 0x0000170f, 0x00001756, 0x00001770,
+	0x00001788, 0x000017df,
+} // Size: 608 bytes
 
-const zhData string = "" + // Size: 6222 bytes
+const zhData string = "" + // Size: 6111 bytes
 	"\x04\x00\x01 .\x02使用箭头键进行导航：↓ ↑ → ←\x02此交互式工具将创建一个新的矿工角色，并为其创建基本配置层。\x02" +
 	"该过程部分幂等。一旦创建了新的矿工角色，并且随后的步骤失败，用户需要运行 'curio config new-cluster < 矿工 ID" +
 	" >' 来完成配置。\x02这个交互式工具可以在5分钟内将lotus-miner迁移到Curio。\x02每一步都需要您的确认，并且可以撤销。随" +
 	"时按Ctrl+C退出。\x02在终端中按下Ctrl+C\x02我想要：\x02从现有的 Lotus-Miner 迁移\x02创建一个新的矿工" +
 	"\x02中止剩余步骤。\x02Lotus-Miner到Curio迁移。\x02您是否希望将 Harmony DB 凭据添加到 ~/.bashrc" +
 	" 或 ~/.zshrc 文件中？\x02是\x02否\x02由于 shell %[1]s 不是 BASH 或 ZSH，因此未将数据库变量添加到 " +
-	"RC 文件中。\x02获取用户主目录时出错:\x02打开文件 %[1]s 时出错: %[2]s\x02读取文件 %[1]s 时出错: %[2]s" +
-	"\x02关闭 %[1]s 文件时出错: %[2]s\x02以写入模式打开文件 %[1]s 时出错:\x02写入文件 %[1]s 时出错: %[2" +
-	"]s\x02无法将写入内容刷新到文件 %[1]s: %[2]s\x02重试中.......(%[1]d/5)\x04\x00\x01 !\x02" +
-	"尝试使用%[1]s的网页界面\x02执行 'curio service-setup' 以在此节点上设置 Curio 服务，并在其他节点上执行" +
-	"相同操作\x02如果适用，您现在可以迁移您的市场节点(%[1]s)。\x02更多信息请访问 http://docs.curiostorage" +
-	".org\x02新矿工初始化完成。\x02将 lotus-miner config.toml 迁移到 Curio 的数据库配置中。\x02获取 " +
-	"API 时出错：%[1]s\x02无法获取FullNode的API信息：%[1]w\x02获取令牌时出错：%[1]s\x02发现无法迁移的扇区。" +
-	"您想要继续吗？\x02是的，继续\x02不，中止\x02中止迁移。\x02保存配置到层时出错：%[1]s。正在中止迁移\x02Curio 团" +
-	"队希望改进您使用的软件。告诉团队您正在使用 `%[1]s`。\x02选择您想与Curio团队分享的内容。\x02个人数据：矿工 ID，Cur" +
-	"io 版本，链（%[1]s 或 %[2]s）。签名。\x02聚合-匿名：版本，链和矿工算力（分桶）。\x02提示：我是在任何链上运行 Curio" +
-	" 的人。\x02没有。\x02获取矿工功率时出错：%[1]s\x02整理消息时出错：%[1]s\x02获取矿工信息时出错：%[1]s\x02签署" +
-	"消息时出错：%[1]s\x02发送消息时出错：%[1]s\x04\x00\x01 0\x02发送消息时出错：状态%[1]s，消息：\x02消" +
-	"息已发送。\x04\x00\x01 \x0a\x02文档：\x02'%[1]s'层存储通用配置。所有Curio实例都可以在其%[2]s参数中" +
-	"包含它。\x02您可以添加其他层进行每台机器的配置更改。\x02Filecoin %[1]s 频道：%[2]s 和 %[3]s\x02通过冗" +
-	"余增加可靠性：使用至少后层启动多台机器：'curio run --layers=post'\x02一个数据库可以服务多个矿工ID：为每个lo" +
-	"tus-miner运行迁移。\x02已连接到Yugabyte。模式是当前的。\x02已连接到Yugabyte\x02开始之前，请确保您的密封管道" +
-	"已排空并关闭lotus-miner。\x02选择您的lotus-miner配置目录的位置？\x02其他\x02输入%[1]s使用的配置目录的" +
-	"路径\x04\x00\x01 \x1f\x02未提供路径，放弃迁移\x02无法读取提供的目录中的config.toml文件，错误：%[1]s" +
-	"\x02无法从目录创建repo：%[1]s。 中止迁移\x02无法锁定矿工repo。 您的矿工必须停止：%[1]s\x0a 中止迁移\x02读取" +
-	"矿工配置\x04\x00\x01\x0a\x15\x02步骤完成：%[1]s\x02初始化新的矿工角色。\x02输入创建新矿工所需的信息" +
-	"\x02所有者钱包: %[1]s\x02工人钱包: %[1]s\x02发送者钱包: %[1]s\x02扇区大小: %[1]s\x02继续验证地址" +
-	"并创建新的矿工角色。\x04\x00\x01  \x02矿工创建错误发生: %[1]s\x02输入所有者地址\x02未提供地址\x02解析地" +
-	"址失败: %[1]s\x02输入 %[1]s 地址\x02选择扇区大小\x0264 GiB\x0232 GiB\x028 MiB\x022 " +
-	"KiB\x04\x00\x01 \x1a\x02扇区选择失败: %[1]s\x02解析扇区大小失败: %[1]s\x02创建矿工角色失败: %[" +
-	"1]s\x02矿工 %[1]s 创建成功\x02无法访问数据库: %[1]s\x02连接到完整节点 API 时发生错误: %[1]s\x02预初" +
-	"始化步骤完成\x02生成密码的随机字节失败: %[1]s\x02请不要再次运行引导设置，因为矿工创建不是幂等的。 您需要运行 'curio " +
-	"config new-cluster %[1]s' 来完成配置。\x02无法获取 FullNode 的 API 信息: %[1]w\x02无法验" +
-	"证来自守护进程节点的授权令牌: %[1]s\x02无法生成默认配置: %[1]s\x02无法将 'base' 配置层插入数据库: %[1]s" +
-	"\x02配置 'base' 已更新以包含此矿工的地址\x02从数据库加载基本配置失败：%[1]s\x02解析基本配置失败：%[1]s\x02重新" +
-	"生成基本配置失败: %[1]s\x02输入连接到您的Yugabyte数据库安装的信息（https://download.yugabyte.c" +
-	"om/）\x02主机：%[1]s\x02端口：%[1]s\x02用户名：%[1]s\x02密码：%[1]s\x02数据库：%[1]s\x02继续" +
-	"连接和更新架构。\x04\x00\x01 3\x02发生数据库配置错误，放弃迁移：%[1]s\x02输入Yugabyte数据库主机（S）" +
-	"\x02未提供主机\x02输入Yugabyte数据库 %[1]s\x02未提供值\x02连接到Yugabyte数据库时出错：%[1]s\x02此" +
-	"交互式工具创建/替换 Curio 服务文件并为其创建基本的 env 文件。\x02服务文件 %[1]s 已存在于 %[2]s，未做任何更改。" +
-	"\x02检查 %[1]s 的服务文件时出错: %[2]s\x02写入服务文件时出错: %[1]s\x02服务文件 %[1]s 已成功创建于 %[" +
-	"2]s\x02重新加载 systemd 时出错: %[1]s\x02启用服务时出错: %[1]s\x04\x00\x01\x0a\x1a\x02" +
-	"服务 %[1]s 已启用。\x02输入信息以配置您的 Curio 节点\x02CURIO_LAYERS: %[1]s\x02CURIO_RE" +
-	"PO_PATH: %[1]s\x02CURIO_NODE_NAME: %[1]s\x02添加 FIL_PROOFS_PARAMETER_CACH" +
-	"E 等其他变量。\x02继续更新 env 文件。\x04\x00\x01 ,\x02发生环境配置错误，放弃中: %[1]s\x02输入此节点要使" +
-	"用的配置层名称。默认情况下已包含 Base\x02未提供层\x02输入 %[1]s\x02您是否希望添加 FIL_PROOFS_PARAME" +
-	"TER_CACHE 等其他变量？(y/n)\x02未添加其他变量\x02开始输入您的附加环境变量，每行一个变量。使用 Ctrl+D 完成输入:" +
-	"\x02读取输入时出错: %[1]s\x02跳过无效输入: %[1]s\x02打开或创建文件 %[1]s 时出错: %[2]s\x02写入文件 " +
+	"RC 文件中。\x02获取用户主目录时出错:\x02以写入模式打开文件 %[1]s 时出错:\x02写入文件 %[1]s 时出错: %[2]s" +
+	"\x02未能将写入数据刷新到文件 %[1]s：%[2]s\x02重试中.......(%[1]d/5)\x02已完成 %[1]s 文件的更新" +
+	"\x04\x00\x01 !\x02尝试使用%[1]s的网页界面\x02执行 'curio service-setup' 以在此节点上设置 Cu" +
+	"rio 服务，并在其他节点上执行相同操作\x02如果适用，您现在可以迁移您的市场节点(%[1]s)。\x02更多信息请访问 http://doc" +
+	"s.curiostorage.org\x02新矿工初始化完成。\x02将 lotus-miner config.toml 迁移到 Curio 的" +
+	"数据库配置中。\x02获取 API 时出错：%[1]s\x02无法获取FullNode的API信息：%[1]w\x02获取令牌时出错：%[1" +
+	"]s\x02发现无法迁移的扇区。您想要继续吗？\x02是的，继续\x02不，中止\x02中止迁移。\x02保存配置到层时出错：%[1]s。正在中" +
+	"止迁移\x02Curio 团队希望改进您使用的软件。告诉团队您正在使用 `%[1]s`。\x02选择您想与Curio团队分享的内容。\x02" +
+	"个人数据：矿工 ID，Curio 版本，链（%[1]s 或 %[2]s）。签名。\x02聚合-匿名：版本，链和矿工算力（分桶）。\x02提示" +
+	"：我是在任何链上运行 Curio 的人。\x02没有。\x02获取矿工功率时出错：%[1]s\x02整理消息时出错：%[1]s\x02获取矿" +
+	"工信息时出错：%[1]s\x02签署消息时出错：%[1]s\x02发送消息时出错：%[1]s\x04\x00\x01 0\x02发送消息时出" +
+	"错：状态%[1]s，消息：\x02消息已发送。\x04\x00\x01 \x0a\x02文档：\x02'%[1]s'层存储通用配置。所有Cu" +
+	"rio实例都可以在其%[2]s参数中包含它。\x02您可以添加其他层进行每台机器的配置更改。\x02Filecoin %[1]s 频道：%[2]" +
+	"s 和 %[3]s\x02通过冗余增加可靠性：使用至少后层启动多台机器：'curio run --layers=post'\x02一个数据库可以" +
+	"服务多个矿工ID：为每个lotus-miner运行迁移。\x02已连接到Yugabyte。模式是当前的。\x02已连接到Yugabyte" +
+	"\x02开始之前，请确保您的密封管道已排空并关闭lotus-miner。\x02选择您的lotus-miner配置目录的位置？\x02其他" +
+	"\x02输入%[1]s使用的配置目录的路径\x04\x00\x01 \x1f\x02未提供路径，放弃迁移\x02无法读取提供的目录中的confi" +
+	"g.toml文件，错误：%[1]s\x02无法从目录创建repo：%[1]s。 中止迁移\x02无法锁定矿工repo。 您的矿工必须停止：%[1" +
+	"]s\x0a 中止迁移\x02读取矿工配置\x04\x00\x01\x0a\x15\x02步骤完成：%[1]s\x02初始化新的矿工角色。" +
+	"\x02输入创建新矿工所需的信息\x02所有者钱包: %[1]s\x02工人钱包: %[1]s\x02发送者钱包: %[1]s\x02扇区大小:" +
+	" %[1]s\x02继续验证地址并创建新的矿工角色。\x04\x00\x01  \x02矿工创建错误发生: %[1]s\x02输入所有者地址" +
+	"\x02未提供地址\x02解析地址失败: %[1]s\x02输入 %[1]s 地址\x02选择扇区大小\x0264 GiB\x0232 GiB" +
+	"\x028 MiB\x022 KiB\x04\x00\x01 \x1a\x02扇区选择失败: %[1]s\x02解析扇区大小失败: %[1]s" +
+	"\x02创建矿工角色失败: %[1]s\x02矿工 %[1]s 创建成功\x02无法访问数据库: %[1]s\x02连接到完整节点 API 时发" +
+	"生错误: %[1]s\x02预初始化步骤完成\x02生成密码的随机字节失败: %[1]s\x02请不要再次运行引导设置，因为矿工创建不是幂等" +
+	"的。 您需要运行 'curio config new-cluster %[1]s' 来完成配置。\x02无法获取 FullNode 的 AP" +
+	"I 信息: %[1]w\x02无法验证来自守护进程节点的授权令牌: %[1]s\x02无法生成默认配置: %[1]s\x02无法将 'base'" +
+	" 配置层插入数据库: %[1]s\x02配置 'base' 已更新以包含此矿工的地址\x02从数据库加载基本配置失败：%[1]s\x02解析基本" +
+	"配置失败：%[1]s\x02重新生成基本配置失败: %[1]s\x02输入连接到您的Yugabyte数据库安装的信息（https://dow" +
+	"nload.yugabyte.com/）\x02主机：%[1]s\x02端口：%[1]s\x02用户名：%[1]s\x02密码：%[1]s" +
+	"\x02数据库：%[1]s\x02继续连接和更新架构。\x04\x00\x01 3\x02发生数据库配置错误，放弃迁移：%[1]s\x02输入Y" +
+	"ugabyte数据库主机（S）\x02未提供主机\x02输入Yugabyte数据库 %[1]s\x02未提供值\x02连接到Yugabyte数据" +
+	"库时出错：%[1]s\x02此交互式工具创建/替换 Curio 服务文件并为其创建基本的 env 文件。\x02服务文件 %[1]s 已存在" +
+	"于 %[2]s，未做任何更改。\x02检查 %[1]s 的服务文件时出错: %[2]s\x02写入服务文件时出错: %[1]s\x02服务文" +
+	"件 %[1]s 已成功创建于 %[2]s\x02重新加载 systemd 时出错: %[1]s\x02启用服务时出错: %[1]s\x04" +
+	"\x00\x01\x0a\x1a\x02服务 %[1]s 已启用。\x02输入信息以配置您的 Curio 节点\x02CURIO_LAYERS:" +
+	" %[1]s\x02CURIO_REPO_PATH: %[1]s\x02CURIO_NODE_NAME: %[1]s\x02添加其他变量，例如 " +
+	"FIL_PROOFS_PARAMETER_CACHE: %[1]s\x02继续更新 env 文件。\x04\x00\x01 ,\x02发生环境配" +
+	"置错误，放弃中: %[1]s\x02输入此节点要使用的配置层名称。默认情况下已包含 Base\x02未提供层\x02输入 %[1]s\x02" +
+	"您是否希望添加 FIL_PROOFS_PARAMETER_CACHE 等其他变量？(y/n)\x02未添加其他变量\x02开始输入您的附加环" +
+	"境变量，每行一个变量。使用 Ctrl+D 完成输入:\x02读取输入时出错: %[1]s\x02跳过无效输入: %[1]s\x02写入文件 " +
 	"%[1]s 时出错: %[2]s\x02服务环境文件 /etc/curio.env 已成功创建。\x02正在迁移%[1]d个扇区的元数据。" +
 	"\x02'base'配置已更新，包括该矿工的地址（%[1]s）及其钱包设置。\x02比较配置%[1]s和%[2]s。矿工ID之间除了钱包地址的变" +
 	"化应该是需要的运行者的一个新的、最小的层。\x02'base'配置已创建，以类似于这个lotus-miner的config.toml。" +
 	"\x04\x00\x01 \x15\x02层%[1]s已创建。\x04\x00\x01 \x13\x02要使用配置：\x02运行Curio：使用" +
 	"机器或cgroup隔离，使用命令（附带示例层选择）："
 
-	// Total table size 23670 bytes (23KiB); checksum: D742C53
+	// Total table size 23249 bytes (22KiB); checksum: 7CABFF1C

--- a/cmd/curio/internal/translations/locales/en/out.gotext.json
+++ b/cmd/curio/internal/translations/locales/en/out.gotext.json
@@ -89,42 +89,177 @@
             "fuzzy": true
         },
         {
-            "id": "Where should we save your database config file?",
-            "message": "Where should we save your database config file?",
-            "translation": "Where should we save your database config file?",
-            "translatorComment": "Copied from source.",
-            "fuzzy": true
-        },
-        {
-            "id": "Aborting migration.",
-            "message": "Aborting migration.",
-            "translation": "Aborting migration.",
+            "id": "Not adding DB variables to RC file as shell {Shell} is not BASH or ZSH.",
+            "message": "Not adding DB variables to RC file as shell {Shell} is not BASH or ZSH.",
+            "translation": "Not adding DB variables to RC file as shell {Shell} is not BASH or ZSH.",
             "translatorComment": "Copied from source.",
             "placeholders": [
                 {
-                    "id": "Error",
-                    "string": "%[1]v",
+                    "id": "Shell",
+                    "string": "%[1]s",
                     "type": "string",
                     "underlyingType": "string",
                     "argNum": 1,
-                    "expr": "err.Error()"
+                    "expr": "shell"
                 }
             ],
             "fuzzy": true
         },
         {
-            "id": "Error writing file: {Error}",
-            "message": "Error writing file: {Error}",
-            "translation": "Error writing file: {Error}",
+            "id": "Error getting user home directory:",
+            "message": "Error getting user home directory:",
+            "translation": "Error getting user home directory:",
             "translatorComment": "Copied from source.",
             "placeholders": [
                 {
-                    "id": "Error",
+                    "id": "Err",
+                    "string": "%[1]v",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 1,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error opening {RcFile} file: {Err}",
+            "message": "Error opening {RcFile} file: {Err}",
+            "translation": "Error opening {RcFile} file: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "RcFile",
                     "string": "%[1]s",
                     "type": "string",
                     "underlyingType": "string",
                     "argNum": 1,
-                    "expr": "err.Error()"
+                    "expr": "rcFile"
+                },
+                {
+                    "id": "Err",
+                    "string": "%[2]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 2,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error reading {RcFile} file: {Err}",
+            "message": "Error reading {RcFile} file: {Err}",
+            "translation": "Error reading {RcFile} file: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "RcFile",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "rcFile"
+                },
+                {
+                    "id": "Err",
+                    "string": "%[2]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 2,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error opening {RcFile} file in write mode:",
+            "message": "Error opening {RcFile} file in write mode:",
+            "translation": "Error opening {RcFile} file in write mode:",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "RcFile",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "rcFile"
+                },
+                {
+                    "id": "Err",
+                    "string": "%[2]v",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 2,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error writing to {RcFile} file: {Err}",
+            "message": "Error writing to {RcFile} file: {Err}",
+            "translation": "Error writing to {RcFile} file: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "RcFile",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "rcFile"
+                },
+                {
+                    "id": "Err",
+                    "string": "%[2]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 2,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Failed to flush thw writes to file {RcFile}: {Err}",
+            "message": "Failed to flush thw writes to file {RcFile}: {Err}",
+            "translation": "Failed to flush thw writes to file {RcFile}: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "RcFile",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "rcFile"
+                },
+                {
+                    "id": "Err",
+                    "string": "%[2]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 2,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Retrying.......({I}/5)",
+            "message": "Retrying.......({I}/5)",
+            "translation": "Retrying.......({I}/5)",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "I",
+                    "string": "%[1]d",
+                    "type": "int",
+                    "underlyingType": "int",
+                    "argNum": 1,
+                    "expr": "i"
                 }
             ],
             "fuzzy": true
@@ -147,9 +282,9 @@
             "fuzzy": true
         },
         {
-            "id": "For more servers, make /etc/curio.env with the curio.env database env and add the CURIO_LAYERS env to assign purposes.",
-            "message": "For more servers, make /etc/curio.env with the curio.env database env and add the CURIO_LAYERS env to assign purposes.",
-            "translation": "For more servers, make /etc/curio.env with the curio.env database env and add the CURIO_LAYERS env to assign purposes.",
+            "id": "Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes",
+            "message": "Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes",
+            "translation": "Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes",
             "translatorComment": "Copied from source.",
             "fuzzy": true
         },
@@ -261,6 +396,23 @@
             "message": "No, abort",
             "translation": "No, abort",
             "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Aborting migration.",
+            "message": "Aborting migration.",
+            "translation": "Aborting migration.",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Error",
+                    "string": "%[1]v",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "err.Error()"
+                }
+            ],
             "fuzzy": true
         },
         {
@@ -1314,6 +1466,326 @@
                     "expr": "err.Error()"
                 }
             ],
+            "fuzzy": true
+        },
+        {
+            "id": "This interactive tool creates/replace Curio service file and creates the basic env file for it.",
+            "message": "This interactive tool creates/replace Curio service file and creates the basic env file for it.",
+            "translation": "This interactive tool creates/replace Curio service file and creates the basic env file for it.",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Service file {ServiceName} already exists at {ServicePath}, no changes made.",
+            "message": "Service file {ServiceName} already exists at {ServicePath}, no changes made.",
+            "translation": "Service file {ServiceName} already exists at {ServicePath}, no changes made.",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "ServiceName",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "serviceName"
+                },
+                {
+                    "id": "ServicePath",
+                    "string": "%[2]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 2,
+                    "expr": "servicePath"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error checking for service file at {ServicePath}: {Err}",
+            "message": "Error checking for service file at {ServicePath}: {Err}",
+            "translation": "Error checking for service file at {ServicePath}: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "ServicePath",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "servicePath"
+                },
+                {
+                    "id": "Err",
+                    "string": "%[2]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 2,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error writing service file: {Err}",
+            "message": "Error writing service file: {Err}",
+            "translation": "Error writing service file: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Err",
+                    "string": "%[1]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 1,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Service file {ServiceName} created successfully at {TargetServicePath}",
+            "message": "Service file {ServiceName} created successfully at {TargetServicePath}",
+            "translation": "Service file {ServiceName} created successfully at {TargetServicePath}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "ServiceName",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "serviceName"
+                },
+                {
+                    "id": "TargetServicePath",
+                    "string": "%[2]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 2,
+                    "expr": "targetServicePath"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error reloading systemd: {Err}",
+            "message": "Error reloading systemd: {Err}",
+            "translation": "Error reloading systemd: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Err",
+                    "string": "%[1]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 1,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error enabling service: {Err}",
+            "message": "Error enabling service: {Err}",
+            "translation": "Error enabling service: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Err",
+                    "string": "%[1]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 1,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Service {ServiceName} enabled.",
+            "message": "Service {ServiceName} enabled.",
+            "translation": "Service {ServiceName} enabled.",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "ServiceName",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "serviceName"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Enter the info to configure your Curio node",
+            "message": "Enter the info to configure your Curio node",
+            "translation": "Enter the info to configure your Curio node",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "CURIO_LAYERS: {}",
+            "message": "CURIO_LAYERS: {}",
+            "translation": "CURIO_LAYERS: {}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "\"\""
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "CURIO_REPO_PATH: {Curio}",
+            "message": "CURIO_REPO_PATH: {Curio}",
+            "translation": "CURIO_REPO_PATH: {Curio}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Curio",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "\"~/.curio\""
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "CURIO_NODE_NAME: {}",
+            "message": "CURIO_NODE_NAME: {}",
+            "translation": "CURIO_NODE_NAME: {}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "\"\""
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Continue update the env file.",
+            "message": "Continue update the env file.",
+            "translation": "Continue update the env file.",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Env config error occurred, abandoning: {Error}",
+            "message": "Env config error occurred, abandoning: {Error}",
+            "translation": "Env config error occurred, abandoning: {Error}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Error",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "err.Error()"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Enter the config layer name to use for this node. Base is already included by default",
+            "message": "Enter the config layer name to use for this node. Base is already included by default",
+            "translation": "Enter the config layer name to use for this node. Base is already included by default",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "No layer provided",
+            "message": "No layer provided",
+            "translation": "No layer provided",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Enter the {Stringrepo_path_node_namei_1}",
+            "message": "Enter the {Stringrepo_path_node_namei_1}",
+            "translation": "Enter the {Stringrepo_path_node_namei_1}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Stringrepo_path_node_namei_1",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "[]string{\"repo path\", \"node name\"}[i-1]"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error opening or creating file {EnvFilePath}: {Err}",
+            "message": "Error opening or creating file {EnvFilePath}: {Err}",
+            "translation": "Error opening or creating file {EnvFilePath}: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "EnvFilePath",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "envFilePath"
+                },
+                {
+                    "id": "Err",
+                    "string": "%[2]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 2,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error writing to file {EnvFilePath}: {Err}",
+            "message": "Error writing to file {EnvFilePath}: {Err}",
+            "translation": "Error writing to file {EnvFilePath}: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "EnvFilePath",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "envFilePath"
+                },
+                {
+                    "id": "Err",
+                    "string": "%[2]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 2,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Service env file /etc/curio.env created successfully.",
+            "message": "Service env file /etc/curio.env created successfully.",
+            "translation": "Service env file /etc/curio.env created successfully.",
+            "translatorComment": "Copied from source.",
             "fuzzy": true
         },
         {

--- a/cmd/curio/internal/translations/locales/en/out.gotext.json
+++ b/cmd/curio/internal/translations/locales/en/out.gotext.json
@@ -144,81 +144,6 @@
             "fuzzy": true
         },
         {
-            "id": "Error opening {RcFile} file: {Err}",
-            "message": "Error opening {RcFile} file: {Err}",
-            "translation": "Error opening {RcFile} file: {Err}",
-            "translatorComment": "Copied from source.",
-            "placeholders": [
-                {
-                    "id": "RcFile",
-                    "string": "%[1]s",
-                    "type": "string",
-                    "underlyingType": "string",
-                    "argNum": 1,
-                    "expr": "rcFile"
-                },
-                {
-                    "id": "Err",
-                    "string": "%[2]s",
-                    "type": "error",
-                    "underlyingType": "interface{Error() string}",
-                    "argNum": 2,
-                    "expr": "err"
-                }
-            ],
-            "fuzzy": true
-        },
-        {
-            "id": "Error reading {RcFile} file: {Err}",
-            "message": "Error reading {RcFile} file: {Err}",
-            "translation": "Error reading {RcFile} file: {Err}",
-            "translatorComment": "Copied from source.",
-            "placeholders": [
-                {
-                    "id": "RcFile",
-                    "string": "%[1]s",
-                    "type": "string",
-                    "underlyingType": "string",
-                    "argNum": 1,
-                    "expr": "rcFile"
-                },
-                {
-                    "id": "Err",
-                    "string": "%[2]s",
-                    "type": "error",
-                    "underlyingType": "interface{Error() string}",
-                    "argNum": 2,
-                    "expr": "err"
-                }
-            ],
-            "fuzzy": true
-        },
-        {
-            "id": "Error closing {RcFile} file: {Err}",
-            "message": "Error closing {RcFile} file: {Err}",
-            "translation": "Error closing {RcFile} file: {Err}",
-            "translatorComment": "Copied from source.",
-            "placeholders": [
-                {
-                    "id": "RcFile",
-                    "string": "%[1]s",
-                    "type": "string",
-                    "underlyingType": "string",
-                    "argNum": 1,
-                    "expr": "rcFile"
-                },
-                {
-                    "id": "Err",
-                    "string": "%[2]s",
-                    "type": "error",
-                    "underlyingType": "interface{Error() string}",
-                    "argNum": 2,
-                    "expr": "err"
-                }
-            ],
-            "fuzzy": true
-        },
-        {
             "id": "Error opening {RcFile} file in write mode:",
             "message": "Error opening {RcFile} file in write mode:",
             "translation": "Error opening {RcFile} file in write mode:",
@@ -269,9 +194,9 @@
             "fuzzy": true
         },
         {
-            "id": "Failed to flush thw writes to file {RcFile}: {Err}",
-            "message": "Failed to flush thw writes to file {RcFile}: {Err}",
-            "translation": "Failed to flush thw writes to file {RcFile}: {Err}",
+            "id": "Failed to flush the writes to file {RcFile}: {Err}",
+            "message": "Failed to flush the writes to file {RcFile}: {Err}",
+            "translation": "Failed to flush the writes to file {RcFile}: {Err}",
             "translatorComment": "Copied from source.",
             "placeholders": [
                 {
@@ -306,6 +231,23 @@
                     "underlyingType": "int",
                     "argNum": 1,
                     "expr": "i"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Finished updating the {RcFile} file",
+            "message": "Finished updating the {RcFile} file",
+            "translation": "Finished updating the {RcFile} file",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "RcFile",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "rcFile"
                 }
             ],
             "fuzzy": true
@@ -1672,61 +1614,71 @@
             "fuzzy": true
         },
         {
-            "id": "CURIO_LAYERS: {}",
-            "message": "CURIO_LAYERS: {}",
-            "translation": "CURIO_LAYERS: {}",
+            "id": "CURIO_LAYERS: {Layers}",
+            "message": "CURIO_LAYERS: {Layers}",
+            "translation": "CURIO_LAYERS: {Layers}",
             "translatorComment": "Copied from source.",
             "placeholders": [
                 {
-                    "id": "",
+                    "id": "Layers",
                     "string": "%[1]s",
-                    "type": "string",
-                    "underlyingType": "string",
+                    "type": "[]string",
+                    "underlyingType": "[]string",
                     "argNum": 1,
-                    "expr": "\"\""
+                    "expr": "layers"
                 }
             ],
             "fuzzy": true
         },
         {
-            "id": "CURIO_REPO_PATH: {Curio}",
-            "message": "CURIO_REPO_PATH: {Curio}",
-            "translation": "CURIO_REPO_PATH: {Curio}",
+            "id": "CURIO_REPO_PATH: {RepoPath}",
+            "message": "CURIO_REPO_PATH: {RepoPath}",
+            "translation": "CURIO_REPO_PATH: {RepoPath}",
             "translatorComment": "Copied from source.",
             "placeholders": [
                 {
-                    "id": "Curio",
+                    "id": "RepoPath",
                     "string": "%[1]s",
                     "type": "string",
                     "underlyingType": "string",
                     "argNum": 1,
-                    "expr": "\"~/.curio\""
+                    "expr": "repoPath"
                 }
             ],
             "fuzzy": true
         },
         {
-            "id": "CURIO_NODE_NAME: {}",
-            "message": "CURIO_NODE_NAME: {}",
-            "translation": "CURIO_NODE_NAME: {}",
+            "id": "CURIO_NODE_NAME: {NodeName}",
+            "message": "CURIO_NODE_NAME: {NodeName}",
+            "translation": "CURIO_NODE_NAME: {NodeName}",
             "translatorComment": "Copied from source.",
             "placeholders": [
                 {
-                    "id": "",
+                    "id": "NodeName",
                     "string": "%[1]s",
                     "type": "string",
                     "underlyingType": "string",
                     "argNum": 1,
-                    "expr": "\"\""
+                    "expr": "nodeName"
                 }
             ],
             "fuzzy": true
         },
         {
-            "id": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE.",
-            "message": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE.",
-            "translation": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE.",
+            "id": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE: {EnvVars}",
+            "message": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE: {EnvVars}",
+            "translation": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE: {EnvVars}",
             "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "EnvVars",
+                    "string": "%[1]s",
+                    "type": "[]string",
+                    "underlyingType": "[]string",
+                    "argNum": 1,
+                    "expr": "envVars"
+                }
+            ],
             "fuzzy": true
         },
         {
@@ -1835,31 +1787,6 @@
                     "underlyingType": "string",
                     "argNum": 1,
                     "expr": "envVar"
-                }
-            ],
-            "fuzzy": true
-        },
-        {
-            "id": "Error opening or creating file {EnvFilePath}: {Err}",
-            "message": "Error opening or creating file {EnvFilePath}: {Err}",
-            "translation": "Error opening or creating file {EnvFilePath}: {Err}",
-            "translatorComment": "Copied from source.",
-            "placeholders": [
-                {
-                    "id": "EnvFilePath",
-                    "string": "%[1]s",
-                    "type": "string",
-                    "underlyingType": "string",
-                    "argNum": 1,
-                    "expr": "envFilePath"
-                },
-                {
-                    "id": "Err",
-                    "string": "%[2]s",
-                    "type": "error",
-                    "underlyingType": "interface{Error() string}",
-                    "argNum": 2,
-                    "expr": "err"
                 }
             ],
             "fuzzy": true

--- a/cmd/curio/internal/translations/locales/en/out.gotext.json
+++ b/cmd/curio/internal/translations/locales/en/out.gotext.json
@@ -89,6 +89,27 @@
             "fuzzy": true
         },
         {
+            "id": "Do you wish to add Harmony DB credentials to your ~/.bashrc or ~/.zshrc file?",
+            "message": "Do you wish to add Harmony DB credentials to your ~/.bashrc or ~/.zshrc file?",
+            "translation": "Do you wish to add Harmony DB credentials to your ~/.bashrc or ~/.zshrc file?",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Yes",
+            "message": "Yes",
+            "translation": "Yes",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "No",
+            "message": "No",
+            "translation": "No",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
             "id": "Not adding DB variables to RC file as shell {Shell} is not BASH or ZSH.",
             "message": "Not adding DB variables to RC file as shell {Shell} is not BASH or ZSH.",
             "translation": "Not adding DB variables to RC file as shell {Shell} is not BASH or ZSH.",
@@ -151,6 +172,31 @@
             "id": "Error reading {RcFile} file: {Err}",
             "message": "Error reading {RcFile} file: {Err}",
             "translation": "Error reading {RcFile} file: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "RcFile",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "rcFile"
+                },
+                {
+                    "id": "Err",
+                    "string": "%[2]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 2,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Error closing {RcFile} file: {Err}",
+            "message": "Error closing {RcFile} file: {Err}",
+            "translation": "Error closing {RcFile} file: {Err}",
             "translatorComment": "Copied from source.",
             "placeholders": [
                 {
@@ -1677,6 +1723,13 @@
             "fuzzy": true
         },
         {
+            "id": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE.",
+            "message": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE.",
+            "translation": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE.",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
             "id": "Continue update the env file.",
             "message": "Continue update the env file.",
             "translation": "Continue update the env file.",
@@ -1727,6 +1780,61 @@
                     "underlyingType": "string",
                     "argNum": 1,
                     "expr": "[]string{\"repo path\", \"node name\"}[i-1]"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Do you want to add additional variables like FIL_PROOFS_PARAMETER_CACHE? (y/n)",
+            "message": "Do you want to add additional variables like FIL_PROOFS_PARAMETER_CACHE? (y/n)",
+            "translation": "Do you want to add additional variables like FIL_PROOFS_PARAMETER_CACHE? (y/n)",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "No additional variables added",
+            "message": "No additional variables added",
+            "translation": "No additional variables added",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:",
+            "message": "Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:",
+            "translation": "Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
+            "id": "Error reading input: {Err}",
+            "message": "Error reading input: {Err}",
+            "translation": "Error reading input: {Err}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "Err",
+                    "string": "%[1]s",
+                    "type": "error",
+                    "underlyingType": "interface{Error() string}",
+                    "argNum": 1,
+                    "expr": "err"
+                }
+            ],
+            "fuzzy": true
+        },
+        {
+            "id": "Skipping invalid input: {EnvVar}",
+            "message": "Skipping invalid input: {EnvVar}",
+            "translation": "Skipping invalid input: {EnvVar}",
+            "translatorComment": "Copied from source.",
+            "placeholders": [
+                {
+                    "id": "EnvVar",
+                    "string": "%[1]s",
+                    "type": "string",
+                    "underlyingType": "string",
+                    "argNum": 1,
+                    "expr": "envVar"
                 }
             ],
             "fuzzy": true

--- a/cmd/curio/internal/translations/locales/ko/messages.gotext.json
+++ b/cmd/curio/internal/translations/locales/ko/messages.gotext.json
@@ -1131,90 +1131,270 @@
             "translation": "데이터베이스 구성 파일을 어디에 저장해야 하나요?",
             "message": "Where should we save your database config file?",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "Error writing file: {Error}",
             "translation": "파일 쓰기 오류: {Error}",
             "message": "Error writing file: {Error}",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "Try the web interface with {Rendercurio_run___layersgui}",
             "translation": "{Rendercurio_run___layersgui}와 함께 웹 인터페이스를 시도해보세요",
             "message": "Try the web interface with {Rendercurio_run___layersgui}",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "For more servers, copy curio.env to /etc/curio.env and add the CURIO_LAYERS env to assign purposes.",
             "translation": "더 많은 서버를 위해 curio.env를 /etc/curio.env로 복사하고 목적을 할당하기 위해 CURIO_LAYERS 환경 변수를 추가하세요.",
             "message": "For more servers, copy curio.env to /etc/curio.env and add the CURIO_LAYERS env to assign purposes.",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "Owner Wallet: {String}",
             "translation": "소유자 지갑: {String}",
             "message": "Owner Wallet: {String}",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "Worker Wallet: {String}",
             "translation": "작업자 지갑: {String}",
             "message": "Worker Wallet: {String}",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "Sender Wallet: {String}",
             "translation": "발송자 지갑: {String}",
             "message": "Sender Wallet: {String}",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "Select the Sector Size",
             "translation": "섹터 크기 선택",
             "message": "Select the Sector Size",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "64 GiB",
             "translation": "64 GiB",
             "message": "64 GiB",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "32 GiB",
             "translation": "32 GiB",
             "message": "32 GiB",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "8 MiB",
             "translation": "8 MiB",
             "message": "8 MiB",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "2 KiB",
             "translation": "2 KiB",
             "message": "2 KiB",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "Sector selection failed: {Error}",
             "translation": "섹터 선택 실패: {Error}",
             "message": "Sector selection failed: {Error}",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "For more servers, make /etc/curio.env with the curio.env database env and add the CURIO_LAYERS env to assign purposes.",
             "translation": "더 많은 서버를 위해 /etc/curio.env 파일을 curio.env 데이터베이스 환경으로 만들고 목적을 할당하기 위해 CURIO_LAYERS 환경 변수를 추가하세요.",
             "message": "For more servers, make /etc/curio.env with the curio.env database env and add the CURIO_LAYERS env to assign purposes.",
             "placeholder": null
-          },
-          {
+        },
+        {
             "id": "Additional info is at http://docs.curiostorage.org",
             "translation": "추가 정보는 http://docs.curiostorage.org 에 있습니다.",
             "message": "Additional info is at http://docs.curiostorage.org",
             "placeholder": null
-          }
+        },
+        {
+            "id": "Not adding DB variables to RC file as shell {Shell} is not BASH or ZSH.",
+            "translation": "셸 {Shell}이 BASH 또는 ZSH가 아니므로 RC 파일에 DB 변수를 추가하지 않습니다.",
+            "message": "Not adding DB variables to RC file as shell {Shell} is not BASH or ZSH.",
+            "placeholder": null
+        },
+        {
+            "id": "Error getting user home directory:",
+            "translation": "사용자 홈 디렉토리를 가져오는 중 오류 발생:",
+            "message": "Error getting user home directory:",
+            "placeholder": null
+        },
+        {
+            "id": "Error opening {RcFile} file: {Err}",
+            "translation": "{RcFile} 파일을 여는 중 오류 발생: {Err}",
+            "message": "Error opening {RcFile} file: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Error reading {RcFile} file: {Err}",
+            "translation": "{RcFile} 파일을 읽는 중 오류 발생: {Err}",
+            "message": "Error reading {RcFile} file: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Error opening {RcFile} file in write mode:",
+            "translation": "{RcFile} 파일을 쓰기 모드로 여는 중 오류 발생:",
+            "message": "Error opening {RcFile} file in write mode:",
+            "placeholder": null
+        },
+        {
+            "id": "Error writing to {RcFile} file: {Err}",
+            "translation": "{RcFile} 파일에 쓰는 중 오류 발생: {Err}",
+            "message": "Error writing to {RcFile} file: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Failed to flush thw writes to file {RcFile}: {Err}",
+            "translation": "{RcFile} 파일에 쓰기 내용을 플러시하는 데 실패했습니다: {Err}",
+            "message": "Failed to flush thw writes to file {RcFile}: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Retrying.......({I}/5)",
+            "translation": "다시 시도 중.......({I}/5)",
+            "message": "Retrying.......({I}/5)",
+            "placeholder": null
+        },
+        {
+            "id": "Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes",
+            "translation": "이 노드에서 Curio 서비스를 설정하려면 'curio service-setup'을 실행하고 다른 노드에서도 동일하게 진행하십시오.",
+            "message": "Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes",
+            "placeholder": null
+        },
+        {
+            "id": "This interactive tool creates/replace Curio service file and creates the basic env file for it.",
+            "translation": "이 대화형 도구는 Curio 서비스 파일을 생성/교체하고 기본 env 파일을 생성합니다.",
+            "message": "This interactive tool creates/replace Curio service file and creates the basic env file for it.",
+            "placeholder": null
+        },
+        {
+            "id": "This process is idempotent.",
+            "translation": "이 과정은 멱등적입니다.",
+            "message": "This process is idempotent.",
+            "placeholder": null
+        },
+        {
+            "id": "Service file {ServiceName} already exists at {ServicePath}, no changes made.",
+            "translation": "서비스 파일 {ServiceName}이 {ServicePath}에 이미 존재합니다. 변경 사항 없음.",
+            "message": "Service file {ServiceName} already exists at {ServicePath}, no changes made.",
+            "placeholder": null
+        },
+        {
+            "id": "Error checking for service file at {ServicePath}: {Err}",
+            "translation": "{ServicePath}에서 서비스 파일을 확인하는 중 오류 발생: {Err}",
+            "message": "Error checking for service file at {ServicePath}: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Error writing service file: {Err}",
+            "translation": "서비스 파일을 쓰는 중 오류 발생: {Err}",
+            "message": "Error writing service file: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Service file {ServiceName} created successfully at {TargetServicePath}",
+            "translation": "서비스 파일 {ServiceName}이 {TargetServicePath}에 성공적으로 생성되었습니다.",
+            "message": "Service file {ServiceName} created successfully at {TargetServicePath}",
+            "placeholder": null
+        },
+        {
+            "id": "Error reloading systemd: {Err}",
+            "translation": "systemd를 다시 로드하는 중 오류 발생: {Err}",
+            "message": "Error reloading systemd: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Error enabling service: {Err}",
+            "translation": "서비스를 활성화하는 중 오류 발생: {Err}",
+            "message": "Error enabling service: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Service {ServiceName} enabled.",
+            "translation": "서비스 {ServiceName}이 활성화되었습니다.",
+            "message": "Service {ServiceName} enabled.",
+            "placeholder": null
+        },
+        {
+            "id": "Enter the info to configure your Curio node",
+            "translation": "Curio 노드를 구성할 정보를 입력하십시오",
+            "message": "Enter the info to configure your Curio node",
+            "placeholder": null
+        },
+        {
+            "id": "CURIO_LAYERS: {}",
+            "translation": "CURIO_LAYERS: {}",
+            "message": "CURIO_LAYERS: {}",
+            "placeholder": null
+        },
+        {
+            "id": "CURIO_REPO_PATH: {Curio}",
+            "translation": "CURIO_REPO_PATH: {Curio}",
+            "message": "CURIO_REPO_PATH: {Curio}",
+            "placeholder": null
+        },
+        {
+            "id": "CURIO_NODE_NAME: {}",
+            "translation": "CURIO_NODE_NAME: {}",
+            "message": "CURIO_NODE_NAME: {}",
+            "placeholder": null
+        },
+        {
+            "id": "Continue update the env file.",
+            "translation": "env 파일 업데이트를 계속하십시오.",
+            "message": "Continue update the env file.",
+            "placeholder": null
+        },
+        {
+            "id": "Env config error occurred, abandoning: {Error}",
+            "translation": "환경 설정 오류 발생, 중단 중: {Error}",
+            "message": "Env config error occurred, abandoning: {Error}",
+            "placeholder": null
+        },
+        {
+            "id": "Enter the config layer name to use for this node. Base is already included by default",
+            "translation": "이 노드에 사용할 구성 레이어 이름을 입력하십시오. 기본값으로 Base가 이미 포함되어 있습니다",
+            "message": "Enter the config layer name to use for this node. Base is already included by default",
+            "placeholder": null
+        },
+        {
+            "id": "No layer provided",
+            "translation": "레이어가 제공되지 않았습니다",
+            "message": "No layer provided",
+            "placeholder": null
+        },
+        {
+            "id": "Enter the {Stringrepo_path_node_namei_1}",
+            "translation": "{Stringrepo_path_node_namei_1}을(를) 입력하십시오",
+            "message": "Enter the {Stringrepo_path_node_namei_1}",
+            "placeholder": null
+        },
+        {
+            "id": "Error opening or creating file {EnvFilePath}: {Err}",
+            "translation": "파일 {EnvFilePath}을(를) 열거나 생성하는 중 오류 발생: {Err}",
+            "message": "Error opening or creating file {EnvFilePath}: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Error writing to file {EnvFilePath}: {Err}",
+            "translation": "파일 {EnvFilePath}에 쓰는 중 오류 발생: {Err}",
+            "message": "Error writing to file {EnvFilePath}: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Service env file /etc/curio.env created successfully.",
+            "translation": "서비스 환경 파일 /etc/curio.env이(가) 성공적으로 생성되었습니다.",
+            "message": "Service env file /etc/curio.env created successfully.",
+            "placeholder": null
+        }
     ]
 }

--- a/cmd/curio/internal/translations/locales/ko/messages.gotext.json
+++ b/cmd/curio/internal/translations/locales/ko/messages.gotext.json
@@ -1395,6 +1395,66 @@
             "translation": "서비스 환경 파일 /etc/curio.env이(가) 성공적으로 생성되었습니다.",
             "message": "Service env file /etc/curio.env created successfully.",
             "placeholder": null
+        },
+        {
+            "id": "Do you wish to add Harmony DB credentials to your ~/.bashrc or ~/.zshrc file?",
+            "translation": "Harmony DB 자격 증명을 ~/.bashrc 또는 ~/.zshrc 파일에 추가하시겠습니까?",
+            "message": "Do you wish to add Harmony DB credentials to your ~/.bashrc or ~/.zshrc file?",
+            "placeholder": null
+        },
+        {
+            "id": "Yes",
+            "translation": "예",
+            "message": "Yes",
+            "placeholder": null
+        },
+        {
+            "id": "No",
+            "translation": "아니요",
+            "message": "No",
+            "placeholder": null
+        },
+        {
+            "id": "Error closing {RcFile} file: {Err}",
+            "translation": "{RcFile} 파일을 닫는 중 오류 발생: {Err}",
+            "message": "Error closing {RcFile} file: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE.",
+            "translation": "FIL_PROOFS_PARAMETER_CACHE와 같은 추가 변수를 추가하세요.",
+            "message": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE.",
+            "placeholder": null
+        },
+        {
+            "id": "Do you want to add additional variables like FIL_PROOFS_PARAMETER_CACHE? (y/n)",
+            "translation": "FIL_PROOFS_PARAMETER_CACHE와 같은 추가 변수를 추가하시겠습니까? (y/n)",
+            "message": "Do you want to add additional variables like FIL_PROOFS_PARAMETER_CACHE? (y/n)",
+            "placeholder": null
+        },
+        {
+            "id": "No additional variables added",
+            "translation": "추가 변수가 추가되지 않았습니다",
+            "message": "No additional variables added",
+            "placeholder": null
+        },
+        {
+            "id": "Error reading input: {Err}",
+            "translation": "입력을 읽는 중 오류 발생: {Err}",
+            "message": "Error reading input: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Skipping invalid input: {EnvVar}",
+            "translation": "잘못된 입력 건너뜀: {EnvVar}",
+            "message": "Skipping invalid input: {EnvVar}",
+            "placeholder": null
+        },
+        {
+            "id": "Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:",
+            "translation": "추가 환경 변수를 한 줄에 하나씩 입력하세요. 완료하려면 Ctrl+D를 사용하세요:",
+            "message": "Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:",
+            "placeholder": null
         }
     ]
 }

--- a/cmd/curio/internal/translations/locales/ko/messages.gotext.json
+++ b/cmd/curio/internal/translations/locales/ko/messages.gotext.json
@@ -1455,6 +1455,42 @@
             "translation": "추가 환경 변수를 한 줄에 하나씩 입력하세요. 완료하려면 Ctrl+D를 사용하세요:",
             "message": "Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:",
             "placeholder": null
+        },
+        {
+            "id": "Failed to flush the writes to file {RcFile}: {Err}",
+            "translation": "파일 {RcFile}에 쓰기를 플러시하지 못했습니다: {Err}",
+            "message": "Failed to flush the writes to file {RcFile}: {Err}",
+            "placeholder": null
+        },
+        {
+            "id": "Finished updating the {RcFile} file",
+            "translation": "{RcFile} 파일 업데이트를 완료했습니다",
+            "message": "Finished updating the {RcFile} file",
+            "placeholder": null
+        },
+        {
+            "id": "CURIO_LAYERS: {Layers}",
+            "translation": "CURIO_LAYERS: {Layers}",
+            "message": "CURIO_LAYERS: {Layers}",
+            "placeholder": null
+        },
+        {
+            "id": "CURIO_REPO_PATH: {RepoPath}",
+            "translation": "CURIO_REPO_PATH: {RepoPath}",
+            "message": "CURIO_REPO_PATH: {RepoPath}",
+            "placeholder": null
+        },
+        {
+            "id": "CURIO_NODE_NAME: {NodeName}",
+            "translation": "CURIO_NODE_NAME: {NodeName}",
+            "message": "CURIO_NODE_NAME: {NodeName}",
+            "placeholder": null
+        },
+        {
+            "id": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE: {EnvVars}",
+            "translation": "FIL_PROOFS_PARAMETER_CACHE와 같은 추가 변수를 추가하세요: {EnvVars}",
+            "message": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE: {EnvVars}",
+            "placeholder": null
         }
     ]
 }

--- a/cmd/curio/internal/translations/locales/zh/messages.gotext.json
+++ b/cmd/curio/internal/translations/locales/zh/messages.gotext.json
@@ -1185,6 +1185,186 @@
       "translation": "更多信息请访问 http://docs.curiostorage.org",
       "message": "Additional info is at http://docs.curiostorage.org",
       "placeholder": null
+    },
+    {
+      "id": "Not adding DB variables to RC file as shell {Shell} is not BASH or ZSH.",
+      "translation": "由于 shell {Shell} 不是 BASH 或 ZSH，因此未将数据库变量添加到 RC 文件中。",
+      "message": "Not adding DB variables to RC file as shell {Shell} is not BASH or ZSH.",
+      "placeholder": null
+    },
+    {
+      "id": "Error getting user home directory:",
+      "translation": "获取用户主目录时出错:",
+      "message": "Error getting user home directory:",
+      "placeholder": null
+    },
+    {
+      "id": "Error opening {RcFile} file: {Err}",
+      "translation": "打开文件 {RcFile} 时出错: {Err}",
+      "message": "Error opening {RcFile} file: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Error reading {RcFile} file: {Err}",
+      "translation": "读取文件 {RcFile} 时出错: {Err}",
+      "message": "Error reading {RcFile} file: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Error opening {RcFile} file in write mode:",
+      "translation": "以写入模式打开文件 {RcFile} 时出错:",
+      "message": "Error opening {RcFile} file in write mode:",
+      "placeholder": null
+    },
+    {
+      "id": "Error writing to {RcFile} file: {Err}",
+      "translation": "写入文件 {RcFile} 时出错: {Err}",
+      "message": "Error writing to {RcFile} file: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Failed to flush thw writes to file {RcFile}: {Err}",
+      "translation": "无法将写入内容刷新到文件 {RcFile}: {Err}",
+      "message": "Failed to flush thw writes to file {RcFile}: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Retrying.......({I}/5)",
+      "translation": "重试中.......({I}/5)",
+      "message": "Retrying.......({I}/5)",
+      "placeholder": null
+    },
+    {
+      "id": "Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes",
+      "translation": "执行 'curio service-setup' 以在此节点上设置 Curio 服务，并在其他节点上执行相同操作",
+      "message": "Execute 'curio service-setup' to setup the Curio service on this node and proceed to do the same on the other nodes",
+      "placeholder": null
+    },
+    {
+      "id": "This interactive tool creates/replace Curio service file and creates the basic env file for it.",
+      "translation": "此交互式工具创建/替换 Curio 服务文件并为其创建基本的 env 文件。",
+      "message": "This interactive tool creates/replace Curio service file and creates the basic env file for it.",
+      "placeholder": null
+    },
+    {
+      "id": "This process is idempotent.",
+      "translation": "此过程是幂等的。",
+      "message": "This process is idempotent.",
+      "placeholder": null
+    },
+    {
+      "id": "Service file {ServiceName} already exists at {ServicePath}, no changes made.",
+      "translation": "服务文件 {ServiceName} 已存在于 {ServicePath}，未做任何更改。",
+      "message": "Service file {ServiceName} already exists at {ServicePath}, no changes made.",
+      "placeholder": null
+    },
+    {
+      "id": "Error checking for service file at {ServicePath}: {Err}",
+      "translation": "检查 {ServicePath} 的服务文件时出错: {Err}",
+      "message": "Error checking for service file at {ServicePath}: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Error writing service file: {Err}",
+      "translation": "写入服务文件时出错: {Err}",
+      "message": "Error writing service file: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Service file {ServiceName} created successfully at {TargetServicePath}",
+      "translation": "服务文件 {ServiceName} 已成功创建于 {TargetServicePath}",
+      "message": "Service file {ServiceName} created successfully at {TargetServicePath}",
+      "placeholder": null
+    },
+    {
+      "id": "Error reloading systemd: {Err}",
+      "translation": "重新加载 systemd 时出错: {Err}",
+      "message": "Error reloading systemd: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Error enabling service: {Err}",
+      "translation": "启用服务时出错: {Err}",
+      "message": "Error enabling service: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Service {ServiceName} enabled.",
+      "translation": "服务 {ServiceName} 已启用。",
+      "message": "Service {ServiceName} enabled.",
+      "placeholder": null
+    },
+    {
+      "id": "Enter the info to configure your Curio node",
+      "translation": "输入信息以配置您的 Curio 节点",
+      "message": "Enter the info to configure your Curio node",
+      "placeholder": null
+    },
+    {
+      "id": "CURIO_LAYERS: {}",
+      "translation": "CURIO_LAYERS: {}",
+      "message": "CURIO_LAYERS: {}",
+      "placeholder": null
+    },
+    {
+      "id": "CURIO_REPO_PATH: {Curio}",
+      "translation": "CURIO_REPO_PATH: {Curio}",
+      "message": "CURIO_REPO_PATH: {Curio}",
+      "placeholder": null
+    },
+    {
+      "id": "CURIO_NODE_NAME: {}",
+      "translation": "CURIO_NODE_NAME: {}",
+      "message": "CURIO_NODE_NAME: {}",
+      "placeholder": null
+    },
+    {
+      "id": "Continue update the env file.",
+      "translation": "继续更新 env 文件。",
+      "message": "Continue update the env file.",
+      "placeholder": null
+    },
+    {
+      "id": "Env config error occurred, abandoning: {Error}",
+      "translation": "发生环境配置错误，放弃中: {Error}",
+      "message": "Env config error occurred, abandoning: {Error}",
+      "placeholder": null
+    },
+    {
+      "id": "Enter the config layer name to use for this node. Base is already included by default",
+      "translation": "输入此节点要使用的配置层名称。默认情况下已包含 Base",
+      "message": "Enter the config layer name to use for this node. Base is already included by default",
+      "placeholder": null
+    },
+    {
+      "id": "No layer provided",
+      "translation": "未提供层",
+      "message": "No layer provided",
+      "placeholder": null
+    },
+    {
+      "id": "Enter the {Stringrepo_path_node_namei_1}",
+      "translation": "输入 {Stringrepo_path_node_namei_1}",
+      "message": "Enter the {Stringrepo_path_node_namei_1}",
+      "placeholder": null
+    },
+    {
+      "id": "Error opening or creating file {EnvFilePath}: {Err}",
+      "translation": "打开或创建文件 {EnvFilePath} 时出错: {Err}",
+      "message": "Error opening or creating file {EnvFilePath}: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Error writing to file {EnvFilePath}: {Err}",
+      "translation": "写入文件 {EnvFilePath} 时出错: {Err}",
+      "message": "Error writing to file {EnvFilePath}: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Service env file /etc/curio.env created successfully.",
+      "translation": "服务环境文件 /etc/curio.env 已成功创建。",
+      "message": "Service env file /etc/curio.env created successfully.",
+      "placeholder": null
     }
   ]
 }

--- a/cmd/curio/internal/translations/locales/zh/messages.gotext.json
+++ b/cmd/curio/internal/translations/locales/zh/messages.gotext.json
@@ -1365,6 +1365,66 @@
       "translation": "服务环境文件 /etc/curio.env 已成功创建。",
       "message": "Service env file /etc/curio.env created successfully.",
       "placeholder": null
+    },
+    {
+      "id": "Do you wish to add Harmony DB credentials to your ~/.bashrc or ~/.zshrc file?",
+      "translation": "您是否希望将 Harmony DB 凭据添加到 ~/.bashrc 或 ~/.zshrc 文件中？",
+      "message": "Do you wish to add Harmony DB credentials to your ~/.bashrc or ~/.zshrc file?",
+      "placeholder": null
+    },
+    {
+      "id": "Yes",
+      "translation": "是",
+      "message": "Yes",
+      "placeholder": null
+    },
+    {
+      "id": "No",
+      "translation": "否",
+      "message": "No",
+      "placeholder": null
+    },
+    {
+      "id": "Error closing {RcFile} file: {Err}",
+      "translation": "关闭 {RcFile} 文件时出错: {Err}",
+      "message": "Error closing {RcFile} file: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE.",
+      "translation": "添加 FIL_PROOFS_PARAMETER_CACHE 等其他变量。",
+      "message": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE.",
+      "placeholder": null
+    },
+    {
+      "id": "Do you want to add additional variables like FIL_PROOFS_PARAMETER_CACHE? (y/n)",
+      "translation": "您是否希望添加 FIL_PROOFS_PARAMETER_CACHE 等其他变量？(y/n)",
+      "message": "Do you want to add additional variables like FIL_PROOFS_PARAMETER_CACHE? (y/n)",
+      "placeholder": null
+    },
+    {
+      "id": "No additional variables added",
+      "translation": "未添加其他变量",
+      "message": "No additional variables added",
+      "placeholder": null
+    },
+    {
+      "id": "Error reading input: {Err}",
+      "translation": "读取输入时出错: {Err}",
+      "message": "Error reading input: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Skipping invalid input: {EnvVar}",
+      "translation": "跳过无效输入: {EnvVar}",
+      "message": "Skipping invalid input: {EnvVar}",
+      "placeholder": null
+    },
+    {
+      "id": "Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:",
+      "translation": "开始输入您的附加环境变量，每行一个变量。使用 Ctrl+D 完成输入:",
+      "message": "Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:",
+      "placeholder": null
     }
   ]
 }

--- a/cmd/curio/internal/translations/locales/zh/messages.gotext.json
+++ b/cmd/curio/internal/translations/locales/zh/messages.gotext.json
@@ -1425,6 +1425,42 @@
       "translation": "开始输入您的附加环境变量，每行一个变量。使用 Ctrl+D 完成输入:",
       "message": "Start typing your additional environment variables one variable per line. Use Ctrl+D to finish:",
       "placeholder": null
+    },
+    {
+      "id": "Failed to flush the writes to file {RcFile}: {Err}",
+      "translation": "未能将写入数据刷新到文件 {RcFile}：{Err}",
+      "message": "Failed to flush the writes to file {RcFile}: {Err}",
+      "placeholder": null
+    },
+    {
+      "id": "Finished updating the {RcFile} file",
+      "translation": "已完成 {RcFile} 文件的更新",
+      "message": "Finished updating the {RcFile} file",
+      "placeholder": null
+    },
+    {
+      "id": "CURIO_LAYERS: {Layers}",
+      "translation": "CURIO_LAYERS: {Layers}",
+      "message": "CURIO_LAYERS: {Layers}",
+      "placeholder": null
+    },
+    {
+      "id": "CURIO_REPO_PATH: {RepoPath}",
+      "translation": "CURIO_REPO_PATH: {RepoPath}",
+      "message": "CURIO_REPO_PATH: {RepoPath}",
+      "placeholder": null
+    },
+    {
+      "id": "CURIO_NODE_NAME: {NodeName}",
+      "translation": "CURIO_NODE_NAME: {NodeName}",
+      "message": "CURIO_NODE_NAME: {NodeName}",
+      "placeholder": null
+    },
+    {
+      "id": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE: {EnvVars}",
+      "translation": "添加其他变量，例如 FIL_PROOFS_PARAMETER_CACHE: {EnvVars}",
+      "message": "Add additional variables like FIL_PROOFS_PARAMETER_CACHE: {EnvVars}",
+      "placeholder": null
     }
   ]
 }

--- a/cmd/curio/internal/translations/updateLang.sh
+++ b/cmd/curio/internal/translations/updateLang.sh
@@ -2,7 +2,7 @@
 
 #OP: Only run if some file in ../guidedsetup* is newer than catalog.go
 # Change this condition if using translations more widely.
-if [ "$(find ../../guidedsetup/* -newer catalog.go)" ]; then
+if [ "$(find ../../guidedsetup/* -newer catalog.go)" ] || [ "$(find locales/* -newer catalog.go)" ]; then
   gotext -srclang=en update -out=catalog.go -lang=en,zh,ko github.com/filecoin-project/curio/cmd/curio/guidedsetup
   go run knowns/main.go ./locales/zh ./locales/ko
 fi

--- a/cmd/curio/main.go
+++ b/cmd/curio/main.go
@@ -63,6 +63,7 @@ func main() {
 		testCmd,
 		webCmd,
 		guidedsetup.GuidedsetupCmd,
+		guidedsetup.ServicesetupCmd,
 		sealCmd,
 		unsealCmd,
 		marketCmd,

--- a/documentation/en/curio-cli/curio.md
+++ b/documentation/en/curio-cli/curio.md
@@ -10,18 +10,18 @@ VERSION:
    1.23.1
 
 COMMANDS:
-   cli           Execute cli commands
-   run           Start a Curio process
-   config        Manage node config by layers. The layer 'base' will always be applied at Curio start-up.
-   test          Utility functions for testing
-   web           Start Curio web interface
-   guided-setup  Run the guided setup for migrating from lotus-miner to Curio or Creating a new Curio miner
-   seal          Manage the sealing pipeline
-   unseal        Manage unsealed data
-   market        
-   fetch-params  Fetch proving parameters
-   calc          Math Utils
-   help, h       Shows a list of commands or help for one command
+   cli            Execute cli commands
+   run            Start a Curio process
+   config         Manage node config by layers. The layer 'base' will always be applied at Curio start-up.
+   test           Utility functions for testing
+   web            Start Curio web interface
+   guided-setup   Run the guided setup for migrating from lotus-miner to Curio or Creating a new Curio miner
+   service-setup  Run the service setup for a new Curio node. This command will take input from user and create/modify the service files
+   seal           Manage the sealing pipeline
+   market         
+   fetch-params   Fetch proving parameters
+   calc           Math Utils
+   help, h        Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --color              use color in display output (default: depends on output being a TTY)
@@ -483,6 +483,18 @@ NAME:
 
 USAGE:
    curio guided-setup [command options] [arguments...]
+
+OPTIONS:
+   --help, -h  show help
+```
+
+## curio service-setup
+```
+NAME:
+   curio service-setup - Run the service setup for a new Curio node. This command will take input from user and create/modify the service files
+
+USAGE:
+   curio service-setup [command options] [arguments...]
 
 OPTIONS:
    --help, -h  show help

--- a/documentation/en/curio-cli/curio.md
+++ b/documentation/en/curio-cli/curio.md
@@ -18,6 +18,7 @@ COMMANDS:
    guided-setup   Run the guided setup for migrating from lotus-miner to Curio or Creating a new Curio miner
    service-setup  Run the service setup for a new Curio node. This command will take input from user and create/modify the service files
    seal           Manage the sealing pipeline
+   unseal         Manage unsealed data
    market         
    fetch-params   Fetch proving parameters
    calc           Math Utils


### PR DESCRIPTION
This PR modifies the following:
1. The guided-setup no longer create a curio.env file. It simply adds the DB related variables to .bashrc/.zshrc files. This allows users to run curio commands easily after guided-setup. In the end, it also prompts user to run `service-setup` command.

2. The new service-setup command creates the service files and then takes user input for DB and other vars to creates the /etc/curio.env file. 