### PR TITLE
fix: mark deal sealed in a DB transaction

### DIFF
--- a/harmony/harmonydb/sql/20241028-padding.sql
+++ b/harmony/harmonydb/sql/20241028-padding.sql
@@ -1,3 +1,4 @@
+-- This function is replaced in 20250310-fix-ingest.sql
 CREATE OR REPLACE FUNCTION transfer_and_delete_sorted_open_piece(v_sp_id bigint, v_sector_number bigint)
 RETURNS void AS $$
 DECLARE
@@ -75,7 +76,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-
+-- This function is replaced in 20250310-fix-ingest.sql
 CREATE OR REPLACE FUNCTION transfer_and_delete_sorted_open_piece_snap(v_sp_id bigint, v_sector_number bigint)
 RETURNS void AS $$
 DECLARE

--- a/harmony/harmonydb/sql/20250310-fix-ingest.sql
+++ b/harmony/harmonydb/sql/20250310-fix-ingest.sql
@@ -1,3 +1,5 @@
+-- This functions rearranges the pieces in open sector based on piece_size and then
+-- inserts them into the SDR pipeline table. This is done to align the inter piece padding.
 CREATE OR REPLACE FUNCTION transfer_and_delete_sorted_open_piece(v_sp_id bigint, v_sector_number bigint)
 RETURNS void AS $$
 DECLARE
@@ -72,7 +74,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-
+-- This functions rearranges the pieces in open sector based on piece_size and then
+-- inserts them into the Snap pipeline table. This is done to align the inter piece padding.
 CREATE OR REPLACE FUNCTION transfer_and_delete_sorted_open_piece_snap(v_sp_id bigint, v_sector_number bigint)
 RETURNS void AS $$
 DECLARE

--- a/harmony/harmonydb/sql/20250310-fix-ingest.sql
+++ b/harmony/harmonydb/sql/20250310-fix-ingest.sql
@@ -1,0 +1,145 @@
+CREATE OR REPLACE FUNCTION transfer_and_delete_sorted_open_piece(v_sp_id bigint, v_sector_number bigint)
+RETURNS void AS $$
+DECLARE
+sorted_pieces RECORD;
+new_index INT := 0;
+BEGIN
+    -- Sort open_sector_pieces by piece_size in descending order and update piece_index
+    FOR sorted_pieces IN
+    SELECT piece_index AS old_index, piece_size, piece_cid, data_url, data_headers,
+           data_raw_size, data_delete_on_finalize, f05_publish_cid, f05_deal_id,
+           f05_deal_proposal, f05_deal_start_epoch, f05_deal_end_epoch, direct_start_epoch,
+           direct_end_epoch, direct_piece_activation_manifest, created_at
+    FROM open_sector_pieces
+    WHERE sp_id = v_sp_id AND sector_number = v_sector_number
+    ORDER BY piece_size DESC  -- Descending order for biggest size first
+
+    LOOP
+        -- Insert sorted data into sectors_sdr_initial_pieces with updated piece_index
+        INSERT INTO sectors_sdr_initial_pieces (
+            sp_id,
+            sector_number,
+            piece_index,
+            piece_cid,
+            piece_size,
+            data_url,
+            data_headers,
+            data_raw_size,
+            data_delete_on_finalize,
+            f05_publish_cid,
+            f05_deal_id,
+            f05_deal_proposal,
+            f05_deal_start_epoch,
+            f05_deal_end_epoch,
+            direct_start_epoch,
+            direct_end_epoch,
+            direct_piece_activation_manifest,
+            created_at
+        )
+        VALUES (
+                   v_sp_id,
+                   v_sector_number,
+                   new_index,  -- Insert new_index as piece_index
+                   sorted_pieces.piece_cid,
+                   sorted_pieces.piece_size,
+                   sorted_pieces.data_url,
+                   sorted_pieces.data_headers,
+                   sorted_pieces.data_raw_size,
+                   sorted_pieces.data_delete_on_finalize,
+                   sorted_pieces.f05_publish_cid,
+                   sorted_pieces.f05_deal_id,
+                   sorted_pieces.f05_deal_proposal,
+                   sorted_pieces.f05_deal_start_epoch,
+                   sorted_pieces.f05_deal_end_epoch,
+                   sorted_pieces.direct_start_epoch,
+                   sorted_pieces.direct_end_epoch,
+                   sorted_pieces.direct_piece_activation_manifest,
+                   sorted_pieces.created_at
+               );
+
+        new_index := new_index + 1;
+    END LOOP;
+
+
+    -- Delete entries from open_sector_pieces after successful transfer
+    IF FOUND THEN
+        DELETE FROM open_sector_pieces
+        WHERE sp_id = v_sp_id AND sector_number = v_sector_number;
+    ELSE
+        RAISE EXCEPTION 'No data found to transfer for sp_id % and sector_number %', v_sp_id, v_sector_number;
+    END IF;
+
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION transfer_and_delete_sorted_open_piece_snap(v_sp_id bigint, v_sector_number bigint)
+RETURNS void AS $$
+DECLARE
+sorted_pieces RECORD;
+new_index INT := 0;
+BEGIN
+    -- If the related open_sector_pieces.f05_deal_id is not null, raise an exception
+    IF EXISTS (
+        SELECT 1
+        FROM open_sector_pieces
+        WHERE sp_id = v_sp_id AND sector_number = v_sector_number AND f05_deal_id IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION 'Cannot transfer open_sector_pieces with f05_deal_id not null for sp_id % and sector_number %', v_sp_id, v_sector_number;
+    END IF;
+
+    -- Sort open_sector_pieces by piece_size in descending order and update piece_index
+    FOR sorted_pieces IN
+    SELECT piece_index AS old_index, piece_size, piece_cid, data_url, data_headers,
+           data_raw_size, data_delete_on_finalize, direct_start_epoch,
+           direct_end_epoch, direct_piece_activation_manifest, created_at
+    FROM open_sector_pieces
+    WHERE sp_id = v_sp_id AND sector_number = v_sector_number
+    ORDER BY piece_size DESC  -- Descending order for biggest size first
+
+    LOOP
+        -- Insert sorted data into sectors_snap_initial_pieces with updated piece_index
+        INSERT INTO sectors_snap_initial_pieces (
+            sp_id,
+            sector_number,
+            piece_index,
+            piece_cid,
+            piece_size,
+            data_url,
+            data_headers,
+            data_raw_size,
+            data_delete_on_finalize,
+            direct_start_epoch,
+            direct_end_epoch,
+            direct_piece_activation_manifest,
+            created_at
+        )
+        VALUES (
+                   v_sp_id,
+                   v_sector_number,
+                   new_index,  -- Insert new_index as piece_index
+                   sorted_pieces.piece_cid,
+                   sorted_pieces.piece_size,
+                   sorted_pieces.data_url,
+                   sorted_pieces.data_headers,
+                   sorted_pieces.data_raw_size,
+                   sorted_pieces.data_delete_on_finalize,
+                   sorted_pieces.direct_start_epoch,
+                   sorted_pieces.direct_end_epoch,
+                   sorted_pieces.direct_piece_activation_manifest,
+                   sorted_pieces.created_at
+               );
+
+        new_index := new_index + 1;
+    END LOOP;
+
+    -- Delete entries from open_sector_pieces after successful transfer
+    IF FOUND THEN
+        DELETE FROM open_sector_pieces
+        WHERE sp_id = v_sp_id AND sector_number = v_sector_number;
+    ELSE
+        RAISE EXCEPTION 'No data found to transfer for sp_id % and sector_number %', v_sp_id, v_sector_number;
+    END IF;
+
+END;
+$$ LANGUAGE plpgsql;

--- a/tasks/snap/task_submit.go
+++ b/tasks/snap/task_submit.go
@@ -688,27 +688,38 @@ func (s *SubmitTask) schedule(ctx context.Context, addTaskFunc harmonytask.AddTa
 		})
 	}
 
