### PR TITLE
experiment: GPU Overprovisioning

### DIFF
--- a/harmony/resources/getGPU.go
+++ b/harmony/resources/getGPU.go
@@ -11,6 +11,19 @@ import (
 	ffi "github.com/filecoin-project/filecoin-ffi"
 )
 
+var GpuOverprovisionFactor = 1
+
+func init() {
+	if nstr := os.Getenv("HARMONY_GPU_OVERPROVISION_FACTOR"); nstr != "" {
+		n, err := strconv.Atoi(nstr)
+		if err != nil {
+			logger.Errorf("parsing HARMONY_GPU_OVERPROVISION_FACTOR failed: %+v", err)
+		} else {
+			GpuOverprovisionFactor = n
+		}
+	}
+}
+
 func getGPUDevices() float64 { // GPU boolean
 	if nstr := os.Getenv("HARMONY_OVERRIDE_GPUS"); nstr != "" {
 		n, err := strconv.ParseFloat(nstr, 64)
@@ -22,13 +35,13 @@ func getGPUDevices() float64 { // GPU boolean
 	}
 
 	gpus, err := ffi.GetGPUDevices()
-	logger.Infow("GPUs", "list", gpus)
+	logger.Infow("GPUs", "list", gpus, "overprovision_factor", GpuOverprovisionFactor)
 	if err != nil {
 		logger.Errorf("getting gpu devices failed: %+v", err)
 	}
 	all := strings.ToLower(strings.Join(gpus, ","))
 	if len(gpus) > 1 || strings.Contains(all, "ati") || strings.Contains(all, "nvidia") {
-		return float64(len(gpus))
+		return float64(len(gpus) * GpuOverprovisionFactor)
 	}
 	return 0
 }

--- a/lib/ffiselect/ffiselect.go
+++ b/lib/ffiselect/ffiselect.go
@@ -3,7 +3,6 @@ package ffiselect
 import (
 	"bytes"
 	"context"
-	"github.com/filecoin-project/curio/harmony/resources"
 	"io"
 	"os"
 	"os/exec"
@@ -20,6 +19,7 @@ import (
 	"github.com/filecoin-project/go-state-types/proof"
 
 	"github.com/filecoin-project/curio/build"
+	"github.com/filecoin-project/curio/harmony/resources"
 	"github.com/filecoin-project/curio/lib/storiface"
 )
 

--- a/lib/ffiselect/ffiselect.go
+++ b/lib/ffiselect/ffiselect.go
@@ -3,6 +3,7 @@ package ffiselect
 import (
 	"bytes"
 	"context"
+	"github.com/filecoin-project/curio/harmony/resources"
 	"io"
 	"os"
 	"os/exec"
@@ -45,9 +46,11 @@ func init() {
 		ch = make(chan string, 1)
 		ch <- "0"
 	} else {
-		ch = make(chan string, len(devices))
-		for i := 0; i < len(devices); i++ {
-			ch <- strconv.Itoa(i)
+		nSlots := len(devices) * resources.GpuOverprovisionFactor
+
+		ch = make(chan string, nSlots)
+		for i := 0; i < nSlots; i++ {
+			ch <- strconv.Itoa(i / resources.GpuOverprovisionFactor)
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a new env-var knob, `HARMONY_GPU_OVERPROVISION_FACTOR`, which when set to values >1 will make each "GPU" present itself as N GPUs.

For example when set to 2 on a snap encode worker, each GPU will handle two independent encode processes at once. TBD if this makes sense. Note that snark workloads will probably struggle with memory on non-enterprise GPUs.