### PR TITLE
fix(pdp): fix ed25519 auth

### DIFF
--- a/pdp/auth.go
+++ b/pdp/auth.go
@@ -77,7 +77,7 @@ func (p *PDPService) verifyJWTToken(r *http.Request) (string, error) {
 		}
 
 		if isEd25519 {
-			pubKey, ok := pubKeyInterface.(*ed25519.PublicKey)
+			pubKey, ok := pubKeyInterface.(ed25519.PublicKey)
 			if !ok {
 				return nil, fmt.Errorf("public key is not ED25519")
 			}


### PR DESCRIPTION
fix annoying bug - x509 does not parse to pointer type on ed25519

From the doc on x509.ParsePKIXPublicKey

```golang
// ParsePKIXPublicKey parses a public key in PKIX, ASN.1 DER form. The encoded
// public key is a SubjectPublicKeyInfo structure (see RFC 5280, Section 4.1).
//
// It returns a *[rsa.PublicKey], *[dsa.PublicKey], *[ecdsa.PublicKey],
// [ed25519.PublicKey] (not a pointer), or *[ecdh.PublicKey] (for X25519).
// More types might be supported in the future.
//
// This kind of key is commonly encoded in PEM blocks of type "PUBLIC KEY".
```