### PR TITLE
seal/snap: Handle insufficient funds errors correctly

### DIFF
--- a/tasks/seal/poller_commit_msg.go
+++ b/tasks/seal/poller_commit_msg.go
@@ -82,7 +82,7 @@ func (s *SealPoller) pollCommitMsgLanded(ctx context.Context, task pollTask) err
 
 func (s *SealPoller) pollCommitMsgFail(ctx context.Context, maddr address.Address, task pollTask, execResult dbExecResult) error {
 	switch exitcode.ExitCode(execResult.ExecutedRcptExitCode) {
-	case exitcode.SysErrInsufficientFunds:
+	case exitcode.SysErrInsufficientFunds, exitcode.ErrInsufficientFunds:
 		fallthrough
 	case exitcode.SysErrOutOfGas:
 		// just retry

--- a/tasks/seal/poller_precommit_msg.go
+++ b/tasks/seal/poller_precommit_msg.go
@@ -91,7 +91,7 @@ func (s *SealPoller) pollPrecommitMsgLanded(ctx context.Context, task pollTask) 
 
 func (s *SealPoller) pollPrecommitMsgFail(ctx context.Context, task pollTask, execResult dbExecResult) error {
 	switch exitcode.ExitCode(execResult.ExecutedRcptExitCode) {
-	case exitcode.SysErrInsufficientFunds:
+	case exitcode.SysErrInsufficientFunds, exitcode.ErrInsufficientFunds:
 		fallthrough
 	case exitcode.SysErrOutOfGas:
 		// just retry


### PR DESCRIPTION
Apparently there are two ways in which messages can fail with out-of-funds

This PR adds a retry for the second way.

Note that if the sender is still out of funds the immediate retry will still likely fail, but on gas estimation, without sending the message, but after that the sector will be in a retry-able state

Also added logic for sending retry in snapdeals pipeline