### PR TITLE
feat: restart button for sectors

### DIFF
--- a/web/static/pages/sector/sector-info.mjs
+++ b/web/static/pages/sector/sector-info.mjs
@@ -20,6 +20,10 @@ customElements.define('sector-info',class SectorInfo extends LitElement {
         await RPCCall('SectorResume', [this.data.SpID, this.data.SectorNumber]);
         window.location.reload();
     }
+    async restartSector() {
+        await RPCCall('SectorRestart', [this.data.SpID, this.data.SectorNumber]);
+        window.location.reload();
+    }
 
     render() {
         if (!this.data) {
@@ -29,14 +33,22 @@ customElements.define('sector-info',class SectorInfo extends LitElement {
         return html`
             <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
             <link rel="stylesheet" href="/ux/main.css" onload="document.body.style.visibility = 'initial'">
-
-            <h2>Sector ${this.data.SectorNumber}</h2>
-            <div>
-                <details>
-                    <summary class="btn btn-warning">Remove ${!this.data.PipelinePoRep?.Failed ? '(THIS SECTOR IS NOT FAILED!)' : ''}</summary>
-                    <button class="btn btn-danger" @click="${() => this.removeSector()}">Confirm Remove</button>
-                </details>
-                ${this.data.Resumable ? html`<button class="btn btn-primary" @click="${() => this.resumeSector()}">Resume</button>` : ''}
+            <div class="row" style="margin-bottom: 20px;">
+                <h2 style="text-align: center; margin-top: 20px;">Sector ${this.data.SectorNumber}</h2>
+                <div class="col-md-auto">
+                    <details>
+                        <summary class="btn btn-warning">Remove ${!this.data.PipelinePoRep?.Failed ? '(THIS SECTOR IS NOT FAILED!)' : ''}</summary>
+                        <button class="btn btn-danger" @click="${() => this.removeSector()}">Confirm Remove</button>
+                    </details>
+                </div>
+                <div class="col-md-auto">
+                    ${this.data.Restart ? html`<details>
+                        <summary class="btn btn-warning">Restart (THIS WILL RESTART SECTOR FROM SDR!)</summary>
+                        <button class="btn btn-danger" @click="${() => this.restartSector()}"> Confirm Restart</button></details>` : ''}
+                </div>
+                <div class="col-md-auto">
+                    ${this.data.Resumable ? html`<button class="btn btn-primary" @click="${() => this.resumeSector()}">Resume</button>` : ''}
+                </div>
             </div>
             <div>
                 <h3>PoRep Pipeline</h3>


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/curio/issues/247

## Restart Button on failed sector
<img width="911" alt="Screenshot 2024-10-09 at 10 49 02 PM" src="https://github.com/user-attachments/assets/76ae0643-6649-43f9-bdb2-c0d09ecbf8d1">

## SDR restarted for sector
<img width="1574" alt="Screenshot 2024-10-09 at 10 49 22 PM" src="https://github.com/user-attachments/assets/1f25fa85-4b8a-4aed-8ed8-a4d8863a503c">

# PoRep Pipeline after restart
<img width="1568" alt="Screenshot 2024-10-09 at 10 49 38 PM" src="https://github.com/user-attachments/assets/3f303cae-1fe4-447e-9655-00ae7e9e767d">

## Progress after failing on TreeRC
<img width="783" alt="Screenshot 2024-10-09 at 10 55 02 PM" src="https://github.com/user-attachments/assets/d2144677-a8c6-48ab-af99-e594cf377d1e">

## No Restart button if PreCommit message sent
<img width="717" alt="Screenshot 2024-10-09 at 11 13 30 PM" src="https://github.com/user-attachments/assets/a0c1df05-cee5-492f-838c-8a685649bee5">

<img width="788" alt="Screenshot 2024-10-09 at 11 13 41 PM" src="https://github.com/user-attachments/assets/5e51309d-a905-4b09-99b1-70670cf04d9d">

## Updated Sectors page for better visiblity
<img width="1546" alt="Screenshot 2024-10-09 at 11 36 11 PM" src="https://github.com/user-attachments/assets/bae7b6b2-4b47-4714-8b8e-ebb627f86e9a">
