### PR TITLE
feat(pdp): add endpoint to poll for completed upload

### DIFF
--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -104,6 +104,9 @@ func Routes(r *chi.Mux, p *PDPService) {
 	// POST /pdp/piece
 	r.Post(path.Join(PDPRoutePath, "/piece"), p.handlePiecePost)
 
+	// GET /pdp/piece/
+	r.Get(path.Join(PDPRoutePath, "/piece/"), p.handleFindPiece)
+
 	// PUT /pdp/piece/upload/{uploadUUID}
 	r.Put(path.Join(PDPRoutePath, "/piece/upload/{uploadUUID}"), p.handlePieceUpload)
 }

--- a/pdp/handlers_upload.go
+++ b/pdp/handlers_upload.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -170,7 +171,7 @@ func (p *PDPService) handlePiecePost(w http.ResponseWriter, r *http.Request) {
 					return false, fmt.Errorf("failed to insert into parked_piece_refs: %w", err)
 				}
 
-				// Create a new 'pdp_piece_uploads' entry pointing to the 'pdp_piecerefs' entry
+				// Create a new 'pdp_piece_uploads' entry pointing to the 'parked_piece_refs' entry
 				uploadUUID = uuid.New()
 				_, err = tx.Exec(`
                 INSERT INTO pdp_piece_uploads (id, service, piece_cid, notify_url, piece_ref, check_hash_codec, check_hash, check_size)
@@ -441,4 +442,58 @@ func (p *PDPService) handlePieceUpload(w http.ResponseWriter, r *http.Request) {
 
 	// Respond with 204 No Content
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// handle find piece allows one to look up a pdp piece by its original post data as
+// query parameters
+func (p *PDPService) handleFindPiece(w http.ResponseWriter, r *http.Request) {
+	// Verify that the request is authorized using ECDSA JWT
+	serviceID, err := p.verifyJWTToken(r)
+	if err != nil {
+		http.Error(w, "Unauthorized: "+err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	// Parse query parameters
+
+	sizeString := r.URL.Query().Get("size")
+	size, err := strconv.ParseInt(sizeString, 10, 64)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("errors parsing size: %s", err.Error()), 400)
+		return
+	}
+	req := PieceHash{
+		Name: r.URL.Query().Get("name"),
+		Hash: r.URL.Query().Get("hash"),
+		Size: size,
+	}
+
+	ctx := r.Context()
+
+	pieceCid, havePieceCid, err := req.commp(ctx, p.db)
+	if err != nil {
+		http.Error(w, "Failed to process request: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// upload either not complete or does not exist
+	if !havePieceCid {
+		http.NotFound(w, r)
+		return
+	}
+	response := struct {
+		Service  string `json:"service"`
+		PieceCID string `json:"piece_cid"`
+	}{
+		Service:  serviceID,
+		PieceCID: pieceCid.String(),
+	}
+
+	// encode response
+	w.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(w).Encode(response)
+	if err != nil {
+		http.Error(w, "Failed to write response: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 }


### PR DESCRIPTION
# Goals

This enables a service using PDP to query based on its upload parameters and poll for upload completion. The primary requirement is this should only return a piece cid if there is a retrievable piece for the given parameters.

# Implementation

- Add an provides an endpoint to look up a piece cid for a given set of upload parameters. It will only respond if the piece exists. It will also mark if the piece is retriavable and whether it's ready for PDP aggregation. This largely mimics some initial logic from POST /pdp/piece that determines if it's 201 created (new upload) or 200 (existing upload)
- Add docs for new endpoint
- Correct one comment that appears to refer to the wrong table.

# For discussion

Currently, this will succeed as soon as the piece finishes uploading, and it will seperately note if the piece is retrievable and ready for aggregation. A previous version would 404 if the piece was not retrievable.