### PR TITLE
Add Prometheus service discovery endpoint

### DIFF
--- a/cmd/curio/rpc/rpc.go
+++ b/cmd/curio/rpc/rpc.go
@@ -503,7 +503,10 @@ func prometheusServiceDiscovery(ctx context.Context, deps *deps.Deps) http.Handl
 			    harmony_machine_details md ON m.id = md.machine_id;`)
 		if err != nil {
 			log.Errorf("failed to fetch hosts: %s", err)
-			resp.Write([]byte("[]"))
+			_, err = resp.Write([]byte("[]"))
+			if err != nil {
+				log.Errorf("failed to write response: %s", err)
+			}
 		} else {
 			var services []service
 			for _, h := range hosts {

--- a/cmd/curio/rpc/rpc.go
+++ b/cmd/curio/rpc/rpc.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -511,7 +510,7 @@ func prometheusServiceDiscovery(ctx context.Context, deps *deps.Deps) http.Handl
 			var services []service
 			for _, h := range hosts {
 				ss := service{
-					Targets: []string{path.Join(h.Host, "/debug/metrics")},
+					Targets: []string{h.Host},
 					Labels:  map[string]string{},
 				}
 				for _, layer := range strings.Split(h.Layers, ",") {

--- a/cmd/curio/rpc/rpc.go
+++ b/cmd/curio/rpc/rpc.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/gbrlsnchs/jwt/v3"
@@ -509,14 +508,12 @@ func prometheusServiceDiscovery(ctx context.Context, deps *deps.Deps) http.Handl
 		} else {
 			var services []service
 			for _, h := range hosts {
-				ss := service{
+				services = append(services, service{
 					Targets: []string{h.Host},
-					Labels:  map[string]string{},
-				}
-				for _, layer := range strings.Split(h.Layers, ",") {
-					ss.Labels["layer_"+layer] = "true"
-				}
-				services = append(services, ss)
+					Labels: map[string]string{
+						"layers": h.Layers,
+					},
+				})
 			}
 			enc := json.NewEncoder(resp)
 			if err := enc.Encode(services); err != nil {

--- a/cmd/curio/rpc/rpc.go
+++ b/cmd/curio/rpc/rpc.go
@@ -491,7 +491,6 @@ func prometheusServiceDiscovery(ctx context.Context, deps *deps.Deps) http.Handl
 	hnd := func(resp http.ResponseWriter, req *http.Request) {
 
 		resp.Header().Set("Content-Type", "application/json")
-		resp.Header().Set("X-Prometheus-Refresh-Interval-Seconds", "30")
 
 		var hosts []host
 		err := deps.DB.Select(ctx, &hosts, `


### PR DESCRIPTION
This PR adds a Prometheus HTTP Service Discovery endpoint, which allows Prometheus to dynamically discover and scrape Curio nodes in the network.

Implements a new HTTP handler at `/debug/service-discovery` that returns a JSON list of targets in [Prometheus SD format](https://prometheus.io/docs/prometheus/latest/http_sd/)

## Usage

Add the following job to your Prometheus configuration:
```
- job_name: 'curio'
    metrics_path: 'debug/metrics'
    http_sd_configs:
      - url: 'http://your-curio-node:port/debug/service-discovery'
```

This feature has been tested in my development environment and is working properly.

![image](https://github.com/user-attachments/assets/6f4db5bf-7094-456a-a32f-a9e7869bf5e0)
