### PR TITLE
webui: Show storage use breakdown by file type

### DIFF
--- a/web/api/webrpc/storage_stats.go
+++ b/web/api/webrpc/storage_stats.go
@@ -3,6 +3,7 @@ package webrpc
 import (
 	"context"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -79,6 +80,167 @@ func (a *WebRPC) StorageUseStats(ctx context.Context) ([]StorageUseStats, error)
 	}
 
 	return stats, nil
+}
+
+// StorageStoreStats holds the aggregated store (can_store) stats for a given file type.
+type StorageStoreStats struct {
+	Type      string `json:"type"`
+	Capacity  int64  `json:"capacity"`
+	Available int64  `json:"available"`
+	Used      int64  `json:"used"`
+
+	CapStr    string `json:"cap_str"`
+	UseStr    string `json:"use_str"`
+	AvailStr  string `json:"avail_str"`
+}
+
+// storagePathRow mirrors the columns we need from the storage_path table.
+type storagePathRow struct {
+	StorageID  string `db:"storage_id"`
+	AllowTypes string `db:"allow_types"`
+	DenyTypes  string `db:"deny_types"`
+	Capacity   int64  `db:"capacity"`
+	Available  int64  `db:"available"`
+	CanStore   bool   `db:"can_store"`
+}
+
+// parseCSV splits a comma‐separated string into a slice of trimmed strings.
+// An empty string returns an empty slice.
+func parseCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	var out []string
+	for _, part := range parts {
+		t := strings.TrimSpace(part)
+		if t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// StorageStoreTypeStats returns aggregated capacity and available space for store-type paths,
+// grouped by each file type. A given storage path’s capacity is counted for a file type if its
+// allow/deny lists (if set) permit that file type. In addition, if the resulting list contains
+// more than a chosen threshold of entries, the lower-volume ones are merged into a single "Other" entry.
+func (a *WebRPC) StorageStoreTypeStats(ctx context.Context) ([]StorageStoreStats, error) {
+	// Query all storage paths that are available for storing.
+	var paths []*storagePathRow
+	const query = `
+		SELECT storage_id, allow_types, deny_types, capacity, available, can_store
+		FROM storage_path
+		WHERE can_store = true
+	`
+	if err := a.deps.DB.Select(ctx, &paths, query); err != nil {
+		return nil, xerrors.Errorf("querying storage paths: %w", err)
+	}
+
+	// map paths into by-storage-id
+	byStorageID := make(map[string]*storagePathRow)
+	for _, p := range paths {
+		byStorageID[p.StorageID] = p
+	}
+
+	// map paths into by-type
+	pathsForTypeMap := make(map[storiface.SectorFileType][]string)
+	for _, p := range paths {
+		allowList := parseCSV(p.AllowTypes)
+		denyList := parseCSV(p.DenyTypes)
+		for _, ft := range storiface.PathTypes {
+			if ft.Allowed(allowList, denyList) {
+				pathsForTypeMap[ft] = append(pathsForTypeMap[ft], p.StorageID)
+			}
+		}
+	}
+
+	// figure out "Other" which is the most shared set of storage ids
+	sharedMap := make(map[string]int)
+	for _, paths := range pathsForTypeMap {
+		pathSetStr := strings.Join(paths, ",")
+		sharedMap[pathSetStr]++
+	}
+
+	// find the most shared set of storage ids
+	var mostSharedPathSet string
+	var mostSharedCount int
+	for pathSetStr, count := range sharedMap {
+		if count > mostSharedCount {
+			mostSharedCount = count
+			mostSharedPathSet = pathSetStr
+		}
+	}
+
+	// remove the most shared path set from the map
+	for ft, paths := range pathsForTypeMap {
+		if strings.Join(paths, ",") == mostSharedPathSet {
+			delete(pathsForTypeMap, ft)
+		}
+	}
+
+	// add the "Other" entry
+	ftOther := storiface.FTNone
+	pathsForTypeMap[ftOther] = strings.Split(mostSharedPathSet, ",")
+
+	// Aggregate per file type based on the computed pathsForTypeMap,
+	// then if there is more than one entry, compute overall storage totals and return
+	// a top-level "Storage" entry with sub-entries (their Type field is prefixed to indicate sub-level).
+	var statsByType []StorageStoreStats
+	for ft, storageIDs := range pathsForTypeMap {
+		var capacity, available int64
+		seen := make(map[string]bool)
+		for _, sid := range storageIDs {
+			if seen[sid] {
+				continue
+			}
+			seen[sid] = true
+			if sp, ok := byStorageID[sid]; ok {
+				capacity += sp.Capacity
+				available += sp.Available
+			}
+		}
+		used := capacity - available
+		var label string
+		if ft == storiface.FTNone {
+			label = "other"
+		} else {
+			label = ft.String()
+		}
+		statsByType = append(statsByType, StorageStoreStats{
+			Type:      label,
+			Capacity:  capacity,
+			Available: available,
+			Used:      used,
+			CapStr:    types.SizeStr(types.NewInt(uint64(capacity))),
+			UseStr:    types.SizeStr(types.NewInt(uint64(used))),
+			AvailStr:  types.SizeStr(types.NewInt(uint64(available))),
+		})
+	}
+
+	// Sort the file-type breakdown descending by Capacity.
+	sort.Slice(statsByType, func(i, j int) bool {
+		return statsByType[i].Capacity > statsByType[j].Capacity
+	})
+
+	// If there is more than one entry, create a top-level "Storage" row that sums overall capacity/available,
+	// and then show the breakdown as sub-entries (by indenting the Type field).
+	if len(statsByType) == 1 {
+		return []StorageStoreStats{}, nil
+	}
+
+	sort.Slice(statsByType, func(i, j int) bool {
+		// Compute available percentage (Available / Capacity) for each entry.
+		// If Capacity is zero, use 0 to avoid division by zero.
+		var percI, percJ float64
+		if statsByType[i].Capacity > 0 {
+			percI = float64(statsByType[i].Available) / float64(statsByType[i].Capacity)
+		}
+		if statsByType[j].Capacity > 0 {
+			percJ = float64(statsByType[j].Available) / float64(statsByType[j].Capacity)
+		}
+		return percI < percJ
+	})
+
+	// Otherwise, if there is only one aggregated entry, return that.
+	return statsByType, nil
 }
 
 type StorageGCMark struct {

--- a/web/static/storage-use.mjs
+++ b/web/static/storage-use.mjs
@@ -1,43 +1,108 @@
 import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
 import RPCCall from '/lib/jsonrpc.mjs';
-customElements.define('storage-use',class StorageUse extends LitElement {
+
+customElements.define('storage-use', class StorageUse extends LitElement {
+    static styles = css`
+    /* Style for sub-rows: indented and with slightly smaller text/background tint */
+    .sub-row td {
+      padding-left: 40px;
+      background-color: #2a2a2a;
+      font-size: 0.9em;
+    }
+  `;
+
     constructor() {
         super();
         this.data = [];
-        this.loadData();
     }
 
     async loadData() {
-        this.data = await RPCCall('StorageUseStats');
+        // Load summary storage use stats.
+        const summary = await RPCCall('StorageUseStats');
+        // Load breakdown stats by file type.
+        const storeBreakdown = await RPCCall('StorageStoreTypeStats');
+
+        // Determine if we have a detailed breakdown:
+        // if there is more than one entry, or the single entry is not "Other"
+        const hasDetailedBreakdown = storeBreakdown.length > 1 ||
+            (storeBreakdown.length === 1 && storeBreakdown[0].type !== 'Other');
+
+        // If we have a detailed breakdown, merge it into the summary data by
+        // attaching the store breakdown as subEntries to the "Store" row.
+        if (hasDetailedBreakdown) {
+            summary.forEach(row => {
+                if (row.Type === "Store") {
+                    row.subEntries = storeBreakdown;
+                }
+            });
+        }
+
+        this.data = summary;
         this.requestUpdate();
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.loadData();
     }
 
     render() {
         return html`
-            <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-            <link rel="stylesheet" href="/ux/main.css" onload="document.body.style.visibility = 'initial'">
-            <table class="table table-dark">
-                <thead>
-                <tr>
-                    <th>Type</th>
-                    <th>Storage</th>
-                    <th></th>
-                </tr>
-                </thead>
-                <tbody>
-                ${this.data.map(entry => html`
-                    <tr>
-                        <td>${entry.Type}</td>
-                        <td>${entry.UseStr} / ${entry.CapStr} (${(100-100*entry.Available/entry.Capacity).toFixed(2)}%)</td>
-                        <td>
-                            <div style="display: inline-block; width: 250px; height: 16px; border: #3f3f3f 3px solid;">
-                                <div style="width: ${(100-100*entry.Available/entry.Capacity).toFixed(2)}%; height: 10px; background-color: green"></div>
-                            </div>
-                        </td>
-                    </tr>
-                    `)}
-                </tbody>
-            </table>
+      <!-- Including Bootstrap and our main stylesheet -->
+      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+            rel="stylesheet" crossorigin="anonymous">
+      <link rel="stylesheet" href="/ux/main.css" onload="document.body.style.visibility = 'initial'">
+      <table class="table table-dark">
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Storage</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          ${this.data.map(row => this.renderRow(row))}
+        </tbody>
+      </table>
+    `;
+    }
+
+    renderRow(row) {
+        // Calculate percentage used if capacity > 0.
+        const pct = row.Capacity > 0 ? (100 - 100 * row.Available / row.Capacity).toFixed(2) : "0";
+        // Use the pre-formatted strings if available; otherwise, fall back to raw numbers.
+        const usedStr = row.UseStr || (row.Capacity - row.Available);
+        const capStr = row.CapStr || row.Capacity;
+        return html`
+            <tr>
+                <td>${row.Type}</td>
+                <td>${usedStr} / ${capStr} (${pct}%)</td>
+                <td>
+                    <div style="display:inline-block; width:250px; height:16px; border:3px solid #3f3f3f;">
+                        <div style="width:${pct}%; height:10px; background-color:green;"></div>
+                    </div>
+                </td>
+            </tr>
+            ${row.subEntries ? row.subEntries.map(sub => this.renderSubRow(sub)) : ''}
         `;
     }
-} );
+
+    renderSubRow(sub) {
+        // For sub-entries from the breakdown RPC, assume keys: type, capacity, available, and avail_str.
+        // pct here remains the used percentage for bar rendering.
+        const pct = sub.capacity > 0 ? (100 - 100 * sub.available / sub.capacity).toFixed(2) : "0";
+        // Calculate available percentage as 100 - used percentage.
+        const availablePct = sub.capacity > 0 ? (100 - parseFloat(pct)).toFixed(2) : "0";
+        return html`
+      <tr class="sub-row">
+        <td>${sub.type}</td>
+        <td>Available: ${sub.avail_str} (${availablePct}%)</td>
+        <td>
+          <div style="display:inline-block; width:220px; height:14px; border:2px solid #3f3f3f;">
+            <div style="width:${pct}%; height:10px; background-color:green;"></div>
+          </div>
+        </td>
+      </tr>
+    `;
+    }
+});


### PR DESCRIPTION
With path type filters it's quite hard to know how much space is left for a given file type.

![2025-02-04-154524_726x287_scrot](https://github.com/user-attachments/assets/911d091b-9ea3-4456-a913-941c3a2b44fc)

(in the future we can add a special storage page with more details, and also showing per-SP-filter available space)
