### PR TITLE
Perform recover of sectors repeatedly throught the day. Also default to not check sectors before generating proof

### DIFF
--- a/tasks/window/compute_do.go
+++ b/tasks/window/compute_do.go
@@ -31,7 +31,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-const disablePreChecks = false // todo config
+const disablePreChecks = true // todo config
 
 func (t *WdPostTask) DoPartition(ctx context.Context, ts *types.TipSet, maddr address.Address, di *dline.Info, partIdx uint64, test bool) (out *miner2.SubmitWindowedPoStParams, err error) {
 	defer func() {

--- a/tasks/window/recover_task.go
+++ b/tasks/window/recover_task.go
@@ -267,7 +267,7 @@ func (w *WdPostRecoverDeclareTask) processHeadChange(ctx context.Context, revert
 		}
 
 		// repeat checks for [2, 4, 6, 8, 10, 12, 14, 16, ... 38], the closer deadline is prioritized
-		for i := 1; i < 19; i++ {
+		for i := 1; i < 20; i++ {
 			// declaring 2*i deadlines ahead
 			declDeadline := (di.Index + uint64(2*i)) % di.WPoStPeriodDeadlines
 


### PR DESCRIPTION
As the title says, doing the recovery of sectrors 2 deadlines before the partition deadline is not enough as it can have overlapps with other deadlines, for instance trying to recover deadline 2 while generating deadline 0. This causes reads to overlap and cause issues.

Also, if we already did recovery of a sector, the default should be to not recheck that sector while doing a deadline, so while the configuration value "DisableWDPoStPreChecks" is not implemented, this should help SP greately.