### PR TITLE
feat: Simpler IPNI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,9 @@ build/.update-modules:
 # end git modules
 
 ## CUDA Library Path
-setup_cuda:
-	$(eval CUDA_PATH := $(shell dirname $$(dirname $$(which nvcc))))
-	$(eval CUDA_LIB_PATH := $(CUDA_PATH)/lib64)
-	export LIBRARY_PATH=$(CUDA_LIB_PATH)
-.PHONY: setup_cuda
+$(eval CUDA_PATH := $(shell dirname $$(dirname $$(which nvcc))))
+$(eval CUDA_LIB_PATH := $(CUDA_PATH)/lib64)
+export LIBRARY_PATH=$(CUDA_LIB_PATH)
 
 ## MAIN BINARIES
 
@@ -98,7 +96,7 @@ BINS+=sptool
 
 ifeq ($(shell uname),Linux)
 
-batchdep: setup_cuda build/.supraseal-install
+batchdep: build/.supraseal-install
 batchdep: $(BUILD_DEPS)
 .PHONY: batchdep
 

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -855,17 +855,6 @@ an IP address`,
 allow indexer nodes to process announcements. Default: False`,
 		},
 		{
-			Name: "EntriesCacheCapacity",
-			Type: "int",
-
-			Comment: `EntriesCacheCapacity sets the maximum capacity to use for caching the indexing advertisement
-entries. Defaults to 4096 if not specified. The cache is evicted using LRU policy. The
-maximum storage used by the cache is a factor of EntriesCacheCapacity, EntriesChunkSize(16384) and
-the length of multihashes being advertised. For example, advertising 128-bit long multihashes
-with the default EntriesCacheCapacity, and EntriesChunkSize(16384) means the cache size can grow to
-1GiB when full.`,
-		},
-		{
 			Name: "WebHost",
 			Type: "string",
 

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -91,7 +91,6 @@ func DefaultCurioConfig() *CurioConfig {
 					ExpectedSnapSealDuration:  Duration(2 * time.Hour),
 				},
 				IPNI: IPNIConfig{
-					EntriesCacheCapacity: 4096,
 					WebHost:              "https://cid.contact",
 					DirectAnnounceURLs:   []string{"https://cid.contact/ingest/announce"},
 					AnnounceAddresses:    []string{},
@@ -679,14 +678,6 @@ type IPNIConfig struct {
 	// Disable set whether to disable indexing announcement to the network and expose endpoints that
 	// allow indexer nodes to process announcements. Default: False
 	Disable bool
-
-	// EntriesCacheCapacity sets the maximum capacity to use for caching the indexing advertisement
-	// entries. Defaults to 4096 if not specified. The cache is evicted using LRU policy. The
-	// maximum storage used by the cache is a factor of EntriesCacheCapacity, EntriesChunkSize(16384) and
-	// the length of multihashes being advertised. For example, advertising 128-bit long multihashes
-	// with the default EntriesCacheCapacity, and EntriesChunkSize(16384) means the cache size can grow to
-	// 1GiB when full.
-	EntriesCacheCapacity int
 
 	// The network indexer host that the web UI should link to for published announcements
 	// TODO: should we use this for checking published heas before publishing? Later commit

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -91,9 +91,9 @@ func DefaultCurioConfig() *CurioConfig {
 					ExpectedSnapSealDuration:  Duration(2 * time.Hour),
 				},
 				IPNI: IPNIConfig{
-					WebHost:              "https://cid.contact",
-					DirectAnnounceURLs:   []string{"https://cid.contact/ingest/announce"},
-					AnnounceAddresses:    []string{},
+					WebHost:            "https://cid.contact",
+					DirectAnnounceURLs: []string{"https://cid.contact/ingest/announce"},
+					AnnounceAddresses:  []string{},
 				},
 			},
 		},

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -438,16 +438,6 @@ description: The default curio configuration
       # type: bool
       #Disable = false
 
-      # EntriesCacheCapacity sets the maximum capacity to use for caching the indexing advertisement
-      # entries. Defaults to 4096 if not specified. The cache is evicted using LRU policy. The
-      # maximum storage used by the cache is a factor of EntriesCacheCapacity, EntriesChunkSize(16384) and
-      # the length of multihashes being advertised. For example, advertising 128-bit long multihashes
-      # with the default EntriesCacheCapacity, and EntriesChunkSize(16384) means the cache size can grow to
-      # 1GiB when full.
-      #
-      # type: int
-      #EntriesCacheCapacity = 4096
-
       # The network indexer host that the web UI should link to for published announcements
       # TODO: should we use this for checking published heas before publishing? Later commit
       #

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,9 @@ require (
 	github.com/minio/sha256-simd v1.0.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.13.0
+	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.3
+	github.com/multiformats/go-varint v0.0.7
 	github.com/open-rpc/meta-schema v0.0.0-20201029221707-1b72ef2ea333
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.0
@@ -265,9 +267,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect
-	github.com/multiformats/go-multicodec v0.9.0 // indirect
 	github.com/multiformats/go-multistream v0.5.0 // indirect
-	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nikkolasg/hexjson v0.1.0 // indirect
 	github.com/nkovacs/streamquote v1.0.0 // indirect

--- a/harmony/harmonydb/sql/20240731-market-migration.sql
+++ b/harmony/harmonydb/sql/20240731-market-migration.sql
@@ -91,7 +91,7 @@ CREATE OR REPLACE FUNCTION process_piece_deal(
     _sp_id BIGINT,
     _sector_num BIGINT,
     _piece_offset BIGINT,
-    _piece_length BIGINT,
+    _piece_length BIGINT, -- padded length
     _raw_size BIGINT,
     _indexed BOOLEAN,
     _legacy_deal BOOLEAN DEFAULT FALSE,

--- a/harmony/harmonydb/sql/20240823-ipni.sql
+++ b/harmony/harmonydb/sql/20240823-ipni.sql
@@ -37,14 +37,16 @@ CREATE TABLE ipni_head (
     FOREIGN KEY (head) REFERENCES ipni(ad_cid) ON DELETE RESTRICT -- Prevents deletion if it's referenced
 );
 
+-- This table stores metadata for ipni ad entry chunks. This metadata is used to reconstruct the original ad entry from
+-- on-disk .car block headers or from data in the piece index database.
 CREATE TABLE ipni_chunks (
-    cid TEXT PRIMARY KEY,
-    piece_cid TEXT NOT NULL,
-    chunk_num INTEGER NOT NULL,
-    first_cid TEXT,
-    start_offset BIGINT,
-    num_blocks BIGINT NOT NULL,
-    from_car BOOLEAN NOT NULL,
+    cid TEXT PRIMARY KEY, -- CID of the chunk
+    piece_cid TEXT NOT NULL, -- Related Piece CID
+    chunk_num INTEGER NOT NULL, -- Chunk number within the piece. Chunk 0 has no "next" link.
+    first_cid TEXT, -- In case of db-based chunks, the CID of the first cid in the chunk
+    start_offset BIGINT, -- In case of .car-based chunks, the offset in the .car file where the chunk starts
+    num_blocks BIGINT NOT NULL, -- Number of blocks in the chunk
+    from_car BOOLEAN NOT NULL, -- Whether the chunk is from a .car file or from the database
     CHECK (
         (from_car = FALSE AND first_cid IS NOT NULL AND start_offset IS NULL) OR
         (from_car = TRUE AND first_cid IS NULL AND start_offset IS NOT NULL)

--- a/harmony/harmonydb/sql/20240823-ipni.sql
+++ b/harmony/harmonydb/sql/20240823-ipni.sql
@@ -48,7 +48,9 @@ CREATE TABLE ipni_chunks (
     CHECK (
         (from_car = FALSE AND first_cid IS NOT NULL AND start_offset IS NULL) OR
         (from_car = TRUE AND first_cid IS NULL AND start_offset IS NOT NULL)
-    )
+    ),
+
+    UNIQUE (piece_cid, chunk_num)
 );
 
 CREATE OR REPLACE FUNCTION insert_ad_and_update_head(

--- a/harmony/harmonydb/sql/20240823-ipni.sql
+++ b/harmony/harmonydb/sql/20240823-ipni.sql
@@ -37,6 +37,20 @@ CREATE TABLE ipni_head (
     FOREIGN KEY (head) REFERENCES ipni(ad_cid) ON DELETE RESTRICT -- Prevents deletion if it's referenced
 );
 
+CREATE TABLE ipni_chunks (
+    cid TEXT PRIMARY KEY,
+    piece_cid TEXT NOT NULL,
+    chunk_num INTEGER NOT NULL,
+    first_cid TEXT,
+    start_offset BIGINT,
+    num_blocks BIGINT NOT NULL,
+    from_car BOOLEAN NOT NULL,
+    CHECK (
+        (from_car = FALSE AND first_cid IS NOT NULL AND start_offset IS NULL) OR
+        (from_car = TRUE AND first_cid IS NULL AND start_offset IS NOT NULL)
+    )
+);
+
 CREATE OR REPLACE FUNCTION insert_ad_and_update_head(
     _ad_cid TEXT,
     _context_id BYTEA,

--- a/market/ipni/chunker/chunker.go
+++ b/market/ipni/chunker/chunker.go
@@ -12,7 +12,7 @@ var log = logging.Logger("chunker")
 
 const entriesChunkSize = 16384
 
-func newEntriesChunkNode(mhs []multihash.Multihash, next ipld.Link) (datamodel.Node, error) {
+func NewEntriesChunkNode(mhs []multihash.Multihash, next ipld.Link) (datamodel.Node, error) {
 	chunk := schema.EntryChunk{
 		Entries: mhs,
 	}

--- a/market/ipni/chunker/chunker.go
+++ b/market/ipni/chunker/chunker.go
@@ -1,91 +1,16 @@
 package chunker
 
 import (
-	"errors"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipni/go-libipni/ingest/schema"
 	"github.com/multiformats/go-multihash"
-	"io"
-
-	"github.com/filecoin-project/curio/market/ipni/ipniculib"
 )
 
 var log = logging.Logger("chunker")
 
 const entriesChunkSize = 16384
-
-// Chunker chunks advertisement entries as a chained series of schema.EntryChunk nodes.
-// See: NewChunker
-type Chunker struct {
-	chunkSize int
-}
-
-// NewChunker instantiates a new chain chunker that given a provider.MultihashIterator it drains
-// all its mulithashes and stores them in the given link system represented as a chain of
-// schema.EntryChunk nodes where each chunk contains no more than chunkSize number of multihashes.
-//
-// See: schema.EntryChunk.
-func NewChunker() *Chunker {
-	return &Chunker{
-		chunkSize: entriesChunkSize,
-	}
-}
-
-type HashIterator interface {
-	Next() (multihash.Multihash, error)
-}
-
-// Chunk chunks all the mulithashes returned by the given iterator into a chain of schema.EntryChunk
-// nodes where each chunk contains no more than chunkSize number of multihashes and returns the link
-// the root chunk node.
-//
-// See: schema.EntryChunk.
-func (ls *Chunker) Chunk(mhi HashIterator) (ipld.Link, error) {
-	mhs := make([]multihash.Multihash, 0, ls.chunkSize)
-	var next ipld.Link
-	var mhCount, chunkCount int
-	for {
-		mh, err := mhi.Next()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return nil, err
-		}
-		mhs = append(mhs, mh)
-		if len(mhs) >= ls.chunkSize {
-			cNode, err := newEntriesChunkNode(mhs, next)
-			if err != nil {
-				return nil, err
-			}
-			next, err = ipniculib.NodeToLink(cNode, schema.Linkproto)
-			if err != nil {
-				return nil, err
-			}
-			chunkCount++
-			mhCount += len(mhs)
-			// NewLinkedListOfMhs makes it own copy, so safe to reuse mhs
-			mhs = mhs[:0]
-		}
-	}
-	if len(mhs) != 0 {
-		cNode, err := newEntriesChunkNode(mhs, next)
-		if err != nil {
-			return nil, err
-		}
-		next, err = ipniculib.NodeToLink(cNode, schema.Linkproto)
-		if err != nil {
-			return nil, err
-		}
-		chunkCount++
-		mhCount += len(mhs)
-	}
-
-	log.Infow("Generated linked chunks of multihashes", "totalMhCount", mhCount, "chunkCount", chunkCount)
-	return next, nil
-}
 
 func newEntriesChunkNode(mhs []multihash.Multihash, next ipld.Link) (datamodel.Node, error) {
 	chunk := schema.EntryChunk{

--- a/market/ipni/chunker/initial-chunker.go
+++ b/market/ipni/chunker/initial-chunker.go
@@ -1,0 +1,129 @@
+package chunker
+
+import (
+	"bytes"
+	"github.com/filecoin-project/curio/market/ipni/ipniculib"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipni/go-libipni/ingest/schema"
+	"github.com/multiformats/go-multihash"
+	"sort"
+)
+
+const longChainThreshold = 500_000
+
+// InitialChunker is used for initial entry chain creation.
+// It employs a dual strategy, where it tracks the number of entries, and:
+// For chains with less than longChainThreshold entries, it accumulates entries in memory.
+// which will then form a sorted chain of schema.EntryChunk nodes. This allows creation of
+// ad chains which are read from the index database.
+// For chains with more than longChainThreshold entries, it creates a chain of schema.EntryChunk nodes
+// in car order, noting where each chunk starts and ends in the car file.
+type InitialChunker struct {
+	chunkSize int
+
+	ingestedSoFar int64
+
+	// db-order ingest, up to longChainThreshold
+	dbMultihashes []multihash.Multihash
+
+	// car-order ingest, after longChainThreshold
+	carPending    []multihash.Multihash
+	carChunkStart *int64
+	carChunkNodes int64
+
+	prevChunks []carChunkMeta
+}
+
+type carChunkMeta struct {
+	link  ipld.Link
+	start int64
+	nodes int64
+}
+
+func NewInitialChunker() *InitialChunker {
+	return &InitialChunker{
+		chunkSize: entriesChunkSize,
+	}
+}
+
+func (c *InitialChunker) Accept(mh multihash.Multihash, startOff int64) error {
+	if c.ingestedSoFar < longChainThreshold {
+		// db-order ingest
+		c.dbMultihashes = append(c.dbMultihashes, mh)
+	}
+	// note: we always run car-order ingest, even if we're still in db-order ingest
+
+	// free db-order ingest
+	if c.ingestedSoFar >= longChainThreshold {
+		c.dbMultihashes = nil
+	}
+	c.ingestedSoFar++
+
+	// car-order ingest
+
+	// append to car-order ingest
+	c.carPending = append(c.carPending, mh)
+	if c.carChunkStart == nil {
+		c.carChunkStart = &startOff
+		c.carChunkNodes = 0
+	}
+	c.carChunkNodes++
+
+	if len(c.carPending) >= c.chunkSize {
+		// create a chunk
+		var next ipld.Link
+		if len(c.prevChunks) > 0 {
+			next = c.prevChunks[len(c.prevChunks)-1].link
+		}
+
+		cNode, err := newEntriesChunkNode(c.carPending, next)
+		if err != nil {
+			return err
+		}
+
+		link, err := ipniculib.NodeToLink(cNode, schema.Linkproto)
+		if err != nil {
+			return err
+		}
+
+		c.prevChunks = append(c.prevChunks, carChunkMeta{
+			link:  link,
+			start: *c.carChunkStart,
+			nodes: c.carChunkNodes,
+		})
+
+		c.carPending = c.carPending[:0]
+	}
+
+	return nil
+}
+
+func (c *InitialChunker) Finish() error {
+	// note: <= because we're not inserting anything here
+	if c.ingestedSoFar <= longChainThreshold {
+		// db-order ingest
+		return c.finishDB()
+	}
+
+	// car-order ingest
+	return c.finishCAR()
+}
+
+func (c *InitialChunker) finishDB() error {
+	if len(c.dbMultihashes) == 0 {
+		return nil
+	}
+
+	// in db-order ingest, we create a chain of schema.EntryChunk nodes with sorted multihashes
+
+	// sort multihashes
+	sort.Slice(c.dbMultihashes, func(i, j int) bool {
+		return bytes.Compare(c.dbMultihashes[i], c.dbMultihashes[j]) < 0
+	})
+
+	return nil
+}
+
+func (c *InitialChunker) finishCAR() error {
+
+}

--- a/market/ipni/chunker/initial-chunker.go
+++ b/market/ipni/chunker/initial-chunker.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
-	"github.com/ipni/go-libipni/ingest/schema"
 	"github.com/multiformats/go-multihash"
 	"github.com/yugabyte/pgx/v5"
 	"golang.org/x/xerrors"
@@ -90,12 +89,12 @@ func (c *InitialChunker) processCarPending() error {
 		next = c.prevChunks[len(c.prevChunks)-1].link
 	}
 
-	cNode, err := newEntriesChunkNode(c.carPending, next)
+	cNode, err := NewEntriesChunkNode(c.carPending, next)
 	if err != nil {
 		return err
 	}
 
-	link, err := ipniculib.NodeToLink(cNode, schema.Linkproto)
+	link, err := ipniculib.NodeToLink(cNode, ipniculib.EntryLinkproto)
 	if err != nil {
 		return err
 	}
@@ -158,12 +157,12 @@ func (c *InitialChunker) finishDB(ctx context.Context, db *harmonydb.DB, pieceCi
 			next = chunkLinks[i-1]
 		}
 
-		cNode, err := newEntriesChunkNode(chunks[i], next)
+		cNode, err := NewEntriesChunkNode(chunks[i], next)
 		if err != nil {
 			return nil, err
 		}
 
-		link, err := ipniculib.NodeToLink(cNode, schema.Linkproto)
+		link, err := ipniculib.NodeToLink(cNode, ipniculib.EntryLinkproto)
 		if err != nil {
 			return nil, err
 		}

--- a/market/ipni/chunker/initial-chunker.go
+++ b/market/ipni/chunker/initial-chunker.go
@@ -4,15 +4,17 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/filecoin-project/curio/harmony/harmonydb"
-	"github.com/filecoin-project/curio/market/ipni/ipniculib"
+	"sort"
+
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipni/go-libipni/ingest/schema"
 	"github.com/multiformats/go-multihash"
 	"github.com/yugabyte/pgx/v5"
 	"golang.org/x/xerrors"
-	"sort"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/market/ipni/ipniculib"
 )
 
 const longChainThreshold = 500_000

--- a/market/ipni/ipniculib/ipniculib.go
+++ b/market/ipni/ipniculib/ipniculib.go
@@ -1,11 +1,77 @@
 package ipniculib
 
 import (
+	"bufio"
+	"io"
+
+	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime/datamodel"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-varint"
+	"golang.org/x/xerrors"
+)
+
+var (
+	EntryLinkproto = cidlink.LinkPrototype{
+		Prefix: cid.Prefix{
+			Version:  1,
+			Codec:    uint64(multicodec.DagCbor),
+			MhType:   uint64(multicodec.Sha2_256),
+			MhLength: -1,
+		},
+	}
 )
 
 func NodeToLink(node datamodel.Node, lp datamodel.LinkPrototype) (datamodel.Link, error) {
 	linkSystem := cidlink.DefaultLinkSystem()
 	return linkSystem.ComputeLink(lp, node)
+}
+
+// SkipCarNode is a specialized version of carv2.SkipCarNode that skips the car node and returns the CID of the skipped node.
+// Unlike the carv2 version this version never seeks with the assumption that it always operates on dense car files.
+// It also does not need to know the absolute offset in the car file, only needs the reader to start at the beginning of a car entry.
+func SkipCarNode(br *bufio.Reader) (cid.Cid, error) {
+	sectionSize, err := LdReadSize(br, true, 32<<20)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	cidSize, c, err := cid.CidFromReader(io.LimitReader(br, int64(sectionSize)))
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	blockSize := sectionSize - uint64(cidSize)
+	readCnt, err := io.CopyN(io.Discard, br, int64(blockSize))
+	if err != nil {
+		if err == io.EOF {
+			return cid.Undef, io.ErrUnexpectedEOF
+		}
+		return cid.Undef, err
+	}
+
+	if readCnt != int64(blockSize) {
+		return cid.Undef, xerrors.New("unexpected length")
+	}
+
+	return c, nil
+}
+
+func LdReadSize(r *bufio.Reader, zeroLenAsEOF bool, maxReadBytes uint64) (uint64, error) {
+	l, err := varint.ReadUvarint(r)
+	if err != nil {
+		// If the length of bytes read is non-zero when the error is EOF then signal an unclean EOF.
+		if l > 0 && err == io.EOF {
+			return 0, io.ErrUnexpectedEOF
+		}
+		return 0, err
+	} else if l == 0 && zeroLenAsEOF {
+		return 0, io.EOF
+	}
+
+	if l > maxReadBytes { // Don't OOM
+		return 0, xerrors.Errorf("section size %d exceeds maximum allowed size %d", l, maxReadBytes)
+	}
+	return l, nil
 }

--- a/tasks/indexing/task_ipni.go
+++ b/tasks/indexing/task_ipni.go
@@ -161,7 +161,7 @@ func (I *IPNITask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done b
 		return false, xerrors.Errorf("getting CAR multihash iterator: %w", err)
 	}
 
-	lnk, err := chunker.NewChunker(nil).Chunk(*mhi)
+	lnk, err := chunker.NewChunker().Chunk(*mhi)
 	if err != nil {
 		return false, xerrors.Errorf("chunking CAR multihash iterator: %w", err)
 	}

--- a/tasks/indexing/task_ipni.go
+++ b/tasks/indexing/task_ipni.go
@@ -142,25 +142,6 @@ func (I *IPNITask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done b
 		return false, fmt.Errorf("generating index for piece: %w", err)
 	}
 
-	mis := make(index.MultihashIndexSorted)
-	err = mis.Load(recs)
-	if err != nil {
-		return false, xerrors.Errorf("failed to load indexed in multihash sorter: %w", err)
-	}
-
-	// To avoid - Cannot assert pinter to interface
-	idxF := func(sorted *index.MultihashIndexSorted) index.Index {
-		return sorted
-	}
-
-	idx := idxF(&mis)
-	iterableIndex := idx.(index.IterableIndex)
-
-	mhi, err := chunker.CarMultihashIterator(iterableIndex)
-	if err != nil {
-		return false, xerrors.Errorf("getting CAR multihash iterator: %w", err)
-	}
-
 	lnk, err := chunker.NewChunker().Chunk(*mhi)
 	if err != nil {
 		return false, xerrors.Errorf("chunking CAR multihash iterator: %w", err)


### PR DESCRIPTION
* Change IPNI entry creation to be dependent on number of blocks in a piece
  * Below 500k entries per piece (64kb block in 32G) read from DB
  * Above 500k re-create entries by doing range car-reads
  * No caches involved anymore, entries get recreated on the fly, with low latency
* Switched entries from dag-json to dag-cbor, apparently IPNI shouldn't care much, and in the future this will make it easy to switch to the much, much faster cbor-gen for entry creation.
  * Ads remain as dag-json