### PR TITLE
feat: gc: Mark snap sector key files for removal

### DIFF
--- a/cmd/curio/internal/translations/catalog.go
+++ b/cmd/curio/internal/translations/catalog.go
@@ -46,151 +46,152 @@ var messageKeyToIndex = map[string]int{
 	"(for init) use path for long-term storage": 95,
 	"(for init) use path for sealing":           94,
 	"1278 (3.5 years)":                          78,
-	"2 KiB":                                     198,
-	"32 GiB":                                    196,
-	"64 GiB":                                    195,
-	"8 MiB":                                     197,
+	"2 KiB":                                     199,
+	"32 GiB":                                    197,
+	"64 GiB":                                    196,
+	"8 MiB":                                     198,
 	"<sector>":                                  53,
-	"Aborting migration.":                       136,
-	"Aborting remaining steps.":                 133,
+	"Aborting migration.":                       137,
+	"Aborting remaining steps.":                 134,
 	"Add URL to fetch data for offline deals":                          54,
-	"Additional info is at http://docs.curiostorage.org":               141,
+	"Additional info is at http://docs.curiostorage.org":               142,
 	"Address to listen for the GUI on":                                 71,
-	"Aggregate-Anonymous: version, chain, and Miner power (bucketed).": 154,
+	"Aggregate-Anonymous: version, chain, and Miner power (bucketed).": 155,
 	"Analyze and display the layout of batch sealer threads":           1,
 	"Analyze and display the layout of batch sealer threads on your CPU.\n\nIt provides detailed information about CPU utilization for batch sealing operations, including core allocation, thread\ndistribution for different batch sizes.": 2,
 	"CSV file location to use for multiple deal input. Each line in the file should be in the format 'uuid,raw size,url,header1,header2...'":                                                                                                 55,
-	"Cannot reach the DB: %s": 203,
-	"Cannot read the config.toml file in the provided directory, Error: %s": 177,
-	"Check data integrity in unsealed sector files":                         122,
-	"Collection of debugging utilities":                                     114,
+	"Cannot reach the DB: %s": 204,
+	"Cannot read the config.toml file in the provided directory, Error: %s": 178,
+	"Check data integrity in unsealed sector files":                         123,
+	"Collection of debugging utilities":                                     115,
 	"Command separated list of hostnames for yugabyte cluster":              46,
-	"Compare the configurations %s to %s. Changes between the miner IDs other than wallet addreses should be a new, minimal layer for runners that need it.": 231,
-	"Compute WindowPoSt for performance and configuration testing.":                                                                                          109,
+	"Compare the configurations %s to %s. Changes between the miner IDs other than wallet addreses should be a new, minimal layer for runners that need it.": 232,
+	"Compute WindowPoSt for performance and configuration testing.":                                                                                          110,
 	"Compute a proof-of-spacetime for a sector (requires the sector to be pre-sealed). These will not send to the chain.":                                    106,
-	"Configuration 'base' was created to resemble this lotus-miner's config.toml .":                                                                          232,
-	"Configuration 'base' was updated to include this miner's address":                                                                                       212,
-	"Configuration 'base' was updated to include this miner's address (%s) and its wallet setup.":                                                            230,
-	"Connected to Yugabyte":                                                          171,
-	"Connected to Yugabyte. Schema is current.":                                      170,
-	"Continue to connect and update schema.":                                         222,
-	"Continue to verify the addresses and create a new miner actor.":                 188,
+	"Configuration 'base' was created to resemble this lotus-miner's config.toml .":                                                                          233,
+	"Configuration 'base' was updated to include this miner's address":                                                                                       213,
+	"Configuration 'base' was updated to include this miner's address (%s) and its wallet setup.":                                                            231,
+	"Connected to Yugabyte":                                                          172,
+	"Connected to Yugabyte. Schema is current.":                                      171,
+	"Continue to connect and update schema.":                                         223,
+	"Continue to verify the addresses and create a new miner actor.":                 189,
 	"Cordon a machine, set it to maintenance mode":                                   33,
-	"Could not create repo from directory: %s. Aborting migration":                   178,
-	"Could not lock miner repo. Your miner must be stopped: %s\n Aborting migration": 179,
-	"Create a check task for a specific sector, wait for its completion, and output the result.\n   <miner-id>: The storage provider ID\n   <sector-number>: The sector number": 123,
-	"Create a new miner":                                        132,
+	"Could not create repo from directory: %s. Aborting migration":                   179,
+	"Could not lock miner repo. Your miner must be stopped: %s\n Aborting migration": 180,
+	"Create a check task for a specific sector, wait for its completion, and output the result.\n   <miner-id>: The storage provider ID\n   <sector-number>: The sector number": 124,
+	"Create a new miner":                                        133,
 	"Create new configuration for a new cluster":                31,
-	"Ctrl+C pressed in Terminal":                                129,
+	"Ctrl+C pressed in Terminal":                                130,
 	"Custom `HEADER` to include in the HTTP request":            56,
-	"Database config error occurred, abandoning migration: %s ": 223,
-	"Database: %s":    221,
-	"Documentation: ": 164,
-	"Each step needs your confirmation and can be reversed. Press Ctrl+C to exit at any time.": 128,
-	"Enter %s address":                    193,
-	"Enter the Yugabyte database %s":      226,
-	"Enter the Yugabyte database host(s)": 224,
-	"Enter the info to connect to your Yugabyte database installation (https://download.yugabyte.com/)": 216,
-	"Enter the info to create a new miner":                             183,
-	"Enter the owner address":                                          190,
-	"Enter the path to the configuration directory used by %s":         175,
-	"Error connecting to Yugabyte database: %s":                        228,
-	"Error connecting to full node API: %s":                            204,
-	"Error getting API: %s":                                            144,
-	"Error getting miner info: %s":                                     159,
-	"Error getting miner power: %s":                                    157,
-	"Error getting token: %s":                                          146,
-	"Error marshalling message: %s":                                    158,
-	"Error saving config to layer: %s. Aborting Migration":             150,
-	"Error sending message: %s":                                        161,
-	"Error sending message: Status %s, Message: ":                      162,
-	"Error signing message: %s":                                        160,
-	"Error writing file: %s":                                           137,
+	"Database config error occurred, abandoning migration: %s ": 224,
+	"Database: %s":    222,
+	"Documentation: ": 165,
+	"Each step needs your confirmation and can be reversed. Press Ctrl+C to exit at any time.": 129,
+	"Enter %s address":                    194,
+	"Enter the Yugabyte database %s":      227,
+	"Enter the Yugabyte database host(s)": 225,
+	"Enter the info to connect to your Yugabyte database installation (https://download.yugabyte.com/)": 217,
+	"Enter the info to create a new miner":                             184,
+	"Enter the owner address":                                          191,
+	"Enter the path to the configuration directory used by %s":         176,
+	"Error connecting to Yugabyte database: %s":                        229,
+	"Error connecting to full node API: %s":                            205,
+	"Error getting API: %s":                                            145,
+	"Error getting miner info: %s":                                     160,
+	"Error getting miner power: %s":                                    158,
+	"Error getting token: %s":                                          147,
+	"Error marshalling message: %s":                                    159,
+	"Error saving config to layer: %s. Aborting Migration":             151,
+	"Error sending message: %s":                                        162,
+	"Error sending message: Status %s, Message: ":                      163,
+	"Error signing message: %s":                                        161,
+	"Error writing file: %s":                                           138,
 	"Execute cli commands":                                             6,
-	"Failed to create the miner actor: %s":                             201,
-	"Failed to generate default config: %s":                            210,
-	"Failed to generate random bytes for secret: %s":                   206,
-	"Failed to get API info for FullNode: %w":                          208,
-	"Failed to insert 'base' config layer in database: %s":             211,
-	"Failed to load base config from database: %s":                     213,
-	"Failed to parse base config: %s":                                  214,
-	"Failed to parse sector size: %s":                                  200,
-	"Failed to parse the address: %s":                                  192,
-	"Failed to regenerate base config: %s":                             215,
-	"Failed to verify the auth token from daemon node: %s":             209,
+	"Failed to create the miner actor: %s":                             202,
+	"Failed to generate default config: %s":                            211,
+	"Failed to generate random bytes for secret: %s":                   207,
+	"Failed to get API info for FullNode: %w":                          209,
+	"Failed to insert 'base' config layer in database: %s":             212,
+	"Failed to load base config from database: %s":                     214,
+	"Failed to parse base config: %s":                                  215,
+	"Failed to parse sector size: %s":                                  201,
+	"Failed to parse the address: %s":                                  193,
+	"Failed to regenerate base config: %s":                             216,
+	"Failed to verify the auth token from daemon node: %s":             210,
 	"Fetch proving parameters":                                         48,
-	"Filecoin %s channels: %s and %s":                                  167,
+	"Filecoin %s channels: %s and %s":                                  168,
 	"Filecoin decentralized storage network provider":                  43,
-	"Filter by storage provider ID":                                    118,
+	"Filter by storage provider ID":                                    119,
 	"Filter events by actor address; lists all if not specified":       83,
 	"Filter events by sector number; requires --actor to be specified": 84,
-	"For more servers, make /etc/curio.env with the curio.env database env and add the CURIO_LAYERS env to assign purposes.": 139,
+	"For more servers, make /etc/curio.env with the curio.env database env and add the CURIO_LAYERS env to assign purposes.": 140,
 	"Generate a supra_seal configuration": 3,
 	"Generate a supra_seal configuration for a given batch size.\n\nThis command outputs a configuration expected by SupraSeal. Main purpose of this command is for debugging and testing.\nThe config can be used directly with SupraSeal binaries to test it without involving Curio.": 4,
 	"Get Curio node info": 36,
 	"Get a config layer by name. You may want to pipe the output to a file, or use 'less'": 16,
-	"Get information about unsealed data":                                                  116,
-	"Hint: I am someone running Curio on whichever chain.":                                 155,
-	"Host: %s":                               217,
+	"Get information about unsealed data":                                                  117,
+	"Hint: I am someone running Curio on whichever chain.":                                 156,
+	"Host: %s":                               218,
 	"How long to commit sectors for":         77,
-	"I want to:":                             130,
+	"I want to:":                             131,
 	"Ignore sectors that cannot be migrated": 81,
-	"Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'": 168,
-	"Individual Data: Miner ID, Curio version, chain (%s or %s). Signed.":                                                    153,
-	"Initializing a new miner actor.": 182,
+	"Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'": 169,
+	"Individual Data: Miner ID, Curio version, chain (%s or %s). Signed.":                                                    154,
+	"Initializing a new miner actor.": 183,
 	"Interpret stacked config layers by this version of curio, with system-generated comments.": 20,
-	"Layer %s created. ":                                                 233,
+	"Layer %s created. ":                                                 234,
 	"Limit output to the last N events":                                  85,
 	"List config layers present in the DB.":                              18,
-	"List data from the sectors_unseal_pipeline and sectors_meta tables": 117,
+	"List data from the sectors_unseal_pipeline and sectors_meta tables": 118,
 	"List log systems":                                                   38,
 	"List pipeline events":                                               82,
-	"Lotus-Miner to Curio Migration.":                                    134,
+	"Lotus-Miner to Curio Migration.":                                    135,
 	"Manage logging":                                                     37,
 	"Manage node config by layers. The layer 'base' will always be applied at Curio start-up.": 10,
 	"Manage the sealing pipeline":       72,
-	"Manage unsealed data":              115,
+	"Manage unsealed data":              116,
 	"Math Utils":                        0,
-	"Message sent.":                     163,
-	"Migrate from existing Lotus-Miner": 131,
-	"Migrating lotus-miner config.toml to Curio in-database configuration.":                 143,
-	"Migrating metadata for %d sectors.":                                                    229,
-	"Miner %s created successfully":                                                         202,
-	"Miner creation error occurred: %s ":                                                    189,
+	"Message sent.":                     164,
+	"Migrate from existing Lotus-Miner": 132,
+	"Migrating lotus-miner config.toml to Curio in-database configuration.":                 144,
+	"Migrating metadata for %d sectors.":                                                    230,
+	"Miner %s created successfully":                                                         203,
+	"Miner creation error occurred: %s ":                                                    190,
 	"Moves funds from the deal collateral wallet into escrow with the storage market actor": 58,
-	"New Miner initialization complete.":                                                    142,
-	"No address provided":                                                                   191,
-	"No host provided":                                                                      225,
-	"No path provided, abandoning migration ":                                               176,
-	"No value provided":                                                                     227,
-	"No, abort":                                                                             149,
-	"Note: This command is intended to be used to verify PoSt compute performance.\nIt will not send any messages to the chain. Since it can compute any deadline, output may be incorrectly timed for the chain.": 110,
-	"Nothing.":                   156,
+	"New Miner initialization complete.":                                                    143,
+	"No address provided":                                                                   192,
+	"No host provided":                                                                      226,
+	"No path provided, abandoning migration ":                                               177,
+	"No value provided":                                                                     228,
+	"No, abort":                                                                             150,
+	"Note: This command is intended to be used to verify PoSt compute performance.\nIt will not send any messages to the chain. Since it can compute any deadline, output may be incorrectly timed for the chain.": 111,
+	"Nothing.":                   157,
 	"Number of sectors to start": 76,
-	"One database can serve multiple miner IDs: Run a migration for each lotus-miner.": 169,
-	"Other":                              174,
-	"Output file path (default: stdout)": 119,
-	"Owner Wallet: %s":                   184,
-	"Password: %s":                       220,
+	"One database can serve multiple miner IDs: Run a migration for each lotus-miner.": 170,
+	"Other":                              175,
+	"Output file path (default: stdout)": 120,
+	"Owner Wallet: %s":                   185,
+	"Password: %s":                       221,
 	"Path to miner repo":                 80,
-	"Please do not run guided-setup again as miner creation is not idempotent. You need to run 'curio config new-cluster %s' to finish the configuration": 207,
-	"Port: %s":                          218,
-	"Pre-initialization steps complete": 205,
+	"Please do not run guided-setup again as miner creation is not idempotent. You need to run 'curio config new-cluster %s' to finish the configuration": 208,
+	"Port: %s":                          219,
+	"Pre-initialization steps complete": 206,
 	"Print default node config":         11,
-	"Read Miner Config":                 180,
+	"Read Miner Config":                 181,
 	"Remove a named config layer.":      19,
-	"Sector Size: %s":                   187,
-	"Sector selection failed: %s ":      199,
+	"SP ID to compute WindowPoSt for":   109,
+	"Sector Size: %s":                   188,
+	"Sector selection failed: %s ":      200,
 	"Sectors can be stored across many filesystem paths. These\ncommands provide ways to manage the storage a Curio node will use to store sectors\nlong term for proving (references as 'store') as well as how sectors will be\nstored while moving through the sealing pipeline (references as 'seal').": 88,
-	"Select the Sector Size":                                           194,
-	"Select the location of your lotus-miner config directory?":        173,
-	"Select what you want to share with the Curio team.":               152,
-	"Sender Wallet: %s":                                                186,
+	"Select the Sector Size":                                           195,
+	"Select the location of your lotus-miner config directory?":        174,
+	"Select what you want to share with the Curio team.":               153,
+	"Sender Wallet: %s":                                                187,
 	"Set a config layer or the base by providing a filename or stdin.": 13,
 	"Set log level": 39,
 	"Set the log level for logging systems:\n\n   The system flag can be specified multiple times.\n\n   eg) log set-level --system chain --system chainxchg debug\n\n   Available Levels:\n   debug\n   info\n   warn\n   error\n\n   Environment Variables:\n   GOLOG_LOG_LEVEL - Default log level for all log systems\n   GOLOG_LOG_FMT   - Change output log format (json, nocolor)\n   GOLOG_FILE      - Write logs to file\n   GOLOG_OUTPUT    - Specify whether to output to file, stderr, stdout or a combination, i.e. file+stderr\n": 41,
-	"Set the target unseal state for a sector": 120,
-	"Set the target unseal state for a specific sector.\n   <miner-id>: The storage provider ID\n   <sector-number>: The sector number\n   <target-state>: The target state (true, false, or none)\n\n   The unseal target state indicates to curio how an unsealed copy of the sector should be maintained.\n\t   If the target state is true, curio will ensure that the sector is unsealed.\n\t   If the target state is false, curio will ensure that there is no unsealed copy of the sector.\n\t   If the target state is none, curio will not change the current state of the sector.\n\n   Currently when the curio will only start new unseal processes when the target state changes from another state to true.\n\n   When the target state is false, and an unsealed sector file exists, the GC mark step will create a removal mark\n   for the unsealed sector file. The file will only be removed after the removal mark is accepted.\n": 121,
+	"Set the target unseal state for a sector": 121,
+	"Set the target unseal state for a specific sector.\n   <miner-id>: The storage provider ID\n   <sector-number>: The sector number\n   <target-state>: The target state (true, false, or none)\n\n   The unseal target state indicates to curio how an unsealed copy of the sector should be maintained.\n\t   If the target state is true, curio will ensure that the sector is unsealed.\n\t   If the target state is false, curio will ensure that there is no unsealed copy of the sector.\n\t   If the target state is none, curio will not change the current state of the sector.\n\n   Currently when the curio will only start new unseal processes when the target state changes from another state to true.\n\n   When the target state is false, and an unsealed sector file exists, the GC mark step will create a removal mark\n   for the unsealed sector file. The file will only be removed after the removal mark is accepted.\n": 122,
 	"Specify actor address to start sealing sectors for": 51,
 	"Specify wallet address to send the funds from":      60,
 	"Start Curio web interface":                          69,
@@ -199,34 +200,34 @@ var messageKeyToIndex = map[string]int{
 	"Start new sealing operations manually":                      73,
 	"Start sealing new CC sectors":                               75,
 	"Start sealing sectors for all actors now (not on schedule)": 74,
-	"Step Complete: %s\n":                                        181,
+	"Step Complete: %s\n":                                        182,
 	"Stop a running Curio process":                               86,
 	"Storage can be attached to a Curio node using this command. The storage volume\nlist is stored local to the Curio node in storage.json set in curio run. We do not\nrecommend manually modifying this value without further understanding of the\nstorage system.\n\nEach storage volume contains a configuration file which describes the\ncapabilities of the volume. When the '--init' flag is provided, this file will\nbe created using the additional flags.\n\nWeight\nA high weight value means data will be more likely to be stored in this path\n\nSeal\nData for the sealing process will be stored here\n\nStore\nFinalized sectors that will be moved here for long term storage and be proven\nover time\n   ": 91,
 	"Test the windowpost scheduler by running it on the next available curio. If tasks fail all retries, you will need to ctrl+c to exit.":                                                               107,
-	"The '%s' layer stores common configuration. All curio instances can include it in their %s argument.":                                                                                               165,
-	"The Curio team wants to improve the software you use. Tell the team you're using `%s`.":                                                                                                             151,
-	"This interactive tool creates a new miner actor and creates the basic configuration layer for it.":                                                                                                  125,
-	"This interactive tool migrates lotus-miner to Curio in 5 minutes.":                                                                                                                                  127,
-	"This process is partially idempotent. Once a new miner actor has been created and subsequent steps fail, the user need to run 'curio config new-cluster < miner ID >' to finish the configuration.": 126,
-	"To run Curio: With machine or cgroup isolation, use the command (with example layer selection):":                                                                                                    235,
-	"To start, ensure your sealing pipeline is drained and shut-down lotus-miner.":                                                                                                                       172,
-	"To work with the config: ":                            234,
-	"Try the web interface with %s ":                       138,
+	"The '%s' layer stores common configuration. All curio instances can include it in their %s argument.":                                                                                               166,
+	"The Curio team wants to improve the software you use. Tell the team you're using `%s`.":                                                                                                             152,
+	"This interactive tool creates a new miner actor and creates the basic configuration layer for it.":                                                                                                  126,
+	"This interactive tool migrates lotus-miner to Curio in 5 minutes.":                                                                                                                                  128,
+	"This process is partially idempotent. Once a new miner actor has been created and subsequent steps fail, the user need to run 'curio config new-cluster < miner ID >' to finish the configuration.": 127,
+	"To run Curio: With machine or cgroup isolation, use the command (with example layer selection):":                                                                                                    236,
+	"To start, ensure your sealing pipeline is drained and shut-down lotus-miner.":                                                                                                                       173,
+	"To work with the config: ":                            235,
+	"Try the web interface with %s ":                       139,
 	"Uncordon a machine, resume scheduling":                34,
-	"Unmigratable sectors found. Do you want to continue?": 147,
+	"Unmigratable sectors found. Do you want to continue?": 148,
 	"Use synthetic PoRep":                                  52,
-	"Use the arrow keys to navigate: ↓ ↑ → ← ":             124,
-	"Username: %s":                                    219,
+	"Use the arrow keys to navigate: ↓ ↑ → ← ":             125,
+	"Username: %s":                                    220,
 	"Utility functions for testing":                   105,
 	"Wait for Curio api to come online":               8,
-	"Where should we save your database config file?": 135,
-	"Worker Wallet: %s":                               185,
-	"Yes, continue":                                   148,
-	"You can add other layers for per-machine configuration changes.":             166,
-	"You can now migrate your market node (%s), if applicable.":                   140,
+	"Where should we save your database config file?": 136,
+	"Worker Wallet: %s":                               186,
+	"Yes, continue":                                   149,
+	"You can add other layers for per-machine configuration changes.":             167,
+	"You can now migrate your market node (%s), if applicable.":                   141,
 	"Zen3 and later supports two sectors per thread, set to false for older CPUs": 5,
 	"[SP actor address...]":           32,
-	"[deadline index]":                111,
+	"[deadline index]":                112,
 	"[layer name]":                    24,
 	"[level]":                         40,
 	"[miner address] [sector number]": 103,
@@ -238,7 +239,7 @@ var messageKeyToIndex = map[string]int{
 	"allow overwrite of existing layer if source is a different layer":                   27,
 	"attach local storage path":                                                          89,
 	"comma or space separated list of layers to be interpreted (base is always applied)": 22,
-	"could not get API info for FullNode: %w":                                            145,
+	"could not get API info for FullNode: %w":                                            146,
 	"custom node name":                                                68,
 	"deadline to compute WindowPoSt for ":                             108,
 	"depends on output being a TTY":                                   45,
@@ -266,10 +267,10 @@ var messageKeyToIndex = map[string]int{
 	"maximum fee in FIL user is willing to pay for this message":      59,
 	"only list local storage paths":                                   101,
 	"only run init, then return":                                      65,
-	"partition to compute WindowPoSt for":                             113,
+	"partition to compute WindowPoSt for":                             114,
 	"path group names":                                                97,
 	"path groups allowed to pull data from this path (allow all if not specified)": 98,
-	"path to json file containing storage config":                                  112,
+	"path to json file containing storage config":                                  113,
 	"save the whole config into the layer, not just the diff":                      28,
 	"source config layer":                         26,
 	"start sealing a deal sector early":           50,
@@ -278,7 +279,7 @@ var messageKeyToIndex = map[string]int{
 	"use color in display output":                 44,
 }
 
-var enIndex = []uint32{ // 237 elements
+var enIndex = []uint32{ // 238 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000b, 0x00000042, 0x00000126,
 	0x0000014a, 0x0000025a, 0x000002a6, 0x000002bb,
@@ -310,46 +311,46 @@ var enIndex = []uint32{ // 237 elements
 	0x0000156c, 0x000015b9, 0x000015ca, 0x00001617,
 	0x00001631, 0x0000164a, 0x00001668, 0x0000168a,
 	0x000016aa, 0x000016ce, 0x000016ec, 0x00001760,
-	0x000017e5, 0x0000180d, 0x0000184b, 0x00001917,
-	0x00001928, 0x00001954, 0x00001978, 0x0000199a,
-	0x000019af, 0x000019d3, 0x00001a16, 0x00001a34,
-	0x00001a57, 0x00001a80, 0x00001e06, 0x00001e34,
-	0x00001edc, 0x00001f11, 0x00001f73, 0x00002036,
+	0x000017e5, 0x0000180d, 0x0000182d, 0x0000186b,
+	0x00001937, 0x00001948, 0x00001974, 0x00001998,
+	0x000019ba, 0x000019cf, 0x000019f3, 0x00001a36,
+	0x00001a54, 0x00001a77, 0x00001aa0, 0x00001e26,
+	0x00001e54, 0x00001efc, 0x00001f31, 0x00001f93,
 	// Entry 80 - 9F
-	0x00002078, 0x000020d1, 0x000020ec, 0x000020f7,
-	0x00002119, 0x0000212c, 0x00002146, 0x00002166,
-	0x00002196, 0x000021aa, 0x000021c4, 0x000021ea,
-	0x00002261, 0x0000229e, 0x000022d1, 0x000022f4,
-	0x0000233a, 0x00002353, 0x0000237e, 0x00002399,
-	0x000023ce, 0x000023dc, 0x000023e6, 0x0000241e,
-	0x00002478, 0x000024ab, 0x000024f5, 0x00002536,
-	0x0000256b, 0x00002574, 0x00002595, 0x000025b6,
+	0x00002056, 0x00002098, 0x000020f1, 0x0000210c,
+	0x00002117, 0x00002139, 0x0000214c, 0x00002166,
+	0x00002186, 0x000021b6, 0x000021ca, 0x000021e4,
+	0x0000220a, 0x00002281, 0x000022be, 0x000022f1,
+	0x00002314, 0x0000235a, 0x00002373, 0x0000239e,
+	0x000023b9, 0x000023ee, 0x000023fc, 0x00002406,
+	0x0000243e, 0x00002498, 0x000024cb, 0x00002515,
+	0x00002556, 0x0000258b, 0x00002594, 0x000025b5,
 	// Entry A0 - BF
-	0x000025d6, 0x000025f3, 0x00002610, 0x00002643,
-	0x00002651, 0x00002665, 0x000026d0, 0x00002710,
-	0x00002739, 0x000027b0, 0x00002801, 0x0000282b,
-	0x00002841, 0x0000288e, 0x000028c8, 0x000028ce,
-	0x0000290a, 0x00002936, 0x0000297f, 0x000029bf,
-	0x00002a10, 0x00002a22, 0x00002a3c, 0x00002a5c,
-	0x00002a81, 0x00002a95, 0x00002aaa, 0x00002abf,
-	0x00002ad2, 0x00002b11, 0x00002b3b, 0x00002b53,
+	0x000025d6, 0x000025f6, 0x00002613, 0x00002630,
+	0x00002663, 0x00002671, 0x00002685, 0x000026f0,
+	0x00002730, 0x00002759, 0x000027d0, 0x00002821,
+	0x0000284b, 0x00002861, 0x000028ae, 0x000028e8,
+	0x000028ee, 0x0000292a, 0x00002956, 0x0000299f,
+	0x000029df, 0x00002a30, 0x00002a42, 0x00002a5c,
+	0x00002a7c, 0x00002aa1, 0x00002ab5, 0x00002aca,
+	0x00002adf, 0x00002af2, 0x00002b31, 0x00002b5b,
 	// Entry C0 - DF
-	0x00002b67, 0x00002b8a, 0x00002b9e, 0x00002bb5,
-	0x00002bbc, 0x00002bc3, 0x00002bc9, 0x00002bcf,
-	0x00002bf3, 0x00002c16, 0x00002c3e, 0x00002c5f,
-	0x00002c7a, 0x00002ca3, 0x00002cc5, 0x00002cf7,
-	0x00002d8e, 0x00002db9, 0x00002df1, 0x00002e1a,
-	0x00002e52, 0x00002e93, 0x00002ec3, 0x00002ee6,
-	0x00002f0e, 0x00002f70, 0x00002f7c, 0x00002f88,
-	0x00002f98, 0x00002fa8, 0x00002fb8, 0x00002fdf,
+	0x00002b73, 0x00002b87, 0x00002baa, 0x00002bbe,
+	0x00002bd5, 0x00002bdc, 0x00002be3, 0x00002be9,
+	0x00002bef, 0x00002c13, 0x00002c36, 0x00002c5e,
+	0x00002c7f, 0x00002c9a, 0x00002cc3, 0x00002ce5,
+	0x00002d17, 0x00002dae, 0x00002dd9, 0x00002e11,
+	0x00002e3a, 0x00002e72, 0x00002eb3, 0x00002ee3,
+	0x00002f06, 0x00002f2e, 0x00002f90, 0x00002f9c,
+	0x00002fa8, 0x00002fb8, 0x00002fc8, 0x00002fd8,
 	// Entry E0 - FF
-	0x00003020, 0x00003044, 0x00003055, 0x00003077,
-	0x00003089, 0x000030b6, 0x000030dc, 0x0000313b,
-	0x000031d8, 0x00003226, 0x00003240, 0x0000325e,
-	0x000032be,
-} // Size: 972 bytes
+	0x00002fff, 0x00003040, 0x00003064, 0x00003075,
+	0x00003097, 0x000030a9, 0x000030d6, 0x000030fc,
+	0x0000315b, 0x000031f8, 0x00003246, 0x00003260,
+	0x0000327e, 0x000032de,
+} // Size: 976 bytes
 
-const enData string = "" + // Size: 12990 bytes
+const enData string = "" + // Size: 13022 bytes
 	"\x02Math Utils\x02Analyze and display the layout of batch sealer threads" +
 	"\x02Analyze and display the layout of batch sealer threads on your CPU." +
 	"\x0a\x0aIt provides detailed information about CPU utilization for batch" +
@@ -442,112 +443,113 @@ const enData string = "" + // Size: 12990 bytes
 	"r (requires the sector to be pre-sealed). These will not send to the cha" +
 	"in.\x02Test the windowpost scheduler by running it on the next available" +
 	" curio. If tasks fail all retries, you will need to ctrl+c to exit.\x04" +
-	"\x00\x01 #\x02deadline to compute WindowPoSt for\x02Compute WindowPoSt f" +
-	"or performance and configuration testing.\x02Note: This command is inten" +
-	"ded to be used to verify PoSt compute performance.\x0aIt will not send a" +
-	"ny messages to the chain. Since it can compute any deadline, output may " +
-	"be incorrectly timed for the chain.\x02[deadline index]\x02path to json " +
-	"file containing storage config\x02partition to compute WindowPoSt for" +
-	"\x02Collection of debugging utilities\x02Manage unsealed data\x02Get inf" +
-	"ormation about unsealed data\x02List data from the sectors_unseal_pipeli" +
-	"ne and sectors_meta tables\x02Filter by storage provider ID\x02Output fi" +
-	"le path (default: stdout)\x02Set the target unseal state for a sector" +
-	"\x04\x00\x01\x0a\x80\x07\x02Set the target unseal state for a specific s" +
-	"ector.\x0a   <miner-id>: The storage provider ID\x0a   <sector-number>: " +
-	"The sector number\x0a   <target-state>: The target state (true, false, o" +
-	"r none)\x0a\x0a   The unseal target state indicates to curio how an unse" +
-	"aled copy of the sector should be maintained.\x0a\x09   If the target st" +
-	"ate is true, curio will ensure that the sector is unsealed.\x0a\x09   If" +
-	" the target state is false, curio will ensure that there is no unsealed " +
-	"copy of the sector.\x0a\x09   If the target state is none, curio will no" +
-	"t change the current state of the sector.\x0a\x0a   Currently when the c" +
-	"urio will only start new unseal processes when the target state changes " +
-	"from another state to true.\x0a\x0a   When the target state is false, an" +
-	"d an unsealed sector file exists, the GC mark step will create a removal" +
-	" mark\x0a   for the unsealed sector file. The file will only be removed " +
-	"after the removal mark is accepted.\x02Check data integrity in unsealed " +
-	"sector files\x02Create a check task for a specific sector, wait for its " +
-	"completion, and output the result.\x0a   <miner-id>: The storage provide" +
-	"r ID\x0a   <sector-number>: The sector number\x04\x00\x01 0\x02Use the a" +
-	"rrow keys to navigate: ↓ ↑ → ←\x02This interactive tool creates a new mi" +
-	"ner actor and creates the basic configuration layer for it.\x02This proc" +
-	"ess is partially idempotent. Once a new miner actor has been created and" +
-	" subsequent steps fail, the user need to run 'curio config new-cluster <" +
-	" miner ID >' to finish the configuration.\x02This interactive tool migra" +
-	"tes lotus-miner to Curio in 5 minutes.\x02Each step needs your confirmat" +
-	"ion and can be reversed. Press Ctrl+C to exit at any time.\x02Ctrl+C pre" +
-	"ssed in Terminal\x02I want to:\x02Migrate from existing Lotus-Miner\x02C" +
-	"reate a new miner\x02Aborting remaining steps.\x02Lotus-Miner to Curio M" +
-	"igration.\x02Where should we save your database config file?\x02Aborting" +
-	" migration.\x02Error writing file: %[1]s\x04\x00\x01 !\x02Try the web in" +
-	"terface with %[1]s\x02For more servers, make /etc/curio.env with the cur" +
-	"io.env database env and add the CURIO_LAYERS env to assign purposes.\x02" +
-	"You can now migrate your market node (%[1]s), if applicable.\x02Addition" +
-	"al info is at http://docs.curiostorage.org\x02New Miner initialization c" +
-	"omplete.\x02Migrating lotus-miner config.toml to Curio in-database confi" +
-	"guration.\x02Error getting API: %[1]s\x02could not get API info for Full" +
-	"Node: %[1]w\x02Error getting token: %[1]s\x02Unmigratable sectors found." +
-	" Do you want to continue?\x02Yes, continue\x02No, abort\x02Error saving " +
-	"config to layer: %[1]s. Aborting Migration\x02The Curio team wants to im" +
-	"prove the software you use. Tell the team you're using `%[1]s`.\x02Selec" +
-	"t what you want to share with the Curio team.\x02Individual Data: Miner " +
-	"ID, Curio version, chain (%[1]s or %[2]s). Signed.\x02Aggregate-Anonymou" +
-	"s: version, chain, and Miner power (bucketed).\x02Hint: I am someone run" +
-	"ning Curio on whichever chain.\x02Nothing.\x02Error getting miner power:" +
-	" %[1]s\x02Error marshalling message: %[1]s\x02Error getting miner info: " +
-	"%[1]s\x02Error signing message: %[1]s\x02Error sending message: %[1]s" +
-	"\x04\x00\x01 .\x02Error sending message: Status %[1]s, Message:\x02Messa" +
-	"ge sent.\x04\x00\x01 \x0f\x02Documentation:\x02The '%[1]s' layer stores " +
-	"common configuration. All curio instances can include it in their %[2]s " +
-	"argument.\x02You can add other layers for per-machine configuration chan" +
-	"ges.\x02Filecoin %[1]s channels: %[2]s and %[3]s\x02Increase reliability" +
-	" using redundancy: start multiple machines with at-least the post layer:" +
-	" 'curio run --layers=post'\x02One database can serve multiple miner IDs:" +
-	" Run a migration for each lotus-miner.\x02Connected to Yugabyte. Schema " +
-	"is current.\x02Connected to Yugabyte\x02To start, ensure your sealing pi" +
-	"peline is drained and shut-down lotus-miner.\x02Select the location of y" +
-	"our lotus-miner config directory?\x02Other\x02Enter the path to the conf" +
-	"iguration directory used by %[1]s\x04\x00\x01 '\x02No path provided, aba" +
-	"ndoning migration\x02Cannot read the config.toml file in the provided di" +
-	"rectory, Error: %[1]s\x02Could not create repo from directory: %[1]s. Ab" +
-	"orting migration\x02Could not lock miner repo. Your miner must be stoppe" +
-	"d: %[1]s\x0a Aborting migration\x02Read Miner Config\x04\x00\x01\x0a\x15" +
-	"\x02Step Complete: %[1]s\x02Initializing a new miner actor.\x02Enter the" +
-	" info to create a new miner\x02Owner Wallet: %[1]s\x02Worker Wallet: %[1" +
-	"]s\x02Sender Wallet: %[1]s\x02Sector Size: %[1]s\x02Continue to verify t" +
-	"he addresses and create a new miner actor.\x04\x00\x01 %\x02Miner creati" +
-	"on error occurred: %[1]s\x02Enter the owner address\x02No address provid" +
-	"ed\x02Failed to parse the address: %[1]s\x02Enter %[1]s address\x02Selec" +
-	"t the Sector Size\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1f" +
-	"\x02Sector selection failed: %[1]s\x02Failed to parse sector size: %[1]s" +
-	"\x02Failed to create the miner actor: %[1]s\x02Miner %[1]s created succe" +
-	"ssfully\x02Cannot reach the DB: %[1]s\x02Error connecting to full node A" +
-	"PI: %[1]s\x02Pre-initialization steps complete\x02Failed to generate ran" +
-	"dom bytes for secret: %[1]s\x02Please do not run guided-setup again as m" +
-	"iner creation is not idempotent. You need to run 'curio config new-clust" +
-	"er %[1]s' to finish the configuration\x02Failed to get API info for Full" +
-	"Node: %[1]w\x02Failed to verify the auth token from daemon node: %[1]s" +
-	"\x02Failed to generate default config: %[1]s\x02Failed to insert 'base' " +
-	"config layer in database: %[1]s\x02Configuration 'base' was updated to i" +
-	"nclude this miner's address\x02Failed to load base config from database:" +
-	" %[1]s\x02Failed to parse base config: %[1]s\x02Failed to regenerate bas" +
-	"e config: %[1]s\x02Enter the info to connect to your Yugabyte database i" +
-	"nstallation (https://download.yugabyte.com/)\x02Host: %[1]s\x02Port: %[1" +
-	"]s\x02Username: %[1]s\x02Password: %[1]s\x02Database: %[1]s\x02Continue " +
-	"to connect and update schema.\x04\x00\x01 <\x02Database config error occ" +
-	"urred, abandoning migration: %[1]s\x02Enter the Yugabyte database host(s" +
-	")\x02No host provided\x02Enter the Yugabyte database %[1]s\x02No value p" +
-	"rovided\x02Error connecting to Yugabyte database: %[1]s\x02Migrating met" +
-	"adata for %[1]d sectors.\x02Configuration 'base' was updated to include " +
-	"this miner's address (%[1]s) and its wallet setup.\x02Compare the config" +
-	"urations %[1]s to %[2]s. Changes between the miner IDs other than wallet" +
-	" addreses should be a new, minimal layer for runners that need it.\x02Co" +
-	"nfiguration 'base' was created to resemble this lotus-miner's config.tom" +
-	"l .\x04\x00\x01 \x15\x02Layer %[1]s created.\x04\x00\x01 \x19\x02To work" +
-	" with the config:\x02To run Curio: With machine or cgroup isolation, use" +
-	" the command (with example layer selection):"
+	"\x00\x01 #\x02deadline to compute WindowPoSt for\x02SP ID to compute Win" +
+	"dowPoSt for\x02Compute WindowPoSt for performance and configuration test" +
+	"ing.\x02Note: This command is intended to be used to verify PoSt compute" +
+	" performance.\x0aIt will not send any messages to the chain. Since it ca" +
+	"n compute any deadline, output may be incorrectly timed for the chain." +
+	"\x02[deadline index]\x02path to json file containing storage config\x02p" +
+	"artition to compute WindowPoSt for\x02Collection of debugging utilities" +
+	"\x02Manage unsealed data\x02Get information about unsealed data\x02List " +
+	"data from the sectors_unseal_pipeline and sectors_meta tables\x02Filter " +
+	"by storage provider ID\x02Output file path (default: stdout)\x02Set the " +
+	"target unseal state for a sector\x04\x00\x01\x0a\x80\x07\x02Set the targ" +
+	"et unseal state for a specific sector.\x0a   <miner-id>: The storage pro" +
+	"vider ID\x0a   <sector-number>: The sector number\x0a   <target-state>: " +
+	"The target state (true, false, or none)\x0a\x0a   The unseal target stat" +
+	"e indicates to curio how an unsealed copy of the sector should be mainta" +
+	"ined.\x0a\x09   If the target state is true, curio will ensure that the " +
+	"sector is unsealed.\x0a\x09   If the target state is false, curio will e" +
+	"nsure that there is no unsealed copy of the sector.\x0a\x09   If the tar" +
+	"get state is none, curio will not change the current state of the sector" +
+	".\x0a\x0a   Currently when the curio will only start new unseal processe" +
+	"s when the target state changes from another state to true.\x0a\x0a   Wh" +
+	"en the target state is false, and an unsealed sector file exists, the GC" +
+	" mark step will create a removal mark\x0a   for the unsealed sector file" +
+	". The file will only be removed after the removal mark is accepted.\x02C" +
+	"heck data integrity in unsealed sector files\x02Create a check task for " +
+	"a specific sector, wait for its completion, and output the result.\x0a  " +
+	" <miner-id>: The storage provider ID\x0a   <sector-number>: The sector n" +
+	"umber\x04\x00\x01 0\x02Use the arrow keys to navigate: ↓ ↑ → ←\x02This i" +
+	"nteractive tool creates a new miner actor and creates the basic configur" +
+	"ation layer for it.\x02This process is partially idempotent. Once a new " +
+	"miner actor has been created and subsequent steps fail, the user need to" +
+	" run 'curio config new-cluster < miner ID >' to finish the configuration" +
+	".\x02This interactive tool migrates lotus-miner to Curio in 5 minutes." +
+	"\x02Each step needs your confirmation and can be reversed. Press Ctrl+C " +
+	"to exit at any time.\x02Ctrl+C pressed in Terminal\x02I want to:\x02Migr" +
+	"ate from existing Lotus-Miner\x02Create a new miner\x02Aborting remainin" +
+	"g steps.\x02Lotus-Miner to Curio Migration.\x02Where should we save your" +
+	" database config file?\x02Aborting migration.\x02Error writing file: %[1" +
+	"]s\x04\x00\x01 !\x02Try the web interface with %[1]s\x02For more servers" +
+	", make /etc/curio.env with the curio.env database env and add the CURIO_" +
+	"LAYERS env to assign purposes.\x02You can now migrate your market node (" +
+	"%[1]s), if applicable.\x02Additional info is at http://docs.curiostorage" +
+	".org\x02New Miner initialization complete.\x02Migrating lotus-miner conf" +
+	"ig.toml to Curio in-database configuration.\x02Error getting API: %[1]s" +
+	"\x02could not get API info for FullNode: %[1]w\x02Error getting token: %" +
+	"[1]s\x02Unmigratable sectors found. Do you want to continue?\x02Yes, con" +
+	"tinue\x02No, abort\x02Error saving config to layer: %[1]s. Aborting Migr" +
+	"ation\x02The Curio team wants to improve the software you use. Tell the " +
+	"team you're using `%[1]s`.\x02Select what you want to share with the Cur" +
+	"io team.\x02Individual Data: Miner ID, Curio version, chain (%[1]s or %[" +
+	"2]s). Signed.\x02Aggregate-Anonymous: version, chain, and Miner power (b" +
+	"ucketed).\x02Hint: I am someone running Curio on whichever chain.\x02Not" +
+	"hing.\x02Error getting miner power: %[1]s\x02Error marshalling message: " +
+	"%[1]s\x02Error getting miner info: %[1]s\x02Error signing message: %[1]s" +
+	"\x02Error sending message: %[1]s\x04\x00\x01 .\x02Error sending message:" +
+	" Status %[1]s, Message:\x02Message sent.\x04\x00\x01 \x0f\x02Documentati" +
+	"on:\x02The '%[1]s' layer stores common configuration. All curio instance" +
+	"s can include it in their %[2]s argument.\x02You can add other layers fo" +
+	"r per-machine configuration changes.\x02Filecoin %[1]s channels: %[2]s a" +
+	"nd %[3]s\x02Increase reliability using redundancy: start multiple machin" +
+	"es with at-least the post layer: 'curio run --layers=post'\x02One databa" +
+	"se can serve multiple miner IDs: Run a migration for each lotus-miner." +
+	"\x02Connected to Yugabyte. Schema is current.\x02Connected to Yugabyte" +
+	"\x02To start, ensure your sealing pipeline is drained and shut-down lotu" +
+	"s-miner.\x02Select the location of your lotus-miner config directory?" +
+	"\x02Other\x02Enter the path to the configuration directory used by %[1]s" +
+	"\x04\x00\x01 '\x02No path provided, abandoning migration\x02Cannot read " +
+	"the config.toml file in the provided directory, Error: %[1]s\x02Could no" +
+	"t create repo from directory: %[1]s. Aborting migration\x02Could not loc" +
+	"k miner repo. Your miner must be stopped: %[1]s\x0a Aborting migration" +
+	"\x02Read Miner Config\x04\x00\x01\x0a\x15\x02Step Complete: %[1]s\x02Ini" +
+	"tializing a new miner actor.\x02Enter the info to create a new miner\x02" +
+	"Owner Wallet: %[1]s\x02Worker Wallet: %[1]s\x02Sender Wallet: %[1]s\x02S" +
+	"ector Size: %[1]s\x02Continue to verify the addresses and create a new m" +
+	"iner actor.\x04\x00\x01 %\x02Miner creation error occurred: %[1]s\x02Ent" +
+	"er the owner address\x02No address provided\x02Failed to parse the addre" +
+	"ss: %[1]s\x02Enter %[1]s address\x02Select the Sector Size\x0264 GiB\x02" +
+	"32 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1f\x02Sector selection failed: %[" +
+	"1]s\x02Failed to parse sector size: %[1]s\x02Failed to create the miner " +
+	"actor: %[1]s\x02Miner %[1]s created successfully\x02Cannot reach the DB:" +
+	" %[1]s\x02Error connecting to full node API: %[1]s\x02Pre-initialization" +
+	" steps complete\x02Failed to generate random bytes for secret: %[1]s\x02" +
+	"Please do not run guided-setup again as miner creation is not idempotent" +
+	". You need to run 'curio config new-cluster %[1]s' to finish the configu" +
+	"ration\x02Failed to get API info for FullNode: %[1]w\x02Failed to verify" +
+	" the auth token from daemon node: %[1]s\x02Failed to generate default co" +
+	"nfig: %[1]s\x02Failed to insert 'base' config layer in database: %[1]s" +
+	"\x02Configuration 'base' was updated to include this miner's address\x02" +
+	"Failed to load base config from database: %[1]s\x02Failed to parse base " +
+	"config: %[1]s\x02Failed to regenerate base config: %[1]s\x02Enter the in" +
+	"fo to connect to your Yugabyte database installation (https://download.y" +
+	"ugabyte.com/)\x02Host: %[1]s\x02Port: %[1]s\x02Username: %[1]s\x02Passwo" +
+	"rd: %[1]s\x02Database: %[1]s\x02Continue to connect and update schema." +
+	"\x04\x00\x01 <\x02Database config error occurred, abandoning migration: " +
+	"%[1]s\x02Enter the Yugabyte database host(s)\x02No host provided\x02Ente" +
+	"r the Yugabyte database %[1]s\x02No value provided\x02Error connecting t" +
+	"o Yugabyte database: %[1]s\x02Migrating metadata for %[1]d sectors.\x02C" +
+	"onfiguration 'base' was updated to include this miner's address (%[1]s) " +
+	"and its wallet setup.\x02Compare the configurations %[1]s to %[2]s. Chan" +
+	"ges between the miner IDs other than wallet addreses should be a new, mi" +
+	"nimal layer for runners that need it.\x02Configuration 'base' was create" +
+	"d to resemble this lotus-miner's config.toml .\x04\x00\x01 \x15\x02Layer" +
+	" %[1]s created.\x04\x00\x01 \x19\x02To work with the config:\x02To run C" +
+	"urio: With machine or cgroup isolation, use the command (with example la" +
+	"yer selection):"
 
-var koIndex = []uint32{ // 237 elements
+var koIndex = []uint32{ // 238 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000014, 0x0000004e, 0x00000168,
 	0x00000181, 0x000002b1, 0x00000328, 0x0000033a,
@@ -579,46 +581,46 @@ var koIndex = []uint32{ // 237 elements
 	0x00001914, 0x0000197c, 0x00001991, 0x000019f9,
 	0x00001a1b, 0x00001a3d, 0x00001a62, 0x00001a8d,
 	0x00001ab0, 0x00001ad9, 0x00001afa, 0x00001b70,
-	0x00001c1a, 0x00001c3e, 0x00001c77, 0x00001d69,
-	0x00001d7c, 0x00001dba, 0x00001ddc, 0x00001dfa,
-	0x00001e18, 0x00001e4a, 0x00001e91, 0x00001eb8,
-	0x00001ee8, 0x00001f11, 0x000022f1, 0x00002327,
-	0x000023db, 0x0000241f, 0x0000249c, 0x0000259c,
+	0x00001c1a, 0x00001c3e, 0x00001c60, 0x00001c99,
+	0x00001d8b, 0x00001d9e, 0x00001ddc, 0x00001dfe,
+	0x00001e1c, 0x00001e3a, 0x00001e6c, 0x00001eb3,
+	0x00001eda, 0x00001f0a, 0x00001f33, 0x00002313,
+	0x00002349, 0x000023fd, 0x00002441, 0x000024be,
 	// Entry 80 - 9F
-	0x000025e9, 0x00002664, 0x00002685, 0x00002697,
-	0x000026c0, 0x000026db, 0x00002700, 0x00002723,
-	0x00002769, 0x00002784, 0x000027a0, 0x000027df,
-	0x00002895, 0x000028e5, 0x00002925, 0x0000294b,
-	0x000029a4, 0x000029c3, 0x000029ff, 0x00002a2f,
-	0x00002a7f, 0x00002a8b, 0x00002a9d, 0x00002af5,
-	0x00002b81, 0x00002bba, 0x00002c10, 0x00002c4e,
-	0x00002c9c, 0x00002cb7, 0x00002cf1, 0x00002d24,
+	0x000025be, 0x0000260b, 0x00002686, 0x000026a7,
+	0x000026b9, 0x000026e2, 0x000026fd, 0x00002722,
+	0x00002745, 0x0000278b, 0x000027a6, 0x000027c2,
+	0x00002801, 0x000028b7, 0x00002907, 0x00002947,
+	0x0000296d, 0x000029c6, 0x000029e5, 0x00002a21,
+	0x00002a51, 0x00002aa1, 0x00002aad, 0x00002abf,
+	0x00002b17, 0x00002ba3, 0x00002bdc, 0x00002c32,
+	0x00002c70, 0x00002cbe, 0x00002cd9, 0x00002d13,
 	// Entry A0 - BF
-	0x00002d5e, 0x00002d88, 0x00002db2, 0x00002df4,
-	0x00002e18, 0x00002e25, 0x00002eab, 0x00002efd,
-	0x00002f24, 0x00002fc0, 0x00003052, 0x00003093,
-	0x000030a9, 0x00003114, 0x00003163, 0x0000316a,
-	0x000031b2, 0x00003204, 0x0000325e, 0x000032c8,
-	0x00003359, 0x00003371, 0x0000338b, 0x000033af,
-	0x000033e2, 0x000033fa, 0x00003412, 0x0000342a,
-	0x0000343f, 0x00003496, 0x000034c1, 0x000034d9,
+	0x00002d46, 0x00002d80, 0x00002daa, 0x00002dd4,
+	0x00002e16, 0x00002e3a, 0x00002e47, 0x00002ecd,
+	0x00002f1f, 0x00002f46, 0x00002fe2, 0x00003074,
+	0x000030b5, 0x000030cb, 0x00003136, 0x00003185,
+	0x0000318c, 0x000031d4, 0x00003226, 0x00003280,
+	0x000032ea, 0x0000337b, 0x00003393, 0x000033ad,
+	0x000033d1, 0x00003404, 0x0000341c, 0x00003434,
+	0x0000344c, 0x00003461, 0x000034b8, 0x000034e3,
 	// Entry C0 - DF
-	0x00003500, 0x00003523, 0x00003537, 0x0000354c,
-	0x00003553, 0x0000355a, 0x00003560, 0x00003566,
-	0x00003587, 0x000035b1, 0x000035d7, 0x00003610,
-	0x00003648, 0x00003680, 0x0000369f, 0x000036eb,
-	0x000037a9, 0x000037f5, 0x00003843, 0x00003866,
-	0x000038c2, 0x00003912, 0x00003967, 0x000039aa,
-	0x000039e9, 0x00003a57, 0x00003a68, 0x00003a76,
-	0x00003a8e, 0x00003aa2, 0x00003abc, 0x00003ae6,
+	0x000034fb, 0x00003522, 0x00003545, 0x00003559,
+	0x0000356e, 0x00003575, 0x0000357c, 0x00003582,
+	0x00003588, 0x000035a9, 0x000035d3, 0x000035f9,
+	0x00003632, 0x0000366a, 0x000036a2, 0x000036c1,
+	0x0000370d, 0x000037cb, 0x00003817, 0x00003865,
+	0x00003888, 0x000038e4, 0x00003934, 0x00003989,
+	0x000039cc, 0x00003a0b, 0x00003a79, 0x00003a8a,
+	0x00003a98, 0x00003ab0, 0x00003ac4, 0x00003ade,
 	// Entry E0 - FF
-	0x00003b49, 0x00003b85, 0x00003baf, 0x00003be7,
-	0x00003c0b, 0x00003c5f, 0x00003c97, 0x00003d10,
-	0x00003dca, 0x00003e21, 0x00003e50, 0x00003e77,
-	0x00003f03,
-} // Size: 972 bytes
+	0x00003b08, 0x00003b6b, 0x00003ba7, 0x00003bd1,
+	0x00003c09, 0x00003c2d, 0x00003c81, 0x00003cb9,
+	0x00003d32, 0x00003dec, 0x00003e43, 0x00003e72,
+	0x00003e99, 0x00003f25,
+} // Size: 976 bytes
 
-const koData string = "" + // Size: 16131 bytes
+const koData string = "" + // Size: 16165 bytes
 	"\x02수학 유틸리티\x02배치 실러 스레드의 레이아웃 분석 및 표시\x02CPU에서 배치 실러 스레드의 레이아웃을 분석하고 표시" +
 	"합니다.\x0a\x0a이 작업은 배치 실링 작업의 CPU 사용량에 대한 자세한 정보를 제공하며, 여기에는 코어 할당 및 다양한" +
 	" 배치 크기에 대한 스레드 분포가 포함됩니다.\x02supra_seal 구성 생성\x02주어진 배치 크기에 대한 supra_sea" +
@@ -674,79 +676,79 @@ const koData string = "" + // Size: 16131 bytes
 	"] [섹터 번호]\x02섹터에 대한 바닐라 증명 생성\x02테스트용 유틸리티 기능\x02섹터에 대한 증명 계산 (섹터가 사전 실링" +
 	"되어야 함). 이는 체인으로 전송되지 않습니다.\x02다음 사용 가능한 Curio에서 windowpost 스케줄러를 실행하여 " +
 	"테스트합니다. 모든 재시도가 실패하면 ctrl+c를 눌러 종료해야 합니다.\x04\x00\x01 \x1f\x02WindowPo" +
-	"St를 계산할 기한\x02성능 및 구성 테스트를 위한 WindowPoSt 계산.\x02참고: 이 명령은 PoSt 계산 성능을 검증" +
-	"하기 위해 사용됩니다.\x0a체인으로 메시지를 전송하지 않습니다. 모든 기한을 계산할 수 있으므로 출력이 체인과 부정확하게 일" +
-	"치할 수 있습니다.\x02[기한 인덱스]\x02스토리지 구성 파일이 포함된 JSON 파일의 경로\x02WindowPoSt를 계" +
-	"산할 파티션\x02디버깅 유틸리티 모음\x02미봉인 데이터를 관리\x02미봉인 데이터에 대한 정보 가져오기\x02sectors" +
-	"_unseal_pipeline 및 sectors_meta 테이블의 데이터 나열\x02스토리지 제공자 ID로 필터링\x02출력 파일" +
-	" 경로 (기본값: 표준 출력)\x02섹터의 목표 미봉인 상태 설정\x04\x00\x01\x0a\xda\x07\x02특정 섹터의 목" +
-	"표 미봉인 상태를 설정합니다.\x0a   <miner-id>: 스토리지 제공자 ID\x0a   <sector-number>: " +
-	"섹터 번호\x0a   <target-state>: 목표 상태 (true, false, none 중 하나)\x0a\x0a   미" +
-	"봉인 목표 상태는 Curio가 섹터의 미봉인 복사본을 어떻게 유지할지를 나타냅니다.\x0a\x09   목표 상태가 true이면" +
-	" Curio는 섹터가 미봉인 상태로 유지되도록 보장합니다.\x0a\x09   목표 상태가 false이면 Curio는 섹터에 미봉인" +
-	" 복사본이 없도록 보장합니다.\x0a\x09   목표 상태가 none이면 Curio는 섹터의 현재 상태를 변경하지 않습니다." +
-	"\x0a\x0a   현재, 목표 상태가 다른 상태에서 true로 변경될 때만 Curio는 새로운 미봉인 프로세스를 시작합니다." +
-	"\x0a\x0a   목표 상태가 false이고 미봉인 섹터 파일이 존재하는 경우, GC 마크 단계는 미봉인 섹터 파일에 대한 제거" +
-	" 마크를 생성합니다. 파일은 제거 마크가 승인된 후에만 제거됩니다.\x02미봉인 섹터 파일의 데이터 무결성 확인\x02특정 섹터에" +
-	" 대한 검사 작업을 생성하고 완료를 기다린 후 결과를 출력합니다.\x0a   <miner-id>: 스토리지 제공자 ID\x0a  " +
-	" <sector-number>: 섹터 번호\x04\x00\x01 ?\x02화살표 키를 사용하여 이동하세요: ↓ ↑ → ←\x02이" +
-	" 대화형 도구는 새로운 채굴자 액터를 생성하고 그에 대한 기본 구성 레이어를 생성합니다.\x02이 프로세스는 부분적으로 항등원적입" +
-	"니다. 새로운 채굴자 액터가 생성되었고 후속 단계가 실패하는 경우 사용자는 구성을 완료하기 위해 'curio config ne" +
-	"w-cluster < 채굴자 ID >'를 실행해야 합니다.\x02이 대화형 도구는 5분 안에 lotus-miner를 Curio로 " +
-	"이주합니다.\x02각 단계는 확인이 필요하며 되돌릴 수 있습니다. 언제든지 Ctrl+C를 눌러 종료할 수 있습니다.\x02터미" +
-	"널에서 Ctrl+C가 눌림\x02나는 원한다:\x02기존의 Lotus-Miner에서 이전하기\x02새로운 채굴자 생성\x02나" +
-	"머지 단계를 중단합니다.\x02Lotus-Miner에서 Curio로 이주.\x02데이터베이스 구성 파일을 어디에 저장해야 하나" +
-	"요?\x02마이그레이션 중단.\x02파일 쓰기 오류: %[1]s\x04\x00\x01 :\x02%[1]s와 함께 웹 인터페이스" +
-	"를 시도해보세요\x02더 많은 서버를 위해 /etc/curio.env 파일을 curio.env 데이터베이스 환경으로 만들고 목" +
-	"적을 할당하기 위해 CURIO_LAYERS 환경 변수를 추가하세요.\x02해당하는 경우 이제 시장 노드를 이주할 수 있습니다 " +
-	"(%[1]s).\x02추가 정보는 http://docs.curiostorage.org 에 있습니다.\x02새로운 채굴자 초기화 완" +
-	"료.\x02lotus-miner config.toml을 Curio의 데이터베이스 구성으로 이전 중입니다.\x02API 가져오기" +
-	" 오류: %[1]s\x02FullNode의 API 정보를 가져올 수 없습니다: %[1]w\x02토큰을 가져오는 중 오류 발생: %" +
-	"[1]s\x02이동할 수 없는 섹터가 발견되었습니다. 계속하시겠습니까?\x02예, 계속\x02아니오, 중단\x02레이어에 구성을 " +
-	"저장하는 중 오류 발생: %[1]s. 마이그레이션 중단\x02Curio 팀은 당신이 사용하는 소프트웨어를 개선하고자 합니다. " +
-	"팀에게 `%[1]s`를 사용 중이라고 알려주세요.\x02Curio 팀과 공유하고 싶은 것을 선택하세요.\x02개별 데이터: 채" +
-	"굴자 ID, Curio 버전, 체인 (%[1]s 또는 %[2]s). 서명됨.\x02집계-익명: 버전, 체인, 및 채굴자 파워 " +
-	"(버킷).\x02힌트: 나는 어떤 체인에서든 Curio를 실행 중인 사람입니다.\x02아무것도 없습니다.\x02마이너 파워를 가져" +
-	"오는 중 오류 발생: %[1]s\x02메시지를 마샬하는 중 오류 발생: %[1]s\x02마이너 정보를 가져오는 중 오류 발생:" +
-	" %[1]s\x02메시지 서명 중 오류 발생: %[1]s\x02메시지 전송 중 오류 발생: %[1]s\x04\x00\x01 =" +
-	"\x02메시지 전송 중 오류 발생: 상태 %[1]s, 메시지:\x02메시지가 전송되었습니다.\x04\x00\x01 \x08\x02" +
-	"문서:\x02'%[1]s' 레이어에는 공통 구성이 저장됩니다. 모든 Curio 인스턴스는 %[2]s 인수에 포함시킬 수 있습니" +
-	"다.\x02기계별 구성 변경을 위해 다른 레이어를 추가할 수 있습니다.\x02Filecoin %[1]s 채널: %[2]s 및 " +
-	"%[3]s\x02신뢰성 향상을 위한 중복성 사용: 적어도 post 레이어를 사용하여 여러 대의 기계를 시작하십시오: 'curio " +
-	"run --layers=post'\x02한 개의 데이터베이스는 여러 광부 ID를 제공할 수 있습니다: 각 lotus-miner에 " +
-	"대해 마이그레이션을 실행하세요.\x02Yugabyte에 연결되었습니다. 스키마가 현재입니다.\x02Yugabyte에 연결됨" +
-	"\x02시작하려면 밀봉 파이프라인이 비어 있고 lotus-miner가 종료되었는지 확인하세요.\x02로터스 마이너 구성 디렉토리의" +
-	" 위치를 선택하시겠습니까?\x02기타\x02%[1]s에서 사용하는 구성 디렉터리 경로를 입력하세요.\x04\x00\x01 M" +
-	"\x02경로가 제공되지 않았으므로 마이그레이션을 포기합니다\x02제공된 디렉토리에서 config.toml 파일을 읽을 수 없습니다" +
-	". 오류: %[1]s\x02디렉토리에서 저장소를 생성할 수 없습니다: %[1]s. 마이그레이션을 중단합니다.\x02광부 저장소를 " +
-	"잠금 해제할 수 없습니다. 귀하의 광부를 중지해야 합니다: %[1]s\x0a 마이그레이션을 중단합니다.\x02마이너 구성 읽기" +
-	"\x04\x00\x01\x0a\x15\x02단계 완료: %[1]s\x02새 채굴자 액터 초기화 중.\x02새 채굴자를 생성하기 위" +
-	"한 정보 입력\x02소유자 지갑: %[1]s\x02작업자 지갑: %[1]s\x02발송자 지갑: %[1]s\x02섹터 크기: %" +
-	"[1]s\x02주소를 확인하고 새 채굴자 액터를 생성하려면 계속 진행하세요.\x04\x00\x01 &\x02채굴자 생성 오류 발생" +
-	": %[1]s\x02소유자 주소 입력\x02주소가 제공되지 않았습니다\x02주소 구문 분석 실패: %[1]s\x02%[1]s 주소" +
-	" 입력\x02섹터 크기 선택\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1c" +
-	"\x02섹터 선택 실패: %[1]s\x02섹터 크기 구문 분석 실패: %[1]s\x02채굴자 액터 생성 실패: %[1]s\x02%" +
-	"[1]s 채굴자가 성공적으로 생성되었습니다\x02데이터베이스에 연결할 수 없습니다: %[1]s\x02풀 노드 API에 연결하는 중" +
-	" 오류 발생: %[1]s\x02사전 초기화 단계 완료\x02비밀번호를 위한 랜덤 바이트 생성에 실패했습니다: %[1]s\x02마이" +
-	"너 생성은 idempotent하지 않으므로 가이드 설정을 다시 실행하지 마십시오. 구성을 완료하려면 'curio config " +
-	"new-cluster %[1]s'를 실행해야 합니다.\x02FullNode에 대한 API 정보를 가져오는 데 실패했습니다: %[1" +
-	"]w\x02데몬 노드로부터 인증 토큰을 확인하는 중 오류 발생: %[1]s\x02기본 구성 생성 실패: %[1]s\x02데이터베이" +
-	"스에 'base' 구성 레이어를 삽입하는 데 실패했습니다: %[1]s\x02이 마이너 주소를 포함한 구성 'base'가 업데이" +
-	"트되었습니다.\x02데이터베이스에서 기본 구성을 로드하는 데 실패했습니다: %[1]s\x02기본 구성을 구문 분석하는 데 실패" +
-	"했습니다: %[1]s\x02기본 구성을 재생성하는 데 실패했습니다: %[1]s\x02Yugabyte 데이터베이스 설치에 연결할" +
-	" 정보를 입력하십시오 (https://download.yugabyte.com/)\x02호스트: %[1]s\x02포트: %[1]s" +
-	"\x02사용자 이름: %[1]s\x02비밀번호: %[1]s\x02데이터베이스: %[1]s\x02계속 연결 및 스키마 업데이트." +
-	"\x04\x00\x01 ^\x02데이터베이스 구성 오류가 발생하여 마이그레이션을 포기합니다: %[1]s\x02Yugabyte 데이" +
-	"터베이스 호스트를 입력하십시오\x02호스트가 제공되지 않았습니다\x02Yugabyte 데이터베이스 %[1]s을 입력하십시오" +
-	"\x02값이 제공되지 않았습니다\x02Yugabyte 데이터베이스에 연결하는 중 오류가 발생했습니다: %[1]s\x02%[1]d " +
-	"섹터의 메타데이터를 이동 중입니다.\x02기본 설정 'base'가 이 마이너의 주소(%[1]s) 및 지갑 설정을 포함하도록 업" +
-	"데이트되었습니다.\x02구성 %[1]s를 %[2]s과 비교하세요. 지갑 주소 이외의 마이너 ID 사이의 변경 사항은 필요한 실" +
-	"행자를 위한 새로운 최소한의 레이어여야 합니다.\x02'base' 설정이 이 lotus-miner의 config.toml과 유" +
-	"사하게 만들어졌습니다.\x04\x00\x01 *\x02레이어 %[1]s가 생성되었습니다.\x04\x00\x01 \x22\x02" +
-	"구성 파일을 사용하려면:\x02Curio를 실행하려면: 기계 또는 cgroup 격리를 사용하여 다음 명령을 사용하세요 (예제 " +
-	"레이어 선택과 함께):"
+	"St를 계산할 기한\x02WindowPoSt 계산을 위한 SP ID\x02성능 및 구성 테스트를 위한 WindowPoSt 계산." +
+	"\x02참고: 이 명령은 PoSt 계산 성능을 검증하기 위해 사용됩니다.\x0a체인으로 메시지를 전송하지 않습니다. 모든 기한을 " +
+	"계산할 수 있으므로 출력이 체인과 부정확하게 일치할 수 있습니다.\x02[기한 인덱스]\x02스토리지 구성 파일이 포함된 JS" +
+	"ON 파일의 경로\x02WindowPoSt를 계산할 파티션\x02디버깅 유틸리티 모음\x02미봉인 데이터를 관리\x02미봉인 데이" +
+	"터에 대한 정보 가져오기\x02sectors_unseal_pipeline 및 sectors_meta 테이블의 데이터 나열" +
+	"\x02스토리지 제공자 ID로 필터링\x02출력 파일 경로 (기본값: 표준 출력)\x02섹터의 목표 미봉인 상태 설정\x04" +
+	"\x00\x01\x0a\xda\x07\x02특정 섹터의 목표 미봉인 상태를 설정합니다.\x0a   <miner-id>: 스토리지 " +
+	"제공자 ID\x0a   <sector-number>: 섹터 번호\x0a   <target-state>: 목표 상태 (true," +
+	" false, none 중 하나)\x0a\x0a   미봉인 목표 상태는 Curio가 섹터의 미봉인 복사본을 어떻게 유지할지를 나타" +
+	"냅니다.\x0a\x09   목표 상태가 true이면 Curio는 섹터가 미봉인 상태로 유지되도록 보장합니다.\x0a\x09  " +
+	" 목표 상태가 false이면 Curio는 섹터에 미봉인 복사본이 없도록 보장합니다.\x0a\x09   목표 상태가 none이면 C" +
+	"urio는 섹터의 현재 상태를 변경하지 않습니다.\x0a\x0a   현재, 목표 상태가 다른 상태에서 true로 변경될 때만 Cu" +
+	"rio는 새로운 미봉인 프로세스를 시작합니다.\x0a\x0a   목표 상태가 false이고 미봉인 섹터 파일이 존재하는 경우, G" +
+	"C 마크 단계는 미봉인 섹터 파일에 대한 제거 마크를 생성합니다. 파일은 제거 마크가 승인된 후에만 제거됩니다.\x02미봉인 섹터" +
+	" 파일의 데이터 무결성 확인\x02특정 섹터에 대한 검사 작업을 생성하고 완료를 기다린 후 결과를 출력합니다.\x0a   <min" +
+	"er-id>: 스토리지 제공자 ID\x0a   <sector-number>: 섹터 번호\x04\x00\x01 ?\x02화살표 키를" +
+	" 사용하여 이동하세요: ↓ ↑ → ←\x02이 대화형 도구는 새로운 채굴자 액터를 생성하고 그에 대한 기본 구성 레이어를 생성합니" +
+	"다.\x02이 프로세스는 부분적으로 항등원적입니다. 새로운 채굴자 액터가 생성되었고 후속 단계가 실패하는 경우 사용자는 구성을" +
+	" 완료하기 위해 'curio config new-cluster < 채굴자 ID >'를 실행해야 합니다.\x02이 대화형 도구는 5" +
+	"분 안에 lotus-miner를 Curio로 이주합니다.\x02각 단계는 확인이 필요하며 되돌릴 수 있습니다. 언제든지 Ctr" +
+	"l+C를 눌러 종료할 수 있습니다.\x02터미널에서 Ctrl+C가 눌림\x02나는 원한다:\x02기존의 Lotus-Miner에서 " +
+	"이전하기\x02새로운 채굴자 생성\x02나머지 단계를 중단합니다.\x02Lotus-Miner에서 Curio로 이주.\x02데이" +
+	"터베이스 구성 파일을 어디에 저장해야 하나요?\x02마이그레이션 중단.\x02파일 쓰기 오류: %[1]s\x04\x00\x01" +
+	" :\x02%[1]s와 함께 웹 인터페이스를 시도해보세요\x02더 많은 서버를 위해 /etc/curio.env 파일을 curio." +
+	"env 데이터베이스 환경으로 만들고 목적을 할당하기 위해 CURIO_LAYERS 환경 변수를 추가하세요.\x02해당하는 경우 이제" +
+	" 시장 노드를 이주할 수 있습니다 (%[1]s).\x02추가 정보는 http://docs.curiostorage.org 에 있습니" +
+	"다.\x02새로운 채굴자 초기화 완료.\x02lotus-miner config.toml을 Curio의 데이터베이스 구성으로 이" +
+	"전 중입니다.\x02API 가져오기 오류: %[1]s\x02FullNode의 API 정보를 가져올 수 없습니다: %[1]w" +
+	"\x02토큰을 가져오는 중 오류 발생: %[1]s\x02이동할 수 없는 섹터가 발견되었습니다. 계속하시겠습니까?\x02예, 계속" +
+	"\x02아니오, 중단\x02레이어에 구성을 저장하는 중 오류 발생: %[1]s. 마이그레이션 중단\x02Curio 팀은 당신이 사" +
+	"용하는 소프트웨어를 개선하고자 합니다. 팀에게 `%[1]s`를 사용 중이라고 알려주세요.\x02Curio 팀과 공유하고 싶은 " +
+	"것을 선택하세요.\x02개별 데이터: 채굴자 ID, Curio 버전, 체인 (%[1]s 또는 %[2]s). 서명됨.\x02집계" +
+	"-익명: 버전, 체인, 및 채굴자 파워 (버킷).\x02힌트: 나는 어떤 체인에서든 Curio를 실행 중인 사람입니다.\x02아무" +
+	"것도 없습니다.\x02마이너 파워를 가져오는 중 오류 발생: %[1]s\x02메시지를 마샬하는 중 오류 발생: %[1]s" +
+	"\x02마이너 정보를 가져오는 중 오류 발생: %[1]s\x02메시지 서명 중 오류 발생: %[1]s\x02메시지 전송 중 오류 " +
+	"발생: %[1]s\x04\x00\x01 =\x02메시지 전송 중 오류 발생: 상태 %[1]s, 메시지:\x02메시지가 전송되었" +
+	"습니다.\x04\x00\x01 \x08\x02문서:\x02'%[1]s' 레이어에는 공통 구성이 저장됩니다. 모든 Curio 인" +
+	"스턴스는 %[2]s 인수에 포함시킬 수 있습니다.\x02기계별 구성 변경을 위해 다른 레이어를 추가할 수 있습니다.\x02Fi" +
+	"lecoin %[1]s 채널: %[2]s 및 %[3]s\x02신뢰성 향상을 위한 중복성 사용: 적어도 post 레이어를 사용하여 " +
+	"여러 대의 기계를 시작하십시오: 'curio run --layers=post'\x02한 개의 데이터베이스는 여러 광부 ID를 " +
+	"제공할 수 있습니다: 각 lotus-miner에 대해 마이그레이션을 실행하세요.\x02Yugabyte에 연결되었습니다. 스키마" +
+	"가 현재입니다.\x02Yugabyte에 연결됨\x02시작하려면 밀봉 파이프라인이 비어 있고 lotus-miner가 종료되었는지" +
+	" 확인하세요.\x02로터스 마이너 구성 디렉토리의 위치를 선택하시겠습니까?\x02기타\x02%[1]s에서 사용하는 구성 디렉터리 " +
+	"경로를 입력하세요.\x04\x00\x01 M\x02경로가 제공되지 않았으므로 마이그레이션을 포기합니다\x02제공된 디렉토리에서" +
+	" config.toml 파일을 읽을 수 없습니다. 오류: %[1]s\x02디렉토리에서 저장소를 생성할 수 없습니다: %[1]s. " +
+	"마이그레이션을 중단합니다.\x02광부 저장소를 잠금 해제할 수 없습니다. 귀하의 광부를 중지해야 합니다: %[1]s\x0a 마" +
+	"이그레이션을 중단합니다.\x02마이너 구성 읽기\x04\x00\x01\x0a\x15\x02단계 완료: %[1]s\x02새 채굴" +
+	"자 액터 초기화 중.\x02새 채굴자를 생성하기 위한 정보 입력\x02소유자 지갑: %[1]s\x02작업자 지갑: %[1]s" +
+	"\x02발송자 지갑: %[1]s\x02섹터 크기: %[1]s\x02주소를 확인하고 새 채굴자 액터를 생성하려면 계속 진행하세요." +
+	"\x04\x00\x01 &\x02채굴자 생성 오류 발생: %[1]s\x02소유자 주소 입력\x02주소가 제공되지 않았습니다\x02" +
+	"주소 구문 분석 실패: %[1]s\x02%[1]s 주소 입력\x02섹터 크기 선택\x0264 GiB\x0232 GiB\x028" +
+	" MiB\x022 KiB\x04\x00\x01 \x1c\x02섹터 선택 실패: %[1]s\x02섹터 크기 구문 분석 실패: %[1" +
+	"]s\x02채굴자 액터 생성 실패: %[1]s\x02%[1]s 채굴자가 성공적으로 생성되었습니다\x02데이터베이스에 연결할 수 없" +
+	"습니다: %[1]s\x02풀 노드 API에 연결하는 중 오류 발생: %[1]s\x02사전 초기화 단계 완료\x02비밀번호를 위" +
+	"한 랜덤 바이트 생성에 실패했습니다: %[1]s\x02마이너 생성은 idempotent하지 않으므로 가이드 설정을 다시 실행하" +
+	"지 마십시오. 구성을 완료하려면 'curio config new-cluster %[1]s'를 실행해야 합니다.\x02FullN" +
+	"ode에 대한 API 정보를 가져오는 데 실패했습니다: %[1]w\x02데몬 노드로부터 인증 토큰을 확인하는 중 오류 발생: %[" +
+	"1]s\x02기본 구성 생성 실패: %[1]s\x02데이터베이스에 'base' 구성 레이어를 삽입하는 데 실패했습니다: %[1]s" +
+	"\x02이 마이너 주소를 포함한 구성 'base'가 업데이트되었습니다.\x02데이터베이스에서 기본 구성을 로드하는 데 실패했습니다" +
+	": %[1]s\x02기본 구성을 구문 분석하는 데 실패했습니다: %[1]s\x02기본 구성을 재생성하는 데 실패했습니다: %[1]" +
+	"s\x02Yugabyte 데이터베이스 설치에 연결할 정보를 입력하십시오 (https://download.yugabyte.com/)" +
+	"\x02호스트: %[1]s\x02포트: %[1]s\x02사용자 이름: %[1]s\x02비밀번호: %[1]s\x02데이터베이스: %" +
+	"[1]s\x02계속 연결 및 스키마 업데이트.\x04\x00\x01 ^\x02데이터베이스 구성 오류가 발생하여 마이그레이션을 포기" +
+	"합니다: %[1]s\x02Yugabyte 데이터베이스 호스트를 입력하십시오\x02호스트가 제공되지 않았습니다\x02Yugaby" +
+	"te 데이터베이스 %[1]s을 입력하십시오\x02값이 제공되지 않았습니다\x02Yugabyte 데이터베이스에 연결하는 중 오류가 " +
+	"발생했습니다: %[1]s\x02%[1]d 섹터의 메타데이터를 이동 중입니다.\x02기본 설정 'base'가 이 마이너의 주소(" +
+	"%[1]s) 및 지갑 설정을 포함하도록 업데이트되었습니다.\x02구성 %[1]s를 %[2]s과 비교하세요. 지갑 주소 이외의 마이" +
+	"너 ID 사이의 변경 사항은 필요한 실행자를 위한 새로운 최소한의 레이어여야 합니다.\x02'base' 설정이 이 lotus-" +
+	"miner의 config.toml과 유사하게 만들어졌습니다.\x04\x00\x01 *\x02레이어 %[1]s가 생성되었습니다." +
+	"\x04\x00\x01 \x22\x02구성 파일을 사용하려면:\x02Curio를 실행하려면: 기계 또는 cgroup 격리를 사용하" +
+	"여 다음 명령을 사용하세요 (예제 레이어 선택과 함께):"
 
-var zhIndex = []uint32{ // 237 elements
+var zhIndex = []uint32{ // 238 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000d, 0x00000038, 0x000000e6,
 	0x000000ff, 0x000001d8, 0x00000229, 0x0000023b,
@@ -778,46 +780,46 @@ var zhIndex = []uint32{ // 237 elements
 	0x0000135f, 0x000013c0, 0x000013d0, 0x00001422,
 	0x0000143b, 0x00001454, 0x00001470, 0x0000148f,
 	0x000014ad, 0x000014cf, 0x000014e5, 0x00001543,
-	0x000015c8, 0x000015ef, 0x00001623, 0x000016d0,
-	0x000016e5, 0x00001710, 0x0000172c, 0x0000173f,
-	0x00001758, 0x00001777, 0x000017ba, 0x000017d7,
-	0x00001805, 0x00001827, 0x00001b28, 0x00001b59,
-	0x00001bdf, 0x00001c12, 0x00001c6a, 0x00001d13,
+	0x000015c8, 0x000015ef, 0x0000161d, 0x00001651,
+	0x000016fe, 0x00001713, 0x0000173e, 0x0000175a,
+	0x0000176d, 0x00001786, 0x000017a5, 0x000017e8,
+	0x00001805, 0x00001833, 0x00001855, 0x00001b56,
+	0x00001b87, 0x00001c0d, 0x00001c40, 0x00001c98,
 	// Entry 80 - 9F
-	0x00001d5b, 0x00001daa, 0x00001dc3, 0x00001dd0,
-	0x00001df0, 0x00001e09, 0x00001e1f, 0x00001e3c,
-	0x00001e79, 0x00001e89, 0x00001ea3, 0x00001ec9,
-	0x00001f50, 0x00001f91, 0x00001fc4, 0x00001fe0,
-	0x00002025, 0x00002042, 0x0000206b, 0x00002089,
-	0x000020bd, 0x000020cd, 0x000020da, 0x00002113,
-	0x00002167, 0x00002194, 0x000021e3, 0x0000221e,
-	0x00002253, 0x0000225d, 0x00002281, 0x0000229f,
+	0x00001d41, 0x00001d89, 0x00001dd8, 0x00001df1,
+	0x00001dfe, 0x00001e1e, 0x00001e37, 0x00001e4d,
+	0x00001e6a, 0x00001ea7, 0x00001eb7, 0x00001ed1,
+	0x00001ef7, 0x00001f7e, 0x00001fbf, 0x00001ff2,
+	0x0000200e, 0x00002053, 0x00002070, 0x00002099,
+	0x000020b7, 0x000020eb, 0x000020fb, 0x00002108,
+	0x00002141, 0x00002195, 0x000021c2, 0x00002211,
+	0x0000224c, 0x00002281, 0x0000228b, 0x000022af,
 	// Entry A0 - BF
-	0x000022c3, 0x000022e1, 0x000022ff, 0x00002334,
-	0x00002347, 0x00002356, 0x000023b0, 0x000023ed,
-	0x00002415, 0x00002474, 0x000024c4, 0x000024f1,
-	0x00002506, 0x00002551, 0x00002581, 0x00002588,
-	0x000025b2, 0x000025d6, 0x0000261a, 0x0000264c,
-	0x00002695, 0x000026a8, 0x000026c2, 0x000026e1,
-	0x00002706, 0x0000271d, 0x00002731, 0x00002748,
-	0x0000275c, 0x0000278d, 0x000027b2, 0x000027c8,
+	0x000022cd, 0x000022f1, 0x0000230f, 0x0000232d,
+	0x00002362, 0x00002375, 0x00002384, 0x000023de,
+	0x0000241b, 0x00002443, 0x000024a2, 0x000024f2,
+	0x0000251f, 0x00002534, 0x0000257f, 0x000025af,
+	0x000025b6, 0x000025e0, 0x00002604, 0x00002648,
+	0x0000267a, 0x000026c3, 0x000026d6, 0x000026f0,
+	0x0000270f, 0x00002734, 0x0000274b, 0x0000275f,
+	0x00002776, 0x0000278a, 0x000027bb, 0x000027e0,
 	// Entry C0 - DF
-	0x000027d8, 0x000027f2, 0x00002806, 0x00002819,
-	0x00002820, 0x00002827, 0x0000282d, 0x00002833,
-	0x00002852, 0x00002872, 0x00002892, 0x000028ac,
-	0x000028c9, 0x000028fa, 0x00002913, 0x0000293c,
-	0x000029c9, 0x000029f5, 0x00002a30, 0x00002a50,
-	0x00002a81, 0x00002ab4, 0x00002ae1, 0x00002b02,
-	0x00002b28, 0x00002b82, 0x00002b91, 0x00002ba0,
-	0x00002bb2, 0x00002bc1, 0x00002bd3, 0x00002bf2,
+	0x000027f6, 0x00002806, 0x00002820, 0x00002834,
+	0x00002847, 0x0000284e, 0x00002855, 0x0000285b,
+	0x00002861, 0x00002880, 0x000028a0, 0x000028c0,
+	0x000028da, 0x000028f7, 0x00002928, 0x00002941,
+	0x0000296a, 0x000029f7, 0x00002a23, 0x00002a5e,
+	0x00002a7e, 0x00002aaf, 0x00002ae2, 0x00002b0f,
+	0x00002b30, 0x00002b56, 0x00002bb0, 0x00002bbf,
+	0x00002bce, 0x00002be0, 0x00002bef, 0x00002c01,
 	// Entry E0 - FF
-	0x00002c2a, 0x00002c4f, 0x00002c5f, 0x00002c7d,
-	0x00002c8a, 0x00002cb6, 0x00002ce0, 0x00002d31,
-	0x00002db3, 0x00002dfa, 0x00002e14, 0x00002e2c,
-	0x00002e83,
-} // Size: 972 bytes
+	0x00002c20, 0x00002c58, 0x00002c7d, 0x00002c8d,
+	0x00002cab, 0x00002cb8, 0x00002ce4, 0x00002d0e,
+	0x00002d5f, 0x00002de1, 0x00002e28, 0x00002e42,
+	0x00002e5a, 0x00002eb1,
+} // Size: 976 bytes
 
-const zhData string = "" + // Size: 11907 bytes
+const zhData string = "" + // Size: 11953 bytes
 	"\x02数学工具\x02分析并显示批量封装线程的布局\x02分析并显示CPU上批量封装线程的布局。\x0a\x0a提供有关批量封装操作的CPU利" +
 	"用率的详细信息，包括核心分配和不同批量大小的线程分布。\x02生成 supra_seal 配置\x02为指定的批量大小生成 supra_se" +
 	"al 配置。\x0a\x0a此命令输出 SupraSeal 所需的配置，主要用于调试和测试。配置可以直接用于 SupraSeal 二进制文件进行" +
@@ -859,57 +861,57 @@ const zhData string = "" + // Size: 11907 bytes
 	"许所有）\x02分离本地存储路径\x02列出本地存储路径\x02仅列出本地存储路径\x02在存储系统中查找扇区\x02[矿工地址] [扇区编" +
 	"号]\x02为一个扇区生成原始证明\x02测试的实用功能\x02为扇区计算时空证明（需要预封装的扇区）。这些将不会发送到链上。\x02通过在" +
 	"下一个可用的 Curio 上运行来测试窗口后调度器。如果所有重试都失败，则需要按 ctrl+c 退出。\x04\x00\x01 \x22" +
-	"\x02计算 WindowPoSt 的截止日期\x02计算 WindowPoSt 以进行性能和配置测试。\x02注意：此命令旨在用于验证 PoS" +
-	"t 计算性能。\x0a它不会向链发送任何消息。由于它可以计算任何截止日期，输出的时间可能与链不符。\x02[截止日期索引]\x02包含存储配置的" +
-	" JSON 文件的路径\x02计算 WindowPoSt 的分区\x02调试工具集合\x02管理未密封的数据\x02获取未密封数据的信息\x02" +
-	"列出来自 sectors_unseal_pipeline 和 sectors_meta 表的数据\x02按存储提供者 ID 过滤\x02输出" +
-	"文件路径（默认：标准输出）\x02设置扇区的目标解封状态\x04\x00\x01\x0a\xfb\x05\x02为特定扇区设置目标解封状态。" +
-	"\x0a   <miner-id>: 存储提供者 ID\x0a   <sector-number>: 扇区号\x0a   <target-sta" +
-	"te>: 目标状态（true、false 或 none）\x0a\x0a   解封目标状态表示 Curio 应如何维护扇区的未密封副本。\x0a" +
-	"\x09   如果目标状态为 true，Curio 将确保扇区未密封。\x0a\x09   如果目标状态为 false，Curio 将确保扇区没" +
-	"有未密封副本。\x0a\x09   如果目标状态为 none，Curio 将不会更改扇区的当前状态。\x0a\x0a   当前，Curio " +
-	"仅在目标状态从其他状态更改为 true 时启动新的解封进程。\x0a\x0a   当目标状态为 false 且存在未密封的扇区文件时，GC " +
-	"标记步骤将为未密封的扇区文件创建一个删除标记。文件将在删除标记被接受后才会被移除。\x02检查未密封扇区文件中的数据完整性\x02为特定扇区" +
-	"创建检查任务，等待其完成并输出结果。\x0a   <miner-id>: 存储提供者 ID\x0a   <sector-number>: 扇" +
-	"区号\x04\x00\x01 .\x02使用箭头键进行导航：↓ ↑ → ←\x02此交互式工具将创建一个新的矿工角色，并为其创建基本配置层。" +
-	"\x02该过程部分幂等。一旦创建了新的矿工角色，并且随后的步骤失败，用户需要运行 'curio config new-cluster < 矿工 " +
-	"ID >' 来完成配置。\x02这个交互式工具可以在5分钟内将lotus-miner迁移到Curio。\x02每一步都需要您的确认，并且可以撤销" +
-	"。随时按Ctrl+C退出。\x02在终端中按下Ctrl+C\x02我想要：\x02从现有的 Lotus-Miner 迁移\x02创建一个新的" +
-	"矿工\x02中止剩余步骤。\x02Lotus-Miner到Curio迁移。\x02我们应该把你的数据库配置文件保存在哪里？\x02中止迁移。" +
-	"\x02写入文件错误: %[1]s\x04\x00\x01 !\x02尝试使用%[1]s的网页界面\x02对于更多服务器，请使用 curio.e" +
-	"nv 数据库环境创建 /etc/curio.env 并添加 CURIO_LAYERS 环境变量以分配用途。\x02如果适用，您现在可以迁移您的市" +
-	"场节点(%[1]s)。\x02更多信息请访问 http://docs.curiostorage.org\x02新矿工初始化完成。\x02将 " +
-	"lotus-miner config.toml 迁移到 Curio 的数据库配置中。\x02获取 API 时出错：%[1]s\x02无法获取Fu" +
-	"llNode的API信息：%[1]w\x02获取令牌时出错：%[1]s\x02发现无法迁移的扇区。您想要继续吗？\x02是的，继续\x02不，中" +
-	"止\x02保存配置到层时出错：%[1]s。正在中止迁移\x02Curio 团队希望改进您使用的软件。告诉团队您正在使用 `%[1]s`。" +
-	"\x02选择您想与Curio团队分享的内容。\x02个人数据：矿工 ID，Curio 版本，链（%[1]s 或 %[2]s）。签名。\x02聚合" +
-	"-匿名：版本，链和矿工算力（分桶）。\x02提示：我是在任何链上运行 Curio 的人。\x02没有。\x02获取矿工功率时出错：%[1]s" +
-	"\x02整理消息时出错：%[1]s\x02获取矿工信息时出错：%[1]s\x02签署消息时出错：%[1]s\x02发送消息时出错：%[1]s" +
-	"\x04\x00\x01 0\x02发送消息时出错：状态%[1]s，消息：\x02消息已发送。\x04\x00\x01 \x0a\x02文档：" +
-	"\x02'%[1]s'层存储通用配置。所有Curio实例都可以在其%[2]s参数中包含它。\x02您可以添加其他层进行每台机器的配置更改。" +
-	"\x02Filecoin %[1]s 频道：%[2]s 和 %[3]s\x02通过冗余增加可靠性：使用至少后层启动多台机器：'curio run" +
-	" --layers=post'\x02一个数据库可以服务多个矿工ID：为每个lotus-miner运行迁移。\x02已连接到Yugabyte。模" +
-	"式是当前的。\x02已连接到Yugabyte\x02开始之前，请确保您的密封管道已排空并关闭lotus-miner。\x02选择您的lotu" +
-	"s-miner配置目录的位置？\x02其他\x02输入%[1]s使用的配置目录的路径\x04\x00\x01 \x1f\x02未提供路径，放弃迁" +
-	"移\x02无法读取提供的目录中的config.toml文件，错误：%[1]s\x02无法从目录创建repo：%[1]s。 中止迁移\x02无" +
-	"法锁定矿工repo。 您的矿工必须停止：%[1]s\x0a 中止迁移\x02读取矿工配置\x04\x00\x01\x0a\x15\x02步骤" +
-	"完成：%[1]s\x02初始化新的矿工角色。\x02输入创建新矿工所需的信息\x02所有者钱包: %[1]s\x02工人钱包: %[1]s" +
-	"\x02发送者钱包: %[1]s\x02扇区大小: %[1]s\x02继续验证地址并创建新的矿工角色。\x04\x00\x01  \x02矿工创" +
-	"建错误发生: %[1]s\x02输入所有者地址\x02未提供地址\x02解析地址失败: %[1]s\x02输入 %[1]s 地址\x02选择" +
-	"扇区大小\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1a\x02扇区选择失败:" +
-	" %[1]s\x02解析扇区大小失败: %[1]s\x02创建矿工角色失败: %[1]s\x02矿工 %[1]s 创建成功\x02无法访问数据库" +
-	": %[1]s\x02连接到完整节点 API 时发生错误: %[1]s\x02预初始化步骤完成\x02生成密码的随机字节失败: %[1]s" +
-	"\x02请不要再次运行引导设置，因为矿工创建不是幂等的。 您需要运行 'curio config new-cluster %[1]s' 来完成配" +
-	"置。\x02无法获取 FullNode 的 API 信息: %[1]w\x02无法验证来自守护进程节点的授权令牌: %[1]s\x02无法生" +
-	"成默认配置: %[1]s\x02无法将 'base' 配置层插入数据库: %[1]s\x02配置 'base' 已更新以包含此矿工的地址" +
-	"\x02从数据库加载基本配置失败：%[1]s\x02解析基本配置失败：%[1]s\x02重新生成基本配置失败: %[1]s\x02输入连接到您的" +
-	"Yugabyte数据库安装的信息（https://download.yugabyte.com/）\x02主机：%[1]s\x02端口：%[1]s" +
-	"\x02用户名：%[1]s\x02密码：%[1]s\x02数据库：%[1]s\x02继续连接和更新架构。\x04\x00\x01 3\x02发生" +
-	"数据库配置错误，放弃迁移：%[1]s\x02输入Yugabyte数据库主机（S）\x02未提供主机\x02输入Yugabyte数据库 %[1" +
-	"]s\x02未提供值\x02连接到Yugabyte数据库时出错：%[1]s\x02正在迁移%[1]d个扇区的元数据。\x02'base'配置已更" +
-	"新，包括该矿工的地址（%[1]s）及其钱包设置。\x02比较配置%[1]s和%[2]s。矿工ID之间除了钱包地址的变化应该是需要的运行者的一" +
-	"个新的、最小的层。\x02'base'配置已创建，以类似于这个lotus-miner的config.toml。\x04\x00\x01 " +
-	"\x15\x02层%[1]s已创建。\x04\x00\x01 \x13\x02要使用配置：\x02运行Curio：使用机器或cgroup隔离，使" +
-	"用命令（附带示例层选择）："
+	"\x02计算 WindowPoSt 的截止日期\x02用于计算 WindowPoSt 的存储提供者 ID\x02计算 WindowPoSt 以进" +
+	"行性能和配置测试。\x02注意：此命令旨在用于验证 PoSt 计算性能。\x0a它不会向链发送任何消息。由于它可以计算任何截止日期，输出的时" +
+	"间可能与链不符。\x02[截止日期索引]\x02包含存储配置的 JSON 文件的路径\x02计算 WindowPoSt 的分区\x02调试工" +
+	"具集合\x02管理未密封的数据\x02获取未密封数据的信息\x02列出来自 sectors_unseal_pipeline 和 sector" +
+	"s_meta 表的数据\x02按存储提供者 ID 过滤\x02输出文件路径（默认：标准输出）\x02设置扇区的目标解封状态\x04\x00" +
+	"\x01\x0a\xfb\x05\x02为特定扇区设置目标解封状态。\x0a   <miner-id>: 存储提供者 ID\x0a   <sec" +
+	"tor-number>: 扇区号\x0a   <target-state>: 目标状态（true、false 或 none）\x0a\x0a  " +
+	" 解封目标状态表示 Curio 应如何维护扇区的未密封副本。\x0a\x09   如果目标状态为 true，Curio 将确保扇区未密封。" +
+	"\x0a\x09   如果目标状态为 false，Curio 将确保扇区没有未密封副本。\x0a\x09   如果目标状态为 none，Curi" +
+	"o 将不会更改扇区的当前状态。\x0a\x0a   当前，Curio 仅在目标状态从其他状态更改为 true 时启动新的解封进程。\x0a" +
+	"\x0a   当目标状态为 false 且存在未密封的扇区文件时，GC 标记步骤将为未密封的扇区文件创建一个删除标记。文件将在删除标记被接受后才" +
+	"会被移除。\x02检查未密封扇区文件中的数据完整性\x02为特定扇区创建检查任务，等待其完成并输出结果。\x0a   <miner-id>:" +
+	" 存储提供者 ID\x0a   <sector-number>: 扇区号\x04\x00\x01 .\x02使用箭头键进行导航：↓ ↑ → ←" +
+	"\x02此交互式工具将创建一个新的矿工角色，并为其创建基本配置层。\x02该过程部分幂等。一旦创建了新的矿工角色，并且随后的步骤失败，用户需要运" +
+	"行 'curio config new-cluster < 矿工 ID >' 来完成配置。\x02这个交互式工具可以在5分钟内将lotus-" +
+	"miner迁移到Curio。\x02每一步都需要您的确认，并且可以撤销。随时按Ctrl+C退出。\x02在终端中按下Ctrl+C\x02我想要：" +
+	"\x02从现有的 Lotus-Miner 迁移\x02创建一个新的矿工\x02中止剩余步骤。\x02Lotus-Miner到Curio迁移。" +
+	"\x02我们应该把你的数据库配置文件保存在哪里？\x02中止迁移。\x02写入文件错误: %[1]s\x04\x00\x01 !\x02尝试使用" +
+	"%[1]s的网页界面\x02对于更多服务器，请使用 curio.env 数据库环境创建 /etc/curio.env 并添加 CURIO_LAY" +
+	"ERS 环境变量以分配用途。\x02如果适用，您现在可以迁移您的市场节点(%[1]s)。\x02更多信息请访问 http://docs.curi" +
+	"ostorage.org\x02新矿工初始化完成。\x02将 lotus-miner config.toml 迁移到 Curio 的数据库配置中" +
+	"。\x02获取 API 时出错：%[1]s\x02无法获取FullNode的API信息：%[1]w\x02获取令牌时出错：%[1]s\x02" +
+	"发现无法迁移的扇区。您想要继续吗？\x02是的，继续\x02不，中止\x02保存配置到层时出错：%[1]s。正在中止迁移\x02Curio " +
+	"团队希望改进您使用的软件。告诉团队您正在使用 `%[1]s`。\x02选择您想与Curio团队分享的内容。\x02个人数据：矿工 ID，Cu" +
+	"rio 版本，链（%[1]s 或 %[2]s）。签名。\x02聚合-匿名：版本，链和矿工算力（分桶）。\x02提示：我是在任何链上运行 Curi" +
+	"o 的人。\x02没有。\x02获取矿工功率时出错：%[1]s\x02整理消息时出错：%[1]s\x02获取矿工信息时出错：%[1]s\x02签" +
+	"署消息时出错：%[1]s\x02发送消息时出错：%[1]s\x04\x00\x01 0\x02发送消息时出错：状态%[1]s，消息：\x02" +
+	"消息已发送。\x04\x00\x01 \x0a\x02文档：\x02'%[1]s'层存储通用配置。所有Curio实例都可以在其%[2]s参数" +
+	"中包含它。\x02您可以添加其他层进行每台机器的配置更改。\x02Filecoin %[1]s 频道：%[2]s 和 %[3]s\x02通过" +
+	"冗余增加可靠性：使用至少后层启动多台机器：'curio run --layers=post'\x02一个数据库可以服务多个矿工ID：为每个l" +
+	"otus-miner运行迁移。\x02已连接到Yugabyte。模式是当前的。\x02已连接到Yugabyte\x02开始之前，请确保您的密封管" +
+	"道已排空并关闭lotus-miner。\x02选择您的lotus-miner配置目录的位置？\x02其他\x02输入%[1]s使用的配置目录" +
+	"的路径\x04\x00\x01 \x1f\x02未提供路径，放弃迁移\x02无法读取提供的目录中的config.toml文件，错误：%[1]" +
+	"s\x02无法从目录创建repo：%[1]s。 中止迁移\x02无法锁定矿工repo。 您的矿工必须停止：%[1]s\x0a 中止迁移\x02读" +
+	"取矿工配置\x04\x00\x01\x0a\x15\x02步骤完成：%[1]s\x02初始化新的矿工角色。\x02输入创建新矿工所需的信息" +
+	"\x02所有者钱包: %[1]s\x02工人钱包: %[1]s\x02发送者钱包: %[1]s\x02扇区大小: %[1]s\x02继续验证地址" +
+	"并创建新的矿工角色。\x04\x00\x01  \x02矿工创建错误发生: %[1]s\x02输入所有者地址\x02未提供地址\x02解析地" +
+	"址失败: %[1]s\x02输入 %[1]s 地址\x02选择扇区大小\x0264 GiB\x0232 GiB\x028 MiB\x022 " +
+	"KiB\x04\x00\x01 \x1a\x02扇区选择失败: %[1]s\x02解析扇区大小失败: %[1]s\x02创建矿工角色失败: %[" +
+	"1]s\x02矿工 %[1]s 创建成功\x02无法访问数据库: %[1]s\x02连接到完整节点 API 时发生错误: %[1]s\x02预初" +
+	"始化步骤完成\x02生成密码的随机字节失败: %[1]s\x02请不要再次运行引导设置，因为矿工创建不是幂等的。 您需要运行 'curio " +
+	"config new-cluster %[1]s' 来完成配置。\x02无法获取 FullNode 的 API 信息: %[1]w\x02无法验" +
+	"证来自守护进程节点的授权令牌: %[1]s\x02无法生成默认配置: %[1]s\x02无法将 'base' 配置层插入数据库: %[1]s" +
+	"\x02配置 'base' 已更新以包含此矿工的地址\x02从数据库加载基本配置失败：%[1]s\x02解析基本配置失败：%[1]s\x02重新" +
+	"生成基本配置失败: %[1]s\x02输入连接到您的Yugabyte数据库安装的信息（https://download.yugabyte.c" +
+	"om/）\x02主机：%[1]s\x02端口：%[1]s\x02用户名：%[1]s\x02密码：%[1]s\x02数据库：%[1]s\x02继续" +
+	"连接和更新架构。\x04\x00\x01 3\x02发生数据库配置错误，放弃迁移：%[1]s\x02输入Yugabyte数据库主机（S）" +
+	"\x02未提供主机\x02输入Yugabyte数据库 %[1]s\x02未提供值\x02连接到Yugabyte数据库时出错：%[1]s\x02正" +
+	"在迁移%[1]d个扇区的元数据。\x02'base'配置已更新，包括该矿工的地址（%[1]s）及其钱包设置。\x02比较配置%[1]s和%[" +
+	"2]s。矿工ID之间除了钱包地址的变化应该是需要的运行者的一个新的、最小的层。\x02'base'配置已创建，以类似于这个lotus-miner" +
+	"的config.toml。\x04\x00\x01 \x15\x02层%[1]s已创建。\x04\x00\x01 \x13\x02要使用配置" +
+	"：\x02运行Curio：使用机器或cgroup隔离，使用命令（附带示例层选择）："
 
-	// Total table size 43944 bytes (42KiB); checksum: 1E10F645
+	// Total table size 44068 bytes (43KiB); checksum: E4B8C074

--- a/cmd/curio/internal/translations/locales/en/out.gotext.json
+++ b/cmd/curio/internal/translations/locales/en/out.gotext.json
@@ -765,6 +765,13 @@
             "fuzzy": true
         },
         {
+            "id": "SP ID to compute WindowPoSt for",
+            "message": "SP ID to compute WindowPoSt for",
+            "translation": "SP ID to compute WindowPoSt for",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
             "id": "Compute WindowPoSt for performance and configuration testing.",
             "message": "Compute WindowPoSt for performance and configuration testing.",
             "translation": "Compute WindowPoSt for performance and configuration testing.",

--- a/cmd/curio/internal/translations/locales/ko/messages.gotext.json
+++ b/cmd/curio/internal/translations/locales/ko/messages.gotext.json
@@ -1995,6 +1995,12 @@
             "translation": "섹터에 대한 바닐라 증명 생성",
             "message": "generate vanilla proof for a sector",
             "placeholder": null
+        },
+        {
+            "id": "SP ID to compute WindowPoSt for",
+            "translation": "WindowPoSt 계산을 위한 SP ID",
+            "message": "SP ID to compute WindowPoSt for",
+            "placeholder": null
         }
     ]
 }

--- a/cmd/curio/internal/translations/locales/zh/messages.gotext.json
+++ b/cmd/curio/internal/translations/locales/zh/messages.gotext.json
@@ -1965,6 +1965,12 @@
       "translation": "为一个扇区生成原始证明",
       "message": "generate vanilla proof for a sector",
       "placeholder": null
+    },
+    {
+      "id": "SP ID to compute WindowPoSt for",
+      "translation": "用于计算 WindowPoSt 的存储提供者 ID",
+      "message": "SP ID to compute WindowPoSt for",
+      "placeholder": null
     }
   ]
 }

--- a/cmd/curio/test-cli.go
+++ b/cmd/curio/test-cli.go
@@ -66,7 +66,7 @@ var wdPostTaskCmd = &cli.Command{
 			Usage: translations.T("list of layers to be interpreted (atop defaults). Default: base"),
 		},
 		&cli.StringFlag{
-			Name: "addr",
+			Name:  "addr",
 			Usage: translations.T("SP ID to compute WindowPoSt for"),
 		},
 	},

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -500,10 +500,24 @@ func GetDepsCLI(ctx context.Context, cctx *cli.Context) (*Deps, error) {
 		fullCloser()
 	}()
 
