### PR TITLE
fix: Pass correct tags to sptool calibnet build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ BINS+=curio
 
 sptool: $(BUILD_DEPS)
 	rm -f sptool
-	$(GOCC) build $(GOFLAGS) -o sptool ./cmd/sptool
+	$(GOCC) build $(GOFLAGS) -tags "$(CURIO_TAGS)" -o sptool ./cmd/sptool
 .PHONY: sptool
 BINS+=sptool
 


### PR DESCRIPTION
Likely a regression from https://github.com/filecoin-project/curio/pull/211