### PR TITLE
fix: sealsupra: Only schedule when needed

### DIFF
--- a/tasks/sealsupra/task_supraseal.go
+++ b/tasks/sealsupra/task_supraseal.go
@@ -442,6 +442,15 @@ func (s *SupraSeal) Adder(taskFunc harmonytask.AddTaskFunc) {
 }
 
 func (s *SupraSeal) schedule(taskFunc harmonytask.AddTaskFunc) error {
+	if s.slots.Available() == 0 {
+		return nil
+	}
+
+	if err := hugepageutil.CheckHugePages(36); err != nil {
+		log.Warnw("huge pages check failed, try 'sudo sysctl -w vm.nr_hugepages=36' and make sure your system uses 1G huge pages", "err", err)
+		return nil
+	}
+
 	taskFunc(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
 		// claim [sectors] pipeline entries
 		var sectors []struct {


### PR DESCRIPTION
Without this batch tasks would be added when CanAccept would refuse them.

Normally this wouldn't be much of an issue, but if there are batch machines in the cluster capable of different batch sizes, one could "take" all unbatched sectors from the other machine.

This PR makes it so that batches are only created when needed.