+	maddrs := map[dtypes.MinerAddress]bool{}
+	if len(maddrs) == 0 {
+		for _, s := range cfg.Addresses {
+			for _, s := range s.MinerAddresses {
+				addr, err := address.NewFromString(s)
+				if err != nil {
+					return nil, err
+				}
+				maddrs[dtypes.MinerAddress(addr)] = true
+			}
+		}
+	}
+
 	return &Deps{
 		Cfg:   cfg,
 		DB:    db,
 		Chain: full,
+		Maddrs: maddrs,
 	}, nil
 }
 

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -514,9 +514,9 @@ func GetDepsCLI(ctx context.Context, cctx *cli.Context) (*Deps, error) {
 	}
 
 	return &Deps{
-		Cfg:   cfg,
-		DB:    db,
-		Chain: full,
+		Cfg:    cfg,
+		DB:     db,
+		Chain:  full,
 		Maddrs: maddrs,
 	}, nil
 }

--- a/documentation/en/curio-cli/curio.md
+++ b/documentation/en/curio-cli/curio.md
@@ -511,6 +511,7 @@ USAGE:
 OPTIONS:
    --deadline value                   deadline to compute WindowPoSt for  (default: 0)
    --layers value [ --layers value ]  list of layers to be interpreted (atop defaults). Default: base