-	// update landed
-	var tasks []struct {
-		SpID         int64 `db:"sp_id"`
-		SectorNumber int64 `db:"sector_number"`
-	}
-
-	err := s.db.Select(ctx, &tasks, `SELECT sp_id, sector_number FROM sectors_snap_pipeline WHERE after_encode = TRUE AND after_prove = TRUE AND after_prove_msg_success = FALSE AND after_submit = TRUE`)
-	if err != nil {
-		return xerrors.Errorf("getting tasks: %w", err)
-	}
-
-	for _, t := range tasks {
-		if err := s.updateLanded(ctx, t.SpID, t.SectorNumber); err != nil {
-			log.Errorw("updating landed", "sp", t.SpID, "sector", t.SectorNumber, "err", err)
+	comm, err := s.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (commit bool, err error) {
+		// update landed
+		var tasks []struct {
+			SpID         int64 `db:"sp_id"`
+			SectorNumber int64 `db:"sector_number"`
 		}
+
+		err = tx.Select(&tasks, `SELECT sp_id, sector_number FROM sectors_snap_pipeline WHERE after_encode = TRUE AND after_prove = TRUE AND after_prove_msg_success = FALSE AND after_submit = TRUE`)
+		if err != nil {
+			return false, xerrors.Errorf("getting tasks: %w", err)
+		}
+
+		for _, t := range tasks {
+			if err := s.updateLanded(ctx, tx, t.SpID, t.SectorNumber); err != nil {
+				log.Errorw("updating landed", "sp", t.SpID, "sector", t.SectorNumber, "err", err)
+				return false, xerrors.Errorf("updating landed for sp %d, sector %d: %w", t.SpID, t.SectorNumber, err)
+			}
+		}
+		return true, nil
+	}, harmonydb.OptionRetry())
+	if err != nil {
+		return xerrors.Errorf("updating landed: %w", err)
+	}
+
+	if !comm {
+		return xerrors.Errorf("updating landed: transaction failed")
 	}
 
 	return nil
 }
 
