### PR TITLE
Feat/libp2p fixes

### DIFF
--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -123,12 +123,12 @@ type CurioConfig struct {
 	// Addresses of wallets per MinerAddress (one of the fields).
 	Addresses []CurioAddresses
 	Proving   CurioProvingConfig
+	HTTP      HTTPConfig
 	Market    MarketConfig
 	Ingest    CurioIngestConfig
 	Seal      CurioSealConfig
 	Apis      ApisConfig
 	Alerting  CurioAlertingConfig
-	HTTP      HTTPConfig
 }
 
 func DefaultDefaultMaxFee() types.FIL {
@@ -545,21 +545,21 @@ type MarketConfig struct {
 }
 
 type StorageMarketConfig struct {
+	// MK12 encompasses all configuration related to deal protocol mk1.2.0 and mk1.2.1 (i.e. Boost deals)
+	MK12 MK12Config
+
+	// IPNI configuration for ipni-provider
+	IPNI IPNIConfig
+
+	// Indexing configuration for deal indexing
+	Indexing IndexingConfig
+
 	// PieceLocator is a list of HTTP url and headers combination to query for a piece for offline deals
 	// User can run a remote file server which can host all the pieces over the HTTP and supply a reader when requested.
 	// The server must have 2 endpoints
 	// 	1. /pieces?id=pieceCID responds with 200 if found or 404 if not. Must send header "Content-Length" with file size as value
 	//  2. /data?id=pieceCID must provide a reader for the requested piece
 	PieceLocator []PieceLocatorConfig
-
-	// Indexing configuration for deal indexing
-	Indexing IndexingConfig
-
-	// IPNI configuration for ipni-provider
-	IPNI IPNIConfig
-
-	// MK12 encompasses all configuration related to deal protocol mk1.2.0 and mk1.2.1 (i.e. Boost deals)
-	MK12 MK12Config
 }
 
 type MK12Config struct {
@@ -605,9 +605,6 @@ type IndexingConfig struct {
 }
 
 type Libp2pConfig struct {
-	// Miners ID for which MK12 deals (boosts) should be disabled
-	DisabledMiners []string
-
 	// Binding address for the libp2p host - 0 means random port.
 	// Format: multiaddress; see https://multiformats.io/multiaddr/
 	ListenAddresses []string
@@ -647,9 +644,6 @@ type HTTPConfig struct {
 	// DomainName specifies the domain name that the server uses to serve HTTP requests. DomainName cannot be empty and cannot be
 	// an IP address
 	DomainName string
-
-	// CertCacheDir path to the cache directory for storing SSL certificates needed for HTTPS.
-	CertCacheDir string
 
 	// ListenAddress is the address that the server listens for HTTP requests.
 	ListenAddress string

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -580,6 +580,9 @@ type MK12Config struct {
 	// Warning: If this check is skipped and there is a commP mismatch, all deals in the
 	// sector will need to be sent again
 	SkipCommP bool
+
+	// DisabledMiners is a list of miner addresses that should be excluded from online deal making protocols
+	DisabledMiners []string
 }
 
 type PieceLocatorConfig struct {

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -79,12 +79,6 @@ func DefaultCurioConfig() *CurioConfig {
 					InsertBatchSize:   15000,
 				},
 				MK12: MK12Config{
-					Libp2p: Libp2pConfig{
-						DisabledMiners:      []string{},
-						ListenAddresses:     []string{"/ip4/0.0.0.0/tcp/12200", "/ip4/0.0.0.0/udp/12280/quic-v1/webtransport"},
-						AnnounceAddresses:   []string{},
-						NoAnnounceAddresses: []string{},
-					},
 					PublishMsgPeriod:          Duration(5 * time.Minute),
 					MaxDealsPerPublishMsg:     8,
 					MaxPublishDealFee:         types.MustParseFIL("0.5 FIL"),
@@ -563,9 +557,6 @@ type StorageMarketConfig struct {
 }
 
 type MK12Config struct {
-	// Libp2p is a list of libp2p config for all miner IDs.
-	Libp2p Libp2pConfig
-
 	// When a deal is ready to publish, the amount of time to wait for more
 	// deals to be ready to publish before publishing them all as a batch
 	PublishMsgPeriod Duration
@@ -602,19 +593,6 @@ type IndexingConfig struct {
 
 	// Number of concurrent inserts to split AddIndex calls to
 	InsertConcurrency int
-}
-
-type Libp2pConfig struct {
-	// Binding address for the libp2p host - 0 means random port.
-	// Format: multiaddress; see https://multiformats.io/multiaddr/
-	ListenAddresses []string
-	// Addresses to explicitally announce to other peers. If not specified,
-	// all interface addresses are announced
-	// Format: multiaddress
-	AnnounceAddresses []string
-	// Addresses to not announce
-	// Format: multiaddress
-	NoAnnounceAddresses []string
 }
 
 type IPNIConfig struct {

--- a/harmony/harmonydb/sql/20240731-market-migration.sql
+++ b/harmony/harmonydb/sql/20240731-market-migration.sql
@@ -281,7 +281,7 @@ BEGIN
         LIMIT 1;
 
     -- If running_on is already set
-    IF current_running_on IS NOT NULL THEN
+    IF current_running_on IS NOT NULL AND current_running_on != _running_on THEN
             -- Check if updated_at is more than 5 minutes old
             IF last_updated < NOW() - INTERVAL '5 minutes' THEN
                 -- Update running_on and updated_at

--- a/harmony/harmonydb/sql/20240731-market-migration.sql
+++ b/harmony/harmonydb/sql/20240731-market-migration.sql
@@ -261,8 +261,8 @@ CREATE TABLE market_offline_urls (
 
 -- This table is used for coordinating libp2p nodes
 CREATE TABLE libp2p (
-    sp_id BIGINT NOT NULL PRIMARY KEY,
-    priv_key BYTEA NOT NULL,
+    priv_key BYTEA NOT NULL PRIMARY KEY,
+    peer_id TEXT NOT NULL UNIQUE,
     running_on TEXT DEFAULT NULL,
     updated_at TIMESTAMPTZ DEFAULT NULL
 );

--- a/harmony/harmonydb/sql/20240731-market-migration.sql
+++ b/harmony/harmonydb/sql/20240731-market-migration.sql
@@ -263,42 +263,59 @@ CREATE TABLE market_offline_urls (
 CREATE TABLE libp2p (
     priv_key BYTEA NOT NULL PRIMARY KEY,
     peer_id TEXT NOT NULL UNIQUE,
-    running_on TEXT DEFAULT NULL,
-    updated_at TIMESTAMPTZ DEFAULT NULL
+    running_on TEXT DEFAULT NULL, -- harmonymachines machine id (host:port)
+    local_listen TEXT DEFAULT NULL, -- libp2p listen address within the local network (ip should be the same as running_on)
+    updated_at TIMESTAMPTZ DEFAULT NULL,
+    singleton BOOLEAN DEFAULT TRUE CHECK ( singleton = TRUE ) UNIQUE -- Allows one row in the table
 );
 
 -- -- Function used to update the libp2p table
-CREATE OR REPLACE FUNCTION update_libp2p_node(_running_on TEXT)
-RETURNS VOID AS $$
+CREATE OR REPLACE FUNCTION update_libp2p_node(
+    _running_on TEXT,
+    _maybe_priv_key BYTEA, -- Possible initial values
+    _maybe_peerid TEXT
+)
+    RETURNS BYTEA AS $$
 DECLARE
-current_running_on TEXT;
+    current_running_on TEXT;
     last_updated TIMESTAMPTZ;
+    existing_priv_key BYTEA;
+    existing_peer_id TEXT;
 BEGIN
-    -- Fetch the current values of running_on and updated_at
-    SELECT running_on, updated_at INTO current_running_on, last_updated
+    -- Attempt to fetch the existing row
+    SELECT priv_key, peer_id, running_on, updated_at
+    INTO existing_priv_key, existing_peer_id, current_running_on, last_updated
     FROM libp2p
-    WHERE running_on IS NOT NULL
-        LIMIT 1;
+    LIMIT 1;
 
-    -- If running_on is already set
-    IF current_running_on IS NOT NULL AND current_running_on != _running_on THEN
-            -- Check if updated_at is more than 5 minutes old
+    IF existing_priv_key IS NULL THEN
+        -- No existing row; insert a new one
+        INSERT INTO libp2p (priv_key, peer_id, running_on, updated_at)
+        VALUES (_maybe_priv_key, _maybe_peerid, _running_on, NOW() AT TIME ZONE 'UTC');
+        RETURN _maybe_priv_key;
+    ELSE
+        -- Existing row found; proceed with update logic
+        IF current_running_on IS NOT NULL AND current_running_on != _running_on THEN
+            -- Check if the last update was more than 5 minutes ago
             IF last_updated < NOW() - INTERVAL '5 minutes' THEN
                 -- Update running_on and updated_at
                 UPDATE libp2p
                 SET running_on = _running_on,
                     updated_at = NOW() AT TIME ZONE 'UTC'
-                WHERE running_on = current_running_on;
+                WHERE priv_key = existing_priv_key;
             ELSE
                 -- Raise an exception if the node was updated within the last 5 minutes
                 RAISE EXCEPTION 'Libp2p node already running on "%"', current_running_on;
             END IF;
-    ELSE
-            -- If running_on is NULL, set it and update the timestamp
+        ELSE
+            -- Update running_on and updated_at if running_on is NULL or unchanged
             UPDATE libp2p
             SET running_on = _running_on,
                 updated_at = NOW() AT TIME ZONE 'UTC'
-            WHERE running_on IS NULL;
+            WHERE priv_key = existing_priv_key;
+        END IF;
+        -- Return the existing priv_key
+        RETURN existing_priv_key;
     END IF;
 END;
 $$ LANGUAGE plpgsql;

--- a/harmony/harmonydb/sql/20240823-ipni.sql
+++ b/harmony/harmonydb/sql/20240823-ipni.sql
@@ -1,4 +1,10 @@
 -- Table for storing IPNI ads
+CREATE TABLE ipni_peerid (
+    priv_key BYTEA NOT NULL PRIMARY KEY,
+    peer_id TEXT NOT NULL UNIQUE,
+    sp_id BIGINT NOT NULL
+);
+
 CREATE TABLE ipni (
     order_number BIGSERIAL PRIMARY KEY, -- Unique increasing order number
     ad_cid TEXT NOT NULL,

--- a/market/ipni/ipni-provider/ipni-provider.go
+++ b/market/ipni/ipni-provider/ipni-provider.go
@@ -102,7 +102,7 @@ func NewProvider(d *deps.Deps) (*Provider, error) {
 
 	keyMap := make(map[string]*peerInfo)
 
-	rows, err := d.DB.Query(ctx, `SELECT priv_key FROM libp2p`)
+	rows, err := d.DB.Query(ctx, `SELECT priv_key FROM ipni_peerid`)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get private libp2p keys from DB: %w", err)
 	}

--- a/market/libp2p/redirector.go
+++ b/market/libp2p/redirector.go
@@ -1,0 +1,154 @@
+package libp2p
+
+import (
+	"fmt"
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/go-chi/chi/v5"
+	"github.com/gorilla/websocket"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/yugabyte/pgx/v5"
+	"golang.org/x/xerrors"
+	"net/http"
+)
+
+// Redirector struct with a database connection
+type Redirector struct {
+	db *harmonydb.DB // Replace with your actual DB wrapper if different
+}
+
+// NewRedirector creates a new Redirector with a database connection
+func NewRedirector(db *harmonydb.DB) *Redirector {
+	return &Redirector{db: db}
+}
+
+// Router sets up the route for the WebSocket connection
+func Router(mux *chi.Mux, rp *Redirector) {
+	mux.Get("/libp2p", rp.handleLibp2pWebsocket)
+}
+
+// handleLibp2pWebsocket proxies the WebSocket connection to the local_listen address
+func (rp *Redirector) handleLibp2pWebsocket(w http.ResponseWriter, r *http.Request) {
+	// Fetch the local_listen address from the database
+	var localListen string
+	err := rp.db.QueryRow(r.Context(), "SELECT local_listen FROM libp2p").Scan(&localListen)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			http.Error(w, "Remote LibP2P host undefined", http.StatusBadGateway)
+			return
+		}
+
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		log.Infof("Database error: %v", err)
+		return
+	}
+
+	// Parse the multiaddress to get the WebSocket URL
+	wsURL, err := multiAddrToWsURL(localListen)
+	if err != nil {
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		log.Infof("Error parsing multiaddress: %v", err)
+		return
+	}
+
+	// Upgrade the client connection to a WebSocket connection
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
+	}
+
+	clientConn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Infof("WebSocket upgrade error: %v", err)
+		return
+	}
+	defer clientConn.Close()
+
+	// Connect to the target WebSocket server
+	targetConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		log.Infof("Error connecting to target WebSocket server: %v", err)
+		return
+	}
+	defer targetConn.Close()
+
+	// Proxy data between clientConn and targetConn
+	errc := make(chan error, 2)
+
+	// Start goroutines for bidirectional copying
+	go proxyWebSocket(clientConn, targetConn, errc)
+	go proxyWebSocket(targetConn, clientConn, errc)
+
+	// Wait for one of the connections to error out
+	if err := <-errc; err != nil {
+		log.Infof("WebSocket proxy error: %v", err)
+	}
+}
+
+// proxyWebSocket copies messages from src to dst WebSocket connections
+func proxyWebSocket(src, dst *websocket.Conn, errc chan error) {
+	for {
+		messageType, message, err := src.ReadMessage()
+		if err != nil {
+			errc <- err
+			break
+		}
+		err = dst.WriteMessage(messageType, message)
+		if err != nil {
+			errc <- err
+			break
+		}
+	}
+}
+
+// multiAddrToWsURL converts a multiaddress to a WebSocket URL
+func multiAddrToWsURL(maddrStr string) (string, error) {
+	maddr, err := ma.NewMultiaddr(maddrStr)
+	if err != nil {
+		return "", xerrors.Errorf("error parsing multiaddress: %w", err)
+	}
+
+	var (
+		host        string
+		port        string
+		isWebSocket bool
+		isSecure    bool
+	)
+
+	for _, p := range maddr.Protocols() {
+		switch p.Code {
+		case ma.P_IP4, ma.P_IP6, ma.P_DNS4, ma.P_DNS6, ma.P_DNS:
+			hostValue, err := maddr.ValueForProtocol(p.Code)
+			if err != nil {
+				return "", xerrors.Errorf("error getting host value: %w", err)
+			}
+			host = hostValue
+		case ma.P_TCP:
+			portValue, err := maddr.ValueForProtocol(ma.P_TCP)
+			if err != nil {
+				return "", xerrors.Errorf("error getting port value: %w", err)
+			}
+			port = portValue
+		case ma.P_WS:
+			isWebSocket = true
+		case ma.P_WSS:
+			isWebSocket = true
+			isSecure = true
+		default:
+			// Unsupported protocol
+		}
+	}
+
+	if !isWebSocket {
+		return "", xerrors.Errorf("multiaddress does not contain websocket protocol")
+	}
+
+	scheme := "ws"
+	if isSecure {
+		scheme = "wss"
+	}
+
+	wsURL := fmt.Sprintf("%s://%s:%s/", scheme, host, port)
+	return wsURL, nil
+}

--- a/tasks/storage-market/storage_market.go
+++ b/tasks/storage-market/storage_market.go
@@ -64,24 +64,25 @@ type CurioStorageDealMarket struct {
 }
 
 type MK12Pipeline struct {
-	UUID           string          `db:"uuid"`
-	SpID           int64           `db:"sp_id"`
-	Started        bool            `db:"started"`
-	PieceCid       string          `db:"piece_cid"`
-	Offline        bool            `db:"offline"`
-	Downloaded     bool            `db:"downloaded"`
-	RawSize        int64           `db:"raw_size"`
-	URL            string          `db:"url"`
-	Headers        json.RawMessage `db:"headers"`
-	CommTaskID     *int64          `db:"commp_task_id"`
-	AfterCommp     bool            `db:"after_commp"`
-	PSDWaitTime    time.Time       `db:"psd_wait_time"`
-	PSDTaskID      *int64          `db:"psd_task_id"`
-	AfterPSD       bool            `db:"after_psd"`
-	FindDealTaskID *int64          `db:"find_deal_task_id"`
-	AfterFindDeal  bool            `db:"after_find_deal"`
-	Sector         *int64          `db:"sector"`
-	Offset         *int64          `db:"sector_offset"`
+	UUID       string          `db:"uuid"`
+	SpID       int64           `db:"sp_id"`
+	Started    bool            `db:"started"`
+	PieceCid   string          `db:"piece_cid"`
+	Offline    bool            `db:"offline"`
+	Downloaded bool            `db:"downloaded"`
+	RawSize    int64           `db:"raw_size"`
+	URL        string          `db:"url"`
+	Headers    json.RawMessage `db:"headers"`
+
+	CommTaskID     *int64    `db:"commp_task_id"`
+	AfterCommp     bool      `db:"after_commp"`
+	PSDWaitTime    time.Time `db:"psd_wait_time"`
+	PSDTaskID      *int64    `db:"psd_task_id"`
+	AfterPSD       bool      `db:"after_psd"`
+	FindDealTaskID *int64    `db:"find_deal_task_id"`
+	AfterFindDeal  bool      `db:"after_find_deal"`
+	Sector         *int64    `db:"sector"`
+	Offset         *int64    `db:"sector_offset"`
 }
 
 func NewCurioStorageDealMarket(miners []address.Address, db *harmonydb.DB, cfg *config.CurioConfig, sc *ffi.SealCalls, mapi storageMarketAPI) *CurioStorageDealMarket {
@@ -195,18 +196,19 @@ func (d *CurioStorageDealMarket) processMK12Deals(ctx context.Context) {
 									p.sp_id as sp_id,
 									p.started as started,
 									p.piece_cid as piece_cid,
-									p.offline as offline,
 									p.raw_size as raw_size,
+									
+									p.offline as offline,
 									p.url as url,
 									p.headers as headers,
+									
 									p.commp_task_id as commp_task_id,
 									p.after_commp as after_commp,
 									p.psd_task_id as psd_task_id,
 									p.after_psd as after_psd,
 									p.find_deal_task_id as find_deal_task_id,
 									p.after_find_deal as after_find_deal,
-									p.psd_wait_time as psd_wait_time,
-									b.start_epoch as start_epoch
+									p.psd_wait_time as psd_wait_time
 								FROM 
 									market_mk12_deal_pipeline p
 								LEFT JOIN 


### PR DESCRIPTION
* Single libp2p per cluster, runs on one leader
* Curio HTTP servers redirect `/` websocket connections to the leader libp2p endpoint
* IPNI now uses a separate table to manage per-SP PeerIDs, never used in libp2p instances
  * Doesn't matter because Graphsync is not a thing anymore