### PR TITLE
fix(f3): handle failure to receive manifest from the client

### DIFF
--- a/tasks/f3/f3_task.go
+++ b/tasks/f3/f3_task.go
@@ -198,6 +198,7 @@ func (f *F3Task) awaitLeaseExpiry(ctx context.Context, stillOwned func() bool, l
 			}
 			log.Errorw("Failed to check F3 progress while awaiting lease expiry. Retrying after backoff.", "attempts", backoff.Attempt(), "backoff", backoff.Duration(), "err", err)
 			time.Sleep(backoff.Duration())
+			continue
 		case manifest == nil || manifest.NetworkName != lease.Network:
 			// If we got an unexpected manifest, or no manifest, go back to the
 			// beginning and try to get another ticket. Switching from having a manifest


### PR DESCRIPTION
If we keep going here, we'll panic. See (also includes a regression test):

https://github.com/filecoin-project/lotus/pull/12634