### PR TITLE
feat: Balance Manager

### DIFF
--- a/alertmanager/alerts.go
+++ b/alertmanager/alerts.go
@@ -348,34 +348,9 @@ func (al *alerts) getAddresses() ([]address.Address, []address.Address, error) {
 			return nil, nil, xerrors.Errorf("could not read layer '%s': %w", layer, err)
 		}
 
-		// This is a workaround to set the length of [[Addresses]] correctly before we do toml.Decode.
-		// The reason this is required is that toml libraries create nil pointer to uninitialized structs.
-		// This in turn causes failure to decode types like types.FIL which are struct with unexported pointer inside
-		type AddressLengthDetector struct {
-			Addresses []struct{} `toml:"Addresses"`
-		}
-
-		var lengthDetector AddressLengthDetector
-		_, err = toml.Decode(text, &lengthDetector)
+		err = config.FixTOML(text, cfg)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("Error decoding TOML for length detection: %w", err)
-		}
-
-		l := len(lengthDetector.Addresses)
-		il := len(cfg.Addresses)
-
-		for l > il {
-			cfg.Addresses = append(cfg.Addresses, config.CurioAddresses{
-				PreCommitControl:      []string{},
-				CommitControl:         []string{},
-				DealPublishControl:    []string{},
-				TerminateControl:      []string{},
-				DisableOwnerFallback:  false,
-				DisableWorkerFallback: false,
-				MinerAddresses:        []string{},
-				BalanceManager:        config.DefaultBalanceManager(),
-			})
-			il++
+			return nil, nil, err
 		}
 
 		_, err = toml.Decode(text, cfg)

