### PR TITLE
fix: snap: Correctly handle non-filplus deals

### DIFF
--- a/market/deal_ingest_snap.go
+++ b/market/deal_ingest_snap.go
@@ -30,6 +30,7 @@ import (
 )
 
 const IdealEndEpochBuffer = 2 * builtin.EpochsInDay
+const MaxEndEpochBufferUnverified = 180 * builtin.EpochsInDay
 
 // assuming that snap takes up to 20min to get to submitting the message we want to avoid sectors from deadlines which will
 // become immutable in the next 20min (40 epochs)
@@ -264,6 +265,8 @@ func (p *PieceIngesterSnap) AllocatePieceToSector(ctx context.Context, maddr add
 		vd.tmax = alloc.TermMax
 
 		maxExpiration = int64(head.Height() + alloc.TermMax)
+	} else {
+		maxExpiration = int64(piece.DealSchedule.EndEpoch) + MaxEndEpochBufferUnverified
 	}
 	propJson, err = json.Marshal(piece.PieceActivationManifest)
 	if err != nil {


### PR DESCRIPTION
`maxExpiration` checks were added after the initial testing, and somehow until now no one noticed that snap doesn't work with non-filplus deals.

Not setting that value meant that we were looking for sectors expiring 