### PR TITLE
cunative: Only pull in native deps with a tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ deps: $(BUILD_DEPS)
 
 ## ldflags -s -w strips binary
 
+curio: GOFLAGS+=-tags=cunative
 curio: $(BUILD_DEPS)
 	rm -f curio
 	GOAMD64=v3 CGO_LDFLAGS_ALLOW=$(CGO_LDFLAGS_ALLOW) $(GOCC) build $(GOFLAGS) -o curio -ldflags " -s -w \

--- a/lib/ffi/cunative/decode_sdr.go
+++ b/lib/ffi/cunative/decode_sdr.go
@@ -1,3 +1,5 @@
+//go:build cunative
+
 package cunative
 
 /*

--- a/lib/ffi/cunative/decode_snap.go
+++ b/lib/ffi/cunative/decode_snap.go
@@ -1,3 +1,5 @@
+//go:build cunative
+
 package cunative
 
 /*

--- a/lib/ffi/cunative/decode_snap_test.go
+++ b/lib/ffi/cunative/decode_snap_test.go
@@ -1,3 +1,5 @@
+//go:build cunative
+
 package cunative
 
 import (

--- a/lib/ffi/cunative/decode_test.go
+++ b/lib/ffi/cunative/decode_test.go
@@ -1,3 +1,5 @@
+//go:build cunative
+
 package cunative
 
 import (

--- a/lib/ffi/cunative/nonative.go
+++ b/lib/ffi/cunative/nonative.go
@@ -1,0 +1,19 @@
+//go:build !cunative
+
+package cunative
+
+import (
+	"io"
+
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/go-state-types/abi"
+)
+
+func DecodeSnap(spt abi.RegisteredSealProof, commD, commK cid.Cid, key, replica io.Reader, out io.Writer) error {
+	panic("DecodeSnap: cunative build tag not enabled")
+}
+
+func Decode(replica, key io.Reader, out io.Writer) error {
+	panic("Decode: cunative build tag not enabled")
+}


### PR DESCRIPTION
This makes it possible to use curio as a library again.

Context: https://filecoinproject.slack.com/archives/C06GD1SS56Y/p1727193366887699