### PR TITLE
wip: Supraseal healthpage output

### DIFF
--- a/lib/supraffi/common.go
+++ b/lib/supraffi/common.go
@@ -1,0 +1,75 @@
+package supraffi
+
+import "time"
+
+// HealthInfo represents NVMe device health information in a more Go-friendly format
+type HealthInfo struct {
+	// Critical warning flags
+	CriticalWarning byte
+
+	// Temperature information in celsius
+	Temperature        float64
+	TemperatureSensors []float64
+	WarningTempTime    time.Duration
+	CriticalTempTime   time.Duration
+
+	// Reliability metrics
+	AvailableSpare          uint8
+	AvailableSpareThreshold uint8
+	PercentageUsed          uint8
+
+	// Usage statistics
+	DataUnitsRead      uint64 // in 512-byte units
+	DataUnitsWritten   uint64 // in 512-byte units
+	HostReadCommands   uint64
+	HostWriteCommands  uint64
+	ControllerBusyTime time.Duration
+
+	// Power and error statistics
+	PowerCycles     uint64
+	PowerOnHours    time.Duration
+	UnsafeShutdowns uint64
+	MediaErrors     uint64
+	ErrorLogEntries uint64
+}
+
+// Helper methods for interpreting critical warning flags
+const (
+	WarningSpareSpace       = 1 << 0
+	WarningTemperature      = 1 << 1
+	WarningReliability      = 1 << 2
+	WarningReadOnly         = 1 << 3
+	WarningVolatileMemory   = 1 << 4
+	WarningPersistentMemory = 1 << 5
+)
+
+// HasWarning checks if a specific warning flag is set
+func (h *HealthInfo) HasWarning(flag byte) bool {
+	return (h.CriticalWarning & flag) != 0
+}
+
+// GetWarnings returns a slice of active warning descriptions
+func (h *HealthInfo) GetWarnings() []string {
+	var warnings []string
+
+	if h.HasWarning(WarningSpareSpace) {
+		warnings = append(warnings, "available spare space has fallen below threshold")
+	}
+	if h.HasWarning(WarningTemperature) {
+		warnings = append(warnings, "temperature is above critical threshold")
+	}
+	if h.HasWarning(WarningReliability) {
+		warnings = append(warnings, "device reliability has been degraded")
+	}
+	if h.HasWarning(WarningReadOnly) {
+		warnings = append(warnings, "media has been placed in read only mode")
+	}
+	if h.HasWarning(WarningVolatileMemory) {
+		warnings = append(warnings, "volatile memory backup device has failed")
+	}
+	if h.HasWarning(WarningPersistentMemory) {
+		warnings = append(warnings, "persistent memory region has become read-only")
+	}
+
+	return warnings
+}

