### PR TITLE
Avoiding race condition in batching

### DIFF
--- a/tasks/seal/poller_commit_msg.go
+++ b/tasks/seal/poller_commit_msg.go
@@ -111,7 +111,10 @@ func (s *SealPoller) pollStartBatchCommitMsg(ctx context.Context, tasks []pollTa
 				cutoff := abi.ChainEpoch(0)
 				earliest := time.Now()
 				for _, pt := range pts[i:end] {
-
+                                        if pt.SectorNumber == 0 { // Assuming SectorNumber is always set for valid pollTask
+                                                log.Warnf("Skipping uninitialized pollTask in batch processing")
+                                                continue
+                                        }
 					if cutoff == 0 || pt.StartEpoch < cutoff {
 						cutoff = pt.StartEpoch
 					}


### PR DESCRIPTION
Should fix :

Feb 12 12:20:07 curioc2b curio[517407]: panic: runtime error: invalid memory address or nil pointer dereference
Feb 12 12:20:07 curioc2b curio[517407]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x18078ff]
Feb 12 12:20:07 curioc2b curio[517407]: goroutine 2771 [running]:
Feb 12 12:20:07 curioc2b curio[517407]: github.com/filecoin-project/curio/tasks/seal.(*SealPoller).pollStartBatchCommitMsg(0xc0003068c0, {0x4906bb0, 0xc00066c050}, {0xc001f44000, 0x844, 0x0?})
Feb 12 12:20:07 curioc2b curio[517407]: #011/root/curio/tasks/seal/poller_commit_msg.go:119 +0x139f
Feb 12 12:20:07 curioc2b curio[517407]: github.com/filecoin-project/curio/tasks/seal.(*SealPoller).poll(0xc0003068c0, {0x4906bb0, 0xc00066c050})
Feb 12 12:20:07 curioc2b curio[517407]: #011/root/curio/tasks/seal/poller.go:267 +0x6c5
Feb 12 12:20:07 curioc2b curio[517407]: github.com/filecoin-project/curio/tasks/seal.(*SealPoller).RunPoller(0xc0003068c0, {0x4906bb0, 0xc00066c050})
Feb 12 12:20:07 curioc2b curio[517407]: #011/root/curio/tasks/seal/poller.go:120 +0x113
Feb 12 12:20:07 curioc2b curio[517407]: created by github.com/filecoin-project/curio/cmd/curio/tasks.addSealingTasks in goroutine 1
Feb 12 12:20:07 curioc2b curio[517407]: #011/root/curio/cmd/curio/tasks/tasks.go:316 +0x2465
Feb 12 12:20:07 curioc2b systemd[1]: curio.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
