### PR TITLE
update metrics

### DIFF
--- a/harmony/harmonydb/sql/20230719-harmony.sql
+++ b/harmony/harmonydb/sql/20230719-harmony.sql
@@ -18,7 +18,9 @@ CREATE TABLE harmony_task (
     added_by INTEGER NOT NULL,
     previous_task INTEGER,
     name varchar(16) NOT NULL
-    -- retries INTEGER NOT NULL DEFAULT 0 -- added later
+    -- retries INTEGER NOT NULL DEFAULT 0  (added in 20240927-task-retrywait.sql)
+    -- wait_accumulated INTERVAL DEFAULT '0 seconds' (added in 20250226-harmonytask-waittime.sql)
+
 );
 COMMENT ON COLUMN harmony_task.initiated_by IS 'The task ID whose completion occasioned this task.';
 COMMENT ON COLUMN harmony_task.owner_id IS 'The foreign key to harmony_machines.';

--- a/harmony/harmonydb/sql/20250226-harmonytask-waittime.sql
+++ b/harmony/harmonydb/sql/20250226-harmonytask-waittime.sql
@@ -1,0 +1,1 @@
+ALTER TABLE harmony_task ADD COLUMN wait_accumulated INTERVAL DEFAULT '0 seconds';


### PR DESCRIPTION
This PR added following new metrics:

- task_duration_seconds_per_task
- task_wait_duration_seconds_per_task
- task_wait_duration_seconds
- task_failure_duration_seconds
- task_failure_duration_seconds_per_task

These should make it easy to identify gaps in pipeline and scheduling. 