--- a/lib/supraffi/common.go
+++ b/lib/supraffi/common.go
@@ -7,7 +7,7 @@ type HealthInfo struct {
 	// Critical warning flags
 	CriticalWarning byte
 
-	// Temperature information in celsius
+	// Temperature information in Celsius
 	Temperature        float64
 	TemperatureSensors []float64
 	WarningTempTime    time.Duration

--- a/lib/supraffi/no_supraseal.go
+++ b/lib/supraffi/no_supraseal.go
@@ -47,6 +47,10 @@ func GenerateMultiString(paths []Path) (string, error) {
 	return buffer.String(), nil
 }
 
+func GetHealthInfo() ([]HealthInfo, error) {
+	panic("GetHealthInfo: supraseal build tag not enabled")
+}
+
 // Pc2 performs the pc2 operation.
 func Pc2(blockOffset uint64, numSectors int, outputDir string, sectorSize uint64) int {
 	panic("Pc2: supraseal build tag not enabled")

--- a/lib/supraffi/seal.go
+++ b/lib/supraffi/seal.go
@@ -10,31 +10,36 @@ package supraffi
    #include "supra_seal.h"
    #include <stdlib.h>
 
-   typedef struct nvme_health_info {
-	uint8_t  critical_warning;
-	int16_t  temperature;
-	uint8_t  available_spare;
-	uint8_t  available_spare_threshold;
-	uint8_t  percentage_used;
-	uint64_t data_units_read;
-	uint64_t data_units_written;
-	uint64_t host_read_commands;
-	uint64_t host_write_commands;
-	uint64_t controller_busy_time;
-	uint64_t power_cycles;
-	uint64_t power_on_hours;
-	uint64_t unsafe_shutdowns;
-	uint64_t media_errors;
-	uint64_t num_error_info_log_entries;
-	uint32_t warning_temp_time;
-	uint32_t critical_temp_time;
-	int16_t  temp_sensors[8];
+typedef struct nvme_health_info {
+        uint8_t  critical_warning;
+        int16_t  temperature;
+        uint8_t  available_spare;
+        uint8_t  available_spare_threshold;
+        uint8_t  percentage_used;
+        uint64_t data_units_read;
+        uint64_t data_units_written;
+        uint64_t host_read_commands;
+        uint64_t host_write_commands;
+        uint64_t controller_busy_time;
+        uint64_t power_cycles;
+        uint64_t power_on_hours;
+        uint64_t unsafe_shutdowns;
+        uint64_t media_errors;
+        uint64_t num_error_info_log_entries;
+        uint32_t warning_temp_time;
+        uint32_t critical_temp_time;
+        int16_t  temp_sensors[8];
   } nvme_health_info_t;
+
+size_t get_nvme_health_info(nvme_health_info_t* health_infos, size_t max_controllers);
+
 */
 import "C"
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
+	"time"
 	"unsafe"
 )
 
@@ -158,19 +163,59 @@ func SupraSealInit(sectorSize uint64, configFile string) {
 	C.supra_seal_init(C.size_t(sectorSize), cConfigFile)
 }
 
-type NVMeHealthInfo C.nvme_health_info_t
-
-func GetNVMeHealthInfo() []NVMeHealthInfo {
-	// Allocate space for up to 64 controllers (adjust as needed)
+// GetHealthInfo retrieves health information for all NVMe devices
+func GetHealthInfo() ([]HealthInfo, error) {
+	// Allocate space for raw C struct
 	const maxControllers = 64
-	healthInfos := make([]NVMeHealthInfo, maxControllers)
+	rawInfos := make([]C.nvme_health_info_t, maxControllers)
 
+	// Get health info from C
 	count := C.get_nvme_health_info(
-		(*C.nvme_health_info_t)(unsafe.Pointer(&healthInfos[0])),
+		(*C.nvme_health_info_t)(unsafe.Pointer(&rawInfos[0])),
 		C.size_t(maxControllers),
 	)
 
-	return healthInfos[:count]
+	if count == 0 {
+		return nil, fmt.Errorf("no NVMe controllers found")
+	}
+
+	// Convert C structs to Go structs
+	healthInfos := make([]HealthInfo, count)
+	for i := 0; i < int(count); i++ {
+		raw := &rawInfos[i]
+
+		// Convert temperature sensors, filtering out unused ones
+		sensors := make([]float64, 0, 8)
+		for _, temp := range raw.temp_sensors {
+			if temp != 0 {
+				sensors = append(sensors, float64(temp))
+			}
+		}
+
+		// todo likely not entirely correct
+		healthInfos[i] = HealthInfo{
+			CriticalWarning:         byte(raw.critical_warning),
+			Temperature:             float64(raw.temperature), // celsius??
+			TemperatureSensors:      sensors,
+			WarningTempTime:         time.Duration(raw.warning_temp_time) * time.Minute,
+			CriticalTempTime:        time.Duration(raw.critical_temp_time) * time.Minute,
+			AvailableSpare:          uint8(raw.available_spare),
+			AvailableSpareThreshold: uint8(raw.available_spare_threshold),
+			PercentageUsed:          uint8(raw.percentage_used),
+			DataUnitsRead:           uint64(raw.data_units_read),
+			DataUnitsWritten:        uint64(raw.data_units_written),
+			HostReadCommands:        uint64(raw.host_read_commands),
+			HostWriteCommands:       uint64(raw.host_write_commands),
+			ControllerBusyTime:      time.Duration(raw.controller_busy_time) * time.Minute,
+			PowerCycles:             uint64(raw.power_cycles),
+			PowerOnHours:            time.Duration(raw.power_on_hours) * time.Hour,
+			UnsafeShutdowns:         uint64(raw.unsafe_shutdowns),
+			MediaErrors:             uint64(raw.media_errors),
+			ErrorLogEntries:         uint64(raw.num_error_info_log_entries),
+		}
+	}
+
+	return healthInfos, nil
 }
 
 // Pc1 performs the pc1 operation.

--- a/tasks/sealsupra/metrics.go
+++ b/tasks/sealsupra/metrics.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	phaseKey, _ = tag.NewKey("phase")
-	pre         = "sealsupra_"
+	phaseKey, _      = tag.NewKey("phase")
+	nvmeDeviceKey, _ = tag.NewKey("nvme_device")
+	pre              = "sealsupra_"
 )
 
 // SupraSealMeasures groups all SupraSeal metrics.
@@ -16,10 +17,42 @@ var SupraSealMeasures = struct {
 	PhaseLockCount    *stats.Int64Measure
 	PhaseWaitingCount *stats.Int64Measure
 	PhaseAvgDuration  *stats.Float64Measure
+
+	// NVMe Health measures
+	NVMeTemperature     *stats.Float64Measure
+	NVMeAvailableSpare  *stats.Int64Measure
+	NVMePercentageUsed  *stats.Int64Measure
+	NVMePowerCycles     *stats.Int64Measure
+	NVMePowerOnHours    *stats.Float64Measure
+	NVMeUnsafeShutdowns *stats.Int64Measure
+	NVMeMediaErrors     *stats.Int64Measure
+	NVMeErrorLogEntries *stats.Int64Measure
+	NVMeCriticalWarning *stats.Int64Measure
+
+	NVMeBytesRead    *stats.Int64Measure
+	NVMeBytesWritten *stats.Int64Measure
+	NVMeReadIO       *stats.Int64Measure
+	NVMeWriteIO      *stats.Int64Measure
 }{
 	PhaseLockCount:    stats.Int64(pre+"phase_lock_count", "Number of active locks in each phase", stats.UnitDimensionless),
 	PhaseWaitingCount: stats.Int64(pre+"phase_waiting_count", "Number of goroutines waiting for a phase lock", stats.UnitDimensionless),
 	PhaseAvgDuration:  stats.Float64(pre+"phase_avg_duration", "Average duration of each phase in seconds", stats.UnitSeconds),
+
+	// NVMe Health measures
+	NVMeTemperature:     stats.Float64(pre+"nvme_temperature_celsius", "NVMe Temperature in Celsius", stats.UnitDimensionless),
+	NVMeAvailableSpare:  stats.Int64(pre+"nvme_available_spare", "NVMe Available Spare", stats.UnitDimensionless),
+	NVMePercentageUsed:  stats.Int64(pre+"nvme_percentage_used", "NVMe Percentage Used", stats.UnitDimensionless),
+	NVMePowerCycles:     stats.Int64(pre+"nvme_power_cycles", "NVMe Power Cycles", stats.UnitDimensionless),
+	NVMePowerOnHours:    stats.Float64(pre+"nvme_power_on_hours", "NVMe Power On Hours", stats.UnitDimensionless),
+	NVMeUnsafeShutdowns: stats.Int64(pre+"nvme_unsafe_shutdowns", "NVMe Unsafe Shutdowns", stats.UnitDimensionless),
+	NVMeMediaErrors:     stats.Int64(pre+"nvme_media_errors", "NVMe Media Errors", stats.UnitDimensionless),
+	NVMeErrorLogEntries: stats.Int64(pre+"nvme_error_log_entries", "NVMe Error Log Entries", stats.UnitDimensionless),
+	NVMeCriticalWarning: stats.Int64(pre+"nvme_critical_warning", "NVMe Critical Warning Flags", stats.UnitDimensionless),
+
+	NVMeBytesRead:    stats.Int64(pre+"nvme_bytes_read", "NVMe Bytes Read", stats.UnitBytes),
+	NVMeBytesWritten: stats.Int64(pre+"nvme_bytes_written", "NVMe Bytes Written", stats.UnitBytes),
+	NVMeReadIO:       stats.Int64(pre+"nvme_read_io", "NVMe Read IOs", stats.UnitDimensionless),
+	NVMeWriteIO:      stats.Int64(pre+"nvme_write_io", "NVMe Write IOs", stats.UnitDimensionless),
 }
 
 // init registers the views for SupraSeal metrics.
@@ -39,6 +72,82 @@ func init() {
 			Measure:     SupraSealMeasures.PhaseAvgDuration,
 			Aggregation: view.LastValue(),
 			TagKeys:     []tag.Key{phaseKey},
+		},
+		// NVMe Health views
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeTemperature,
+			Aggregation: view.LastValue(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeAvailableSpare,
+			Aggregation: view.LastValue(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMePercentageUsed,
+			Aggregation: view.LastValue(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMePowerCycles,
+			Aggregation: view.LastValue(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMePowerOnHours,
+			Aggregation: view.LastValue(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeUnsafeShutdowns,
+			Aggregation: view.LastValue(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeMediaErrors,
+			Aggregation: view.LastValue(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeErrorLogEntries,
+			Aggregation: view.LastValue(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeCriticalWarning,
+			Aggregation: view.LastValue(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeBytesRead,
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeBytesWritten,
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeReadIO,
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeWriteIO,
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeReadIO,
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
+		},
+		&view.View{
+			Measure:     SupraSealMeasures.NVMeWriteIO,
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{nvmeDeviceKey},
 		},
 	)
 	if err != nil {

--- a/tasks/sealsupra/task_supraseal.go
+++ b/tasks/sealsupra/task_supraseal.go
@@ -159,8 +159,8 @@ func NewSupraSeal(sectorSize string, batchSize, pipelines int, dualHashers bool,
 
 				// For counters, compute difference from previous values
 				if prevHealthInfos[i].DataUnitsRead != 0 {
-					dataUnitsReadBytes := int64((hi.DataUnitsRead - prevHealthInfos[i].DataUnitsRead) * 512)
-					dataUnitsWrittenBytes := int64((hi.DataUnitsWritten - prevHealthInfos[i].DataUnitsWritten) * 512)
+					dataUnitsReadBytes := int64((hi.DataUnitsRead - prevHealthInfos[i].DataUnitsRead) * 512_000)
+					dataUnitsWrittenBytes := int64((hi.DataUnitsWritten - prevHealthInfos[i].DataUnitsWritten) * 512_000)
 					hostReadCommands := int64(hi.HostReadCommands - prevHealthInfos[i].HostReadCommands)
 					hostWriteCommands := int64(hi.HostWriteCommands - prevHealthInfos[i].HostWriteCommands)
 

--- a/tasks/sealsupra/task_supraseal.go
+++ b/tasks/sealsupra/task_supraseal.go
@@ -5,14 +5,14 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 	"os"
 	"path/filepath"
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/snadrus/must"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"

--- a/tasks/sealsupra/task_supraseal.go
+++ b/tasks/sealsupra/task_supraseal.go
@@ -104,6 +104,31 @@ func NewSupraSeal(sectorSize string, batchSize, pipelines int, dualHashers bool,
 	supraffi.SupraSealInit(uint64(ssize), configFile)
 	log.Infow("supraseal init done")
 
+	{
+		hp, err := supraffi.GetHealthInfo()
+		if err != nil {
+			return nil, xerrors.Errorf("get health page: %w", err)
+		}
+
+		log.Infow("nvme health page", "hp", hp)
+	}
+
+	go func() {
+		// TODO: put this into prometheus metrics instead of printing
+
+		for {
+			time.Sleep(30 * time.Second)
+
+			hp, err := supraffi.GetHealthInfo()
+			if err != nil {
+				log.Errorw("health page get error", "error", err)
+				continue
+			}
+
+			log.Infow("nvme health page", "hp", hp)
+		}
+	}()
+
 	// Get maximum block offset (essentially the number of pages in the smallest nvme device)
 	space := supraffi.GetMaxBlockOffset(uint64(ssize))
 


### PR DESCRIPTION
This PR makes curio output logs like

```
2024-11-10T19:37:18.734Z	INFO	batchseal	sealsupra/task_supraseal.go:128	nvme health page	{"hp": [{"CriticalWarning":0,"Temperature":32,"TemperatureSensors..
```

Eventually that should go to e.g. /metrics/pprof, but for now logs are better than nothing at all


Full example output:
```
{
  "hp": [
    {
      "CriticalWarning": 0,
      "Temperature": 31, // pretty sure this is C
      "TemperatureSensors": [
        31,
        43,
        -273,
        -273,
        -273,
        -273,
        -273,
        -273
      ],
      "WarningTempTime": 0,
      "CriticalTempTime": 0,
      "AvailableSpare": 100,
      "AvailableSpareThreshold": 10,
      "PercentageUsed": 0,
      "DataUnitsRead": 7351772500, // 512B blocks? (maybe 4k? idk, maybe it depends, tho probably just 512B)
      "DataUnitsWritten": 194806471,
      "HostReadCommands": 918971519654, // cumulative iops
      "HostWriteCommands": 24350808844,
      "ControllerBusyTime": 1198800000000000,
      "PowerCycles": 10,
      "PowerOnHours": 25329600000000000,
      "UnsafeShutdowns": 6,
      "MediaErrors": 0,
      "ErrorLogEntries": 2
    },
    {
      "CriticalWarning": 0,
      "Temperature": 31,
      "TemperatureSensors": [
        31,
        40,
        -273,
        -273,
        -273,
        -273,
        -273,
        -273
      ],
      "WarningTempTime": 0,
      "CriticalTempTime": 0,
      "AvailableSpare": 100,
      "AvailableSpareThreshold": 10,
      "PercentageUsed": 0,
      "DataUnitsRead": 7000076004,
      "DataUnitsWritten": 185866591,
      "HostReadCommands": 875009457677,
      "HostWriteCommands": 23233323845,
      "ControllerBusyTime": 1096440000000000,
      "PowerCycles": 9,
      "PowerOnHours": 25329600000000000,
      "UnsafeShutdowns": 4,
      "MediaErrors": 0,
      "ErrorLogEntries": 0
    },
    {
      "CriticalWarning": 0,
      "Temperature": 31,
      "TemperatureSensors": [
        31,
        40,
        -273,
        -273,
        -273,
        -273,
        -273,
        -273
      ],
      "WarningTempTime": 0,
      "CriticalTempTime": 0,
      "AvailableSpare": 100,
      "AvailableSpareThreshold": 10,
      "PercentageUsed": 0,
      "DataUnitsRead": 6999993907,
      "DataUnitsWritten": 185866662,
      "HostReadCommands": 874999195551,
      "HostWriteCommands": 23233332667,
      "ControllerBusyTime": 1095000000000000,
      "PowerCycles": 10,
      "PowerOnHours": 25329600000000000,
      "UnsafeShutdowns": 5,
      "MediaErrors": 0,
      "ErrorLogEntries": 0
    },
    {
      "CriticalWarning": 0,
      "Temperature": 32,
      "TemperatureSensors": [
        32,
        43,
        -273,
        -273,
        -273,
        -273,
        -273,
        -273
      ],
      "WarningTempTime": 0,
      "CriticalTempTime": 0,
      "AvailableSpare": 100,
      "AvailableSpareThreshold": 10,
      "PercentageUsed": 0,
      "DataUnitsRead": 7850355961,
      "DataUnitsWritten": 207678358,
      "HostReadCommands": 981294440416,
      "HostWriteCommands": 25959794741,
      "ControllerBusyTime": 1219860000000000,
      "PowerCycles": 19,
      "PowerOnHours": 25398000000000000,
      "UnsafeShutdowns": 14,
      "MediaErrors": 0,
      "ErrorLogEntries": 1
    },
    {
      "CriticalWarning": 0,
      "Temperature": 31,
      "TemperatureSensors": [
        31,
        41,
        -273,
        -273,
        -273,
        -273,
        -273,
        -273
      ],
      "WarningTempTime": 0,
      "CriticalTempTime": 0,
      "AvailableSpare": 100,
      "AvailableSpareThreshold": 10,
      "PercentageUsed": 0,
      "DataUnitsRead": 7850253556,
      "DataUnitsWritten": 207678078,
      "HostReadCommands": 981281639756,
      "HostWriteCommands": 25959759728,
      "ControllerBusyTime": 1220940000000000,
      "PowerCycles": 18,
      "PowerOnHours": 25398000000000000,
      "UnsafeShutdowns": 13,
      "MediaErrors": 0,
      "ErrorLogEntries": 0
    },
    {
      "CriticalWarning": 0,
      "Temperature": 31,
      "TemperatureSensors": [
        31,
        41,
        -273,
        -273,
        -273,
        -273,
        -273,
        -273
      ],
      "WarningTempTime": 0,
      "CriticalTempTime": 0,
      "AvailableSpare": 100,
      "AvailableSpareThreshold": 10,
      "PercentageUsed": 0,
      "DataUnitsRead": 7850331280,
      "DataUnitsWritten": 207678096,
      "HostReadCommands": 981291356925,
      "HostWriteCommands": 25959761922,
      "ControllerBusyTime": 1220580000000000,
      "PowerCycles": 18,
      "PowerOnHours": 25398000000000000,
      "UnsafeShutdowns": 13,
      "MediaErrors": 0,
      "ErrorLogEntries": 0
    },
    {
      "CriticalWarning": 0,
      "Temperature": 31,
      "TemperatureSensors": [
        31,
        41,
        -273,
        -273,
        -273,
        -273,
        -273,
        -273
      ],
      "WarningTempTime": 0,
      "CriticalTempTime": 0,
      "AvailableSpare": 100,
      "AvailableSpareThreshold": 10,
      "PercentageUsed": 0,
      "DataUnitsRead": 7850250971,
      "DataUnitsWritten": 207678127,
      "HostReadCommands": 981281304787,
      "HostWriteCommands": 25959765851,
      "ControllerBusyTime": 1220580000000000,
      "PowerCycles": 18,
      "PowerOnHours": 25398000000000000,
      "UnsafeShutdowns": 13,
      "MediaErrors": 0,
      "ErrorLogEntries": 0
    },
    {
      "CriticalWarning": 0,
      "Temperature": 32,
      "TemperatureSensors": [
        32,
        41,
        -273,
        -273,
        -273,
        -273,
        -273,
        -273
      ],
      "WarningTempTime": 0,
      "CriticalTempTime": 0,
      "AvailableSpare": 100,
      "AvailableSpareThreshold": 10,
      "PercentageUsed": 0,
      "DataUnitsRead": 7850350058,
      "DataUnitsWritten": 207678226,
      "HostReadCommands": 981293708152,
      "HostWriteCommands": 25959778161,
      "ControllerBusyTime": 1220640000000000,
      "PowerCycles": 18,
      "PowerOnHours": 25398000000000000,
      "UnsafeShutdowns": 13,
      "MediaErrors": 0,
      "ErrorLogEntries": 1
    },
    {
      "CriticalWarning": 0,
      "Temperature": 31,
      "TemperatureSensors": [
        31,
        41,
        -273,
        -273,
        -273,
        -273,
        -273,
        -273
      ],
      "WarningTempTime": 0,
      "CriticalTempTime": 0,
      "AvailableSpare": 100,
      "AvailableSpareThreshold": 10,
      "PercentageUsed": 0,
      "DataUnitsRead": 7850251672,
      "DataUnitsWritten": 207677851,
      "HostReadCommands": 981281406204,
      "HostWriteCommands": 25959731256,
      "ControllerBusyTime": 1221240000000000,
      "PowerCycles": 18,
      "PowerOnHours": 25398000000000000,
      "UnsafeShutdowns": 13,
      "MediaErrors": 0,
      "ErrorLogEntries": 0
    },
    {
      "CriticalWarning": 0,
      "Temperature": 31,
      "TemperatureSensors": [
        31,
        40,
        -273,
        -273,
        -273,
        -273,
        -273,
        -273
      ],
      "WarningTempTime": 0,
      "CriticalTempTime": 0,
      "AvailableSpare": 100,
      "AvailableSpareThreshold": 10,
      "PercentageUsed": 0,
      "DataUnitsRead": 7849566782,
      "DataUnitsWritten": 207090606,
      "HostReadCommands": 981195798647,
      "HostWriteCommands": 25886325749,
      "ControllerBusyTime": 1221000000000000,
      "PowerCycles": 18,
      "PowerOnHours": 25398000000000000,
      "UnsafeShutdowns": 13,
      "MediaErrors": 0,
      "ErrorLogEntries": 0
    }
  ]
}
```
