### PR TITLE
feat: implement retry wait mechanism for task retries

### DIFF
--- a/harmony/harmonydb/sql/20240927-task-retrywait.sql
+++ b/harmony/harmonydb/sql/20240927-task-retrywait.sql
@@ -1,0 +1,1 @@
+ALTER TABLE harmony_task ADD COLUMN retries BIGINT NOT NULL DEFAULT 0;

--- a/harmony/harmonytask/task_type_handler.go
+++ b/harmony/harmonytask/task_type_handler.go
@@ -259,7 +259,8 @@ func (h *taskTypeHandler) recordCompletion(tID TaskID, sectorID *abi.SectorID, w
 retryRecordCompletion:
 	cm, err := h.TaskEngine.db.BeginTransaction(h.TaskEngine.ctx, func(tx *harmonydb.Tx) (bool, error) {
 		var postedTime time.Time
-		err := tx.QueryRow(`SELECT posted_time FROM harmony_task WHERE id=$1`, tID).Scan(&postedTime)
+		var retries uint
+		err := tx.QueryRow(`SELECT posted_time, retries FROM harmony_task WHERE id=$1`, tID).Scan(&postedTime, &retries)
 
 		if err != nil {
 			return false, fmt.Errorf("could not log completion: %w ", err)
@@ -280,16 +281,8 @@ retryRecordCompletion:
 				result = "error: " + doErr.Error()
 			}
 			var deleteTask bool
-			if h.MaxFailures > 0 {
-				ct := uint(0)
-				err = tx.QueryRow(`SELECT count(*) FROM harmony_task_history 
-				WHERE task_id=$1 AND result=FALSE`, tID).Scan(&ct)
-				if err != nil {
-					return false, fmt.Errorf("could not read task history: %w", err)
-				}
-				if ct >= h.MaxFailures {
-					deleteTask = true
-				}
+			if h.MaxFailures > 0 && retries >= h.MaxFailures {
+				deleteTask = true
 			}
 			if deleteTask {
 				_, err = tx.Exec("DELETE FROM harmony_task WHERE id=$1", tID)
@@ -298,7 +291,7 @@ retryRecordCompletion:
 				}
 				// Note: Extra Info is left laying around for later review & clean-up
 			} else {
-				_, err := tx.Exec(`UPDATE harmony_task SET owner_id=NULL WHERE id=$1`, tID)
+				_, err := tx.Exec(`UPDATE harmony_task SET owner_id=NULL, retries=$1, update_time=CURRENT_TIMESTAMP  WHERE id=$2`, retries+1, tID)
 				if err != nil {
 					return false, fmt.Errorf("could not disown failed task: %v %v", tID, err)
 				}

--- a/tasks/message/sender.go
+++ b/tasks/message/sender.go
@@ -246,6 +246,12 @@ func (s *SendTask) TypeDetails() harmonytask.TaskTypeDetails {
 		},
 		MaxFailures: 1000,
 		Follows:     nil,
+		RetryWait: func(retries int) time.Duration {
+			if retries < 10 {
+				return time.Second * time.Duration(retries)
+			}
+			return time.Second * 10
+		},
 	}
 }
 


### PR DESCRIPTION
The following changes have been made in this PR:
1. Added a `retries` field to the `harmony_task` table to track the number of retries for a task.
2. Added a `RetryWait` field to `TaskTypeDetails` to set the wait time before retrying a task, which can be `nil`.
3. Set `RetryWait` for the `SendMessage` task, while other tasks do not have it set (can be set as needed in the future).
