### PR TITLE
Fix acme challenge

### DIFF
--- a/cuhttp/server.go
+++ b/cuhttp/server.go
@@ -2,7 +2,6 @@ package cuhttp
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"strings"
@@ -166,9 +165,7 @@ func StartHTTPServer(ctx context.Context, d *deps.Deps) error {
 			HostPolicy: autocert.HostWhitelist(cfg.DomainName),
 		}
 
-		server.TLSConfig = &tls.Config{
-			GetCertificate: certManager.GetCertificate,
-		}
+		server.TLSConfig = certManager.TLSConfig()
 	}
 
 	// We don't need to run an HTTP server. Any HTTP request should simply be handled as HTTPS.


### PR DESCRIPTION
ACME protocol is misconfigured so lets encrypt fails on new cert requests.  See this thread: https://filecoinproject.slack.com/archives/C0717TGU7V2/p1738321145982859