### PR TITLE
storage: Add post challenge reading metrics

### DIFF
--- a/harmony/harmonydb/metrics.go
+++ b/harmony/harmonydb/metrics.go
@@ -5,8 +5,6 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-
-	"github.com/filecoin-project/lotus/metrics"
 )
 
 var (
@@ -43,7 +41,7 @@ var DBMeasures = struct {
 
 // CacheViews groups all cache-related default views.
 func init() {
-	metrics.RegisterViews(
+	err := view.Register(
 		&view.View{
 			Measure:     DBMeasures.Hits,
 			Aggregation: view.Sum(),
@@ -65,7 +63,10 @@ func init() {
 			TagKeys:     []tag.Key{dbTag},
 		},
 	)
-	err := prometheus.Register(DBMeasures.Waits)
+	if err != nil {
+		panic(err)
+	}
+	err = prometheus.Register(DBMeasures.Waits)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/paths/local.go
+++ b/lib/paths/local.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 	"math/bits"
 	"math/rand"
 	"os"
@@ -18,6 +16,8 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"golang.org/x/xerrors"
 
 	ffi "github.com/filecoin-project/filecoin-ffi"

--- a/lib/paths/local.go
+++ b/lib/paths/local.go
@@ -967,7 +967,7 @@ func (st *Local) GenerateSingleVanillaProof(ctx context.Context, minerID abi.Act
 		if err != nil {
 			// Record the error with tags
 			ctx, _ = tag.New(ctx,
-				tag.Upsert(updateTagKey, fmt.Sprintf("%t", si.Update)),
+				tag.Upsert(updateTagKey, fmt.Sprintf("%t", si.Update != "")),
 				tag.Upsert(cacheIDTagKey, ""),
 				tag.Upsert(sealedIDTagKey, ""),
 			)
@@ -981,7 +981,7 @@ func (st *Local) GenerateSingleVanillaProof(ctx context.Context, minerID abi.Act
 		if err != nil {
 			// Record the error with tags
 			ctx, _ = tag.New(ctx,
-				tag.Upsert(updateTagKey, fmt.Sprintf("%t", si.Update)),
+				tag.Upsert(updateTagKey, fmt.Sprintf("%t", si.Update != "")),
 				tag.Upsert(cacheIDTagKey, ""),
 				tag.Upsert(sealedIDTagKey, ""),
 			)

--- a/lib/paths/metrics.go
+++ b/lib/paths/metrics.go
@@ -1,0 +1,48 @@
+package paths
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	updateTagKey, _   = tag.NewKey("update")
+	cacheIDTagKey, _  = tag.NewKey("cache_id")
+	sealedIDTagKey, _ = tag.NewKey("sealed_id")
+
+	pre = "curio_stor_"
+
+	// Buckets for the duration histogram (in seconds)
+	durationBuckets = []float64{0.1, 1, 5, 12, 20, 60, 90, 150, 300, 500, 900, 1500, 3000, 6000, 15000, 30000, 60000, 90000, 200_000, 600_000, 1000_000}
+)
+
+var (
+	// Measures
+	GenerateSingleVanillaProofCalls    = stats.Int64(pre+"generate_single_vanilla_proof_calls", "Number of calls to GenerateSingleVanillaProof", stats.UnitDimensionless)
+	GenerateSingleVanillaProofErrors   = stats.Int64(pre+"generate_single_vanilla_proof_errors", "Number of errors in GenerateSingleVanillaProof", stats.UnitDimensionless)
+	GenerateSingleVanillaProofDuration = stats.Int64(pre+"generate_single_vanilla_proof_duration_seconds", "Duration of GenerateSingleVanillaProof in seconds", stats.UnitMilliseconds)
+)
+
+func init() {
+	err := view.Register(
+		&view.View{
+			Measure:     GenerateSingleVanillaProofCalls,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{updateTagKey, cacheIDTagKey, sealedIDTagKey},
+		},
+		&view.View{
+			Measure:     GenerateSingleVanillaProofErrors,
+			Aggregation: view.Count(),
+			TagKeys:     []tag.Key{updateTagKey, cacheIDTagKey, sealedIDTagKey},
+		},
+		&view.View{
+			Measure:     GenerateSingleVanillaProofDuration,
+			Aggregation: view.Distribution(durationBuckets...),
+			TagKeys:     []tag.Key{updateTagKey, cacheIDTagKey, sealedIDTagKey},
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Output in the /metrics endpoint looks like
```
# HELP curio_curio_stor_generate_single_vanilla_proof_duration_seconds Duration of GenerateSingleVanillaProof in seconds
# TYPE curio_curio_stor_generate_single_vanilla_proof_duration_seconds histogram
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="0.1"} 0
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="1"} 0
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="5"} 6
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="12"} 38
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="20"} 69
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="60"} 116
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="90"} 124
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="150"} 139
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="300"} 146
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="500"} 146
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="900"} 146
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="1500"} 146
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="3000"} 146
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="6000"} 146
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="15000"} 146
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="30000"} 146
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="60000"} 146
curio_curio_stor_generate_single_vanilla_proof_duration_seconds_bucket{cache_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",sealed_id="a18b0ebe-7177-42f1-aa73-81869e822d8d",update="false",le="90000"} 146
```

Should make it easier to figure out which storage is slow at reading PoSt challenges