+   --addr value                       SP ID to compute WindowPoSt for
    --help, -h                         show help
 ```
 

--- a/tasks/gc/storage_gc_mark.go
+++ b/tasks/gc/storage_gc_mark.go
@@ -2,7 +2,6 @@ package gc
 
 import (
 	"context"
-	"github.com/filecoin-project/go-state-types/builtin"
 	"time"
 
 	cbor "github.com/ipfs/go-ipld-cbor"
@@ -11,6 +10,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin"
 	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"

--- a/tasks/gc/storage_gc_mark.go
+++ b/tasks/gc/storage_gc_mark.go
@@ -370,6 +370,10 @@ func (s *StorageGCMark) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 
 		for storageId, decls := range storageSectors {
 			for _, decl := range decls {
+				if !decl.SectorFileType.Has(storiface.FTSealed) {
+					continue
+				}
+
 				if _, ok := marks[decl.SectorID]; !ok {
 					continue
 				}

--- a/web/api/webrpc/sector.go
+++ b/web/api/webrpc/sector.go
@@ -119,7 +119,7 @@ type SectorPieceMeta struct {
 
 	DealID           *string `db:"deal_id"`
 	DataUrl          *string `db:"data_url"`
-	DataRawSize      int64   `db:"data_raw_size"`
+	DataRawSize      *int64  `db:"data_raw_size"`
 	DeleteOnFinalize *bool   `db:"data_delete_on_finalize"`
 
 	F05PublishCid *string `db:"f05_publish_cid"`
@@ -519,7 +519,7 @@ func (a *WebRPC) SectorInfo(ctx context.Context, sp string, intid int64) (*Secto
 
 	for i := range pieces {
 		pieces[i].StrPieceSize = types.SizeStr(types.NewInt(uint64(pieces[i].PieceSize)))
-		pieces[i].StrDataRawSize = types.SizeStr(types.NewInt(uint64(pieces[i].DataRawSize)))
+		pieces[i].StrDataRawSize = types.SizeStr(types.NewInt(uint64(derefOrZero(pieces[i].DataRawSize))))
 
 		id, isPiecePark := strings.CutPrefix(derefOrZero(pieces[i].DataUrl), "pieceref:")
 		if !isPiecePark {

--- a/web/static/gc/gc-marks.mjs
+++ b/web/static/gc/gc-marks.mjs
@@ -130,7 +130,7 @@ class StorageGCStats extends LitElement {
                 ${this.data.map(entry => html`
                     <tr>
                         <td>${entry.Miner}</td>
-                        <td>${entry.SectorNum}</td>
+                        <td><a href="/pages/sector/?sp=${entry.Miner}&id=${entry.SectorNum}">${entry.SectorNum}</a></td>
                         <td>
                             <div>${entry.StorageID}</div>
                             <div>${entry.Urls}</div>


### PR DESCRIPTION
This PR adds additional marking logic to GC Mark task for cleaning up non-needed post-snap sector key files (original CC sector files):

Sectors where:
* `sectors_meta` table indicates a snap sector (orig_unsealed_cid != cur_sealed_cid)
* On-chain sector info is not null (1.5 finality ago)
* On-chain sector info has a non-nil SectorKeyCID indicating the sector is a snap sector
* On disk, the `update` and `update-cache` files are present for the sector, indicating that PoSt logic won't use the sealed file
* Have the sealed file on disk

Will have the sealed file (only) marked for GC