### PR TITLE
fix: post: create skipped bitfield to avoid panics with faults

### DIFF
--- a/tasks/window/compute_do.go
+++ b/tasks/window/compute_do.go
@@ -103,7 +103,8 @@ func (t *WdPostTask) DoPartition(ctx context.Context, ts *types.TipSet, maddr ad
 		}
 
 		postPartition = miner2.PoStPartition{
-			Index: partIdx,
+			Index:   partIdx,
+			Skipped: bitfield.New(),
 		}
 
 		log.Infow("running window post",


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/filecoin-project/curio/pull/252

Below we call `postPartition.Skipped`, which internally will try to write to an uninitialized map