### PR TITLE
fix: Correct supra single hasher core assignments

### DIFF
--- a/tasks/sealsupra/supra_config.go
+++ b/tasks/sealsupra/supra_config.go
@@ -239,7 +239,7 @@ func GenerateSupraSealConfig(info SystemInfo, dualHashers bool, batchSize int, n
 
 		sectorConfig.Coordinators = append(sectorConfig.Coordinators, CoordinatorConfig{
 			Core:    coreNum,
-			Hashers: (toAssign - 1) * info.ThreadsPerCore,
+			Hashers: (toAssign - 1) * config.HashersPerCore,
 		})
 
 		i -= toAssign


### PR DESCRIPTION
Previous code made incorrect assumption on how hashers behave, after this fix it's possible to run supraseal in single-hasher mode.