### PR TITLE
fix: deal label storage in DB

### DIFF
--- a/harmony/harmonydb/sql/20241030-deal-label.sql
+++ b/harmony/harmonydb/sql/20241030-deal-label.sql
@@ -1,0 +1,2 @@
+ALTER TABLE market_mk12_deals
+    ADD COLUMN label BYTEA;

--- a/tasks/storage-market/task_psd.go
+++ b/tasks/storage-market/task_psd.go
@@ -1,6 +1,7 @@
 package storage_market
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -66,15 +67,17 @@ func (p *PSDTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bo
 	ctx := context.Background()
 
 	var bdeals []struct {
-		Prop json.RawMessage `db:"proposal"`
-		Sig  []byte          `db:"proposal_signature"`
-		UUID string          `db:"uuid"`
+		Prop  json.RawMessage `db:"proposal"`
+		Sig   []byte          `db:"proposal_signature"`
+		UUID  string          `db:"uuid"`
+		Label []byte          `db:"label"`
 	}
 
 	err = p.db.Select(ctx, &bdeals, `SELECT 
 										p.uuid,
 										b.proposal,
-										b.proposal_signature
+										b.proposal_signature,
+										b.label
 									FROM 
 										market_mk12_deal_pipeline p
 									JOIN 
@@ -107,6 +110,16 @@ func (p *PSDTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bo
 		if err != nil {
 			return false, xerrors.Errorf("unmarshal signature: %w", err)
 		}
+
+		// Unmarshal Label from cbor and replace in proposal. This fixes the problem where non-string
+		// labels are saved as "" in json in DB
+		var l market.DealLabel
+		lr := bytes.NewReader(d.Label)
+		err = l.UnmarshalCBOR(lr)
+		if err != nil {
+			return false, xerrors.Errorf("unmarshal label: %w", err)
+		}
+		prop.Label = l
 
 		deals = append(deals, deal{
 			uuid: d.UUID,


### PR DESCRIPTION
We save the label as bytes outside of the proposal and then read the same each time we need proposal. Proposal in sector_metadata and pipeline will still be missing this label but we don't really care about that as Label is only useful for market process. 