### PR TITLE
fix: Update config comment with expected input and defaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,8 @@ jobs:
       - run: git submodule update --init
       - install-ubuntu-deps
       - run: make deps
+      - run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.60.1
       - run:
           name: Lint
           command: |

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ install-completions:
 	install -C ./scripts/completion/bash_autocomplete /usr/share/bash-completion/completions/curio
 	install -C ./scripts/completion/zsh_autocomplete /usr/local/share/zsh/site-functions/_curio
 
-cu2k: GOFLAGS+=-tags=2k
+cu2k: CURIO_TAGS+= 2k
 cu2k: curio
 
 cfgdoc-gen:

--- a/cmd/curio/config_test.go
+++ b/cmd/curio/config_test.go
@@ -589,7 +589,7 @@ func TestConfig(t *testing.T) {
 func TestCustomConfigDurationJson(t *testing.T) {
 	ref := new(jsonschema.Reflector)
 	ref.Mapper = func(i reflect.Type) *jsonschema.Schema {
-		if i == reflect.TypeOf(config.Duration(time.Second)) {
+		if i == reflect.TypeOf(time.Second) {
 			return &jsonschema.Schema{
 				Type:   "string",
 				Format: "duration",

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -64,9 +64,9 @@ func WindowPostScheduler(ctx context.Context, fc config.CurioFees, pc config.Cur
 	stor paths.Store, idx paths.SectorIndex, max int) (*window2.WdPostTask, *window2.WdPostSubmitTask, *window2.WdPostRecoverDeclareTask, error) {
 
 	// todo config
-	ft := window2.NewSimpleFaultTracker(stor, idx, pc.ParallelCheckLimit, time.Duration(pc.SingleCheckTimeout), time.Duration(pc.PartitionCheckTimeout))
+	ft := window2.NewSimpleFaultTracker(stor, idx, pc.ParallelCheckLimit, pc.SingleCheckTimeout, pc.PartitionCheckTimeout)
 
-	computeTask, err := window2.NewWdPostTask(db, api, ft, stor, verif, paramck, chainSched, addresses, max, pc.ParallelCheckLimit, time.Duration(pc.SingleCheckTimeout))
+	computeTask, err := window2.NewWdPostTask(db, api, ft, stor, verif, paramck, chainSched, addresses, max, pc.ParallelCheckLimit, pc.SingleCheckTimeout)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/sptool/toolbox_deal_tools.go
+++ b/cmd/sptool/toolbox_deal_tools.go
@@ -257,7 +257,7 @@ var generateRandCar = &cli.Command{
 	Usage:     "creates a randomly generated dense car",
 	ArgsUsage: "<outputPath>",
 	Flags: []cli.Flag{
-		&cli.IntFlag{
+		&cli.Int64Flag{
 			Name:    "size",
 			Aliases: []string{"s"},
 			Usage:   "The size of the data to turn into a car",
@@ -282,11 +282,11 @@ var generateRandCar = &cli.Command{
 		}
 
 		outPath := cctx.Args().Get(0)
-		size := cctx.Int("size")
+		size := cctx.Int64("size")
 		cs := cctx.Int64("chunksize")
 		ml := cctx.Int("maxlinks")
 
-		rf, err := testutils.CreateRandomFile(outPath, int(time.Now().Unix()), size)
+		rf, err := testutils.CreateRandomFile(outPath, time.Now().Unix(), size)
 		if err != nil {
 			return err
 		}

--- a/deps/config/common.go
+++ b/deps/config/common.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"time"
+)
+
 type Common struct {
 	API     API
 	Backup  Backup
@@ -13,7 +17,7 @@ type API struct {
 	// Binding address for the Binary's API
 	ListenAddress       string
 	RemoteListenAddress string
-	Timeout             Duration
+	Timeout             time.Duration
 }
 
 // // Common
@@ -63,7 +67,7 @@ type Libp2p struct {
 	ConnMgrHigh uint
 	// ConnMgrGrace is a time duration that new connections are immune from being
 	// closed by the connection manager.
-	ConnMgrGrace Duration
+	ConnMgrGrace time.Duration
 }
 
 type Pubsub struct {

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -766,26 +766,6 @@ also be bounded by resources available on the machine. (Default: 0 - unlimited)`
 also be bounded by resources available on the machine. (Default: 8 - unlimited)`,
 		},
 	},
-	"Duration time.Duration": {
-		{
-			Name: "func",
-			Type: "(dur",
-
-			Comment: ``,
-		},
-		{
-			Name: "d",
-			Type: ":=",
-
-			Comment: ``,
-		},
-		{
-			Name: "return",
-			Type: "[]byte(d.String()),",
-
-			Comment: ``,
-		},
-	},
 	"HTTPConfig": {
 		{
 			Name: "Enable",

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -763,7 +763,7 @@ also be bounded by resources available on the machine. (Default: 0 - unlimited)`
 			Type: "int",
 
 			Comment: `The maximum amount of indexing and IPNI tasks that can run simultaneously. Note that the maximum number of tasks will
-also be bounded by resources available on the machine. (Default: 8 - unlimited)`,
+also be bounded by resources available on the machine. (Default: 8)`,
 		},
 	},
 	"HTTPConfig": {

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -20,7 +20,7 @@ var Doc = map[string][]DocField{
 			Name: "StorageRPCSecret",
 			Type: "string",
 
-			Comment: `Chain API auth secret for the Curio nodes to use.`,
+			Comment: `API auth secret for the Curio nodes to use. This value should only be set on the bade layer.`,
 		},
 	},
 	"BatchFeeConfig": {
@@ -28,13 +28,13 @@ var Doc = map[string][]DocField{
 			Name: "Base",
 			Type: "types.FIL",
 
-			Comment: ``,
+			Comment: `Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.`,
 		},
 		{
 			Name: "PerSector",
 			Type: "types.FIL",
 
-			Comment: ``,
+			Comment: `Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.`,
 		},
 	},
 	"CommitBatchingConfig": {
@@ -42,19 +42,22 @@ var Doc = map[string][]DocField{
 			Name: "BaseFeeThreshold",
 			Type: "types.FIL",
 
-			Comment: `Base fee value below which we should try to send Commit messages immediately`,
+			Comment: `Base fee value below which we should try to send Commit messages immediately
+Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.005 FIL")`,
 		},
 		{
 			Name: "Timeout",
-			Type: "Duration",
+			Type: "time.Duration",
 
-			Comment: `Maximum amount of time any given sector in the batch can wait for the batch to accumulate`,
+			Comment: `Maximum amount of time any given sector in the batch can wait for the batch to accumulate
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")`,
 		},
 		{
 			Name: "Slack",
-			Type: "Duration",
+			Type: "time.Duration",
 
-			Comment: `Time buffer for forceful batch submission before sectors/deals in batch would start expiring`,
+			Comment: `Time buffer for forceful batch submission before sectors/deals in batch would start expiring
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")`,
 		},
 	},
 	"CompressionConfig": {
@@ -82,25 +85,25 @@ var Doc = map[string][]DocField{
 			Name: "PreCommitControl",
 			Type: "[]string",
 
-			Comment: `Addresses to send PreCommit messages from`,
+			Comment: `PreCommitControl is an array of Addresses to send PreCommit messages from`,
 		},
 		{
 			Name: "CommitControl",
 			Type: "[]string",
 
-			Comment: `Addresses to send Commit messages from`,
+			Comment: `CommitControl is an array of Addresses to send Commit messages from`,
 		},
 		{
 			Name: "DealPublishControl",
 			Type: "[]string",
 
-			Comment: `Address to send the deal collateral from with PublishStorageDeal Message`,
+			Comment: `DealPublishControl is an array of Address to send the deal collateral from with PublishStorageDeal Message`,
 		},
 		{
 			Name: "TerminateControl",
 			Type: "[]string",
 
-			Comment: ``,
+			Comment: `TerminateControl is a list of addresses used to send Terminate messages.`,
 		},
 		{
 			Name: "DisableOwnerFallback",
@@ -122,7 +125,7 @@ over the worker address if this flag is set.`,
 			Name: "MinerAddresses",
 			Type: "[]string",
 
-			Comment: `MinerAddresses are the addresses of the miner actors to use for sending messages`,
+			Comment: `MinerAddresses are the addresses of the miner actors`,
 		},
 	},
 	"CurioAlertingConfig": {
@@ -131,7 +134,8 @@ over the worker address if this flag is set.`,
 			Type: "types.FIL",
 
 			Comment: `MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
-alerts will be triggered for the wallet`,
+alerts will be triggered for the wallet
+Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")`,
 		},
 		{
 			Name: "PagerDuty",
@@ -177,135 +181,109 @@ alerts will be triggered for the wallet`,
 			Name: "Subsystems",
 			Type: "CurioSubsystemsConfig",
 
-			Comment: ``,
+			Comment: `Subsystems defines configuration settings for various subsystems within the Curio node.`,
 		},
 		{
 			Name: "Fees",
 			Type: "CurioFees",
 
-			Comment: ``,
+			Comment: `Fees holds the fee-related configuration parameters for various operations in the Curio node.`,
 		},
 		{
 			Name: "Addresses",
 			Type: "[]CurioAddresses",
 
-			Comment: `Addresses of wallets per MinerAddress (one of the fields).`,
+			Comment: `Addresses specifies the list of miner addresses and their related wallet addresses.`,
 		},
 		{
 			Name: "Proving",
 			Type: "CurioProvingConfig",
 
-			Comment: ``,
+			Comment: `Proving defines the configuration settings related to proving functionality within the Curio node.`,
 		},
 		{
 			Name: "HTTP",
 			Type: "HTTPConfig",
 
-			Comment: ``,
+			Comment: `HTTP represents the configuration for the HTTP server settings in the Curio node.`,
 		},
 		{
 			Name: "Market",
 			Type: "MarketConfig",
 
-			Comment: ``,
+			Comment: `Market specifies configuration options for the Market subsystem within the Curio node.`,
 		},
 		{
 			Name: "Ingest",
 			Type: "CurioIngestConfig",
 
-			Comment: ``,
+			Comment: `Ingest defines configuration parameters for handling and limiting deal ingestion pipelines within the Curio node.`,
 		},
 		{
 			Name: "Seal",
 			Type: "CurioSealConfig",
 
-			Comment: ``,
+			Comment: `Seal defines the configuration related to the sealing process in Curio.`,
 		},
 		{
 			Name: "Apis",
 			Type: "ApisConfig",
 
-			Comment: ``,
+			Comment: `Apis defines the configuration for API-related settings in the Curio system.`,
 		},
 		{
 			Name: "Alerting",
 			Type: "CurioAlertingConfig",
 
-			Comment: ``,
+			Comment: `Alerting specifies configuration settings for alerting mechanisms, including thresholds and external integrations.`,
 		},
 		{
 			Name: "Batching",
 			Type: "CurioBatchingConfig",
 
-			Comment: ``,
+			Comment: `Batching represents the batching configuration for pre-commit, commit, and update operations.`,
 		},
 	},
 	"CurioFees": {
 		{
-			Name: "DefaultMaxFee",
-			Type: "types.FIL",
-
-			Comment: ``,
-		},
-		{
-			Name: "MaxPreCommitGasFee",
-			Type: "types.FIL",
-
-			Comment: ``,
-		},
-		{
-			Name: "MaxCommitGasFee",
-			Type: "types.FIL",
-
-			Comment: ``,
-		},
-		{
 			Name: "MaxPreCommitBatchGasFee",
 			Type: "BatchFeeConfig",
 
-			Comment: `maxBatchFee = maxBase + maxPerSector * nSectors`,
+			Comment: `maxBatchFee = maxBase + maxPerSector * nSectors
+(Default: #Base = "0 FIL" and #PerSector = "0.02 FIL")`,
 		},
 		{
 			Name: "MaxCommitBatchGasFee",
 			Type: "BatchFeeConfig",
 
-			Comment: ``,
+			Comment: `maxBatchFee = maxBase + maxPerSector * nSectors
+(Default: #Base = "0 FIL" and #PerSector = "0.03 FIL")`,
 		},
 		{
 			Name: "MaxUpdateBatchGasFee",
 			Type: "BatchFeeConfig",
 
-			Comment: ``,
-		},
-		{
-			Name: "MaxTerminateGasFee",
-			Type: "types.FIL",
-
-			Comment: ``,
+			Comment: `Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.
+(Default: #Base = "0 FIL" and #PerSector = "0.03 FIL")`,
 		},
 		{
 			Name: "MaxWindowPoStGasFee",
 			Type: "types.FIL",
 
-			Comment: `WindowPoSt is a high-value operation, so the default fee should be high.`,
-		},
-		{
-			Name: "MaxPublishDealsFee",
-			Type: "types.FIL",
-
-			Comment: ``,
+			Comment: `WindowPoSt is a high-value operation, so the default fee should be high.
+Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix. (Default: "5 fil")`,
 		},
 		{
 			Name: "CollateralFromMinerBalance",
 			Type: "bool",
 
-			Comment: `Whether to use available miner balance for sector collateral instead of sending it with each message`,
+			Comment: `Whether to use available miner balance for sector collateral instead of sending it with each message (Default: false)`,
 		},
 		{
 			Name: "DisableCollateralFallback",
 			Type: "bool",
 
-			Comment: `Don't send collateral with messages even if there is no available balance in the miner actor`,
+			Comment: `Don't send collateral with messages even if there is no available balance in the miner actor (Default: false)`,
 		},
 	},
 	"CurioIngestConfig": {
@@ -316,7 +294,7 @@ alerts will be triggered for the wallet`,
 			Comment: `MaxMarketRunningPipelines is the maximum number of market pipelines that can be actively running tasks.
 A "running" pipeline is one that has at least one task currently assigned to a machine (owner_id is not null).
 If this limit is exceeded, the system will apply backpressure to delay processing of new deals.
-0 means unlimited.`,
+0 means unlimited. (Default: 64)`,
 		},
 		{
 			Name: "MaxQueueDownload",
@@ -325,7 +303,7 @@ If this limit is exceeded, the system will apply backpressure to delay processin
 			Comment: `MaxQueueDownload is the maximum number of pipelines that can be queued at the downloading stage,
 waiting for a machine to pick up their task (owner_id is null).
 If this limit is exceeded, the system will apply backpressure to slow the ingestion of new deals.
-0 means unlimited.`,
+0 means unlimited. (Default: 8)`,
 		},
 		{
 			Name: "MaxQueueCommP",
@@ -334,7 +312,7 @@ If this limit is exceeded, the system will apply backpressure to slow the ingest
 			Comment: `MaxQueueCommP is the maximum number of pipelines that can be queued at the CommP (verify) stage,
 waiting for a machine to pick up their verification task (owner_id is null).
 If this limit is exceeded, the system will apply backpressure, delaying new deal processing.
-0 means unlimited.`,
+0 means unlimited. (Default: 8)`,
 		},
 		{
 			Name: "MaxQueueDealSector",
@@ -344,7 +322,7 @@ If this limit is exceeded, the system will apply backpressure, delaying new deal
 0 = unlimited
 Note: This mechanism will delay taking deal data from markets, providing backpressure to the market subsystem.
 The DealSector queue includes deals that are ready to enter the sealing pipeline but are not yet part of it.
-DealSector queue is the first queue in the sealing pipeline, making it the primary backpressure mechanism.`,
+DealSector queue is the first queue in the sealing pipeline, making it the primary backpressure mechanism. (Default: 8)`,
 		},
 		{
 			Name: "MaxQueueSDR",
@@ -356,7 +334,7 @@ Note: This mechanism will delay taking deal data from markets, providing backpre
 The SDR queue includes deals which are in the process of entering the sealing pipeline. In case of the SDR tasks it is
 possible that this queue grows more than this limit(CC sectors), the backpressure is only applied to sectors
 entering the pipeline.
-Only applies to PoRep pipeline (DoSnap = false)`,
+Only applies to PoRep pipeline (DoSnap = false) (Default: 8)`,
 		},
 		{
 			Name: "MaxQueueTrees",
@@ -367,7 +345,7 @@ Only applies to PoRep pipeline (DoSnap = false)`,
 Note: This mechanism will delay taking deal data from markets, providing backpressure to the market subsystem.
 In case of the trees tasks it is possible that this queue grows more than this limit, the backpressure is only
 applied to sectors entering the pipeline.
-Only applies to PoRep pipeline (DoSnap = false)`,
+Only applies to PoRep pipeline (DoSnap = false) (Default: 0)`,
 		},
 		{
 			Name: "MaxQueuePoRep",
@@ -378,7 +356,7 @@ Only applies to PoRep pipeline (DoSnap = false)`,
 Note: This mechanism will delay taking deal data from markets, providing backpressure to the market subsystem.
 Like with the trees tasks, it is possible that this queue grows more than this limit, the backpressure is only
 applied to sectors entering the pipeline.
-Only applies to PoRep pipeline (DoSnap = false)`,
+Only applies to PoRep pipeline (DoSnap = false) (Default: 0)`,
 		},
 		{
 			Name: "MaxQueueSnapEncode",
@@ -387,7 +365,7 @@ Only applies to PoRep pipeline (DoSnap = false)`,
 			Comment: `MaxQueueSnapEncode is the maximum number of sectors that can be queued waiting for UpdateEncode tasks to start.
 0 means unlimited.
 This applies backpressure to the market subsystem by delaying the ingestion of deal data.
-Only applies to the Snap Deals pipeline (DoSnap = true).`,
+Only applies to the Snap Deals pipeline (DoSnap = true). (Default: 16)`,
 		},
 		{
 			Name: "MaxQueueSnapProve",
@@ -395,14 +373,15 @@ Only applies to the Snap Deals pipeline (DoSnap = true).`,
 
 			Comment: `MaxQueueSnapProve is the maximum number of sectors that can be queued waiting for UpdateProve to start processing.
 0 means unlimited.
-This applies backpressure in the Snap Deals pipeline (DoSnap = true) by delaying new deal ingestion.`,
+This applies backpressure in the Snap Deals pipeline (DoSnap = true) by delaying new deal ingestion. (Default: 0)`,
 		},
 		{
 			Name: "MaxDealWaitTime",
-			Type: "Duration",
+			Type: "time.Duration",
 
 			Comment: `Maximum time an open deal sector should wait for more deals before it starts sealing.
-This ensures that sectors don't remain open indefinitely, consuming resources.`,
+This ensures that sectors don't remain open indefinitely, consuming resources.
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")`,
 		},
 		{
 			Name: "DoSnap",
@@ -410,7 +389,7 @@ This ensures that sectors don't remain open indefinitely, consuming resources.`,
 
 			Comment: `DoSnap, when set to true, enables snap deal processing for deals ingested by this instance.
 Unlike lotus-miner, there is no fallback to PoRep when no snap sectors are available.
-When enabled, all deals will be processed as snap deals.`,
+When enabled, all deals will be processed as snap deals. (Default: false)`,
 		},
 	},
 	"CurioProvingConfig": {
@@ -425,22 +404,23 @@ WARNING: Setting this value too low may make sector challenge reading much slowe
 to late submission.
 
 After changing this option, confirm that the new value works in your setup by invoking
-'curio test wd task 0'`,
+'curio test wd task 0' (Default: 32)`,
 		},
 		{
 			Name: "SingleCheckTimeout",
-			Type: "Duration",
+			Type: "time.Duration",
 
 			Comment: `Maximum amount of time a proving pre-check can take for a sector. If the check times out the sector will be skipped
 
 WARNING: Setting this value too low risks in sectors being skipped even though they are accessible, just reading the
 test challenge took longer than this timeout
 WARNING: Setting this value too high risks missing PoSt deadline in case IO operations related to this sector are
-blocked (e.g. in case of disconnected NFS mount)`,
+blocked (e.g. in case of disconnected NFS mount)
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "10m0s")`,
 		},
 		{
 			Name: "PartitionCheckTimeout",
-			Type: "Duration",
+			Type: "time.Duration",
 
 			Comment: `Maximum amount of time a proving pre-check can take for an entire partition. If the check times out, sectors in
 the partition which didn't get checked on time will be skipped
@@ -448,7 +428,7 @@ the partition which didn't get checked on time will be skipped
 WARNING: Setting this value too low risks in sectors being skipped even though they are accessible, just reading the
 test challenge took longer than this timeout
 WARNING: Setting this value too high risks missing PoSt deadline in case IO operations related to this partition are
-blocked or slow`,
+blocked or slow. Time duration string (e.g., "1h2m3s") in TOML format.  (Default: "20m0s")`,
 		},
 	},
 	"CurioSealConfig": {
@@ -457,26 +437,26 @@ blocked or slow`,
 			Type: "string",
 
 			Comment: `BatchSealSectorSize Allows setting the sector size supported by the batch seal task.
-Can be any value as long as it is "32GiB".`,
+Can be any value as long as it is "32GiB". (Default: "32GiB")`,
 		},
 		{
 			Name: "BatchSealBatchSize",
 			Type: "int",
 
-			Comment: `Number of sectors in a seal batch. Depends on hardware and supraseal configuration.`,
+			Comment: `Number of sectors in a seal batch. Depends on hardware and supraseal configuration. (Default: 32)`,
 		},
 		{
 			Name: "BatchSealPipelines",
 			Type: "int",
 
-			Comment: `Number of parallel pipelines. Can be 1 or 2. Depends on available raw block storage`,
+			Comment: `Number of parallel pipelines. Can be 1 or 2. Depends on available raw block storage (Default: 2)`,
 		},
 		{
 			Name: "SingleHasherPerThread",
 			Type: "bool",
 
 			Comment: `SingleHasherPerThread is a compatibility flag for older CPUs. Zen3 and later supports two sectors per thread.
-Set to false for older CPUs (Zen 2 and before).`,
+Set to false for older CPUs (Zen 2 and before). (Default: false)`,
 		},
 		{
 			Name: "LayerNVMEDevices",
@@ -504,13 +484,15 @@ will allow for parallel processing of partitions.
 
 It is possible to have instances handling both WindowPoSt and WinningPoSt, which can provide redundancy without
 the need for additional machines. In setups like this it is generally recommended to run
-partitionsPerDeadline+1 machines.`,
+partitionsPerDeadline+1 machines. (Default: false)`,
 		},
 		{
 			Name: "WindowPostMaxTasks",
 			Type: "int",
 
-			Comment: ``,
+			Comment: `The maximum amount of WindowPostMaxTasks tasks that can run simultaneously. Note that the maximum number of tasks will
+also be bounded by resources available on the machine. We do not recommend setting this value and let system resources determine
+the maximum tasks (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "EnableWinningPost",
@@ -519,13 +501,15 @@ partitionsPerDeadline+1 machines.`,
 			Comment: `EnableWinningPost enables winning post to be executed on this curio instance.
 Each machine in the cluster with WinningPoSt enabled will also participate in the winning post scheduler.
 It is possible to mix machines with WindowPoSt and WinningPoSt enabled, for details see the EnableWindowPost
-documentation.`,
+documentation. (Default: false)`,
 		},
 		{
 			Name: "WinningPostMaxTasks",
 			Type: "int",
 
-			Comment: ``,
+			Comment: `The maximum amount of WinningPostMaxTasks tasks that can run simultaneously. Note that the maximum number of tasks will
+also be bounded by resources available on the machine. We do not recommend setting this value and let system resources determine
+the maximum tasks (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "EnableParkPiece",
@@ -535,13 +519,14 @@ documentation.`,
 pieces from the network and storing them in the storage subsystem until sectors are sealed. This task is
 only applicable when integrating with boost, and should be enabled on nodes which will hold deal data
 from boost until sectors containing the related pieces have the TreeD/TreeR constructed.
-Note that future Curio implementations will have a separate task type for fetching pieces from the internet.`,
+Note that future Curio implementations will have a separate task type for fetching pieces from the internet. (Default: false)`,
 		},
 		{
 			Name: "ParkPieceMaxTasks",
 			Type: "int",
 
-			Comment: ``,
+			Comment: `The maximum amount of ParkPieceMaxTasks tasks that can run simultaneously. Note that the maximum number of tasks will
+also be bounded by resources available on the machine (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "EnableSealSDR",
@@ -554,14 +539,14 @@ SDR is the first task in the sealing pipeline. It's inputs are just the hash of 
 unsealed data (CommD), sector number, miner id, and the seal proof type.
 It's outputs are the 11 layer files in the sector cache directory.
 
-In lotus-miner this was run as part of PreCommit1.`,
+In lotus-miner this was run as part of PreCommit1. (Default: false)`,
 		},
 		{
 			Name: "SealSDRMaxTasks",
 			Type: "int",
 
 			Comment: `The maximum amount of SDR tasks that can run simultaneously. Note that the maximum number of tasks will
-also be bounded by resources available on the machine.`,
+also be bounded by resources available on the machine. (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "SealSDRMinTasks",
@@ -572,7 +557,7 @@ The main purpose of this setting is to allow for enough tasks to accumulate for 
 nodes are present in the cluster, this value should be set to batch_size+1 to allow for the batch sealing node to
 fill up the batch.
 This setting can also be used to give priority to other nodes in the cluster by setting this value to a higher
-value on the nodes which should have less priority.`,
+value on the nodes which should have less priority. (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "EnableSealSDRTrees",
@@ -596,14 +581,14 @@ saving between PreCommit and PoRep generation at the expense of more computation
 
 In lotus-miner this was run as part of PreCommit2 (TreeD was run in PreCommit1).
 Note that nodes with SDRTrees enabled will also answer to Finalize tasks,
-which just remove unneeded tree data after PoRep is computed.`,
+which just remove unneeded tree data after PoRep is computed. (Default: false)`,
 		},
 		{
 			Name: "SealSDRTreesMaxTasks",
 			Type: "int",
 
 			Comment: `The maximum amount of SealSDRTrees tasks that can run simultaneously. Note that the maximum number of tasks will
-also be bounded by resources available on the machine.`,
+also be bounded by resources available on the machine. (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "FinalizeMaxTasks",
@@ -612,7 +597,7 @@ also be bounded by resources available on the machine.`,
 			Comment: `FinalizeMaxTasks is the maximum amount of finalize tasks that can run simultaneously.
 The finalize task is enabled on all machines which also handle SDRTrees tasks. Finalize ALWAYS runs on whichever
 machine holds sector cache files, as it removes unneeded tree data after PoRep is computed.
-Finalize will run in parallel with the SubmitCommitMsg task.`,
+Finalize will run in parallel with the SubmitCommitMsg task. (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "EnableSendPrecommitMsg",
@@ -620,7 +605,7 @@ Finalize will run in parallel with the SubmitCommitMsg task.`,
 
 			Comment: `EnableSendPrecommitMsg enables the sending of precommit messages to the chain
 from this curio instance.
-This runs after SDRTrees and uses the output CommD / CommR (roots of TreeD / TreeR) for the message`,
+This runs after SDRTrees and uses the output CommD / CommR (roots of TreeD / TreeR) for the message (Default: false)`,
 		},
 		{
 			Name: "EnablePoRepProof",
@@ -633,33 +618,33 @@ precommit message lands on chain. This task should run on a machine with a GPU. 
 requested from the machine which holds sector cache files which most likely is the machine which ran the SDRTrees
 task.
 
-In lotus-miner this was Commit1 / Commit2`,
+In lotus-miner this was Commit1 / Commit2 (Default: false)`,
 		},
 		{
 			Name: "PoRepProofMaxTasks",
 			Type: "int",
 
 			Comment: `The maximum amount of PoRepProof tasks that can run simultaneously. Note that the maximum number of tasks will
-also be bounded by resources available on the machine.`,
+also be bounded by resources available on the machine. (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "EnableSendCommitMsg",
 			Type: "bool",
 
 			Comment: `EnableSendCommitMsg enables the sending of commit messages to the chain
-from this curio instance.`,
+from this curio instance. (Default: false)`,
 		},
 		{
 			Name: "RequireActivationSuccess",
 			Type: "bool",
 
-			Comment: `Whether to abort if any sector activation in a batch fails (newly sealed sectors, only with ProveCommitSectors3).`,
+			Comment: `Whether to abort if any sector activation in a batch fails (newly sealed sectors, only with ProveCommitSectors3). (Default: true)`,
 		},
 		{
 			Name: "RequireNotificationSuccess",
 			Type: "bool",
 
-			Comment: `Whether to abort if any sector activation in a batch fails (updating sectors, only with ProveReplicaUpdates3).`,
+			Comment: `Whether to abort if any sector activation in a batch fails (updating sectors, only with ProveReplicaUpdates3). (Default: true)`,
 		},
 		{
 			Name: "EnableMoveStorage",
@@ -669,7 +654,7 @@ from this curio instance.`,
 This tasks should only be enabled on nodes with long-term storage.
 
 The MoveStorage task is the last task in the sealing pipeline. It moves the sealed sector data from the
-SDRTrees machine into long-term storage. This task runs after the Finalize task.`,
+SDRTrees machine into long-term storage. This task runs after the Finalize task. (Default: false)`,
 		},
 		{
 			Name: "NoUnsealedDecode",
@@ -677,7 +662,7 @@ SDRTrees machine into long-term storage. This task runs after the Finalize task.
 
 			Comment: `NoUnsealedDecode disables the decoding sector data on this node. Normally data encoding is enabled by default on
 storage nodes with the MoveStorage task enabled. Setting this option to true means that unsealed data for sectors
-will not be stored on this node`,
+will not be stored on this node (Default: false)`,
 		},
 		{
 			Name: "MoveStorageMaxTasks",
@@ -685,100 +670,100 @@ will not be stored on this node`,
 
 			Comment: `The maximum amount of MoveStorage tasks that can run simultaneously. Note that the maximum number of tasks will
 also be bounded by resources available on the machine. It is recommended that this value is set to a number which
-uses all available network (or disk) bandwidth on the machine without causing bottlenecks.`,
+uses all available network (or disk) bandwidth on the machine without causing bottlenecks. (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "EnableUpdateEncode",
 			Type: "bool",
 
 			Comment: `EnableUpdateEncode enables the encoding step of the SnapDeal process on this curio instance.
-This step involves encoding the data into the sector and computing updated TreeR (uses gpu).`,
+This step involves encoding the data into the sector and computing updated TreeR (uses gpu). (Default: false)`,
 		},
 		{
 			Name: "EnableUpdateProve",
 			Type: "bool",
 
 			Comment: `EnableUpdateProve enables the proving step of the SnapDeal process on this curio instance.
-This step generates the snark proof for the updated sector.`,
+This step generates the snark proof for the updated sector. (Default: false)`,
 		},
 		{
 			Name: "EnableUpdateSubmit",
 			Type: "bool",
 
 			Comment: `EnableUpdateSubmit enables the submission of SnapDeal proofs to the blockchain from this curio instance.
-This step submits the generated proofs to the chain.`,
+This step submits the generated proofs to the chain. (Default: false)`,
 		},
 		{
 			Name: "UpdateEncodeMaxTasks",
 			Type: "int",
 
-			Comment: `UpdateEncodeMaxTasks sets the maximum number of concurrent SnapDeal encoding tasks that can run on this instance.`,
+			Comment: `UpdateEncodeMaxTasks sets the maximum number of concurrent SnapDeal encoding tasks that can run on this instance. (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "UpdateProveMaxTasks",
 			Type: "int",
 
-			Comment: `UpdateProveMaxTasks sets the maximum number of concurrent SnapDeal proving tasks that can run on this instance.`,
+			Comment: `UpdateProveMaxTasks sets the maximum number of concurrent SnapDeal proving tasks that can run on this instance. (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "EnableWebGui",
 			Type: "bool",
 
 			Comment: `EnableWebGui enables the web GUI on this curio instance. The UI has minimal local overhead, but it should
-only need to be run on a single machine in the cluster.`,
+only need to be run on a single machine in the cluster. (Default: false)`,
 		},
 		{
 			Name: "GuiAddress",
 			Type: "string",
 
-			Comment: `The address that should listen for Web GUI requests.`,
+			Comment: `The address that should listen for Web GUI requests. It should be in form "x.x.x.x:1234" (Default: 0.0.0.0:4701)`,
 		},
 		{
 			Name: "UseSyntheticPoRep",
 			Type: "bool",
 
 			Comment: `UseSyntheticPoRep enables the synthetic PoRep for all new sectors. When set to true, will reduce the amount of
-cache data held on disk after the completion of TreeRC task to 11GiB.`,
+cache data held on disk after the completion of TreeRC task to 11GiB. (Default: false)`,
 		},
 		{
 			Name: "SyntheticPoRepMaxTasks",
 			Type: "int",
 
 			Comment: `The maximum amount of SyntheticPoRep tasks that can run simultaneously. Note that the maximum number of tasks will
-also be bounded by resources available on the machine.`,
+also be bounded by resources available on the machine. (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "EnableBatchSeal",
 			Type: "bool",
 
-			Comment: `Batch Seal`,
+			Comment: `EnableBatchSeal enabled SupraSeal batch sealing on the node.  (Default: false)`,
 		},
 		{
 			Name: "EnableDealMarket",
 			Type: "bool",
 
-			Comment: `EnableDealMarket enabled the deal market on the node. This would also enable libp2p on the node, if configured.`,
+			Comment: `EnableDealMarket enabled the deal market on the node. This would also enable libp2p on the node, if configured. (Default: false)`,
 		},
 		{
 			Name: "EnableCommP",
 			Type: "bool",
 
 			Comment: `EnableCommP enables the commP task on te node. CommP is calculated before sending PublishDealMessage for a Mk12 deal
-Must have EnableDealMarket = True`,
+Must have EnableDealMarket = True (Default: false)`,
 		},
 		{
 			Name: "CommPMaxTasks",
 			Type: "int",
 
 			Comment: `The maximum amount of CommP tasks that can run simultaneously. Note that the maximum number of tasks will
-also be bounded by resources available on the machine.`,
+also be bounded by resources available on the machine. (Default: 0 - unlimited)`,
 		},
 		{
 			Name: "IndexingMaxTasks",
 			Type: "int",
 
 			Comment: `The maximum amount of indexing and IPNI tasks that can run simultaneously. Note that the maximum number of tasks will
-also be bounded by resources available on the machine.`,
+also be bounded by resources available on the machine. (Default: 8 - unlimited)`,
 		},
 	},
 	"Duration time.Duration": {
@@ -819,7 +804,7 @@ an IP address`,
 			Name: "ListenAddress",
 			Type: "string",
 
-			Comment: `ListenAddress is the address that the server listens for HTTP requests.`,
+			Comment: `ListenAddress is the address that the server listens for HTTP requests. It should be in form "x.x.x.x:1234" (Default: 0.0.0.0:12310)`,
 		},
 		{
 			Name: "DelegateTLS",
@@ -832,19 +817,22 @@ HTTP and the reverse proxy will handle TLS termination.`,
 			Name: "ReadTimeout",
 			Type: "time.Duration",
 
-			Comment: `ReadTimeout is the maximum duration for reading the entire or next request, including body, from the client.`,
+			Comment: `ReadTimeout is the maximum duration for reading the entire or next request, including body, from the client.
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")`,
 		},
 		{
 			Name: "IdleTimeout",
 			Type: "time.Duration",
 
-			Comment: `IdleTimeout is the maximum duration of an idle session. If set, idle connections are closed after this duration.`,
+			Comment: `IdleTimeout is the maximum duration of an idle session. If set, idle connections are closed after this duration.
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")`,
 		},
 		{
 			Name: "ReadHeaderTimeout",
 			Type: "time.Duration",
 
-			Comment: `ReadHeaderTimeout is amount of time allowed to read request headers`,
+			Comment: `ReadHeaderTimeout is amount of time allowed to read request headers
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")`,
 		},
 		{
 			Name: "EnableCORS",
@@ -899,37 +887,41 @@ heads.`,
 	"MK12Config": {
 		{
 			Name: "PublishMsgPeriod",
-			Type: "Duration",
+			Type: "time.Duration",
 
 			Comment: `When a deal is ready to publish, the amount of time to wait for more
-deals to be ready to publish before publishing them all as a batch`,
+deals to be ready to publish before publishing them all as a batch
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")`,
 		},
 		{
 			Name: "MaxDealsPerPublishMsg",
 			Type: "uint64",
 
 			Comment: `The maximum number of deals to include in a single PublishStorageDeals
-message`,
+message (Default: 8)`,
 		},
 		{
 			Name: "MaxPublishDealFee",
 			Type: "types.FIL",
 
-			Comment: `The maximum fee to pay per deal when sending the PublishStorageDeals message`,
+			Comment: `The maximum fee to pay per deal when sending the PublishStorageDeals message
+Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.5 FIL")`,
 		},
 		{
 			Name: "ExpectedPoRepSealDuration",
-			Type: "Duration",
+			Type: "time.Duration",
 
 			Comment: `ExpectedPoRepSealDuration is the expected time it would take to seal the deal sector
-This will be used to fail the deals which cannot be sealed on time.`,
+This will be used to fail the deals which cannot be sealed on time.
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "8h0m0s")`,
 		},
 		{
 			Name: "ExpectedSnapSealDuration",
-			Type: "Duration",
+			Type: "time.Duration",
 
 			Comment: `ExpectedSnapSealDuration is the expected time it would take to snap the deal sector
-This will be used to fail the deals which cannot be sealed on time.`,
+This will be used to fail the deals which cannot be sealed on time.
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "2h0m0s")`,
 		},
 		{
 			Name: "SkipCommP",
@@ -937,7 +929,7 @@ This will be used to fail the deals which cannot be sealed on time.`,
 
 			Comment: `SkipCommP can be used to skip doing a commP check before PublishDealMessage is sent on chain
 Warning: If this check is skipped and there is a commP mismatch, all deals in the
-sector will need to be sent again`,
+sector will need to be sent again (Default: false)`,
 		},
 		{
 			Name: "DisabledMiners",
@@ -958,19 +950,19 @@ When the cumulative size of all deals in process reaches this number, new deals 
 			Type: "bool",
 
 			Comment: `DenyUnknownClients determines the default behaviour for the deal of clients which are not in allow/deny list
-If True then all deals coming from unknown clients will be rejected.`,
+If True then all deals coming from unknown clients will be rejected. (Default: false)`,
 		},
 		{
 			Name: "DenyOnlineDeals",
 			Type: "bool",
 
-			Comment: `DenyOnlineDeals determines if the storage provider will accept online deals`,
+			Comment: `DenyOnlineDeals determines if the storage provider will accept online deals (Default: false)`,
 		},
 		{
 			Name: "DenyOfflineDeals",
 			Type: "bool",
 
-			Comment: `DenyOfflineDeals determines if the storage provider will accept offline deals`,
+			Comment: `DenyOfflineDeals determines if the storage provider will accept offline deals (Default: false)`,
 		},
 		{
 			Name: "CIDGravityToken",
@@ -984,7 +976,7 @@ If empty then CIDGravity filters are not called.`,
 			Type: "bool",
 
 			Comment: `DefaultCIDGravityAccept when set to true till accept deals when CIDGravity service is not available.
-Default behaviors is to reject the deals`,
+Default behaviors is to reject the deals (Default: false)`,
 		},
 	},
 	"MarketConfig": {
@@ -1037,19 +1029,22 @@ identifier in the integration page for the service.`,
 			Name: "BaseFeeThreshold",
 			Type: "types.FIL",
 
-			Comment: `Base fee value below which we should try to send Precommit messages immediately`,
+			Comment: `Base fee value below which we should try to send Precommit messages immediately
+Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.005 FIL")`,
 		},
 		{
 			Name: "Timeout",
-			Type: "Duration",
+			Type: "time.Duration",
 
-			Comment: `Maximum amount of time any given sector in the batch can wait for the batch to accumulate`,
+			Comment: `Maximum amount of time any given sector in the batch can wait for the batch to accumulate
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "4h0m0s")`,
 		},
 		{
 			Name: "Slack",
-			Type: "Duration",
+			Type: "time.Duration",
 
-			Comment: `Time buffer for forceful batch submission before sectors/deal in batch would start expiring`,
+			Comment: `Time buffer for forceful batch submission before sectors/deal in batch would start expiring
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "6h0m0s")`,
 		},
 	},
 	"PrometheusAlertManagerConfig": {
@@ -1116,19 +1111,22 @@ The server must support "HEAD" request and "GET" request.
 			Name: "BaseFeeThreshold",
 			Type: "types.FIL",
 
-			Comment: `Base fee value below which we should try to send Commit messages immediately`,
+			Comment: `Base fee value below which we should try to send Commit messages immediately
+Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.005 FIL")`,
 		},
 		{
 			Name: "Timeout",
-			Type: "Duration",
+			Type: "time.Duration",
 
-			Comment: `Maximum amount of time any given sector in the batch can wait for the batch to accumulate`,
+			Comment: `Maximum amount of time any given sector in the batch can wait for the batch to accumulate
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")`,
 		},
 		{
 			Name: "Slack",
-			Type: "Duration",
+			Type: "time.Duration",
 
-			Comment: `Time buffer for forceful batch submission before sectors/deals in batch would start expiring`,
+			Comment: `Time buffer for forceful batch submission before sectors/deals in batch would start expiring
+Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")`,
 		},
 	},
 }

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -447,25 +447,6 @@ type CurioProvingConfig struct {
 	PartitionCheckTimeout time.Duration
 }
 
-// Duration is a wrapper type for time.Duration
-// for decoding and encoding from/to TOML
-type Duration time.Duration
-
-func (dur Duration) MarshalText() ([]byte, error) {
-	d := time.Duration(dur)
-	return []byte(d.String()), nil
-}
-
-// UnmarshalText implements interface for TOML decoding
-func (dur *Duration) UnmarshalText(text []byte) error {
-	d, err := time.ParseDuration(string(text))
-	if err != nil {
-		return err
-	}
-	*dur = Duration(d)
-	return err
-}
-
 type CurioIngestConfig struct {
 	// MaxMarketRunningPipelines is the maximum number of market pipelines that can be actively running tasks.
 	// A "running" pipeline is one that has at least one task currently assigned to a machine (owner_id is not null).

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -363,7 +363,7 @@ type CurioSubsystemsConfig struct {
 	CommPMaxTasks int
 
 	// The maximum amount of indexing and IPNI tasks that can run simultaneously. Note that the maximum number of tasks will
-	// also be bounded by resources available on the machine. (Default: 8 - unlimited)
+	// also be bounded by resources available on the machine. (Default: 8)
 	IndexingMaxTasks int
 }
 type CurioFees struct {

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -19,10 +19,6 @@ func DefaultCurioConfig() *CurioConfig {
 			IndexingMaxTasks:           8,
 		},
 		Fees: CurioFees{
-			DefaultMaxFee:      DefaultDefaultMaxFee(),
-			MaxPreCommitGasFee: types.MustParseFIL("0.025"),
-			MaxCommitGasFee:    types.MustParseFIL("0.05"),
-
 			MaxPreCommitBatchGasFee: BatchFeeConfig{
 				Base:      types.MustParseFIL("0"),
 				PerSector: types.MustParseFIL("0.02"),
@@ -36,9 +32,7 @@ func DefaultCurioConfig() *CurioConfig {
 				PerSector: types.MustParseFIL("0.03"),
 			},
 
-			MaxTerminateGasFee:         types.MustParseFIL("0.5"),
 			MaxWindowPoStGasFee:        types.MustParseFIL("5"),
-			MaxPublishDealsFee:         types.MustParseFIL("0.05"),
 			CollateralFromMinerBalance: false,
 			DisableCollateralFallback:  false,
 		},
@@ -51,8 +45,8 @@ func DefaultCurioConfig() *CurioConfig {
 		}},
 		Proving: CurioProvingConfig{
 			ParallelCheckLimit:    32,
-			PartitionCheckTimeout: Duration(20 * time.Minute),
-			SingleCheckTimeout:    Duration(10 * time.Minute),
+			PartitionCheckTimeout: 20 * time.Minute,
+			SingleCheckTimeout:    10 * time.Minute,
 		},
 		Seal: CurioSealConfig{
 			BatchSealPipelines:  2,
@@ -72,7 +66,7 @@ func DefaultCurioConfig() *CurioConfig {
 			MaxQueueSnapEncode: 16,
 			MaxQueueSnapProve:  0,
 
-			MaxDealWaitTime: Duration(1 * time.Hour),
+			MaxDealWaitTime: time.Hour,
 		},
 		Alerting: CurioAlertingConfig{
 			MinimumWalletBalance: types.MustParseFIL("5"),
@@ -86,18 +80,18 @@ func DefaultCurioConfig() *CurioConfig {
 		Batching: CurioBatchingConfig{
 			PreCommit: PreCommitBatchingConfig{
 				BaseFeeThreshold: types.MustParseFIL("0.005"),
-				Timeout:          Duration(4 * time.Hour),
-				Slack:            Duration(6 * time.Hour),
+				Timeout:          4 * time.Hour,
+				Slack:            6 * time.Hour,
 			},
 			Commit: CommitBatchingConfig{
 				BaseFeeThreshold: types.MustParseFIL("0.005"),
-				Timeout:          Duration(1 * time.Hour),
-				Slack:            Duration(1 * time.Hour),
+				Timeout:          time.Hour,
+				Slack:            time.Hour,
 			},
 			Update: UpdateBatchingConfig{
 				BaseFeeThreshold: types.MustParseFIL("0.005"),
-				Timeout:          Duration(1 * time.Hour),
-				Slack:            Duration(1 * time.Hour),
+				Timeout:          time.Hour,
+				Slack:            time.Hour,
 			},
 		},
 		Market: MarketConfig{
@@ -108,11 +102,11 @@ func DefaultCurioConfig() *CurioConfig {
 					InsertBatchSize:   1000,
 				},
 				MK12: MK12Config{
-					PublishMsgPeriod:          Duration(5 * time.Minute),
+					PublishMsgPeriod:          5 * time.Minute,
 					MaxDealsPerPublishMsg:     8,
 					MaxPublishDealFee:         types.MustParseFIL("0.5 FIL"),
-					ExpectedPoRepSealDuration: Duration(8 * time.Hour),
-					ExpectedSnapSealDuration:  Duration(2 * time.Hour),
+					ExpectedPoRepSealDuration: 8 * time.Hour,
+					ExpectedSnapSealDuration:  2 * time.Hour,
 				},
 				IPNI: IPNIConfig{
 					ServiceURL:         []string{"https://cid.contact"},
@@ -136,29 +130,48 @@ func DefaultCurioConfig() *CurioConfig {
 	}
 }
 
+// CurioConfig defines configuration for the Curio node
 type CurioConfig struct {
+
+	// Subsystems defines configuration settings for various subsystems within the Curio node.
 	Subsystems CurioSubsystemsConfig
 
+	// Fees holds the fee-related configuration parameters for various operations in the Curio node.
 	Fees CurioFees
 
-	// Addresses of wallets per MinerAddress (one of the fields).
+	// Addresses specifies the list of miner addresses and their related wallet addresses.
 	Addresses []CurioAddresses
-	Proving   CurioProvingConfig
-	HTTP      HTTPConfig
-	Market    MarketConfig
-	Ingest    CurioIngestConfig
-	Seal      CurioSealConfig
-	Apis      ApisConfig
-	Alerting  CurioAlertingConfig
-	Batching  CurioBatchingConfig
-}
 
-func DefaultDefaultMaxFee() types.FIL {
-	return types.MustParseFIL("0.07")
+	// Proving defines the configuration settings related to proving functionality within the Curio node.
+	Proving CurioProvingConfig
+
+	// HTTP represents the configuration for the HTTP server settings in the Curio node.
+	HTTP HTTPConfig
+
+	// Market specifies configuration options for the Market subsystem within the Curio node.
+	Market MarketConfig
+
+	// Ingest defines configuration parameters for handling and limiting deal ingestion pipelines within the Curio node.
+	Ingest CurioIngestConfig
+
+	// Seal defines the configuration related to the sealing process in Curio.
+	Seal CurioSealConfig
+
+	// Apis defines the configuration for API-related settings in the Curio system.
+	Apis ApisConfig
+
+	// Alerting specifies configuration settings for alerting mechanisms, including thresholds and external integrations.
+	Alerting CurioAlertingConfig
+
+	// Batching represents the batching configuration for pre-commit, commit, and update operations.
+	Batching CurioBatchingConfig
 }
 
 type BatchFeeConfig struct {
-	Base      types.FIL
+	// Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.
+	Base types.FIL
+
+	// Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.
 	PerSector types.FIL
 }
 
@@ -174,23 +187,34 @@ type CurioSubsystemsConfig struct {
 	//
 	// It is possible to have instances handling both WindowPoSt and WinningPoSt, which can provide redundancy without
 	// the need for additional machines. In setups like this it is generally recommended to run
-	// partitionsPerDeadline+1 machines.
-	EnableWindowPost   bool
+	// partitionsPerDeadline+1 machines. (Default: false)
+	EnableWindowPost bool
+
+	// The maximum amount of WindowPostMaxTasks tasks that can run simultaneously. Note that the maximum number of tasks will
+	// also be bounded by resources available on the machine. We do not recommend setting this value and let system resources determine
+	// the maximum tasks (Default: 0 - unlimited)
 	WindowPostMaxTasks int
 
 	// EnableWinningPost enables winning post to be executed on this curio instance.
 	// Each machine in the cluster with WinningPoSt enabled will also participate in the winning post scheduler.
 	// It is possible to mix machines with WindowPoSt and WinningPoSt enabled, for details see the EnableWindowPost
-	// documentation.
-	EnableWinningPost   bool
+	// documentation. (Default: false)
+	EnableWinningPost bool
+
+	// The maximum amount of WinningPostMaxTasks tasks that can run simultaneously. Note that the maximum number of tasks will
+	// also be bounded by resources available on the machine. We do not recommend setting this value and let system resources determine
+	// the maximum tasks (Default: 0 - unlimited)
 	WinningPostMaxTasks int
 
 	// EnableParkPiece enables the "piece parking" task to run on this node. This task is responsible for fetching
 	// pieces from the network and storing them in the storage subsystem until sectors are sealed. This task is
 	// only applicable when integrating with boost, and should be enabled on nodes which will hold deal data
 	// from boost until sectors containing the related pieces have the TreeD/TreeR constructed.
-	// Note that future Curio implementations will have a separate task type for fetching pieces from the internet.
-	EnableParkPiece   bool
+	// Note that future Curio implementations will have a separate task type for fetching pieces from the internet. (Default: false)
+	EnableParkPiece bool
+
+	// The maximum amount of ParkPieceMaxTasks tasks that can run simultaneously. Note that the maximum number of tasks will
+	// also be bounded by resources available on the machine (Default: 0 - unlimited)
 	ParkPieceMaxTasks int
 
 	// EnableSealSDR enables SDR tasks to run. SDR is the long sequential computation
@@ -200,11 +224,11 @@ type CurioSubsystemsConfig struct {
 	// unsealed data (CommD), sector number, miner id, and the seal proof type.
 	// It's outputs are the 11 layer files in the sector cache directory.
 	//
-	// In lotus-miner this was run as part of PreCommit1.
+	// In lotus-miner this was run as part of PreCommit1. (Default: false)
 	EnableSealSDR bool
 
 	// The maximum amount of SDR tasks that can run simultaneously. Note that the maximum number of tasks will
-	// also be bounded by resources available on the machine.
+	// also be bounded by resources available on the machine. (Default: 0 - unlimited)
 	SealSDRMaxTasks int
 
 	// The maximum amount of SDR tasks that need to be queued before the system will start accepting new tasks.
@@ -212,7 +236,7 @@ type CurioSubsystemsConfig struct {
 	// nodes are present in the cluster, this value should be set to batch_size+1 to allow for the batch sealing node to
 	// fill up the batch.
 	// This setting can also be used to give priority to other nodes in the cluster by setting this value to a higher
-	// value on the nodes which should have less priority.
+	// value on the nodes which should have less priority. (Default: 0 - unlimited)
 	SealSDRMinTasks int
 
 	// EnableSealSDRTrees enables the SDR pipeline tree-building task to run.
@@ -233,22 +257,22 @@ type CurioSubsystemsConfig struct {
 	//
 	// In lotus-miner this was run as part of PreCommit2 (TreeD was run in PreCommit1).
 	// Note that nodes with SDRTrees enabled will also answer to Finalize tasks,
-	// which just remove unneeded tree data after PoRep is computed.
+	// which just remove unneeded tree data after PoRep is computed. (Default: false)
 	EnableSealSDRTrees bool
 
 	// The maximum amount of SealSDRTrees tasks that can run simultaneously. Note that the maximum number of tasks will
-	// also be bounded by resources available on the machine.
+	// also be bounded by resources available on the machine. (Default: 0 - unlimited)
 	SealSDRTreesMaxTasks int
 
 	// FinalizeMaxTasks is the maximum amount of finalize tasks that can run simultaneously.
 	// The finalize task is enabled on all machines which also handle SDRTrees tasks. Finalize ALWAYS runs on whichever
 	// machine holds sector cache files, as it removes unneeded tree data after PoRep is computed.
-	// Finalize will run in parallel with the SubmitCommitMsg task.
+	// Finalize will run in parallel with the SubmitCommitMsg task. (Default: 0 - unlimited)
 	FinalizeMaxTasks int
 
 	// EnableSendPrecommitMsg enables the sending of precommit messages to the chain
 	// from this curio instance.
-	// This runs after SDRTrees and uses the output CommD / CommR (roots of TreeD / TreeR) for the message
+	// This runs after SDRTrees and uses the output CommD / CommR (roots of TreeD / TreeR) for the message (Default: false)
 	EnableSendPrecommitMsg bool
 
 	// EnablePoRepProof enables the computation of the porep proof
@@ -258,129 +282,138 @@ type CurioSubsystemsConfig struct {
 	// requested from the machine which holds sector cache files which most likely is the machine which ran the SDRTrees
 	// task.
 	//
-	// In lotus-miner this was Commit1 / Commit2
+	// In lotus-miner this was Commit1 / Commit2 (Default: false)
 	EnablePoRepProof bool
 
 	// The maximum amount of PoRepProof tasks that can run simultaneously. Note that the maximum number of tasks will
-	// also be bounded by resources available on the machine.
+	// also be bounded by resources available on the machine. (Default: 0 - unlimited)
 	PoRepProofMaxTasks int
 
 	// EnableSendCommitMsg enables the sending of commit messages to the chain
-	// from this curio instance.
+	// from this curio instance. (Default: false)
 	EnableSendCommitMsg bool
 
-	// Whether to abort if any sector activation in a batch fails (newly sealed sectors, only with ProveCommitSectors3).
+	// Whether to abort if any sector activation in a batch fails (newly sealed sectors, only with ProveCommitSectors3). (Default: true)
 	RequireActivationSuccess bool
-	// Whether to abort if any sector activation in a batch fails (updating sectors, only with ProveReplicaUpdates3).
+	// Whether to abort if any sector activation in a batch fails (updating sectors, only with ProveReplicaUpdates3). (Default: true)
 	RequireNotificationSuccess bool
 
 	// EnableMoveStorage enables the move-into-long-term-storage task to run on this curio instance.
 	// This tasks should only be enabled on nodes with long-term storage.
 	//
 	// The MoveStorage task is the last task in the sealing pipeline. It moves the sealed sector data from the
-	// SDRTrees machine into long-term storage. This task runs after the Finalize task.
+	// SDRTrees machine into long-term storage. This task runs after the Finalize task. (Default: false)
 	EnableMoveStorage bool
 
 	// NoUnsealedDecode disables the decoding sector data on this node. Normally data encoding is enabled by default on
 	// storage nodes with the MoveStorage task enabled. Setting this option to true means that unsealed data for sectors
-	// will not be stored on this node
+	// will not be stored on this node (Default: false)
 	NoUnsealedDecode bool
 
 	// The maximum amount of MoveStorage tasks that can run simultaneously. Note that the maximum number of tasks will
 	// also be bounded by resources available on the machine. It is recommended that this value is set to a number which
-	// uses all available network (or disk) bandwidth on the machine without causing bottlenecks.
+	// uses all available network (or disk) bandwidth on the machine without causing bottlenecks. (Default: 0 - unlimited)
 	MoveStorageMaxTasks int
 
 	// EnableUpdateEncode enables the encoding step of the SnapDeal process on this curio instance.
-	// This step involves encoding the data into the sector and computing updated TreeR (uses gpu).
+	// This step involves encoding the data into the sector and computing updated TreeR (uses gpu). (Default: false)
 	EnableUpdateEncode bool
 
 	// EnableUpdateProve enables the proving step of the SnapDeal process on this curio instance.
-	// This step generates the snark proof for the updated sector.
+	// This step generates the snark proof for the updated sector. (Default: false)
 	EnableUpdateProve bool
 
 	// EnableUpdateSubmit enables the submission of SnapDeal proofs to the blockchain from this curio instance.
-	// This step submits the generated proofs to the chain.
+	// This step submits the generated proofs to the chain. (Default: false)
 	EnableUpdateSubmit bool
 
-	// UpdateEncodeMaxTasks sets the maximum number of concurrent SnapDeal encoding tasks that can run on this instance.
+	// UpdateEncodeMaxTasks sets the maximum number of concurrent SnapDeal encoding tasks that can run on this instance. (Default: 0 - unlimited)
 	UpdateEncodeMaxTasks int
 
-	// UpdateProveMaxTasks sets the maximum number of concurrent SnapDeal proving tasks that can run on this instance.
+	// UpdateProveMaxTasks sets the maximum number of concurrent SnapDeal proving tasks that can run on this instance. (Default: 0 - unlimited)
 	UpdateProveMaxTasks int
 
 	// EnableWebGui enables the web GUI on this curio instance. The UI has minimal local overhead, but it should
-	// only need to be run on a single machine in the cluster.
+	// only need to be run on a single machine in the cluster. (Default: false)
 	EnableWebGui bool
 
-	// The address that should listen for Web GUI requests.
+	// The address that should listen for Web GUI requests. It should be in form "x.x.x.x:1234" (Default: 0.0.0.0:4701)
 	GuiAddress string
 
 	// UseSyntheticPoRep enables the synthetic PoRep for all new sectors. When set to true, will reduce the amount of
-	// cache data held on disk after the completion of TreeRC task to 11GiB.
+	// cache data held on disk after the completion of TreeRC task to 11GiB. (Default: false)
 	UseSyntheticPoRep bool
 
 	// The maximum amount of SyntheticPoRep tasks that can run simultaneously. Note that the maximum number of tasks will
-	// also be bounded by resources available on the machine.
+	// also be bounded by resources available on the machine. (Default: 0 - unlimited)
 	SyntheticPoRepMaxTasks int
 
-	// Batch Seal
+	// EnableBatchSeal enabled SupraSeal batch sealing on the node.  (Default: false)
 	EnableBatchSeal bool
 
-	// EnableDealMarket enabled the deal market on the node. This would also enable libp2p on the node, if configured.
+	// EnableDealMarket enabled the deal market on the node. This would also enable libp2p on the node, if configured. (Default: false)
 	EnableDealMarket bool
 
 	// EnableCommP enables the commP task on te node. CommP is calculated before sending PublishDealMessage for a Mk12 deal
-	// Must have EnableDealMarket = True
+	// Must have EnableDealMarket = True (Default: false)
 	EnableCommP bool
 
 	// The maximum amount of CommP tasks that can run simultaneously. Note that the maximum number of tasks will
-	// also be bounded by resources available on the machine.
+	// also be bounded by resources available on the machine. (Default: 0 - unlimited)
 	CommPMaxTasks int
 
 	// The maximum amount of indexing and IPNI tasks that can run simultaneously. Note that the maximum number of tasks will
-	// also be bounded by resources available on the machine.
+	// also be bounded by resources available on the machine. (Default: 8 - unlimited)
 	IndexingMaxTasks int
 }
 type CurioFees struct {
-	DefaultMaxFee      types.FIL
-	MaxPreCommitGasFee types.FIL
-	MaxCommitGasFee    types.FIL
+	// maxBatchFee = maxBase + maxPerSector * nSectors
+	// (Default: #Base = "0 FIL" and #PerSector = "0.02 FIL")
+	MaxPreCommitBatchGasFee BatchFeeConfig
 
 	// maxBatchFee = maxBase + maxPerSector * nSectors
-	MaxPreCommitBatchGasFee BatchFeeConfig
-	MaxCommitBatchGasFee    BatchFeeConfig
-	MaxUpdateBatchGasFee    BatchFeeConfig
+	// (Default: #Base = "0 FIL" and #PerSector = "0.03 FIL")
+	MaxCommitBatchGasFee BatchFeeConfig
 
-	MaxTerminateGasFee types.FIL
+	// Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.
+	// (Default: #Base = "0 FIL" and #PerSector = "0.03 FIL")
+	MaxUpdateBatchGasFee BatchFeeConfig
+
 	// WindowPoSt is a high-value operation, so the default fee should be high.
+	// Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix. (Default: "5 fil")
 	MaxWindowPoStGasFee types.FIL
-	MaxPublishDealsFee  types.FIL
-	// Whether to use available miner balance for sector collateral instead of sending it with each message
+
+	// Whether to use available miner balance for sector collateral instead of sending it with each message (Default: false)
 	CollateralFromMinerBalance bool
-	// Don't send collateral with messages even if there is no available balance in the miner actor
+
+	// Don't send collateral with messages even if there is no available balance in the miner actor (Default: false)
 	DisableCollateralFallback bool
 }
 
 type CurioAddresses struct {
-	// Addresses to send PreCommit messages from
+	// PreCommitControl is an array of Addresses to send PreCommit messages from
 	PreCommitControl []string
-	// Addresses to send Commit messages from
+
+	// CommitControl is an array of Addresses to send Commit messages from
 	CommitControl []string
-	// Address to send the deal collateral from with PublishStorageDeal Message
+
+	// DealPublishControl is an array of Address to send the deal collateral from with PublishStorageDeal Message
 	DealPublishControl []string
-	TerminateControl   []string
+
+	// TerminateControl is a list of addresses used to send Terminate messages.
+	TerminateControl []string
 
 	// DisableOwnerFallback disables usage of the owner address for messages
 	// sent automatically
 	DisableOwnerFallback bool
+
 	// DisableWorkerFallback disables usage of the worker address for messages
 	// sent automatically, if control addresses are configured.
 	// A control address that doesn't have enough funds will still be chosen
 	// over the worker address if this flag is set.
 	DisableWorkerFallback bool
 
-	// MinerAddresses are the addresses of the miner actors to use for sending messages
+	// MinerAddresses are the addresses of the miner actors
 	MinerAddresses []string
 }
 
@@ -392,7 +425,7 @@ type CurioProvingConfig struct {
 	// to late submission.
 	//
 	// After changing this option, confirm that the new value works in your setup by invoking
-	// 'curio test wd task 0'
+	// 'curio test wd task 0' (Default: 32)
 	ParallelCheckLimit int
 
 	// Maximum amount of time a proving pre-check can take for a sector. If the check times out the sector will be skipped
@@ -401,7 +434,8 @@ type CurioProvingConfig struct {
 	// test challenge took longer than this timeout
 	// WARNING: Setting this value too high risks missing PoSt deadline in case IO operations related to this sector are
 	// blocked (e.g. in case of disconnected NFS mount)
-	SingleCheckTimeout Duration
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "10m0s")
+	SingleCheckTimeout time.Duration
 
 	// Maximum amount of time a proving pre-check can take for an entire partition. If the check times out, sectors in
 	// the partition which didn't get checked on time will be skipped
@@ -409,8 +443,8 @@ type CurioProvingConfig struct {
 	// WARNING: Setting this value too low risks in sectors being skipped even though they are accessible, just reading the
 	// test challenge took longer than this timeout
 	// WARNING: Setting this value too high risks missing PoSt deadline in case IO operations related to this partition are
-	// blocked or slow
-	PartitionCheckTimeout Duration
+	// blocked or slow. Time duration string (e.g., "1h2m3s") in TOML format.  (Default: "20m0s")
+	PartitionCheckTimeout time.Duration
 }
 
 // Duration is a wrapper type for time.Duration
@@ -436,26 +470,26 @@ type CurioIngestConfig struct {
 	// MaxMarketRunningPipelines is the maximum number of market pipelines that can be actively running tasks.
 	// A "running" pipeline is one that has at least one task currently assigned to a machine (owner_id is not null).
 	// If this limit is exceeded, the system will apply backpressure to delay processing of new deals.
-	// 0 means unlimited.
+	// 0 means unlimited. (Default: 64)
 	MaxMarketRunningPipelines int
 
 	// MaxQueueDownload is the maximum number of pipelines that can be queued at the downloading stage,
 	// waiting for a machine to pick up their task (owner_id is null).
 	// If this limit is exceeded, the system will apply backpressure to slow the ingestion of new deals.
-	// 0 means unlimited.
+	// 0 means unlimited. (Default: 8)
 	MaxQueueDownload int
 
 	// MaxQueueCommP is the maximum number of pipelines that can be queued at the CommP (verify) stage,
 	// waiting for a machine to pick up their verification task (owner_id is null).
 	// If this limit is exceeded, the system will apply backpressure, delaying new deal processing.
-	// 0 means unlimited.
+	// 0 means unlimited. (Default: 8)
 	MaxQueueCommP int
 
 	// Maximum number of sectors that can be queued waiting for deals to start processing.
 	// 0 = unlimited
 	// Note: This mechanism will delay taking deal data from markets, providing backpressure to the market subsystem.
 	// The DealSector queue includes deals that are ready to enter the sealing pipeline but are not yet part of it.
-	// DealSector queue is the first queue in the sealing pipeline, making it the primary backpressure mechanism.
+	// DealSector queue is the first queue in the sealing pipeline, making it the primary backpressure mechanism. (Default: 8)
 	MaxQueueDealSector int
 
 	// Maximum number of sectors that can be queued waiting for SDR to start processing.
@@ -464,7 +498,7 @@ type CurioIngestConfig struct {
 	// The SDR queue includes deals which are in the process of entering the sealing pipeline. In case of the SDR tasks it is
 	// possible that this queue grows more than this limit(CC sectors), the backpressure is only applied to sectors
 	// entering the pipeline.
-	// Only applies to PoRep pipeline (DoSnap = false)
+	// Only applies to PoRep pipeline (DoSnap = false) (Default: 8)
 	MaxQueueSDR int
 
 	// Maximum number of sectors that can be queued waiting for SDRTrees to start processing.
@@ -472,7 +506,7 @@ type CurioIngestConfig struct {
 	// Note: This mechanism will delay taking deal data from markets, providing backpressure to the market subsystem.
 	// In case of the trees tasks it is possible that this queue grows more than this limit, the backpressure is only
 	// applied to sectors entering the pipeline.
-	// Only applies to PoRep pipeline (DoSnap = false)
+	// Only applies to PoRep pipeline (DoSnap = false) (Default: 0)
 	MaxQueueTrees int
 
 	// Maximum number of sectors that can be queued waiting for PoRep to start processing.
@@ -480,33 +514,35 @@ type CurioIngestConfig struct {
 	// Note: This mechanism will delay taking deal data from markets, providing backpressure to the market subsystem.
 	// Like with the trees tasks, it is possible that this queue grows more than this limit, the backpressure is only
 	// applied to sectors entering the pipeline.
-	// Only applies to PoRep pipeline (DoSnap = false)
+	// Only applies to PoRep pipeline (DoSnap = false) (Default: 0)
 	MaxQueuePoRep int
 
 	// MaxQueueSnapEncode is the maximum number of sectors that can be queued waiting for UpdateEncode tasks to start.
 	// 0 means unlimited.
 	// This applies backpressure to the market subsystem by delaying the ingestion of deal data.
-	// Only applies to the Snap Deals pipeline (DoSnap = true).
+	// Only applies to the Snap Deals pipeline (DoSnap = true). (Default: 16)
 	MaxQueueSnapEncode int
 
 	// MaxQueueSnapProve is the maximum number of sectors that can be queued waiting for UpdateProve to start processing.
 	// 0 means unlimited.
-	// This applies backpressure in the Snap Deals pipeline (DoSnap = true) by delaying new deal ingestion.
+	// This applies backpressure in the Snap Deals pipeline (DoSnap = true) by delaying new deal ingestion. (Default: 0)
 	MaxQueueSnapProve int
 
 	// Maximum time an open deal sector should wait for more deals before it starts sealing.
 	// This ensures that sectors don't remain open indefinitely, consuming resources.
-	MaxDealWaitTime Duration
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")
+	MaxDealWaitTime time.Duration
 
 	// DoSnap, when set to true, enables snap deal processing for deals ingested by this instance.
 	// Unlike lotus-miner, there is no fallback to PoRep when no snap sectors are available.
-	// When enabled, all deals will be processed as snap deals.
+	// When enabled, all deals will be processed as snap deals. (Default: false)
 	DoSnap bool
 }
 
 type CurioAlertingConfig struct {
 	// MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
 	// alerts will be triggered for the wallet
+	// Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")
 	MinimumWalletBalance types.FIL
 
 	// PagerDutyConfig is the configuration for the PagerDuty alerting integration.
@@ -521,17 +557,17 @@ type CurioAlertingConfig struct {
 
 type CurioSealConfig struct {
 	// BatchSealSectorSize Allows setting the sector size supported by the batch seal task.
-	// Can be any value as long as it is "32GiB".
+	// Can be any value as long as it is "32GiB". (Default: "32GiB")
 	BatchSealSectorSize string
 
-	// Number of sectors in a seal batch. Depends on hardware and supraseal configuration.
+	// Number of sectors in a seal batch. Depends on hardware and supraseal configuration. (Default: 32)
 	BatchSealBatchSize int
 
-	// Number of parallel pipelines. Can be 1 or 2. Depends on available raw block storage
+	// Number of parallel pipelines. Can be 1 or 2. Depends on available raw block storage (Default: 2)
 	BatchSealPipelines int
 
 	// SingleHasherPerThread is a compatibility flag for older CPUs. Zen3 and later supports two sectors per thread.
-	// Set to false for older CPUs (Zen 2 and before).
+	// Set to false for older CPUs (Zen 2 and before). (Default: false)
 	SingleHasherPerThread bool
 
 	// LayerNVMEDevices is a list of pcie device addresses that should be used for SDR layer storage.
@@ -580,7 +616,7 @@ type ApisConfig struct {
 	// ChainApiInfo is the API endpoint for the Lotus daemon.
 	ChainApiInfo []string
 
-	// Chain API auth secret for the Curio nodes to use.
+	// API auth secret for the Curio nodes to use. This value should only be set on the bade layer.
 	StorageRPCSecret string
 }
 
@@ -597,35 +633,44 @@ type CurioBatchingConfig struct {
 
 type PreCommitBatchingConfig struct {
 	// Base fee value below which we should try to send Precommit messages immediately
+	// Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.005 FIL")
 	BaseFeeThreshold types.FIL
 
 	// Maximum amount of time any given sector in the batch can wait for the batch to accumulate
-	Timeout Duration
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "4h0m0s")
+	Timeout time.Duration
 
 	// Time buffer for forceful batch submission before sectors/deal in batch would start expiring
-	Slack Duration
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "6h0m0s")
+	Slack time.Duration
 }
 
 type CommitBatchingConfig struct {
 	// Base fee value below which we should try to send Commit messages immediately
+	// Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.005 FIL")
 	BaseFeeThreshold types.FIL
 
 	// Maximum amount of time any given sector in the batch can wait for the batch to accumulate
-	Timeout Duration
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")
+	Timeout time.Duration
 
 	// Time buffer for forceful batch submission before sectors/deals in batch would start expiring
-	Slack Duration
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")
+	Slack time.Duration
 }
 
 type UpdateBatchingConfig struct {
 	// Base fee value below which we should try to send Commit messages immediately
+	// Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.005 FIL")
 	BaseFeeThreshold types.FIL
 
 	// Maximum amount of time any given sector in the batch can wait for the batch to accumulate
-	Timeout Duration
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")
+	Timeout time.Duration
 
 	// Time buffer for forceful batch submission before sectors/deals in batch would start expiring
-	Slack Duration
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")
+	Slack time.Duration
 }
 
 type MarketConfig struct {
@@ -654,26 +699,30 @@ type StorageMarketConfig struct {
 type MK12Config struct {
 	// When a deal is ready to publish, the amount of time to wait for more
 	// deals to be ready to publish before publishing them all as a batch
-	PublishMsgPeriod Duration
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")
+	PublishMsgPeriod time.Duration
 
 	// The maximum number of deals to include in a single PublishStorageDeals
-	// message
+	// message (Default: 8)
 	MaxDealsPerPublishMsg uint64
 
 	// The maximum fee to pay per deal when sending the PublishStorageDeals message
+	// Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.5 FIL")
 	MaxPublishDealFee types.FIL
 
 	// ExpectedPoRepSealDuration is the expected time it would take to seal the deal sector
 	// This will be used to fail the deals which cannot be sealed on time.
-	ExpectedPoRepSealDuration Duration
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "8h0m0s")
+	ExpectedPoRepSealDuration time.Duration
 
 	// ExpectedSnapSealDuration is the expected time it would take to snap the deal sector
 	// This will be used to fail the deals which cannot be sealed on time.
-	ExpectedSnapSealDuration Duration
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "2h0m0s")
+	ExpectedSnapSealDuration time.Duration
 
 	// SkipCommP can be used to skip doing a commP check before PublishDealMessage is sent on chain
 	// Warning: If this check is skipped and there is a commP mismatch, all deals in the
-	// sector will need to be sent again
+	// sector will need to be sent again (Default: false)
 	SkipCommP bool
 
 	// DisabledMiners is a list of miner addresses that should be excluded from online deal making protocols
@@ -685,13 +734,13 @@ type MK12Config struct {
 	MaxConcurrentDealSizeGiB int64
 
 	// DenyUnknownClients determines the default behaviour for the deal of clients which are not in allow/deny list
-	// If True then all deals coming from unknown clients will be rejected.
+	// If True then all deals coming from unknown clients will be rejected. (Default: false)
 	DenyUnknownClients bool
 
-	// DenyOnlineDeals determines if the storage provider will accept online deals
+	// DenyOnlineDeals determines if the storage provider will accept online deals (Default: false)
 	DenyOnlineDeals bool
 
-	// DenyOfflineDeals determines if the storage provider will accept offline deals
+	// DenyOfflineDeals determines if the storage provider will accept offline deals (Default: false)
 	DenyOfflineDeals bool
 
 	// CIDGravityToken is the authorization token to use for CIDGravity filters.
@@ -699,7 +748,7 @@ type MK12Config struct {
 	CIDGravityToken string
 
 	// DefaultCIDGravityAccept when set to true till accept deals when CIDGravity service is not available.
-	// Default behaviors is to reject the deals
+	// Default behaviors is to reject the deals (Default: false)
 	DefaultCIDGravityAccept bool
 }
 
@@ -739,7 +788,7 @@ type HTTPConfig struct {
 	// an IP address
 	DomainName string
 
-	// ListenAddress is the address that the server listens for HTTP requests.
+	// ListenAddress is the address that the server listens for HTTP requests. It should be in form "x.x.x.x:1234" (Default: 0.0.0.0:12310)
 	ListenAddress string
 
 	// DelegateTLS allows the server to delegate TLS to a reverse proxy. When enabled the listen address will serve
@@ -747,12 +796,15 @@ type HTTPConfig struct {
 	DelegateTLS bool
 
 	// ReadTimeout is the maximum duration for reading the entire or next request, including body, from the client.
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")
 	ReadTimeout time.Duration
 
 	// IdleTimeout is the maximum duration of an idle session. If set, idle connections are closed after this duration.
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")
 	IdleTimeout time.Duration
 
 	// ReadHeaderTimeout is amount of time allowed to read request headers
+	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")
 	ReadHeaderTimeout time.Duration
 
 	// EnableCORS indicates whether Cross-Origin Resource Sharing (CORS) is enabled or not.

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -5,7 +5,11 @@ description: The default curio configuration
 # Default Curio Configuration
 
 ```toml
+# Subsystems defines configuration settings for various subsystems within the Curio node.
+#
+# type: CurioSubsystemsConfig
 [Subsystems]
+
   # EnableWindowPost enables window post to be executed on this curio instance. Each machine in the cluster
   # with WindowPoSt enabled will also participate in the window post scheduler. It is possible to have multiple
   # machines with WindowPoSt enabled which will provide redundancy, and in case of multiple partitions per deadline,
@@ -13,22 +17,30 @@ description: The default curio configuration
   # 
   # It is possible to have instances handling both WindowPoSt and WinningPoSt, which can provide redundancy without
   # the need for additional machines. In setups like this it is generally recommended to run
-  # partitionsPerDeadline+1 machines.
+  # partitionsPerDeadline+1 machines. (Default: false)
   #
   # type: bool
   #EnableWindowPost = false
 
+  # The maximum amount of WindowPostMaxTasks tasks that can run simultaneously. Note that the maximum number of tasks will
+  # also be bounded by resources available on the machine. We do not recommend setting this value and let system resources determine
+  # the maximum tasks (Default: 0 - unlimited)
+  #
   # type: int
   #WindowPostMaxTasks = 0
 
   # EnableWinningPost enables winning post to be executed on this curio instance.
   # Each machine in the cluster with WinningPoSt enabled will also participate in the winning post scheduler.
   # It is possible to mix machines with WindowPoSt and WinningPoSt enabled, for details see the EnableWindowPost
-  # documentation.
+  # documentation. (Default: false)
   #
   # type: bool
   #EnableWinningPost = false
 
+  # The maximum amount of WinningPostMaxTasks tasks that can run simultaneously. Note that the maximum number of tasks will
+  # also be bounded by resources available on the machine. We do not recommend setting this value and let system resources determine
+  # the maximum tasks (Default: 0 - unlimited)
+  #
   # type: int
   #WinningPostMaxTasks = 0
 
@@ -36,11 +48,14 @@ description: The default curio configuration
   # pieces from the network and storing them in the storage subsystem until sectors are sealed. This task is
   # only applicable when integrating with boost, and should be enabled on nodes which will hold deal data
   # from boost until sectors containing the related pieces have the TreeD/TreeR constructed.
-  # Note that future Curio implementations will have a separate task type for fetching pieces from the internet.
+  # Note that future Curio implementations will have a separate task type for fetching pieces from the internet. (Default: false)
   #
   # type: bool
   #EnableParkPiece = false
 
+  # The maximum amount of ParkPieceMaxTasks tasks that can run simultaneously. Note that the maximum number of tasks will
+  # also be bounded by resources available on the machine (Default: 0 - unlimited)
+  #
   # type: int
   #ParkPieceMaxTasks = 0
 
@@ -51,13 +66,13 @@ description: The default curio configuration
   # unsealed data (CommD), sector number, miner id, and the seal proof type.
   # It's outputs are the 11 layer files in the sector cache directory.
   # 
-  # In lotus-miner this was run as part of PreCommit1.
+  # In lotus-miner this was run as part of PreCommit1. (Default: false)
   #
   # type: bool
   #EnableSealSDR = false
 
   # The maximum amount of SDR tasks that can run simultaneously. Note that the maximum number of tasks will
-  # also be bounded by resources available on the machine.
+  # also be bounded by resources available on the machine. (Default: 0 - unlimited)
   #
   # type: int
   #SealSDRMaxTasks = 0
@@ -67,7 +82,7 @@ description: The default curio configuration
   # nodes are present in the cluster, this value should be set to batch_size+1 to allow for the batch sealing node to
   # fill up the batch.
   # This setting can also be used to give priority to other nodes in the cluster by setting this value to a higher
-  # value on the nodes which should have less priority.
+  # value on the nodes which should have less priority. (Default: 0 - unlimited)
   #
   # type: int
   #SealSDRMinTasks = 0
@@ -90,13 +105,13 @@ description: The default curio configuration
   # 
   # In lotus-miner this was run as part of PreCommit2 (TreeD was run in PreCommit1).
   # Note that nodes with SDRTrees enabled will also answer to Finalize tasks,
-  # which just remove unneeded tree data after PoRep is computed.
+  # which just remove unneeded tree data after PoRep is computed. (Default: false)
   #
   # type: bool
   #EnableSealSDRTrees = false
 
   # The maximum amount of SealSDRTrees tasks that can run simultaneously. Note that the maximum number of tasks will
-  # also be bounded by resources available on the machine.
+  # also be bounded by resources available on the machine. (Default: 0 - unlimited)
   #
   # type: int
   #SealSDRTreesMaxTasks = 0
@@ -104,14 +119,14 @@ description: The default curio configuration
   # FinalizeMaxTasks is the maximum amount of finalize tasks that can run simultaneously.
   # The finalize task is enabled on all machines which also handle SDRTrees tasks. Finalize ALWAYS runs on whichever
   # machine holds sector cache files, as it removes unneeded tree data after PoRep is computed.
-  # Finalize will run in parallel with the SubmitCommitMsg task.
+  # Finalize will run in parallel with the SubmitCommitMsg task. (Default: 0 - unlimited)
   #
   # type: int
   #FinalizeMaxTasks = 0
 
   # EnableSendPrecommitMsg enables the sending of precommit messages to the chain
   # from this curio instance.
-  # This runs after SDRTrees and uses the output CommD / CommR (roots of TreeD / TreeR) for the message
+  # This runs after SDRTrees and uses the output CommD / CommR (roots of TreeD / TreeR) for the message (Default: false)
   #
   # type: bool
   #EnableSendPrecommitMsg = false
@@ -123,29 +138,29 @@ description: The default curio configuration
   # requested from the machine which holds sector cache files which most likely is the machine which ran the SDRTrees
   # task.
   # 
-  # In lotus-miner this was Commit1 / Commit2
+  # In lotus-miner this was Commit1 / Commit2 (Default: false)
   #
   # type: bool
   #EnablePoRepProof = false
 
   # The maximum amount of PoRepProof tasks that can run simultaneously. Note that the maximum number of tasks will
-  # also be bounded by resources available on the machine.
+  # also be bounded by resources available on the machine. (Default: 0 - unlimited)
   #
   # type: int
   #PoRepProofMaxTasks = 0
 
   # EnableSendCommitMsg enables the sending of commit messages to the chain
-  # from this curio instance.
+  # from this curio instance. (Default: false)
   #
   # type: bool
   #EnableSendCommitMsg = false
 
-  # Whether to abort if any sector activation in a batch fails (newly sealed sectors, only with ProveCommitSectors3).
+  # Whether to abort if any sector activation in a batch fails (newly sealed sectors, only with ProveCommitSectors3). (Default: true)
   #
   # type: bool
   #RequireActivationSuccess = true
 
-  # Whether to abort if any sector activation in a batch fails (updating sectors, only with ProveReplicaUpdates3).
+  # Whether to abort if any sector activation in a batch fails (updating sectors, only with ProveReplicaUpdates3). (Default: true)
   #
   # type: bool
   #RequireNotificationSuccess = true
@@ -154,175 +169,225 @@ description: The default curio configuration
   # This tasks should only be enabled on nodes with long-term storage.
   # 
   # The MoveStorage task is the last task in the sealing pipeline. It moves the sealed sector data from the
-  # SDRTrees machine into long-term storage. This task runs after the Finalize task.
+  # SDRTrees machine into long-term storage. This task runs after the Finalize task. (Default: false)
   #
   # type: bool
   #EnableMoveStorage = false
 
   # NoUnsealedDecode disables the decoding sector data on this node. Normally data encoding is enabled by default on
   # storage nodes with the MoveStorage task enabled. Setting this option to true means that unsealed data for sectors
-  # will not be stored on this node
+  # will not be stored on this node (Default: false)
   #
   # type: bool
   #NoUnsealedDecode = false
 
   # The maximum amount of MoveStorage tasks that can run simultaneously. Note that the maximum number of tasks will
   # also be bounded by resources available on the machine. It is recommended that this value is set to a number which
-  # uses all available network (or disk) bandwidth on the machine without causing bottlenecks.
+  # uses all available network (or disk) bandwidth on the machine without causing bottlenecks. (Default: 0 - unlimited)
   #
   # type: int
   #MoveStorageMaxTasks = 0
 
   # EnableUpdateEncode enables the encoding step of the SnapDeal process on this curio instance.
-  # This step involves encoding the data into the sector and computing updated TreeR (uses gpu).
+  # This step involves encoding the data into the sector and computing updated TreeR (uses gpu). (Default: false)
   #
   # type: bool
   #EnableUpdateEncode = false
 
   # EnableUpdateProve enables the proving step of the SnapDeal process on this curio instance.
-  # This step generates the snark proof for the updated sector.
+  # This step generates the snark proof for the updated sector. (Default: false)
   #
   # type: bool
   #EnableUpdateProve = false
 
   # EnableUpdateSubmit enables the submission of SnapDeal proofs to the blockchain from this curio instance.
-  # This step submits the generated proofs to the chain.
+  # This step submits the generated proofs to the chain. (Default: false)
   #
   # type: bool
   #EnableUpdateSubmit = false
 
-  # UpdateEncodeMaxTasks sets the maximum number of concurrent SnapDeal encoding tasks that can run on this instance.
+  # UpdateEncodeMaxTasks sets the maximum number of concurrent SnapDeal encoding tasks that can run on this instance. (Default: 0 - unlimited)
   #
   # type: int
   #UpdateEncodeMaxTasks = 0
 
-  # UpdateProveMaxTasks sets the maximum number of concurrent SnapDeal proving tasks that can run on this instance.
+  # UpdateProveMaxTasks sets the maximum number of concurrent SnapDeal proving tasks that can run on this instance. (Default: 0 - unlimited)
   #
   # type: int
   #UpdateProveMaxTasks = 0
 
   # EnableWebGui enables the web GUI on this curio instance. The UI has minimal local overhead, but it should
-  # only need to be run on a single machine in the cluster.
+  # only need to be run on a single machine in the cluster. (Default: false)
   #
   # type: bool
   #EnableWebGui = false
 
-  # The address that should listen for Web GUI requests.
+  # The address that should listen for Web GUI requests. It should be in form "x.x.x.x:1234" (Default: 0.0.0.0:4701)
   #
   # type: string
   #GuiAddress = "0.0.0.0:4701"
 
   # UseSyntheticPoRep enables the synthetic PoRep for all new sectors. When set to true, will reduce the amount of
-  # cache data held on disk after the completion of TreeRC task to 11GiB.
+  # cache data held on disk after the completion of TreeRC task to 11GiB. (Default: false)
   #
   # type: bool
   #UseSyntheticPoRep = false
 
   # The maximum amount of SyntheticPoRep tasks that can run simultaneously. Note that the maximum number of tasks will
-  # also be bounded by resources available on the machine.
+  # also be bounded by resources available on the machine. (Default: 0 - unlimited)
   #
   # type: int
   #SyntheticPoRepMaxTasks = 0
 
-  # Batch Seal
+  # EnableBatchSeal enabled SupraSeal batch sealing on the node.  (Default: false)
   #
   # type: bool
   #EnableBatchSeal = false
 
-  # EnableDealMarket enabled the deal market on the node. This would also enable libp2p on the node, if configured.
+  # EnableDealMarket enabled the deal market on the node. This would also enable libp2p on the node, if configured. (Default: false)
   #
   # type: bool
   #EnableDealMarket = false
 
   # EnableCommP enables the commP task on te node. CommP is calculated before sending PublishDealMessage for a Mk12 deal
-  # Must have EnableDealMarket = True
+  # Must have EnableDealMarket = True (Default: false)
   #
   # type: bool
   #EnableCommP = false
 
   # The maximum amount of CommP tasks that can run simultaneously. Note that the maximum number of tasks will
-  # also be bounded by resources available on the machine.
+  # also be bounded by resources available on the machine. (Default: 0 - unlimited)
   #
   # type: int
   #CommPMaxTasks = 0
 
   # The maximum amount of indexing and IPNI tasks that can run simultaneously. Note that the maximum number of tasks will
-  # also be bounded by resources available on the machine.
+  # also be bounded by resources available on the machine. (Default: 8 - unlimited)
   #
   # type: int
   #IndexingMaxTasks = 8
 
 
+# Fees holds the fee-related configuration parameters for various operations in the Curio node.
+#
+# type: CurioFees
 [Fees]
-  # type: types.FIL
-  #DefaultMaxFee = "0.07 FIL"
-
-  # type: types.FIL
-  #MaxPreCommitGasFee = "0.025 FIL"
-
-  # type: types.FIL
-  #MaxCommitGasFee = "0.05 FIL"
-
-  # type: types.FIL
-  #MaxTerminateGasFee = "0.5 FIL"
 
   # WindowPoSt is a high-value operation, so the default fee should be high.
+  # Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix. (Default: "5 fil")
   #
   # type: types.FIL
   #MaxWindowPoStGasFee = "5 FIL"
 
-  # type: types.FIL
-  #MaxPublishDealsFee = "0.05 FIL"
-
-  # Whether to use available miner balance for sector collateral instead of sending it with each message
+  # Whether to use available miner balance for sector collateral instead of sending it with each message (Default: false)
   #
   # type: bool
   #CollateralFromMinerBalance = false
 
-  # Don't send collateral with messages even if there is no available balance in the miner actor
+  # Don't send collateral with messages even if there is no available balance in the miner actor (Default: false)
   #
   # type: bool
   #DisableCollateralFallback = false
 
+  # maxBatchFee = maxBase + maxPerSector * nSectors
+  # (Default: #Base = "0 FIL" and #PerSector = "0.02 FIL")
+  #
+  # type: BatchFeeConfig
   [Fees.MaxPreCommitBatchGasFee]
+
+    # Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.
+    #
     # type: types.FIL
     #Base = "0 FIL"
 
+    # Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.
+    #
     # type: types.FIL
     #PerSector = "0.02 FIL"
 
+  # maxBatchFee = maxBase + maxPerSector * nSectors
+  # (Default: #Base = "0 FIL" and #PerSector = "0.03 FIL")
+  #
+  # type: BatchFeeConfig
   [Fees.MaxCommitBatchGasFee]
+
+    # Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.
+    #
     # type: types.FIL
     #Base = "0 FIL"
 
+    # Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.
+    #
     # type: types.FIL
     #PerSector = "0.03 FIL"
 
+  # Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.
+  # (Default: #Base = "0 FIL" and #PerSector = "0.03 FIL")
+  #
+  # type: BatchFeeConfig
   [Fees.MaxUpdateBatchGasFee]
+
+    # Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.
+    #
     # type: types.FIL
     #Base = "0 FIL"
 
+    # Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffix.
+    #
     # type: types.FIL
     #PerSector = "0.03 FIL"
 
 
+# Addresses specifies the list of miner addresses and their related wallet addresses.
+#
+# type: []CurioAddresses
 [[Addresses]]
+
+  # PreCommitControl is an array of Addresses to send PreCommit messages from
+  #
+  # type: []string
   #PreCommitControl = []
 
+  # CommitControl is an array of Addresses to send Commit messages from
+  #
+  # type: []string
   #CommitControl = []
 
+  # DealPublishControl is an array of Address to send the deal collateral from with PublishStorageDeal Message
+  #
+  # type: []string
   #DealPublishControl = []
 
+  # TerminateControl is a list of addresses used to send Terminate messages.
+  #
+  # type: []string
   #TerminateControl = []
 
+  # DisableOwnerFallback disables usage of the owner address for messages
+  # sent automatically
+  #
+  # type: bool
   #DisableOwnerFallback = false
 
+  # DisableWorkerFallback disables usage of the worker address for messages
+  # sent automatically, if control addresses are configured.
+  # A control address that doesn't have enough funds will still be chosen
+  # over the worker address if this flag is set.
+  #
+  # type: bool
   #DisableWorkerFallback = false
 
+  # MinerAddresses are the addresses of the miner actors
+  #
+  # type: []string
   #MinerAddresses = []
 
 
+# Proving defines the configuration settings related to proving functionality within the Curio node.
+#
+# type: CurioProvingConfig
 [Proving]
+
   # Maximum number of sector checks to run in parallel. (0 = unlimited)
   # 
   # WARNING: Setting this value too high may make the node crash by running out of stack
@@ -330,7 +395,7 @@ description: The default curio configuration
   # to late submission.
   # 
   # After changing this option, confirm that the new value works in your setup by invoking
-  # 'curio test wd task 0'
+  # 'curio test wd task 0' (Default: 32)
   #
   # type: int
   #ParallelCheckLimit = 32
@@ -341,8 +406,9 @@ description: The default curio configuration
   # test challenge took longer than this timeout
   # WARNING: Setting this value too high risks missing PoSt deadline in case IO operations related to this sector are
   # blocked (e.g. in case of disconnected NFS mount)
+  # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "10m0s")
   #
-  # type: Duration
+  # type: time.Duration
   #SingleCheckTimeout = "10m0s"
 
   # Maximum amount of time a proving pre-check can take for an entire partition. If the check times out, sectors in
@@ -351,13 +417,17 @@ description: The default curio configuration
   # WARNING: Setting this value too low risks in sectors being skipped even though they are accessible, just reading the
   # test challenge took longer than this timeout
   # WARNING: Setting this value too high risks missing PoSt deadline in case IO operations related to this partition are
-  # blocked or slow
+  # blocked or slow. Time duration string (e.g., "1h2m3s") in TOML format.  (Default: "20m0s")
   #
-  # type: Duration
+  # type: time.Duration
   #PartitionCheckTimeout = "20m0s"
 
 
+# HTTP represents the configuration for the HTTP server settings in the Curio node.
+#
+# type: HTTPConfig
 [HTTP]
+
   # Enable the HTTP server on the node
   #
   # type: bool
@@ -369,7 +439,7 @@ description: The default curio configuration
   # type: string
   #DomainName = ""
 
-  # ListenAddress is the address that the server listens for HTTP requests.
+  # ListenAddress is the address that the server listens for HTTP requests. It should be in form "x.x.x.x:1234" (Default: 0.0.0.0:12310)
   #
   # type: string
   #ListenAddress = "0.0.0.0:12310"
@@ -381,16 +451,19 @@ description: The default curio configuration
   #DelegateTLS = false
 
   # ReadTimeout is the maximum duration for reading the entire or next request, including body, from the client.
+  # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")
   #
   # type: time.Duration
   #ReadTimeout = "10s"
 
   # IdleTimeout is the maximum duration of an idle session. If set, idle connections are closed after this duration.
+  # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")
   #
   # type: time.Duration
   #IdleTimeout = "2m0s"
 
   # ReadHeaderTimeout is amount of time allowed to read request headers
+  # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")
   #
   # type: time.Duration
   #ReadHeaderTimeout = "5s"
@@ -400,7 +473,11 @@ description: The default curio configuration
   # type: bool
   #EnableCORS = true
 
+  # CompressionLevels hold the compression level for various compression methods supported by the server
+  #
+  # type: CompressionConfig
   [HTTP.CompressionLevels]
+
     # type: int
     #GzipLevel = 6
 
@@ -411,8 +488,16 @@ description: The default curio configuration
     #DeflateLevel = 6
 
 
+# Market specifies configuration options for the Market subsystem within the Curio node.
+#
+# type: MarketConfig
 [Market]
+
+  # StorageMarketConfig houses all the deal related market configuration
+  #
+  # type: StorageMarketConfig
   [Market.StorageMarketConfig]
+
     # PieceLocator is a list of HTTP url and headers combination to query for a piece for offline deals
     # User can run a remote file server which can host all the pieces over the HTTP and supply a reader when requested.
     # The server must support "HEAD" request and "GET" request.
@@ -422,39 +507,47 @@ description: The default curio configuration
     # type: []PieceLocatorConfig
     #PieceLocator = []
 
+    # MK12 encompasses all configuration related to deal protocol mk1.2.0 and mk1.2.1 (i.e. Boost deals)
+    #
+    # type: MK12Config
     [Market.StorageMarketConfig.MK12]
+
       # When a deal is ready to publish, the amount of time to wait for more
       # deals to be ready to publish before publishing them all as a batch
+      # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "5m0s")
       #
-      # type: Duration
+      # type: time.Duration
       #PublishMsgPeriod = "5m0s"
 
       # The maximum number of deals to include in a single PublishStorageDeals
-      # message
+      # message (Default: 8)
       #
       # type: uint64
       #MaxDealsPerPublishMsg = 8
 
       # The maximum fee to pay per deal when sending the PublishStorageDeals message
+      # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.5 FIL")
       #
       # type: types.FIL
       #MaxPublishDealFee = "0.5 FIL"
 
       # ExpectedPoRepSealDuration is the expected time it would take to seal the deal sector
       # This will be used to fail the deals which cannot be sealed on time.
+      # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "8h0m0s")
       #
-      # type: Duration
+      # type: time.Duration
       #ExpectedPoRepSealDuration = "8h0m0s"
 
       # ExpectedSnapSealDuration is the expected time it would take to snap the deal sector
       # This will be used to fail the deals which cannot be sealed on time.
+      # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "2h0m0s")
       #
-      # type: Duration
+      # type: time.Duration
       #ExpectedSnapSealDuration = "2h0m0s"
 
       # SkipCommP can be used to skip doing a commP check before PublishDealMessage is sent on chain
       # Warning: If this check is skipped and there is a commP mismatch, all deals in the
-      # sector will need to be sent again
+      # sector will need to be sent again (Default: false)
       #
       # type: bool
       #SkipCommP = false
@@ -467,17 +560,17 @@ description: The default curio configuration
       #MaxConcurrentDealSizeGiB = 0
 
       # DenyUnknownClients determines the default behaviour for the deal of clients which are not in allow/deny list
-      # If True then all deals coming from unknown clients will be rejected.
+      # If True then all deals coming from unknown clients will be rejected. (Default: false)
       #
       # type: bool
       #DenyUnknownClients = false
 
-      # DenyOnlineDeals determines if the storage provider will accept online deals
+      # DenyOnlineDeals determines if the storage provider will accept online deals (Default: false)
       #
       # type: bool
       #DenyOnlineDeals = false
 
-      # DenyOfflineDeals determines if the storage provider will accept offline deals
+      # DenyOfflineDeals determines if the storage provider will accept offline deals (Default: false)
       #
       # type: bool
       #DenyOfflineDeals = false
@@ -489,12 +582,16 @@ description: The default curio configuration
       #CIDGravityToken = ""
 
       # DefaultCIDGravityAccept when set to true till accept deals when CIDGravity service is not available.
-      # Default behaviors is to reject the deals
+      # Default behaviors is to reject the deals (Default: false)
       #
       # type: bool
       #DefaultCIDGravityAccept = false
 
+    # IPNI configuration for ipni-provider
+    #
+    # type: IPNIConfig
     [Market.StorageMarketConfig.IPNI]
+
       # Disable set whether to disable indexing announcement to the network and expose endpoints that
       # allow indexer nodes to process announcements. Default: False
       #
@@ -513,7 +610,11 @@ description: The default curio configuration
       # type: []string
       #DirectAnnounceURLs = ["https://cid.contact/ingest/announce"]
 
+    # Indexing configuration for deal indexing
+    #
+    # type: IndexingConfig
     [Market.StorageMarketConfig.Indexing]
+
       # Number of records per insert batch
       #
       # type: int
@@ -525,11 +626,15 @@ description: The default curio configuration
       #InsertConcurrency = 10
 
 
+# Ingest defines configuration parameters for handling and limiting deal ingestion pipelines within the Curio node.
+#
+# type: CurioIngestConfig
 [Ingest]
+
   # MaxMarketRunningPipelines is the maximum number of market pipelines that can be actively running tasks.
   # A "running" pipeline is one that has at least one task currently assigned to a machine (owner_id is not null).
   # If this limit is exceeded, the system will apply backpressure to delay processing of new deals.
-  # 0 means unlimited.
+  # 0 means unlimited. (Default: 64)
   #
   # type: int
   #MaxMarketRunningPipelines = 64
@@ -537,7 +642,7 @@ description: The default curio configuration
   # MaxQueueDownload is the maximum number of pipelines that can be queued at the downloading stage,
   # waiting for a machine to pick up their task (owner_id is null).
   # If this limit is exceeded, the system will apply backpressure to slow the ingestion of new deals.
-  # 0 means unlimited.
+  # 0 means unlimited. (Default: 8)
   #
   # type: int
   #MaxQueueDownload = 8
@@ -545,7 +650,7 @@ description: The default curio configuration
   # MaxQueueCommP is the maximum number of pipelines that can be queued at the CommP (verify) stage,
   # waiting for a machine to pick up their verification task (owner_id is null).
   # If this limit is exceeded, the system will apply backpressure, delaying new deal processing.
-  # 0 means unlimited.
+  # 0 means unlimited. (Default: 8)
   #
   # type: int
   #MaxQueueCommP = 8
@@ -554,7 +659,7 @@ description: The default curio configuration
   # 0 = unlimited
   # Note: This mechanism will delay taking deal data from markets, providing backpressure to the market subsystem.
   # The DealSector queue includes deals that are ready to enter the sealing pipeline but are not yet part of it.
-  # DealSector queue is the first queue in the sealing pipeline, making it the primary backpressure mechanism.
+  # DealSector queue is the first queue in the sealing pipeline, making it the primary backpressure mechanism. (Default: 8)
   #
   # type: int
   #MaxQueueDealSector = 8
@@ -565,7 +670,7 @@ description: The default curio configuration
   # The SDR queue includes deals which are in the process of entering the sealing pipeline. In case of the SDR tasks it is
   # possible that this queue grows more than this limit(CC sectors), the backpressure is only applied to sectors
   # entering the pipeline.
-  # Only applies to PoRep pipeline (DoSnap = false)
+  # Only applies to PoRep pipeline (DoSnap = false) (Default: 8)
   #
   # type: int
   #MaxQueueSDR = 8
@@ -575,7 +680,7 @@ description: The default curio configuration
   # Note: This mechanism will delay taking deal data from markets, providing backpressure to the market subsystem.
   # In case of the trees tasks it is possible that this queue grows more than this limit, the backpressure is only
   # applied to sectors entering the pipeline.
-  # Only applies to PoRep pipeline (DoSnap = false)
+  # Only applies to PoRep pipeline (DoSnap = false) (Default: 0)
   #
   # type: int
   #MaxQueueTrees = 0
@@ -585,7 +690,7 @@ description: The default curio configuration
   # Note: This mechanism will delay taking deal data from markets, providing backpressure to the market subsystem.
   # Like with the trees tasks, it is possible that this queue grows more than this limit, the backpressure is only
   # applied to sectors entering the pipeline.
-  # Only applies to PoRep pipeline (DoSnap = false)
+  # Only applies to PoRep pipeline (DoSnap = false) (Default: 0)
   #
   # type: int
   #MaxQueuePoRep = 0
@@ -593,71 +698,89 @@ description: The default curio configuration
   # MaxQueueSnapEncode is the maximum number of sectors that can be queued waiting for UpdateEncode tasks to start.
   # 0 means unlimited.
   # This applies backpressure to the market subsystem by delaying the ingestion of deal data.
-  # Only applies to the Snap Deals pipeline (DoSnap = true).
+  # Only applies to the Snap Deals pipeline (DoSnap = true). (Default: 16)
   #
   # type: int
   #MaxQueueSnapEncode = 16
 
   # MaxQueueSnapProve is the maximum number of sectors that can be queued waiting for UpdateProve to start processing.
   # 0 means unlimited.
-  # This applies backpressure in the Snap Deals pipeline (DoSnap = true) by delaying new deal ingestion.
+  # This applies backpressure in the Snap Deals pipeline (DoSnap = true) by delaying new deal ingestion. (Default: 0)
   #
   # type: int
   #MaxQueueSnapProve = 0
 
   # Maximum time an open deal sector should wait for more deals before it starts sealing.
   # This ensures that sectors don't remain open indefinitely, consuming resources.
+  # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")
   #
-  # type: Duration
+  # type: time.Duration
   #MaxDealWaitTime = "1h0m0s"
 
   # DoSnap, when set to true, enables snap deal processing for deals ingested by this instance.
   # Unlike lotus-miner, there is no fallback to PoRep when no snap sectors are available.
-  # When enabled, all deals will be processed as snap deals.
+  # When enabled, all deals will be processed as snap deals. (Default: false)
   #
   # type: bool
   #DoSnap = false
 
 
+# Seal defines the configuration related to the sealing process in Curio.
+#
+# type: CurioSealConfig
 [Seal]
+
   # BatchSealSectorSize Allows setting the sector size supported by the batch seal task.
-  # Can be any value as long as it is "32GiB".
+  # Can be any value as long as it is "32GiB". (Default: "32GiB")
   #
   # type: string
   #BatchSealSectorSize = "32GiB"
 
-  # Number of sectors in a seal batch. Depends on hardware and supraseal configuration.
+  # Number of sectors in a seal batch. Depends on hardware and supraseal configuration. (Default: 32)
   #
   # type: int
   #BatchSealBatchSize = 32
 
-  # Number of parallel pipelines. Can be 1 or 2. Depends on available raw block storage
+  # Number of parallel pipelines. Can be 1 or 2. Depends on available raw block storage (Default: 2)
   #
   # type: int
   #BatchSealPipelines = 2
 
   # SingleHasherPerThread is a compatibility flag for older CPUs. Zen3 and later supports two sectors per thread.
-  # Set to false for older CPUs (Zen 2 and before).
+  # Set to false for older CPUs (Zen 2 and before). (Default: false)
   #
   # type: bool
   #SingleHasherPerThread = false
 
 
+# Apis defines the configuration for API-related settings in the Curio system.
+#
+# type: ApisConfig
 [Apis]
-  # Chain API auth secret for the Curio nodes to use.
+
+  # API auth secret for the Curio nodes to use. This value should only be set on the bade layer.
   #
   # type: string
   #StorageRPCSecret = ""
 
 
+# Alerting specifies configuration settings for alerting mechanisms, including thresholds and external integrations.
+#
+# type: CurioAlertingConfig
 [Alerting]
+
   # MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
   # alerts will be triggered for the wallet
+  # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")
   #
   # type: types.FIL
   #MinimumWalletBalance = "5 FIL"
 
+  # PagerDutyConfig is the configuration for the PagerDuty alerting integration.
+  #
+  # type: PagerDutyConfig
   [Alerting.PagerDuty]
+
     # Enable is a flag to enable or disable the PagerDuty integration.
     #
     # type: bool
@@ -676,7 +799,11 @@ description: The default curio configuration
     # type: string
     #PageDutyIntegrationKey = ""
 
+  # PrometheusAlertManagerConfig is the configuration for the Prometheus AlertManager alerting integration.
+  #
+  # type: PrometheusAlertManagerConfig
   [Alerting.PrometheusAlertManager]
+
     # Enable is a flag to enable or disable the Prometheus AlertManager integration.
     #
     # type: bool
@@ -687,7 +814,11 @@ description: The default curio configuration
     # type: string
     #AlertManagerURL = "http://localhost:9093/api/v2/alerts"
 
+  # SlackWebhookConfig is a configuration type for Slack webhook integration.
+  #
+  # type: SlackWebhookConfig
   [Alerting.SlackWebhook]
+
     # Enable is a flag to enable or disable the Prometheus AlertManager integration.
     #
     # type: bool
@@ -700,53 +831,78 @@ description: The default curio configuration
     #WebHookURL = ""
 
 
+# Batching represents the batching configuration for pre-commit, commit, and update operations.
+#
+# type: CurioBatchingConfig
 [Batching]
+
+  # Precommit Batching configuration
+  #
+  # type: PreCommitBatchingConfig
   [Batching.PreCommit]
+
     # Base fee value below which we should try to send Precommit messages immediately
+    # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.005 FIL")
     #
     # type: types.FIL
     #BaseFeeThreshold = "0.005 FIL"
 
     # Maximum amount of time any given sector in the batch can wait for the batch to accumulate
+    # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "4h0m0s")
     #
-    # type: Duration
+    # type: time.Duration
     #Timeout = "4h0m0s"
 
     # Time buffer for forceful batch submission before sectors/deal in batch would start expiring
+    # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "6h0m0s")
     #
-    # type: Duration
+    # type: time.Duration
     #Slack = "6h0m0s"
 
+  # Commit batching configuration
+  #
+  # type: CommitBatchingConfig
   [Batching.Commit]
+
     # Base fee value below which we should try to send Commit messages immediately
+    # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.005 FIL")
     #
     # type: types.FIL
     #BaseFeeThreshold = "0.005 FIL"
 
     # Maximum amount of time any given sector in the batch can wait for the batch to accumulate
+    # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")
     #
-    # type: Duration
+    # type: time.Duration
     #Timeout = "1h0m0s"
 
     # Time buffer for forceful batch submission before sectors/deals in batch would start expiring
+    # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")
     #
-    # type: Duration
+    # type: time.Duration
     #Slack = "1h0m0s"
 
+  # Snap Deals batching configuration
+  #
+  # type: UpdateBatchingConfig
   [Batching.Update]
+
     # Base fee value below which we should try to send Commit messages immediately
+    # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.005 FIL")
     #
     # type: types.FIL
     #BaseFeeThreshold = "0.005 FIL"
 
     # Maximum amount of time any given sector in the batch can wait for the batch to accumulate
+    # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")
     #
-    # type: Duration
+    # type: time.Duration
     #Timeout = "1h0m0s"
 
     # Time buffer for forceful batch submission before sectors/deals in batch would start expiring
+    # Time duration string (e.g., "1h2m3s") in TOML format. (Default: "1h0m0s")
     #
-    # type: Duration
+    # type: time.Duration
     #Slack = "1h0m0s"
 
 ```

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -262,7 +262,7 @@ description: The default curio configuration
   #CommPMaxTasks = 0
 
   # The maximum amount of indexing and IPNI tasks that can run simultaneously. Note that the maximum number of tasks will
-  # also be bounded by resources available on the machine. (Default: 8 - unlimited)
+  # also be bounded by resources available on the machine. (Default: 8)
   #
   # type: int
   #IndexingMaxTasks = 8

--- a/documentation/en/curio-market/deal-filters.md
+++ b/documentation/en/curio-market/deal-filters.md
@@ -184,7 +184,7 @@ For more details, refer to the [CIDGravity documentation](https://docs.cidgravit
 ## How to Enable CIDGravity in Curio
 
 CIDGravity integration in Curio is controlled through Curio configuration. To enable CIDGravity, you need to set the below parameters in the configuration.
-We highly recommend setting these values in "market" layer or a layer used by all market nodes to control the market behaviour.
+We highly recommend setting these values in "base" layer or a layer used by all market nodes to control the market behaviour.
 
 ```toml
         # CIDGravityToken is the authorization token to use for CIDGravity filters.

--- a/itests/curio_test.go
+++ b/itests/curio_test.go
@@ -163,8 +163,8 @@ func TestCurioHappyPath(t *testing.T) {
 
 	require.Contains(t, baseCfg.Addresses[0].MinerAddresses, maddr.String())
 
-	baseCfg.Batching.PreCommit.Timeout = config.Duration(5 * time.Second)
-	baseCfg.Batching.Commit.Timeout = config.Duration(5 * time.Minute)
+	baseCfg.Batching.PreCommit.Timeout = 5 * time.Second
+	baseCfg.Batching.Commit.Timeout = 5 * time.Minute
 
 	temp := os.TempDir()
 	dir, err := os.MkdirTemp(temp, "curio")

--- a/market/indexstore/indexstore_test.go
+++ b/market/indexstore/indexstore_test.go
@@ -42,7 +42,7 @@ func TestNewIndexStore(t *testing.T) {
 		_ = os.RemoveAll(dir)
 	}()
 
-	rf, err := testutils.CreateRandomFile(dir, int(time.Now().Unix()), 8000000)
+	rf, err := testutils.CreateRandomFile(dir, time.Now().Unix(), 8000000)
 	require.NoError(t, err)
 
 	caropts := []carv2.Option{

--- a/market/storageingest/deal_ingest_seal.go
+++ b/market/storageingest/deal_ingest_seal.go
@@ -139,14 +139,14 @@ func NewPieceIngester(ctx context.Context, db *harmonydb.DB, api PieceIngesterAp
 		idToAddr[abi.ActorID(mid)] = maddr
 	}
 
-	epochs := time.Duration(cfg.Market.StorageMarketConfig.MK12.ExpectedPoRepSealDuration).Seconds() / float64(build.BlockDelaySecs)
+	epochs := cfg.Market.StorageMarketConfig.MK12.ExpectedPoRepSealDuration.Seconds() / float64(build.BlockDelaySecs)
 	expectedEpochs := math.Ceil(epochs)
 
 	pi := &PieceIngester{
 		ctx:                  ctx,
 		db:                   db,
 		api:                  api,
-		maxWaitTime:          time.Duration(cfg.Ingest.MaxDealWaitTime),
+		maxWaitTime:          cfg.Ingest.MaxDealWaitTime,
 		addToID:              addToID,
 		minerDetails:         minerDetails,
 		idToAddr:             idToAddr,

--- a/market/storageingest/deal_ingest_snap.go
+++ b/market/storageingest/deal_ingest_snap.go
@@ -95,14 +95,14 @@ func NewPieceIngesterSnap(ctx context.Context, db *harmonydb.DB, api PieceIngest
 		idToAddr[abi.ActorID(mid)] = maddr
 	}
 
-	epochs := time.Duration(cfg.Market.StorageMarketConfig.MK12.ExpectedSnapSealDuration).Seconds() / float64(build.BlockDelaySecs)
+	epochs := cfg.Market.StorageMarketConfig.MK12.ExpectedSnapSealDuration.Seconds() / float64(build.BlockDelaySecs)
 	expectedEpochs := math.Ceil(epochs)
 
 	pi := &PieceIngesterSnap{
 		ctx:                  ctx,
 		db:                   db,
 		api:                  api,
-		maxWaitTime:          time.Duration(cfg.Ingest.MaxDealWaitTime),
+		maxWaitTime:          cfg.Ingest.MaxDealWaitTime,
 		addToID:              addToID,
 		minerDetails:         minerDetails,
 		idToAddr:             idToAddr,

--- a/tasks/seal/poller.go
+++ b/tasks/seal/poller.go
@@ -89,14 +89,14 @@ func NewPoller(db *harmonydb.DB, api SealPollerAPI, cfg *config.CurioConfig) (*S
 		commit: commitBatchingConfig{
 			MinCommitBatch:   miner.MinAggregatedSectors,
 			MaxCommitBatch:   256,
-			Slack:            time.Duration(cfg.Batching.Commit.Slack),
-			Timeout:          time.Duration(cfg.Batching.Commit.Timeout),
+			Slack:            cfg.Batching.Commit.Slack,
+			Timeout:          cfg.Batching.Commit.Timeout,
 			BaseFeeThreshold: abi.TokenAmount(cfg.Batching.Commit.BaseFeeThreshold),
 		},
 		preCommit: preCommitBatchingConfig{
 			MaxPreCommitBatch: miner15.PreCommitSectorBatchMaxSize,
-			Slack:             time.Duration(cfg.Batching.PreCommit.Slack),
-			Timeout:           time.Duration(cfg.Batching.PreCommit.Timeout),
+			Slack:             cfg.Batching.PreCommit.Slack,
+			Timeout:           cfg.Batching.PreCommit.Timeout,
 			BaseFeeThreshold:  abi.TokenAmount(cfg.Batching.PreCommit.BaseFeeThreshold),
 		},
 	}

--- a/tasks/snap/task_submit.go
+++ b/tasks/snap/task_submit.go
@@ -106,8 +106,8 @@ func NewSubmitTask(db *harmonydb.DB, api SubmitTaskNodeAPI, bstore curiochain.Cu
 				// snap has 16x192 snarks + 50 or so bytes of other message overhead,
 				// so we can only really fit ~20-16 updates in a message
 				MaxUpdateBatch:   16,
-				Slack:            time.Duration(cfg.Batching.Update.Slack),
-				Timeout:          time.Duration(cfg.Batching.Update.Timeout),
+				Slack:            cfg.Batching.Update.Slack,
+				Timeout:          cfg.Batching.Update.Timeout,
 				BaseFeeThreshold: abi.TokenAmount(cfg.Batching.Update.BaseFeeThreshold),
 			},
 			feeCfg:                     &cfg.Fees,

--- a/tasks/storage-market/storage_market.go
+++ b/tasks/storage-market/storage_market.go
@@ -585,7 +585,7 @@ func (d *CurioStorageDealMarket) findURLForOfflineDeals(ctx context.Context, dea
 }
 
 func (d *CurioStorageDealMarket) addPSDTask(ctx context.Context) error {
-	publishPeriod := time.Duration(d.cfg.Market.StorageMarketConfig.MK12.PublishMsgPeriod)
+	publishPeriod := d.cfg.Market.StorageMarketConfig.MK12.PublishMsgPeriod
 	maxDeals := d.cfg.Market.StorageMarketConfig.MK12.MaxDealsPerPublishMsg
 
 	var eligibleSpIDs []struct {

--- a/web/api/apihelper/apihelper.go
+++ b/web/api/apihelper/apihelper.go
@@ -7,12 +7,11 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 )
 
-var log = logging.Logger("cu/web/apihelper")
+var log = logging.Logger("apihelper")
 
 func OrHTTPFail(w http.ResponseWriter, err error) {
 	if err != nil {
-		w.WriteHeader(500)
-		_, _ = w.Write([]byte(err.Error()))
+		http.Error(w, err.Error(), 500)
 		log.Errorw("http fail", "err", err, "stack", string(debug.Stack()))
 		panic(err)
 	}

--- a/web/static/config/edit.html
+++ b/web/static/config/edit.html
@@ -147,7 +147,12 @@
                                         window.location.href = '/pages/config/list/';
                                     })
                                     .catch(error => {
-                                        alert('Error saving data:', error);
+                                        console.error('Error saving data:', error);
+                                        if (error.response && error.response.data) {
+                                            alert('Error saving data: ' + error.response.data.message);
+                                        } else {
+                                            alert('An unexpected error occurred. Please try again.');
+                                        }
                                     });
                             }
                         });

--- a/web/static/pages/market-settings/defaults.mjs
+++ b/web/static/pages/market-settings/defaults.mjs
@@ -35,9 +35,9 @@ class DefaultMarketFilters extends LitElement {
                     CID Gravity is
                     ${this.data.is_cid_gravity_enabled ? 'Enabled' : 'Disabled'}
                 </h4>
-                <h4 class=${this.data.is_deal_rejected_when_cid_gravity_not_reachable ? 'text-danger' : 'text-success'}>
+                <h4 class=${this.data.is_deal_rejected_when_cid_gravity_not_reachable ? 'text-success' : 'text-danger'}>
                     When CID Gravity is not reachable, deals are
-                    ${this.data.is_deal_rejected_when_cid_gravity_not_reachable ? 'Accepted' : 'Rejected'}
+                    ${this.data.is_deal_rejected_when_cid_gravity_not_reachable ? 'Rejected' : 'Accepted'}
                 </h4>
             </div>
         `;


### PR DESCRIPTION
This PR does the following:
1. Dump custom Duration type for TOML as time.Duration is supported by TOML by default now.
2. Removed unused configuration
3. Fix commenting for sections
4. Fix commenting for [Arrays]
5. Small UI and doc fix

```
# Subsystems defines configuration settings for various subsystems within the Curio node.
#
# type: CurioSubsystemsConfig
[Subsystems]

  # EnableWindowPost enables window post to be executed on this curio instance. Each machine in the cluster
  # with WindowPoSt enabled will also participate in the window post scheduler. It is possible to have multiple
  # machines with WindowPoSt enabled which will provide redundancy, and in case of multiple partitions per deadline,
  # will allow for parallel processing of partitions.
```


```
# Market specifies configuration options for the Market subsystem within the Curio node.
#
# type: MarketConfig
[Market]

  # StorageMarketConfig houses all the deal related market configuration
  #
  # type: StorageMarketConfig
  [Market.StorageMarketConfig]

    # MK12 encompasses all configuration related to deal protocol mk1.2.0 and mk1.2.1 (i.e. Boost deals)
    #
    # type: MK12Config
    [Market.StorageMarketConfig.MK12]

```

```
# Addresses specifies the list of miner addresses and their related wallet addresses.
#
# type: []CurioAddresses
[[Addresses]]

  # PreCommitControl is an array of Addresses to send PreCommit messages from
  #
  # type: []string
  #PreCommitControl = []

  # CommitControl is an array of Addresses to send Commit messages from
  #
  # type: []string
  #CommitControl = []

  # DealPublishControl is an array of Address to send the deal collateral from with PublishStorageDeal Message
  #
  # type: []string
  #DealPublishControl = []

```

<img width="634" alt="Screenshot 2025-03-03 at 2 50 55 PM" src="https://github.com/user-attachments/assets/7740c83e-e5cd-42a6-95d8-d38d5cf79fcf" />
<img width="634" alt="Screenshot 2025-03-03 at 2 51 21 PM" src="https://github.com/user-attachments/assets/b7222531-9e13-4ce5-9223-78845575b4eb" />
<img width="634" alt="Screenshot 2025-03-03 at 2 51 29 PM" src="https://github.com/user-attachments/assets/1a107dc4-928a-4a22-8285-3a4a9f946b70" />

## CID Gravity UI fix
### False by default
<img width="750" alt="Screenshot 2025-03-03 at 2 57 14 PM" src="https://github.com/user-attachments/assets/a2a7d1c3-0525-40e9-9ae9-75cb46f8840f" />

### True
<img width="750" alt="Screenshot 2025-03-03 at 2 56 46 PM" src="https://github.com/user-attachments/assets/28d8c0de-2db0-43b0-8532-82e220d79df0" />


