### PR TITLE
fix: harmony: Correctly separate this counters when sharing Max

### DIFF
--- a/tasks/seal/task_sdr.go
+++ b/tasks/seal/task_sdr.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/harmony/resources"
+	"github.com/filecoin-project/curio/harmony/taskhelp"
 	"github.com/filecoin-project/curio/lib/dealdata"
 	ffi2 "github.com/filecoin-project/curio/lib/ffi"
 	"github.com/filecoin-project/curio/lib/paths"
@@ -45,11 +46,11 @@ type SDRTask struct {
 
 	sc *ffi2.SealCalls
 
-	max harmonytask.Limiter
+	max taskhelp.Limiter
 	min int
 }
 
-func NewSDRTask(api SDRAPI, db *harmonydb.DB, sp *SealPoller, sc *ffi2.SealCalls, maxSDR harmonytask.Limiter, minSDR int) *SDRTask {
+func NewSDRTask(api SDRAPI, db *harmonydb.DB, sp *SealPoller, sc *ffi2.SealCalls, maxSDR taskhelp.Limiter, minSDR int) *SDRTask {
 	return &SDRTask{
 		api: api,
 		db:  db,

--- a/tasks/unseal/task_unseal_sdr.go
+++ b/tasks/unseal/task_unseal_sdr.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/harmony/resources"
+	"github.com/filecoin-project/curio/harmony/taskhelp"
 	"github.com/filecoin-project/curio/lib/ffi"
 	"github.com/filecoin-project/curio/lib/passcall"
 	"github.com/filecoin-project/curio/lib/paths"
@@ -30,14 +31,14 @@ type UnsealSDRApi interface {
 }
 
 type TaskUnsealSdr struct {
-	max harmonytask.Limiter
+	max taskhelp.Limiter
 
 	sc  *ffi.SealCalls
 	db  *harmonydb.DB
 	api UnsealSDRApi
 }
 
-func NewTaskUnsealSDR(sc *ffi.SealCalls, db *harmonydb.DB, max harmonytask.Limiter, api UnsealSDRApi) *TaskUnsealSdr {
+func NewTaskUnsealSDR(sc *ffi.SealCalls, db *harmonydb.DB, max taskhelp.Limiter, api UnsealSDRApi) *TaskUnsealSdr {
 	return &TaskUnsealSdr{
 		max: max,
 		sc:  sc,


### PR DESCRIPTION
This was the problem - we use ActiveThis to account for hardware resources - https://github.com/filecoin-project/curio/blob/baad9d01d5480c69a5df64a452b77033cebeb799/harmony/harmonytask/harmonytask.go#L432-L431 - and if a This counter was shared between two tasks (e.g. SDR / unseal-SDR), we'd see each task take double the resources