### PR TITLE
fix: combine piecelocator endpoints

### DIFF
--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -1092,9 +1092,9 @@ Example: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXX
 
 			Comment: `PieceLocator is a list of HTTP url and headers combination to query for a piece for offline deals
 User can run a remote file server which can host all the pieces over the HTTP and supply a reader when requested.
-The server must have 2 endpoints
-1. /pieces?id=pieceCID responds with 200 if found or 404 if not. Must send header "Content-Length" with file size as value
-2. /data?id=pieceCID must provide a reader for the requested piece`,
+The server must support "HEAD" request and "GET" request.
+1. <URL>?id=pieceCID with "HEAD" request responds with 200 if found or 404 if not. Must send header "Content-Length" with file size as value
+2. <URL>?id=pieceCID must provide a reader for the requested piece along with header "Content-Length" with file size as value`,
 		},
 	},
 	"UpdateBatchingConfig": {

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -645,9 +645,9 @@ type StorageMarketConfig struct {
 
 	// PieceLocator is a list of HTTP url and headers combination to query for a piece for offline deals
 	// User can run a remote file server which can host all the pieces over the HTTP and supply a reader when requested.
-	// The server must have 2 endpoints
-	// 	1. /pieces?id=pieceCID responds with 200 if found or 404 if not. Must send header "Content-Length" with file size as value
-	//  2. /data?id=pieceCID must provide a reader for the requested piece
+	// The server must support "HEAD" request and "GET" request.
+	// 	1. <URL>?id=pieceCID with "HEAD" request responds with 200 if found or 404 if not. Must send header "Content-Length" with file size as value
+	//  2. <URL>?id=pieceCID must provide a reader for the requested piece along with header "Content-Length" with file size as value
 	PieceLocator []PieceLocatorConfig
 }
 

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -415,9 +415,9 @@ description: The default curio configuration
   [Market.StorageMarketConfig]
     # PieceLocator is a list of HTTP url and headers combination to query for a piece for offline deals
     # User can run a remote file server which can host all the pieces over the HTTP and supply a reader when requested.
-    # The server must have 2 endpoints
-    # 1. /pieces?id=pieceCID responds with 200 if found or 404 if not. Must send header "Content-Length" with file size as value
-    # 2. /data?id=pieceCID must provide a reader for the requested piece
+    # The server must support "HEAD" request and "GET" request.
+    # 1. <URL>?id=pieceCID with "HEAD" request responds with 200 if found or 404 if not. Must send header "Content-Length" with file size as value
+    # 2. <URL>?id=pieceCID must provide a reader for the requested piece along with header "Content-Length" with file size as value
     #
     # type: []PieceLocatorConfig
     #PieceLocator = []

--- a/tasks/storage-market/storage_market.go
+++ b/tasks/storage-market/storage_market.go
@@ -476,8 +476,8 @@ func (d *CurioStorageDealMarket) findURLForOfflineDeals(ctx context.Context, dea
 		// Check if We can find the URL for this piece on remote servers
 		for rUrl, headers := range d.urls {
 			// Create a new HTTP request
-			urlString := fmt.Sprintf("%s/pieces?id=%s", rUrl, pcid)
-			req, err := http.NewRequest(http.MethodGet, urlString, nil)
+			urlString := fmt.Sprintf("%s?id=%s", rUrl, pcid)
+			req, err := http.NewRequest(http.MethodHead, urlString, nil)
 			if err != nil {
 				return false, xerrors.Errorf("error creating request: %w", err)
 			}
@@ -513,10 +513,8 @@ func (d *CurioStorageDealMarket) findURLForOfflineDeals(ctx context.Context, dea
 				return false, xerrors.Errorf("failed to parse the raw size: %w", err)
 			}
 
-			dataUrl := fmt.Sprintf("%s/data?id=%s", rUrl, pcid)
-
 			_, err = tx.Exec(`UPDATE market_mk12_deal_pipeline SET url = $1, headers = $2, raw_size = $3, started = TRUE 
-                           WHERE uuid = $4 AND started = FALSE`, dataUrl, hdrs, rawSize, deal)
+                           WHERE uuid = $4 AND started = FALSE`, urlString, hdrs, rawSize, deal)
 			if err != nil {
 				return false, xerrors.Errorf("store url for piece %s: updating pipeline: %w", pcid, err)
 			}


### PR DESCRIPTION
PieceLocator expects 2 different endpoints right now for piece info and data. This PR now merges them into one and expects HEAD and GET requests to correctly send the requested data/metadata. 