--- a/cmd/curio/config.go
+++ b/cmd/curio/config.go
@@ -10,7 +10,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/BurntSushi/toml"
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
@@ -292,7 +291,7 @@ var configEditCmd = &cli.Command{
 
 		if cctx.IsSet("source") && source != layer && !cctx.Bool("no-interpret-source") {
 			curioCfg := config.DefaultCurioConfig()
-			if _, err := toml.Decode(sourceConfig, curioCfg); err != nil {
+			if _, err := deps.LoadConfigWithUpgrades(sourceConfig, curioCfg); err != nil {
 				return xerrors.Errorf("parsing source config: %w", err)
 			}
 
@@ -358,12 +357,12 @@ func diff(sourceConf, newConf string) (string, error) {
 	fromSrc := config.DefaultCurioConfig()
 	fromNew := config.DefaultCurioConfig()
 
-	_, err := toml.Decode(sourceConf, fromSrc)
+	_, err := deps.LoadConfigWithUpgrades(sourceConf, fromSrc)
 	if err != nil {
 		return "", xerrors.Errorf("decoding source config: %w", err)
 	}
 
-	_, err = toml.Decode(newConf, fromNew)
+	_, err = deps.LoadConfigWithUpgrades(newConf, fromNew)
 	if err != nil {
 		return "", xerrors.Errorf("decoding new config: %w", err)
 	}

--- a/cmd/curio/config_test.go
+++ b/cmd/curio/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -555,14 +556,17 @@ func TestConfig(t *testing.T) {
 	addr1 := config.CurioAddresses{
 		PreCommitControl:      []string{},
 		CommitControl:         []string{},
+		DealPublishControl:    []string{},
 		TerminateControl:      []string{"t3qroiebizgkz7pvj26reg5r5mqiftrt5hjdske2jzjmlacqr2qj7ytjncreih2mvujxoypwpfusmwpipvxncq"},
 		DisableOwnerFallback:  false,
 		DisableWorkerFallback: false,
 		MinerAddresses:        []string{"t01000"},
+		BalanceManager:        config.DefaultBalanceManager(),
 	}
 
 	addr2 := config.CurioAddresses{
 		MinerAddresses: []string{"t01001"},
+		BalanceManager: config.DefaultBalanceManager(),
 	}
 
 	_, err := deps.LoadConfigWithUpgrades(baseText, baseCfg)
@@ -603,4 +607,67 @@ func TestCustomConfigDurationJson(t *testing.T) {
 	prop, ok := definitions.Properties.Get("SingleCheckTimeout")
 	require.True(t, ok)
 	require.Equal(t, prop.Type, "string")
+}
+
+func TestTOMLDecoding(t *testing.T) {
+
+	def1 := config.DefaultCurioConfig()
+
+	text := `
+[[Addresses]]
+  MinerAddresses = ["t01002"]
+  [Addresses.BalanceManager]
+	[Addresses.BalanceManager.MK12Collateral]
+	  CollateralLowThreshold = "100 FIL"
+
+[[Addresses]]
+  MinerAddresses = ["t01007"]
+  [Addresses.BalanceManager]
+	[Addresses.BalanceManager.MK12Collateral]
+	  CollateralLowThreshold = "50 fil"
+
+[Alerting]
+  [Alerting.PagerDuty]
+  [Alerting.PrometheusAlertManager]
+  [Alerting.SlackWebhook]
+
+[Apis]
+  ChainApiInfo = ["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.Er4BD7iisZ6KwdkjbXrxRlgvOnf_KClzo9Q6V7fvUYs:/dns/lotus/tcp/1234/http"]
+  StorageRPCSecret = "E/RAavP4YYHzKqa+eGXE6LtYTrT5YpToCEHugbTXOoI="
+
+[Batching]
+  [Batching.Commit]
+  [Batching.PreCommit]
+  [Batching.Update]
+
+[Fees]
+  [Fees.MaxCommitBatchGasFee]
+  [Fees.MaxPreCommitBatchGasFee]
+  [Fees.MaxUpdateBatchGasFee]
+
+[HTTP]
+  [HTTP.CompressionLevels]
+
+[Ingest]
+
+[Market]
+  [Market.StorageMarketConfig]
+	[Market.StorageMarketConfig.IPNI]
+	[Market.StorageMarketConfig.Indexing]
+	[Market.StorageMarketConfig.MK12]
+
+[Proving]
+
+[Seal]
+
+[Subsystems]
+`
+
+	_, err := deps.LoadConfigWithUpgrades(text, def1)
+	require.NoError(t, err)
+
+	cb, err := config.ConfigUpdate(def1, config.DefaultCurioConfig(), config.Commented(true), config.DefaultKeepUncommented(), config.NoEnv())
+	require.NoError(t, err)
+
+	fmt.Println(cb)
 }

--- a/cmd/curio/config_test.go
+++ b/cmd/curio/config_test.go
@@ -669,5 +669,5 @@ func TestTOMLDecoding(t *testing.T) {
 	cb, err := config.ConfigUpdate(def1, config.DefaultCurioConfig(), config.Commented(true), config.DefaultKeepUncommented(), config.NoEnv())
 	require.NoError(t, err)
 
-	fmt.Println(cb)
+	fmt.Println(string(cb))
 }

--- a/cmd/curio/guidedsetup/guidedsetup.go
+++ b/cmd/curio/guidedsetup/guidedsetup.go
@@ -627,6 +627,7 @@ func stepNewMinerConfig(d *MigrationData) {
 		DisableOwnerFallback:  false,
 		DisableWorkerFallback: false,
 		MinerAddresses:        []string{d.MinerID.String()},
+		BalanceManager:        config.DefaultBalanceManager(),
 	})
 
 	sk, err := io.ReadAll(io.LimitReader(rand.Reader, 32))

--- a/cmd/curio/guidedsetup/shared.go
+++ b/cmd/curio/guidedsetup/shared.go
@@ -158,6 +158,7 @@ func SaveConfigToLayerMigrateSectors(db *harmonydb.DB, minerRepoPath, chainApiIn
 		TerminateControl:      smCfg.Addresses.TerminateControl,
 		DisableOwnerFallback:  smCfg.Addresses.DisableOwnerFallback,
 		DisableWorkerFallback: smCfg.Addresses.DisableWorkerFallback,
+		BalanceManager:        config.DefaultBalanceManager(),
 	}}
 
 	ks, err := lr.KeyStore()

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -231,6 +231,14 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 				activeTasks = append(activeTasks, commpTask)
 			}
 
+			if cfg.Subsystems.EnableMarketBalanceManager {
+				balMgrTask, err := storage_market.NewMarketBalanceManager(full, miners, cfg, sender)
+				if err != nil {
+					return nil, err
+				}
+				activeTasks = append(activeTasks, balMgrTask)
+			}
+
 			// PSD and Deal find task do not require many resources. They can run on all machines
 			psdTask := storage_market.NewPSDTask(dm, db, sender, as, &cfg.Market.StorageMarketConfig.MK12, full)
 			dealFindTask := storage_market.NewFindDealTask(dm, db, full, &cfg.Market.StorageMarketConfig.MK12)

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -216,6 +216,14 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 		miners = append(miners, address.Address(k))
 	}
 
+	if cfg.Subsystems.EnableBalanceManager {
+		balMgrTask, err := storage_market.NewBalanceManager(full, miners, cfg, sender)
+		if err != nil {
+			return nil, err
+		}
+		activeTasks = append(activeTasks, balMgrTask)
+	}
+
 	{
 		// Market tasks
 		if cfg.Subsystems.EnableDealMarket {
@@ -229,14 +237,6 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 			if cfg.Subsystems.EnableCommP {
 				commpTask := storage_market.NewCommpTask(dm, db, must.One(slrLazy.Val()), full, cfg.Subsystems.CommPMaxTasks)
 				activeTasks = append(activeTasks, commpTask)
-			}
-
-			if cfg.Subsystems.EnableMarketBalanceManager {
-				balMgrTask, err := storage_market.NewMarketBalanceManager(full, miners, cfg, sender)
-				if err != nil {
-					return nil, err
-				}
-				activeTasks = append(activeTasks, balMgrTask)
 			}
 
 			// PSD and Deal find task do not require many resources. They can run on all machines

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -765,6 +765,12 @@ also be bounded by resources available on the machine. (Default: 0 - unlimited)`
 			Comment: `The maximum amount of indexing and IPNI tasks that can run simultaneously. Note that the maximum number of tasks will
 also be bounded by resources available on the machine. (Default: 8)`,
 		},
+		{
+			Name: "EnableMarketBalanceManager",
+			Type: "bool",
+
+			Comment: `EnableMarketBalanceManager enabled the task to automatically manage the market balance of the miner's market actor (Default: false)`,
+		},
 	},
 	"HTTPConfig": {
 		{
@@ -886,6 +892,27 @@ message (Default: 8)`,
 
 			Comment: `The maximum fee to pay per deal when sending the PublishStorageDeals message
 Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.5 FIL")`,
+		},
+		{
+			Name: "DealCollateralWallet",
+			Type: "string",
+
+			Comment: `DealCollateralWallet is the wallet used to add balance to Miner's market balance. This balance is
+utilized for deal collateral in market (f05) deals. If no wallet is set, worker wallet will be used for this.`,
+		},
+		{
+			Name: "CollateralAddThreshold",
+			Type: "types.FIL",
+
+			Comment: `CollateralAddThreshold is the balance below which more balance will be added to miner's market balance
+Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")`,
+		},
+		{
+			Name: "CollateralAddAmount",
+			Type: "types.FIL",
+
+			Comment: `CollateralAddAmount is the amount added to miner's market balance when it falls below CollateralAddThreshold
+Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")`,
 		},
 		{
 			Name: "ExpectedPoRepSealDuration",

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -23,6 +23,14 @@ var Doc = map[string][]DocField{
 			Comment: `API auth secret for the Curio nodes to use. This value should only be set on the bade layer.`,
 		},
 	},
+	"BalanceManagerConfig": {
+		{
+			Name: "MK12Collateral",
+			Type: "MK12CollateralConfig",
+
+			Comment: `MK12Collateral defines the configuration for managing collateral and related balance thresholds in the miner's market.`,
+		},
+	},
 	"BatchFeeConfig": {
 		{
 			Name: "Base",
@@ -284,6 +292,13 @@ Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffi
 			Type: "bool",
 
 			Comment: `Don't send collateral with messages even if there is no available balance in the miner actor (Default: false)`,
+		},
+		{
+			Name: "BalanceManager",
+			Type: "BalanceManagerConfig",
+
+			Comment: `BalanceManagerConfig specifies the configuration parameters for managing wallet balances and actor-related funds,
+including collateral and other operational resources.`,
 		},
 	},
 	"CurioIngestConfig": {
@@ -766,10 +781,10 @@ also be bounded by resources available on the machine. (Default: 0 - unlimited)`
 also be bounded by resources available on the machine. (Default: 8)`,
 		},
 		{
-			Name: "EnableMarketBalanceManager",
+			Name: "EnableBalanceManager",
 			Type: "bool",
 
-			Comment: `EnableMarketBalanceManager enabled the task to automatically manage the market balance of the miner's market actor (Default: false)`,
+			Comment: `EnableBalanceManager enables the task to automatically manage the market balance of the miner's market actor (Default: false)`,
 		},
 	},
 	"HTTPConfig": {
@@ -870,6 +885,30 @@ heads.`,
 			Comment: `Number of concurrent inserts to split AddIndex calls to`,
 		},
 	},
+	"MK12CollateralConfig": {
+		{
+			Name: "DealCollateralWallet",
+			Type: "string",
+
+			Comment: `DealCollateralWallet is the wallet used to add balance to Miner's market balance. This balance is
+utilized for deal collateral in market (f05) deals.`,
+		},
+		{
+			Name: "CollateralLowThreshold",
+			Type: "types.FIL",
+
+			Comment: `CollateralLowThreshold is the balance below which more balance will be added to miner's market balance
+Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")`,
+		},
+		{
+			Name: "CollateralHighThreshold",
+			Type: "types.FIL",
+
+			Comment: `CollateralHighThreshold is the target balance to which the miner's market balance will be topped up
+when it drops below CollateralLowThreshold.
+Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "20 FIL")`,
+		},
+	},
 	"MK12Config": {
 		{
 			Name: "PublishMsgPeriod",
@@ -892,27 +931,6 @@ message (Default: 8)`,
 
 			Comment: `The maximum fee to pay per deal when sending the PublishStorageDeals message
 Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.5 FIL")`,
-		},
-		{
-			Name: "DealCollateralWallet",
-			Type: "string",
-
-			Comment: `DealCollateralWallet is the wallet used to add balance to Miner's market balance. This balance is
-utilized for deal collateral in market (f05) deals. If no wallet is set, worker wallet will be used for this.`,
-		},
-		{
-			Name: "CollateralAddThreshold",
-			Type: "types.FIL",
-
-			Comment: `CollateralAddThreshold is the balance below which more balance will be added to miner's market balance
-Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")`,
-		},
-		{
-			Name: "CollateralAddAmount",
-			Type: "types.FIL",
-
-			Comment: `CollateralAddAmount is the amount added to miner's market balance when it falls below CollateralAddThreshold
-Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")`,
 		},
 		{
 			Name: "ExpectedPoRepSealDuration",

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -135,6 +135,13 @@ over the worker address if this flag is set.`,
 
 			Comment: `MinerAddresses are the addresses of the miner actors`,
 		},
+		{
+			Name: "BalanceManager",
+			Type: "BalanceManagerConfig",
+
+			Comment: `BalanceManagerConfig specifies the configuration parameters for managing wallet balances and actor-related funds,
+including collateral and other operational resources.`,
+		},
 	},
 	"CurioAlertingConfig": {
 		{
@@ -292,13 +299,6 @@ Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffi
 			Type: "bool",
 
 			Comment: `Don't send collateral with messages even if there is no available balance in the miner actor (Default: false)`,
-		},
-		{
-			Name: "BalanceManager",
-			Type: "BalanceManagerConfig",
-
-			Comment: `BalanceManagerConfig specifies the configuration parameters for managing wallet balances and actor-related funds,
-including collateral and other operational resources.`,
 		},
 	},
 	"CurioIngestConfig": {

--- a/deps/config/load.go
+++ b/deps/config/load.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -457,20 +458,15 @@ func ConfigUpdate(cfgCur, cfgDef interface{}, opts ...UpdateCfgOpt) ([]byte, err
 		opts := []cmp.Option{
 			// This equality function compares big.Int
 			cmpopts.IgnoreUnexported(big.Int{}),
-			//cmp.Comparer(func(x, y []string) bool {
-			//	tx, ty := reflect.TypeOf(x), reflect.TypeOf(y)
-			//	if tx.Kind() == reflect.Slice && ty.Kind() == reflect.Slice && tx.Elem().Kind() == reflect.String && ty.Elem().Kind() == reflect.String {
-			//		sort.Strings(x)
-			//		sort.Strings(y)
-			//		return strings.Join(x, "\n") == strings.Join(y, "\n")
-			//	}
-			//	return false
-			//}),
-		}
-
-		diff := cmp.Diff(cfgUpdated, cfgCur, opts...)
-		if diff != "" {
-			return nil, xerrors.Errorf("updated config didn't match current config:\n%s", diff)
+			cmp.Comparer(func(x, y []string) bool {
+				tx, ty := reflect.TypeOf(x), reflect.TypeOf(y)
+				if tx.Kind() == reflect.Slice && ty.Kind() == reflect.Slice && tx.Elem().Kind() == reflect.String && ty.Elem().Kind() == reflect.String {
+					sort.Strings(x)
+					sort.Strings(y)
+					return strings.Join(x, "\n") == strings.Join(y, "\n")
+				}
+				return false
+			}),
 		}
 
 		if !cmp.Equal(cfgUpdated, cfgCur, opts...) {

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -105,6 +105,8 @@ func DefaultCurioConfig() *CurioConfig {
 					PublishMsgPeriod:          5 * time.Minute,
 					MaxDealsPerPublishMsg:     8,
 					MaxPublishDealFee:         types.MustParseFIL("0.5 FIL"),
+					CollateralAddThreshold:    types.MustParseFIL("5 FIL"),
+					CollateralAddAmount:       types.MustParseFIL("5 FIL"),
 					ExpectedPoRepSealDuration: 8 * time.Hour,
 					ExpectedSnapSealDuration:  2 * time.Hour,
 					CIDGravityTokens:          []string{},
@@ -366,6 +368,9 @@ type CurioSubsystemsConfig struct {
 	// The maximum amount of indexing and IPNI tasks that can run simultaneously. Note that the maximum number of tasks will
 	// also be bounded by resources available on the machine. (Default: 8)
 	IndexingMaxTasks int
+
+	// EnableMarketBalanceManager enabled the task to automatically manage the market balance of the miner's market actor (Default: false)
+	EnableMarketBalanceManager bool
 }
 type CurioFees struct {
 	// maxBatchFee = maxBase + maxPerSector * nSectors
@@ -691,6 +696,18 @@ type MK12Config struct {
 	// The maximum fee to pay per deal when sending the PublishStorageDeals message
 	// Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "0.5 FIL")
 	MaxPublishDealFee types.FIL
+
+	// DealCollateralWallet is the wallet used to add balance to Miner's market balance. This balance is
+	// utilized for deal collateral in market (f05) deals. If no wallet is set, worker wallet will be used for this.
+	DealCollateralWallet string
+
+	// CollateralAddThreshold is the balance below which more balance will be added to miner's market balance
+	// Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")
+	CollateralAddThreshold types.FIL
+
+	// CollateralAddAmount is the amount added to miner's market balance when it falls below CollateralAddThreshold
+	// Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")
+	CollateralAddAmount types.FIL
 
 	// ExpectedPoRepSealDuration is the expected time it would take to seal the deal sector
 	// This will be used to fail the deals which cannot be sealed on time.

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -35,12 +35,6 @@ func DefaultCurioConfig() *CurioConfig {
 			MaxWindowPoStGasFee:        types.MustParseFIL("5"),
 			CollateralFromMinerBalance: false,
 			DisableCollateralFallback:  false,
-			BalanceManager: BalanceManagerConfig{
-				MK12Collateral: MK12CollateralConfig{
-					CollateralLowThreshold:  types.MustParseFIL("5 FIL"),
-					CollateralHighThreshold: types.MustParseFIL("20 FIL"),
-				},
-			},
 		},
 		Addresses: []CurioAddresses{{
 			PreCommitControl:   []string{},
@@ -48,6 +42,7 @@ func DefaultCurioConfig() *CurioConfig {
 			DealPublishControl: []string{},
 			TerminateControl:   []string{},
 			MinerAddresses:     []string{},
+			BalanceManager:     DefaultBalanceManager(),
 		}},
 		Proving: CurioProvingConfig{
 			ParallelCheckLimit:    32,
@@ -133,6 +128,16 @@ func DefaultCurioConfig() *CurioConfig {
 				BrotliLevel:  4,
 				DeflateLevel: 6,
 			},
+		},
+	}
+}
+
+func DefaultBalanceManager() BalanceManagerConfig {
+	return BalanceManagerConfig{
+		MK12Collateral: MK12CollateralConfig{
+			DealCollateralWallet:    "",
+			CollateralLowThreshold:  types.MustParseFIL("5 FIL"),
+			CollateralHighThreshold: types.MustParseFIL("20 FIL"),
 		},
 	}
 }
@@ -398,10 +403,6 @@ type CurioFees struct {
 
 	// Don't send collateral with messages even if there is no available balance in the miner actor (Default: false)
 	DisableCollateralFallback bool
-
-	// BalanceManagerConfig specifies the configuration parameters for managing wallet balances and actor-related funds,
-	// including collateral and other operational resources.
-	BalanceManager BalanceManagerConfig
 }
 
 type CurioAddresses struct {
@@ -429,6 +430,10 @@ type CurioAddresses struct {
 
 	// MinerAddresses are the addresses of the miner actors
 	MinerAddresses []string
+
+	// BalanceManagerConfig specifies the configuration parameters for managing wallet balances and actor-related funds,
+	// including collateral and other operational resources.
+	BalanceManager BalanceManagerConfig
 }
 
 type CurioProvingConfig struct {

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -389,34 +389,9 @@ func LoadConfigWithUpgrades(text string, curioConfigWithDefaults *config.CurioCo
 		return line
 	}), "\n")
 
-	// This is a workaround to set the length of [[Addresses]] correctly before we do toml.Decode.
-	// The reason this is required is that toml libraries create nil pointer to uninitialized structs.
-	// This in turn causes failure to decode types like types.FIL which are struct with unexported pointer inside
-	type AddressLengthDetector struct {
-		Addresses []struct{} `toml:"Addresses"`
-	}
-
-	var lengthDetector AddressLengthDetector
-	_, err := toml.Decode(newText, &lengthDetector)
+	err := config.FixTOML(newText, curioConfigWithDefaults)
 	if err != nil {
-		return toml.MetaData{}, xerrors.Errorf("Error decoding TOML for length detection: %w", err)
-	}
-
-	l := len(lengthDetector.Addresses)
-	il := len(curioConfigWithDefaults.Addresses)
-
-	for l > il {
-		curioConfigWithDefaults.Addresses = append(curioConfigWithDefaults.Addresses, config.CurioAddresses{
-			PreCommitControl:      []string{},
-			CommitControl:         []string{},
-			DealPublishControl:    []string{},
-			TerminateControl:      []string{},
-			DisableOwnerFallback:  false,
-			DisableWorkerFallback: false,
-			MinerAddresses:        []string{},
-			BalanceManager:        config.DefaultBalanceManager(),
-		})
-		il++
+		return toml.MetaData{}, err
 	}
 
 	return toml.Decode(newText, &curioConfigWithDefaults)

--- a/documentation/en/SUMMARY.md
+++ b/documentation/en/SUMMARY.md
@@ -14,6 +14,7 @@
 * [Configuration](configuration/README.md)
   * [Listen Address](configuration/listen-address.md)
   * [Alert Manager](configuration/alert-manager.md)
+  * [Balance Manager](configuration/balance-manager.md)
   * [Default Curio Configuration](configuration/default-curio-configuration.md)
 * [Enabling market (Boost) (deprecated)](enabling-market.md)
 * [Curio Market](curio-market/README.md)

--- a/documentation/en/configuration/balance-manager.md
+++ b/documentation/en/configuration/balance-manager.md
@@ -1,0 +1,69 @@
+---
+description: How to configure balance manager in Curio cluster
+---
+
+# Balance Manager
+
+## Overview
+The **Balance Manager** is a subsystem within Curio responsible for **automatically managing balances** for certain actors. Currently, it is used to **top up deal collateral** when the available balance falls below a defined threshold. In future iterations, the Balance Manager will be extended to **handle control addresses and other balance-related operations.**
+
+## Functionality
+The Balance Manager operates on a periodic task cycle and ensures that a miner's **market balance** remains within an acceptable range by:
+1. **Monitoring market balance**: Checks the miner's market escrow balance at regular intervals.
+2. **Comparing against thresholds**:
+    - If the balance drops **below** `CollateralLowThreshold`, additional funds are added.
+    - The balance is topped **up to** `CollateralHighThreshold`.
+3. **Sending transactions**: Issues an `AddBalance` message to the **market actor (`f05`)** from the **configured wallet**.
+4. **Ensuring sufficient funds**: Verifies that the deal collateral wallet has enough balance before sending funds.
+5. In the future, this functionality will be expanded to include maintaining control address and other operational balances.
+
+The Balance Manager runs every **5 minutes** by default (`BalanceCheckInterval`).
+
+## Configuration
+The **Balance Manager configuration** should be defined at the **base layer** within Curio. It is part of the **`BalanceManagerConfig`** section inside the `CurioConfig`.
+
+### **Enabling Balance Manager**
+To enable the Balance Manager, modify the **`EnableBalanceManager`** setting under `Subsystems`:
+
+```toml
+[Subsystems]
+EnableBalanceManager = true  # Set to true to activate Balance Manager
+```
+
+### **Balance Manager Settings**
+The Balance Manager's configuration is located under `Fees`:
+
+```toml
+[Fees.BalanceManager.MK12Collateral]
+DealCollateralWallet = "t3xyz..."  # The wallet used to fund market balance
+CollateralLowThreshold = "5 FIL"    # If market balance drops below this, a top-up is triggered
+CollateralHighThreshold = "20 FIL"   # The target balance after a top-up
+```
+
+#### Configuration Parameters
+| Parameter                 | Description |
+|---------------------------|-------------|
+| `DealCollateralWallet`    | The wallet used to top up the miner's market balance. |
+| `CollateralLowThreshold`  | When the balance falls below this threshold, the Balance Manager triggers a top-up. |
+| `CollateralHighThreshold` | The target balance after a top-up operation is performed. |
+
+### Example Configuration
+```toml
+[Subsystems]
+  EnableBalanceManager = true
+
+[Fees]
+  [Fees.BalanceManager]
+    [Fees.BalanceManager.MK12Collateral]
+      DealCollateralWallet = "t3xyz..."
+      CollateralLowThreshold = "5 FIL"
+      CollateralHighThreshold = "20 FIL"
+```
+
+## Future Enhancements
+Currently, the Balance Manager is only used for deal collateral top-ups, but it will be extended to:
+- Manage control addresses balances.
+- Monitor and maintain additional operation-specific balances.
+
+By enabling the Balance Manager, miners can **automate their collateral management**, reducing the risk of **deal failures due to insufficient balance** while optimizing operational efficiency.
+```

--- a/documentation/en/configuration/balance-manager.md
+++ b/documentation/en/configuration/balance-manager.md
@@ -31,10 +31,10 @@ EnableBalanceManager = true  # Set to true to activate Balance Manager
 ```
 
 ### **Balance Manager Settings**
-The Balance Manager's configuration is located under `Fees`:
+The Balance Manager's configuration is located under `Addresses`:
 
 ```toml
-[Fees.BalanceManager.MK12Collateral]
+[Addresses.BalanceManager.MK12Collateral]
 DealCollateralWallet = "t3xyz..."  # The wallet used to fund market balance
 CollateralLowThreshold = "5 FIL"    # If market balance drops below this, a top-up is triggered
 CollateralHighThreshold = "20 FIL"   # The target balance after a top-up
@@ -52,9 +52,9 @@ CollateralHighThreshold = "20 FIL"   # The target balance after a top-up
 [Subsystems]
   EnableBalanceManager = true
 
-[Fees]
-  [Fees.BalanceManager]
-    [Fees.BalanceManager.MK12Collateral]
+[Addresses]
+  [Addresses.BalanceManager]
+    [Addresses.BalanceManager.MK12Collateral]
       DealCollateralWallet = "t3xyz..."
       CollateralLowThreshold = "5 FIL"
       CollateralHighThreshold = "20 FIL"

--- a/documentation/en/configuration/balance-manager.md
+++ b/documentation/en/configuration/balance-manager.md
@@ -66,4 +66,3 @@ Currently, the Balance Manager is only used for deal collateral top-ups, but it 
 - Monitor and maintain additional operation-specific balances.
 
 By enabling the Balance Manager, miners can **automate their collateral management**, reducing the risk of **deal failures due to insufficient balance** while optimizing operational efficiency.
-```

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -267,10 +267,10 @@ description: The default curio configuration
   # type: int
   #IndexingMaxTasks = 8
 
-  # EnableMarketBalanceManager enabled the task to automatically manage the market balance of the miner's market actor (Default: false)
+  # EnableBalanceManager enables the task to automatically manage the market balance of the miner's market actor (Default: false)
   #
   # type: bool
-  #EnableMarketBalanceManager = false
+  #EnableBalanceManager = false
 
 
 # Fees holds the fee-related configuration parameters for various operations in the Curio node.
@@ -341,6 +341,36 @@ description: The default curio configuration
     #
     # type: types.FIL
     #PerSector = "0.03 FIL"
+
+  # BalanceManagerConfig specifies the configuration parameters for managing wallet balances and actor-related funds,
+  # including collateral and other operational resources.
+  #
+  # type: BalanceManagerConfig
+  [Fees.BalanceManager]
+
+    # MK12Collateral defines the configuration for managing collateral and related balance thresholds in the miner's market.
+    #
+    # type: MK12CollateralConfig
+    [Fees.BalanceManager.MK12Collateral]
+
+      # DealCollateralWallet is the wallet used to add balance to Miner's market balance. This balance is
+      # utilized for deal collateral in market (f05) deals.
+      #
+      # type: string
+      #DealCollateralWallet = ""
+
+      # CollateralLowThreshold is the balance below which more balance will be added to miner's market balance
+      # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")
+      #
+      # type: types.FIL
+      #CollateralLowThreshold = "5 FIL"
+
+      # CollateralHighThreshold is the target balance to which the miner's market balance will be topped up
+      # when it drops below CollateralLowThreshold.
+      # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "20 FIL")
+      #
+      # type: types.FIL
+      #CollateralHighThreshold = "20 FIL"
 
 
 # Addresses specifies the list of miner addresses and their related wallet addresses.
@@ -535,24 +565,6 @@ description: The default curio configuration
       #
       # type: types.FIL
       #MaxPublishDealFee = "0.5 FIL"
-
-      # DealCollateralWallet is the wallet used to add balance to Miner's market balance. This balance is
-      # utilized for deal collateral in market (f05) deals. If no wallet is set, worker wallet will be used for this.
-      #
-      # type: string
-      #DealCollateralWallet = ""
-
-      # CollateralAddThreshold is the balance below which more balance will be added to miner's market balance
-      # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")
-      #
-      # type: types.FIL
-      #CollateralAddThreshold = "5 FIL"
-
-      # CollateralAddAmount is the amount added to miner's market balance when it falls below CollateralAddThreshold
-      # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")
-      #
-      # type: types.FIL
-      #CollateralAddAmount = "5 FIL"
 
       # ExpectedPoRepSealDuration is the expected time it would take to seal the deal sector
       # This will be used to fail the deals which cannot be sealed on time.

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -267,6 +267,11 @@ description: The default curio configuration
   # type: int
   #IndexingMaxTasks = 8
 
+  # EnableMarketBalanceManager enabled the task to automatically manage the market balance of the miner's market actor (Default: false)
+  #
+  # type: bool
+  #EnableMarketBalanceManager = false
+
 
 # Fees holds the fee-related configuration parameters for various operations in the Curio node.
 #
@@ -530,6 +535,24 @@ description: The default curio configuration
       #
       # type: types.FIL
       #MaxPublishDealFee = "0.5 FIL"
+
+      # DealCollateralWallet is the wallet used to add balance to Miner's market balance. This balance is
+      # utilized for deal collateral in market (f05) deals. If no wallet is set, worker wallet will be used for this.
+      #
+      # type: string
+      #DealCollateralWallet = ""
+
+      # CollateralAddThreshold is the balance below which more balance will be added to miner's market balance
+      # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")
+      #
+      # type: types.FIL
+      #CollateralAddThreshold = "5 FIL"
+
+      # CollateralAddAmount is the amount added to miner's market balance when it falls below CollateralAddThreshold
+      # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")
+      #
+      # type: types.FIL
+      #CollateralAddAmount = "5 FIL"
 
       # ExpectedPoRepSealDuration is the expected time it would take to seal the deal sector
       # This will be used to fail the deals which cannot be sealed on time.

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -342,36 +342,6 @@ description: The default curio configuration
     # type: types.FIL
     #PerSector = "0.03 FIL"
 
-  # BalanceManagerConfig specifies the configuration parameters for managing wallet balances and actor-related funds,
-  # including collateral and other operational resources.
-  #
-  # type: BalanceManagerConfig
-  [Fees.BalanceManager]
-
-    # MK12Collateral defines the configuration for managing collateral and related balance thresholds in the miner's market.
-    #
-    # type: MK12CollateralConfig
-    [Fees.BalanceManager.MK12Collateral]
-
-      # DealCollateralWallet is the wallet used to add balance to Miner's market balance. This balance is
-      # utilized for deal collateral in market (f05) deals.
-      #
-      # type: string
-      #DealCollateralWallet = ""
-
-      # CollateralLowThreshold is the balance below which more balance will be added to miner's market balance
-      # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")
-      #
-      # type: types.FIL
-      #CollateralLowThreshold = "5 FIL"
-
-      # CollateralHighThreshold is the target balance to which the miner's market balance will be topped up
-      # when it drops below CollateralLowThreshold.
-      # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "20 FIL")
-      #
-      # type: types.FIL
-      #CollateralHighThreshold = "20 FIL"
-
 
 # Addresses specifies the list of miner addresses and their related wallet addresses.
 #
@@ -416,6 +386,36 @@ description: The default curio configuration
   #
   # type: []string
   #MinerAddresses = []
+
+  # BalanceManagerConfig specifies the configuration parameters for managing wallet balances and actor-related funds,
+  # including collateral and other operational resources.
+  #
+  # type: BalanceManagerConfig
+  [Addresses.BalanceManager]
+
+    # MK12Collateral defines the configuration for managing collateral and related balance thresholds in the miner's market.
+    #
+    # type: MK12CollateralConfig
+    [Addresses.BalanceManager.MK12Collateral]
+
+      # DealCollateralWallet is the wallet used to add balance to Miner's market balance. This balance is
+      # utilized for deal collateral in market (f05) deals.
+      #
+      # type: string
+      #DealCollateralWallet = ""
+
+      # CollateralLowThreshold is the balance below which more balance will be added to miner's market balance
+      # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")
+      #
+      # type: types.FIL
+      #CollateralLowThreshold = "5 FIL"
+
+      # CollateralHighThreshold is the target balance to which the miner's market balance will be topped up
+      # when it drops below CollateralLowThreshold.
+      # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "20 FIL")
+      #
+      # type: types.FIL
+      #CollateralHighThreshold = "20 FIL"
 
 
 # Proving defines the configuration settings related to proving functionality within the Curio node.

--- a/documentation/en/curio-market/ipni-interplanetary-network-indexer-provider.md
+++ b/documentation/en/curio-market/ipni-interplanetary-network-indexer-provider.md
@@ -68,7 +68,7 @@ The behaviour of the Curio IPNI provider is controlled through the `IPNIConfig` 
 
 ### **IPNIConfig Fields**
 
-* **Disable**: Disables indexing announcements if set to `true`. Default: `false`.
+* **Disable**: Disables indexing announcements if set to `true`. Default: `false`. IPNI should be disabled on base layer.
 * **ServiceURL**: URLs for accessing the indexer web UI to view published advertisements.
 * **DirectAnnounceURLs**: URLs of indexing nodes where the provider sends HTTP announcements of new advertisements.
 

--- a/documentation/en/curio-market/storage-market.md
+++ b/documentation/en/curio-market/storage-market.md
@@ -118,32 +118,27 @@ To enable the Curio market on a Curio node, the following configuration changes 
    * Set `EnableDealMarket` to `true` in the `CurioSubsystemsConfig` for at least one node. This enables deal-making capabilities on the node.
 2. **Enable CommP**:
    * On one of the nodes where `EnableDealMarket` is set to `true`, ensure that `EnableCommP` is also set to `true`. This allows the node to compute piece commitments (CommP) before publishing storage deal messages.
-3. **Enable MarketBalanceManager (Optional)**:
-   * On one of the nodes where `EnableDealMarket` is set to `true`, ensure that `EnableMarketBalanceManager` is also set to `true`.
-   * This allows Curio to ensure that miner's market actor always have balance available for deal collaterals. 
-   * If enabled, users must designate a wallet to be used to send the balance
-     * Update `DealCollateralWallet` under the `MK12Config` settings under `StorageMarketConfig` is set.
-4. **Enable HTTP**:
+3. **Enable HTTP**:
    * At least one node must have HTTP enabled to support:
      * Retrievals.
      * IPNI sync.
      * Handling storage deals.
    * To enable HTTP, set the `Enable` flag in the `HTTPConfig` to `true` and specify the `ListenAddress` for the HTTP server.
-5. **Set a Domain Name**:
+4. **Set a Domain Name**:
    * Ensure that a valid `DomainName` is specified in the `HTTPConfig`. This is mandatory for proper HTTP server functionality and essential for enabling TLS. The domain name cannot be an IP address.
    * Domain name should be specified in the base layer
-6. **HTTP Configuration Details**:
+5. **HTTP Configuration Details**:
    * If TLS is managed by a reverse proxy, enable `DelegateTLS` in the `HTTPConfig` to allow the HTTP server to run without handling TLS directly.
    * Configure additional parameters such as `ReadTimeout`, `IdleTimeout`, and `CompressionLevels` to ensure the server operates efficiently.
-7. **Libp2p Activation**:
+6. **Libp2p Activation**:
    * The `libp2p` service will automatically start on one of the servers running the HTTP server where `EnableDealMarket` is set to `true`. If more than 1 node satsifies the condition and the node running libp2p goes down then it will switch over to another node after 5 minutes.
-8. **Other Considerations**:
+7. **Other Considerations**:
    * Ensure the `MK12Config` settings under `StorageMarketConfig` are properly configured for deal publishing. Key parameters include:
      * `PublishMsgPeriod` for deal batching frequency.
      * `MaxDealsPerPublishMsg` for the maximum number of deals per message.
      * `MaxPublishDealFee` to set the fee limit for publishing deals.
    * If handling offline deals, configure `PieceLocator` to specify the endpoints for piece retrieval.
-9. Verify that HTTP server is working:
+8. Verify that HTTP server is working:
 
     * Curl to your domain name and verify that server is reachable from outside\
 

--- a/documentation/en/curio-market/storage-market.md
+++ b/documentation/en/curio-market/storage-market.md
@@ -40,9 +40,6 @@ type MK12Config struct {
     PublishMsgPeriod        Duration
     MaxDealsPerPublishMsg   uint64
     MaxPublishDealFee       types.FIL
-    DealCollateralWallet string
-    CollateralAddThreshold types.FIL
-    CollateralAddAmount types.FIL
     ExpectedPoRepSealDuration Duration
     ExpectedSnapSealDuration Duration
     SkipCommP               bool
@@ -76,17 +73,11 @@ type MK12Config struct {
    MaxConcurrentDealSizeGiB is a sum of all size of all deals which are waiting to be added to a sector when the cumulative size of all deals in process reaches this number, new deals will be rejected. (Default: 0 = unlimited)
 9. **DenyUnknownClients:**\
    DenyUnknownClients determines the default behaviour for the deal of clients which are not in allow/deny list. If True then all deals coming from unknown clients will be rejected.
-10. **DealCollateralWallet**:\
-    The wallet used to fund the miner’s market balance for **deal collateral** in Filecoin market (`f05`) deals. If this wallet is not set, the **worker wallet** will be used instead.
-11. **CollateralAddThreshold**:\
-    Defines the **minimum required balance** in the miner’s market account. If the available balance falls below this threshold, additional funds will be added to prevent deal failures due to insufficient collateral.
-12. **CollateralAddAmount**:\
-    The **amount of FIL** to be added to the miner’s market balance when it drops below `CollateralAddThreshold`.This prevents frequent small top-ups and ensures enough collateral for multiple deals.
-13. **DenyOnlineDeals**: Determines whether the storage provider **accepts online deals**.
-14. **DenyOfflineDeals**: Determines whether the storage provider **accepts offline deals**.
-15. **CIDGravityToken**:\
+10. **DenyOnlineDeals**: Determines whether the storage provider **accepts online deals**.
+11. **DenyOfflineDeals**: Determines whether the storage provider **accepts offline deals**.
+12. **CIDGravityToken**:\
     The authorization token used for **CIDGravity filters**, a service that filters deal proposals based on custom policies. If empty (`""`), **CIDGravity filtering is disabled**. If set, the miner will **query CIDGravity** for each deal proposal before accepting it.
-16. **DefaultCIDGravityAccept**:\
+13. **DefaultCIDGravityAccept**:\
     Defines what happens if the **CIDGravity service is unavailable**. If`true`: **Accepts deals** even if CIDGravity is unreachable. If`false`: **Rejects deals** when CIDGravity is unavailable (**default**).
 
 

--- a/documentation/en/curio-market/storage-market.md
+++ b/documentation/en/curio-market/storage-market.md
@@ -131,6 +131,7 @@ To enable the Curio market on a Curio node, the following configuration changes 
    * To enable HTTP, set the `Enable` flag in the `HTTPConfig` to `true` and specify the `ListenAddress` for the HTTP server.
 5. **Set a Domain Name**:
    * Ensure that a valid `DomainName` is specified in the `HTTPConfig`. This is mandatory for proper HTTP server functionality and essential for enabling TLS. The domain name cannot be an IP address.
+   * Domain name should be specified in the base layer
 6. **HTTP Configuration Details**:
    * If TLS is managed by a reverse proxy, enable `DelegateTLS` in the `HTTPConfig` to allow the HTTP server to run without handling TLS directly.
    * Configure additional parameters such as `ReadTimeout`, `IdleTimeout`, and `CompressionLevels` to ensure the server operates efficiently.

--- a/tasks/storage-market/market_balance.go
+++ b/tasks/storage-market/market_balance.go
@@ -102,7 +102,6 @@ var _ = harmonytask.Reg(&BalanceManager{})
 func (m *BalanceManager) dealMarketBalance(ctx context.Context) error {
 	lowthreshold := abi.TokenAmount(m.cfg.Fees.BalanceManager.MK12Collateral.CollateralLowThreshold)
 	highthreshold := abi.TokenAmount(m.cfg.Fees.BalanceManager.MK12Collateral.CollateralHighThreshold)
-	amount := big.Sub(highthreshold, lowthreshold)
 
 	if m.cfg.Fees.BalanceManager.MK12Collateral.DealCollateralWallet == "" {
 		return xerrors.Errorf("Deal collateral wallet is not set")
@@ -144,6 +143,8 @@ func (m *BalanceManager) dealMarketBalance(ctx context.Context) error {
 				blog.Debugf("Skipping add balance for miner %s, available balance is %s, threshold is %s", miner.String(), avail.String(), lowthreshold.String())
 				continue
 			}
+
+			amount := big.Sub(highthreshold, avail)
 
 			if wbal.LessThan(amount) {
 				return xerrors.Errorf("Worker wallet balance %s is lower than specified amount %s", wbal.String(), amount.String())

--- a/tasks/storage-market/market_balance.go
+++ b/tasks/storage-market/market_balance.go
@@ -23,7 +23,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-const MarketBalanceCheckInterval = 10 * time.Minute
+const MarketBalanceCheckInterval = 5 * time.Minute
 
 type mbalanceApi interface {
 	ChainHead(ctx context.Context) (*types.TipSet, error)
@@ -173,7 +173,7 @@ func (m *MarketBalanceManager) CanAccept(ids []harmonytask.TaskID, engine *harmo
 func (m *MarketBalanceManager) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Max:  taskhelp.Max(1),
-		Name: "MarketBalanceManager",
+		Name: "MarketBalanceMgr",
 		Cost: resources.Resources{
 			Cpu: 1,
 			Ram: 64 << 20,

--- a/tasks/storage-market/market_balance.go
+++ b/tasks/storage-market/market_balance.go
@@ -1,0 +1,189 @@
+package storage_market
+
+import (
+	"context"
+	"time"
+
+	"github.com/samber/lo"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+
+	"github.com/filecoin-project/curio/deps/config"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+	"github.com/filecoin-project/curio/harmony/resources"
+	"github.com/filecoin-project/curio/harmony/taskhelp"
+	"github.com/filecoin-project/curio/tasks/message"
+
+	lapi "github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/actors"
+	marketActor "github.com/filecoin-project/lotus/chain/actors/builtin/market"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+const MarketBalanceCheckInterval = 10 * time.Minute
+
+type mbalanceApi interface {
+	ChainHead(ctx context.Context) (*types.TipSet, error)
+	StateMinerInfo(context.Context, address.Address, types.TipSetKey) (lapi.MinerInfo, error)
+	StateMarketBalance(context.Context, address.Address, types.TipSetKey) (lapi.MarketBalance, error)
+	StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error)
+}
+
+type MarketBalanceManager struct {
+	api    mbalanceApi
+	miners map[string][]address.Address
+	cfg    *config.MK12Config
+	sender *message.Sender
+}
+
+func NewMarketBalanceManager(api mbalanceApi, miners []address.Address, cfg *config.CurioConfig, sender *message.Sender) (*MarketBalanceManager, error) {
+	mk12Cfg := cfg.Market.StorageMarketConfig.MK12
+	var disabledMiners []address.Address
+
+	for _, m := range mk12Cfg.DisabledMiners {
+		maddr, err := address.NewFromString(m)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to parse miner string: %s", err)
+		}
+		disabledMiners = append(disabledMiners, maddr)
+	}
+
+	enabled, _ := lo.Difference(miners, disabledMiners)
+
+	mmap := make(map[string][]address.Address)
+	mmap[mk12Str] = enabled
+
+	return &MarketBalanceManager{
+		api:    api,
+		cfg:    &mk12Cfg,
+		miners: mmap,
+		sender: sender,
+	}, nil
+}
+
+func (m *MarketBalanceManager) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+	llog := log.With("Task", "MarketBalanceManager")
+
+	ctx := context.Background()
+
+	threshold := abi.TokenAmount(m.cfg.CollateralAddThreshold)
+	amount := abi.TokenAmount(m.cfg.CollateralAddAmount)
+
+	for module, miners := range m.miners {
+		if module != mk12Str {
+			continue
+		}
+		for _, miner := range miners {
+			miner := miner
+
+			// Check head in loop in case it changes and wallet balance changes
+			head, err := m.api.ChainHead(ctx)
+			if err != nil {
+				return false, xerrors.Errorf("failed to get chain head: %w", err)
+			}
+
+			bal, err := m.api.StateMarketBalance(ctx, miner, head.Key())
+			if err != nil {
+				return false, xerrors.Errorf("failed to get market balance: %w", err)
+			}
+
+			avail := big.Sub(bal.Escrow, bal.Locked)
+
+			if avail.GreaterThan(threshold) {
+				llog.Debugf("Skipping add balance for miner %s, available balance is %s, threshold is %s", miner.String(), avail.String(), threshold.String())
+				continue
+			}
+
+			var sender address.Address
+
+			if m.cfg.DealCollateralWallet != "" {
+				wallet, err := address.NewFromString(m.cfg.DealCollateralWallet)
+				if err != nil {
+					return false, xerrors.Errorf("failed to parse deal collateral wallet: %w", err)
+				}
+
+				w, err := m.api.StateGetActor(ctx, wallet, head.Key())
+				if err != nil {
+					return false, xerrors.Errorf("failed to get wallet actor: %w", err)
+				}
+
+				if w.Balance.LessThan(amount) {
+					return false, xerrors.Errorf("Collateral wallet balance %s is lower than specified amount %s", w.Balance.String(), amount.String())
+				}
+				sender = wallet
+			} else {
+				mi, err := m.api.StateMinerInfo(ctx, miner, head.Key())
+				if err != nil {
+					return false, xerrors.Errorf("failed to get miner info: %w", err)
+				}
+
+				w, err := m.api.StateGetActor(ctx, mi.Worker, head.Key())
+				if err != nil {
+					return false, xerrors.Errorf("failed to get wallet actor: %w", err)
+				}
+
+				if w.Balance.LessThan(amount) {
+					return false, xerrors.Errorf("Worker wallet balance %s is lower than specified amount %s", w.Balance.String(), amount.String())
+				}
+				sender = mi.Worker
+			}
+
+			params, err := actors.SerializeParams(&miner)
+			if err != nil {
+				return false, xerrors.Errorf("failed to serialize miner address: %w", err)
+			}
+
+			maxfee, err := types.ParseFIL("0.05 FIL")
+			if err != nil {
+				return false, xerrors.Errorf("failed to parse max fee: %w", err)
+			}
+
+			msp := &lapi.MessageSendSpec{
+				MaxFee: abi.TokenAmount(maxfee),
+			}
+
+			msg := &types.Message{
+				To:     marketActor.Address,
+				From:   sender,
+				Value:  amount,
+				Method: marketActor.Methods.AddBalance,
+				Params: params,
+			}
+
+			mcid, err := m.sender.Send(ctx, msg, msp, "Add Market Collateral")
+			if err != nil {
+				return false, xerrors.Errorf("failed to send message: %w", err)
+			}
+
+			llog.Debugf("sent message %s to add collateral to miner %s", mcid.String(), miner.String())
+		}
+	}
+
+	return true, nil
+}
+
+func (m *MarketBalanceManager) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+	id := ids[0]
+	return &id, nil
+}
+
+func (m *MarketBalanceManager) TypeDetails() harmonytask.TaskTypeDetails {
+	return harmonytask.TaskTypeDetails{
+		Max:  taskhelp.Max(1),
+		Name: "MarketBalanceManager",
+		Cost: resources.Resources{
+			Cpu: 1,
+			Ram: 64 << 20,
+			Gpu: 0,
+		},
+		IAmBored: harmonytask.SingletonTaskAdder(MarketBalanceCheckInterval, m),
+	}
+}
+
+func (m *MarketBalanceManager) Adder(taskFunc harmonytask.AddTaskFunc) {}
+
+var _ harmonytask.TaskInterface = &MarketBalanceManager{}
+var _ = harmonytask.Reg(&MarketBalanceManager{})

--- a/web/api/webrpc/sync_state.go
+++ b/web/api/webrpc/sync_state.go
@@ -3,6 +3,7 @@ package webrpc
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/filecoin-project/curio/api"
 	"github.com/filecoin-project/curio/build"
+	"github.com/filecoin-project/curio/deps/config"
 
 	cliutil "github.com/filecoin-project/lotus/cli/util"
 )
@@ -26,6 +28,55 @@ func forEachConfig[T any](a *WebRPC, cb func(name string, v T) error) error {
 
 	for name, tomlStr := range confs { // todo for-each-config
 		var info T
+
+		// Use reflection to check if `T` has an `Addresses` field
+		v := reflect.ValueOf(&info).Elem()
+		t := v.Type()
+
+		var addressesField reflect.Value
+		var addressesFieldIndex int
+
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			if field.Type.Kind() == reflect.Slice && field.Type.Elem() == reflect.TypeOf(config.CurioAddresses{}) {
+				addressesField = v.Field(i)
+				addressesFieldIndex = i
+				break
+			}
+		}
+
+		// If `Addresses` exists, pre-parse TOML to detect its length
+		if addressesField.IsValid() {
+			var lengthDetector struct {
+				Addresses []struct{} `toml:"Addresses"`
+			}
+			_, err := toml.Decode(tomlStr, &lengthDetector)
+			if err != nil {
+				return xerrors.Errorf("Error decoding TOML for length detection for layer %s: %w", name, err)
+			}
+
+			currentLen := addressesField.Len()
+			requiredLen := len(lengthDetector.Addresses)
+
+			// Pre-allocate the correct length in `info`
+			if currentLen < requiredLen {
+				preAllocated := make([]config.CurioAddresses, requiredLen)
+				for i := range preAllocated {
+					preAllocated[i] = config.CurioAddresses{
+						PreCommitControl:      []string{},
+						CommitControl:         []string{},
+						DealPublishControl:    []string{},
+						TerminateControl:      []string{},
+						DisableOwnerFallback:  false,
+						DisableWorkerFallback: false,
+						MinerAddresses:        []string{},
+						BalanceManager:        config.DefaultBalanceManager(),
+					}
+				}
+				v.Field(addressesFieldIndex).Set(reflect.ValueOf(preAllocated))
+			}
+		}
+
 		if err := toml.Unmarshal([]byte(tomlStr), &info); err != nil {
 			return xerrors.Errorf("unmarshaling %s config: %w", name, err)
 		}


### PR DESCRIPTION
This PR adds a new task which can automatically top off the miner's market balance. This balance is used for deal collateral. 

- [x] Test in devnet
- [x] Test after refactor

## Starting with 0 balance
<img width="1008" alt="Screenshot 2025-03-05 at 10 42 56 PM" src="https://github.com/user-attachments/assets/d484fd44-fc67-4ad0-b196-b1df99f16e53" />

## 10 FIL added from worker wallet
<img width="1008" alt="Screenshot 2025-03-05 at 10 49 28 PM" src="https://github.com/user-attachments/assets/ea29f651-fe1f-474f-8f0e-b84ce2f03d58" />

## 50 FIL Added from collateral wallet when Threshold is changed to 15 FIL
<img width="1008" alt="Screenshot 2025-03-05 at 10 52 14 PM" src="https://github.com/user-attachments/assets/431d4282-8ea4-47fa-9b22-18fbf50ced98" />
