### PR TITLE
fix: WinPoSt alert

### DIFF
--- a/alertmanager/alerts.go
+++ b/alertmanager/alerts.go
@@ -598,11 +598,12 @@ func wnPostCheck(al *alerts) {
 		return
 	}
 
+	const slack = 4
+	slackTasks := slack * int64(len(miners))
+
 	expected = expected * int64(len(miners)) // Multiply epochs by number of miner IDs
 
-	// If expected + 3*no of miner >= count >= expected - 3*no of miner i.e. count is off by 3 entries per miner then not a problem
-	// Example: (120 epochs * 3 miners) + 3 * (3 miners) i.e. 369 < 366 < (120 epochs * 3 miners) - 3 * (3 miners) i.e. 351
-	if expected+int64(3*len(miners)) >= count && count >= expected-int64(3*len(miners)) {
+	if count < expected-slackTasks || count > expected+slackTasks {
 		al.alertMap[Name].alertString += fmt.Sprintf("Expected %d WinningPost task and found %d in DB. ", expected, count)
 	}
 


### PR DESCRIPTION
This should fix the math for winningPoSt alerts, making them not fire all the time for no reason