### PR TITLE
Avoiding deadlock when multiple workers try to update at the same time

### DIFF
--- a/tasks/message/watch.go
+++ b/tasks/message/watch.go
@@ -91,7 +91,7 @@ func (mw *MessageWatcher) update() {
 
 	// first if we see pending messages with null owner, assign them to ourselves
 	{
-		n, err := mw.db.Exec(ctx, `UPDATE message_waits SET waiter_machine_id = $1 WHERE waiter_machine_id IS NULL AND executed_tsk_cid IS NULL`, machineID)
+		n, err := mw.db.Exec(ctx, `UPDATE message_waits SET waiter_machine_id = $1 WHERE waiter_machine_id IS NULL AND executed_tsk_cid IS NULL FOR UPDATE SKIP LOCKED`, machineID)
 		if err != nil {
 			log.Errorf("failed to assign pending messages: %+v", err)
 			return

--- a/tasks/seal/poller_commit_msg.go
+++ b/tasks/seal/poller_commit_msg.go
@@ -111,7 +111,10 @@ func (s *SealPoller) pollStartBatchCommitMsg(ctx context.Context, tasks []pollTa
 				cutoff := abi.ChainEpoch(0)
 				earliest := time.Now()
 				for _, pt := range pts[i:end] {
-
+                                        if pt.SectorNumber == 0 { // Assuming SectorNumber is always set for valid pollTask
+                                                log.Warnf("Skipping uninitialized pollTask in batch processing")
+                                                continue
+                                        }
 					if cutoff == 0 || pt.StartEpoch < cutoff {
 						cutoff = pt.StartEpoch
 					}


### PR DESCRIPTION
Fixes :

Feb 13 02:34:30 curio-c2a curio[2434472]: {"level":"error","ts":"2025-02-13T02:34:30.469Z","logger":"curio/message","caller":"message/watch.go:96","msg":"failed to assign pending messages: ERROR: Errors occurred while reaching out to the tablet servers: . Errors from tablet servers: [Operation expired (yb/docdb/deadlock_detector.cc:425): Transaction 7557ba61-5775-4bf4-b5ec-109e1413c497 aborted due to a deadlock: <0>00282b48-c1b3-4206-bab7-de9102c8acf6-><0>7557ba61-5775-4bf4-b5ec-109e1413c497->: kDeadlock (transaction error 6), Operation failed. Try again (yb/docdb/conflict_resolution.cc:92): 7557ba61-5775-4bf4-b5ec-109e1413c497 conflicts with committed transaction: 00282b48-c1b3-4206-bab7-de9102c8acf6 (transaction error 3)] (SQLSTATE XX000)"}