-func (s *SubmitTask) updateLanded(ctx context.Context, spId, sectorNum int64) error {
+func (s *SubmitTask) updateLanded(ctx context.Context, tx *harmonydb.Tx, spId, sectorNum int64) error {
 	var execResult []struct {
 		ProveMsgCID          string `db:"prove_msg_cid"`
 		UpdateSealedCID      string `db:"update_sealed_cid"`
@@ -719,7 +730,7 @@ func (s *SubmitTask) updateLanded(ctx context.Context, spId, sectorNum int64) er
 		ExecutedRcptGasUsed  int64  `db:"executed_rcpt_gas_used"`
 	}
 
-	err := s.db.Select(ctx, &execResult, `SELECT spipeline.prove_msg_cid, spipeline.update_sealed_cid, executed_tsk_cid, executed_tsk_epoch, executed_msg_cid, executed_rcpt_exitcode, executed_rcpt_gas_used
+	err := tx.Select(&execResult, `SELECT spipeline.prove_msg_cid, spipeline.update_sealed_cid, executed_tsk_cid, executed_tsk_epoch, executed_msg_cid, executed_rcpt_exitcode, executed_rcpt_gas_used
 					FROM sectors_snap_pipeline spipeline
 					JOIN message_waits ON spipeline.prove_msg_cid = message_waits.signed_message_cid
 					WHERE sp_id = $1 AND sector_number = $2 AND executed_tsk_epoch IS NOT NULL`, spId, sectorNum)
@@ -739,7 +750,7 @@ func (s *SubmitTask) updateLanded(ctx context.Context, spId, sectorNum int64) er
 			fallthrough
 		case exitcode.SysErrOutOfGas:
 			// just retry
-			n, err := s.db.Exec(ctx, `UPDATE sectors_snap_pipeline SET
+			n, err := tx.Exec(`UPDATE sectors_snap_pipeline SET
 						after_prove_msg_success = FALSE, after_submit = FALSE
 						WHERE sp_id = $2 AND sector_number = $3 AND after_prove_msg_success = FALSE AND after_submit = TRUE`,
 				execResult[0].ExecutedTskCID, spId, sectorNum)
@@ -773,15 +784,15 @@ func (s *SubmitTask) updateLanded(ctx context.Context, spId, sectorNum int64) er
 
 		if si == nil {
 			log.Errorw("todo handle missing sector info (not found after cron)", "sp", spId, "sector", sectorNum, "exec_epoch", execResult[0].ExecutedTskEpoch, "exec_tskcid", execResult[0].ExecutedTskCID, "msg_cid", execResult[0].ExecutedMsgCID)
-			// todo handdle missing sector info (not found after cron)
+			return xerrors.Errorf("sector info not found after prove message SP %d, sector %d, exec_epoch %d, exec_tskcid %s, msg_cid %s", spId, sectorNum, execResult[0].ExecutedTskEpoch, execResult[0].ExecutedTskCID, execResult[0].ExecutedMsgCID)
 		} else {
 			if si.SealedCID.String() != execResult[0].UpdateSealedCID {
 				log.Errorw("sector sealed CID mismatch after update?!", "sp", spId, "sector", sectorNum, "exec_epoch", execResult[0].ExecutedTskEpoch, "exec_tskcid", execResult[0].ExecutedTskCID, "msg_cid", execResult[0].ExecutedMsgCID)
-				return nil
+				return xerrors.Errorf("sector sealed CID mismatch after update?! SP %d, sector %d, exec_epoch %d, exec_tskcid %s, msg_cid %s", spId, sectorNum, execResult[0].ExecutedTskEpoch, execResult[0].ExecutedTskCID, execResult[0].ExecutedMsgCID)
 			}
 			// yay!
 
-			_, err := s.db.Exec(ctx, `UPDATE sectors_snap_pipeline SET
+			_, err := tx.Exec(`UPDATE sectors_snap_pipeline SET
 						after_prove_msg_success = TRUE, prove_msg_tsk = $1
 						WHERE sp_id = $2 AND sector_number = $3 AND after_prove_msg_success = FALSE`,
 				execResult[0].ExecutedTskCID, spId, sectorNum)
@@ -789,7 +800,7 @@ func (s *SubmitTask) updateLanded(ctx context.Context, spId, sectorNum int64) er
 				return xerrors.Errorf("update sectors_snap_pipeline: %w", err)
 			}
 
-			n, err := s.db.Exec(ctx, `UPDATE market_mk12_deal_pipeline SET sealed = TRUE WHERE sp_id = $1 AND sector = $2 AND sealed = FALSE`, spId, sectorNum)
+			n, err := tx.Exec(`UPDATE market_mk12_deal_pipeline SET sealed = TRUE WHERE sp_id = $1 AND sector = $2 AND sealed = FALSE`, spId, sectorNum)
 			if err != nil {
 				return xerrors.Errorf("update market_mk12_deal_pipeline: %w", err)
 			}


### PR DESCRIPTION
This PR does following:
1. Move the CommitLanded and UpdateLanded into a DB transaction.
2. Replace ingest seal now SQL functions to fix below error:

```
2025-03-10 16:00:52 2025-03-10T12:00:52.076Z    ERROR   storage-ingest  storageingest/deal_ingest_seal.go:172   start sealing sector: adding sector to pipeline: ERROR: duplicate key value violates unique constraint "open_sector_pieces_pkey" (SQLSTATE 23505)
```