### PR TITLE
SQL based batch creation

### DIFF
--- a/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
+++ b/harmony/harmonydb/sql/20231217-sdr-pipeline.sql
@@ -69,6 +69,7 @@ create table sectors_sdr_pipeline (
     after_move_storage bool not null default false,
 
     -- commit_ready_at (Added in 20241210-sdr-batching.sql)
+    -- start_epoch bigint default null (Added in 20250312-batching-functions.sql)
 
     -- Commit message sending
     commit_msg_cid text,

--- a/harmony/harmonydb/sql/20250312-batching-functions.sql
+++ b/harmony/harmonydb/sql/20250312-batching-functions.sql
@@ -1,0 +1,375 @@
+ALTER TABLE sectors_sdr_pipeline
+    ADD COLUMN start_epoch BIGINT DEFAULT NULL;
+
+/*
+  This revised function removes any named temporary tables and instead uses a
+  single CTE chain plus a loop in PL/pgSQL. This way, multiple pollers can run
+  concurrently without hitting errors about existing temp tables.
+
+  Steps:
+    1) Lock all rows needing a commit message:
+         - after_porep = TRUE
+         - porep_proof IS NOT NULL
+         - task_id_commit_msg IS NULL
+         - after_commit_msg = FALSE
+         - start_epoch IS NOT NULL
+       We do so with "FOR UPDATE SKIP LOCKED" to avoid collisions among pollers.
+
+    2) In the same query, number these rows per group (sp_id, reg_seal_proof),
+       chunk them by p_max_batch size, and group them to get each batch's:
+         - sp_id, reg_seal_proof
+         - Array of sector_number
+         - MIN(start_epoch)      as batch_start_epoch
+         - MIN(commit_ready_at)  as earliest_ready_at
+
+    3) Iterate over these batches in ascending order, checking for the first batch
+       that meets ANY of:
+         (a) (batch_start_epoch - p_slack_epoch - p_current_height) <= 0
+         (b) (earliest_ready_at + p_timeout_secs) > now()
+         (c) p_basefee_ok = TRUE
+       If found, update those rows in sectors_sdr_pipeline => task_id_commit_msg = p_new_task_id
+       and return the number of rows updated.
+
+    4) If no batch meets a condition, return 0.
+
+  Usage example:
+    SELECT poll_start_batch_commit_msg(
+      slack_epoch_value,
+      current_height_value,
+      max_batch_size,
+      new_task_id_value,
+      basefee_ok_boolean,
+      timeout_secs
+    );
+
+  Important:
+    - Call this function in a transaction.
+    - Because we do "FOR UPDATE SKIP LOCKED," multiple pollers do not process
+      the same rows simultaneously.
+*/
+
+CREATE OR REPLACE FUNCTION poll_start_batch_commit_msg(
+    p_slack_epoch    BIGINT,  -- "Slack" epoch offset
+    p_current_height BIGINT,  -- Current on-chain height
+    p_max_batch      INT,     -- Max sectors per batch
+    p_new_task_id    BIGINT,  -- Task ID to set for a chosen batch
+    p_basefee_ok     BOOLEAN, -- If TRUE, the base fee condition is satisfied
+    p_timeout_secs   INT      -- If earliest_ready + this > now(), condition is met
+)
+-- We return a TABLE of (updated_count BIGINT, reason TEXT),
+-- but in practice it will yield exactly one row.
+RETURNS TABLE (
+    updated_count BIGINT,
+    reason        TEXT
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    batch_rec RECORD;
+    cond_slack   BOOLEAN;
+    cond_timeout BOOLEAN;
+    cond_fee     BOOLEAN;
+BEGIN
+    -- Default outputs if we never find a batch
+    updated_count := 0;
+    reason        := 'NONE';
+    /*
+      Single query logic:
+        (1) Lock rows that need commit assignment (FOR UPDATE SKIP LOCKED).
+        (2) Partition them by (sp_id, reg_seal_proof), using ROW_NUMBER() to break
+            them into sub-batches of size p_max_batch.
+        (3) GROUP those sub-batches to get:
+            - batch_start_epoch = min(start_epoch)
+            - earliest_ready_at = min(commit_ready_at)
+            - sector_nums = array of sector_number
+        (4) Loop over results, check conditions, update if found, return count.
+        (5) If we finish the loop, return 0.
+    */
+    FOR batch_rec IN
+        WITH locked AS (
+            SELECT
+                sp_id,
+                sector_number,
+                start_epoch,
+                commit_ready_at,
+                reg_seal_proof
+            FROM sectors_sdr_pipeline
+            WHERE after_porep        = TRUE
+              AND porep_proof        IS NOT NULL
+              AND task_id_commit_msg IS NULL
+              AND after_commit_msg   = FALSE
+              AND start_epoch        IS NOT NULL
+            ORDER BY sp_id, reg_seal_proof, start_epoch
+            FOR UPDATE SKIP LOCKED
+        ),
+        numbered AS (
+            SELECT
+              l.*,
+              ROW_NUMBER() OVER (
+                PARTITION BY l.sp_id, l.reg_seal_proof
+                ORDER BY l.commit_ready_at
+              ) AS rn
+            FROM locked l
+        ),
+        chunked AS (
+            SELECT
+              sp_id,
+              reg_seal_proof,
+              FLOOR((rn - 1)::NUMERIC / p_max_batch) AS batch_index,
+              start_epoch,
+              commit_ready_at,
+              sector_number
+            FROM numbered
+        ),
+        grouped AS (
+            SELECT
+              sp_id,
+              reg_seal_proof,
+              batch_index,
+              MIN(start_epoch)               AS batch_start_epoch,
+              MIN(commit_ready_at)           AS earliest_ready_at,
+              ARRAY_AGG(sector_number)       AS sector_nums
+            FROM chunked
+            GROUP BY sp_id, reg_seal_proof, batch_index
+            ORDER BY sp_id, reg_seal_proof, batch_index
+        )
+        SELECT
+            sp_id,
+            reg_seal_proof,
+            sector_nums,
+            batch_start_epoch,
+            earliest_ready_at
+        FROM grouped
+    LOOP
+         -- Evaluate conditions separately so we can pick a 'reason' if triggered.
+        cond_slack   := ((batch_rec.batch_start_epoch - p_slack_epoch) <= p_current_height);
+        cond_timeout := (NOW() >= (batch_rec.earliest_ready_at + MAKE_INTERVAL(secs => p_timeout_secs)));
+        cond_fee     := p_basefee_ok;  -- user-supplied boolean
+
+        IF (cond_slack OR cond_timeout OR cond_fee) THEN
+            -- If multiple conditions are true, pick an order of precedence.
+            IF cond_slack THEN
+                reason := 'SLACK (min start epoch: ' || batch_rec.batch_start_epoch || ')';
+            ELSIF cond_timeout THEN
+                reason := 'TIMEOUT (earliest_ready_at: ' || batch_rec.earliest_ready_at || ')';
+            ELSIF cond_fee THEN
+                reason := 'FEE';
+            END IF;
+
+            -- Perform the update
+            UPDATE sectors_sdr_pipeline t
+                SET task_id_commit_msg = p_new_task_id
+            WHERE t.sp_id         = batch_rec.sp_id
+                AND t.reg_seal_proof = batch_rec.reg_seal_proof
+                AND t.sector_number = ANY(batch_rec.sector_nums)
+                AND t.after_porep = TRUE
+                AND t.task_id_commit_msg IS NULL
+                AND t.after_commit_msg = FALSE;
+
+            GET DIAGNOSTICS updated_count = ROW_COUNT;
+
+            RETURN NEXT;
+            RETURN;  -- Return immediately with updated_count and reason
+        END IF;
+    END LOOP;
+
+    -- If we finish the loop with no triggered condition, we return updated_count=0, reason='NONE'
+    RETURN NEXT;
+    RETURN;
+END;
+$$;
+
+/*
+  This function replicates the "batching" logic for sending PreCommit messages,
+  fully in SQL/PLpgSQL.
+
+  Logic in brief:
+    1) Lock all rows that need a precommit message:
+         - after_synth           = TRUE
+         - task_id_precommit_msg = NULL
+         - after_precommit_msg   = FALSE
+       For each row, we compute a "start_epoch" via COALESCE of any deal-based
+       epoch (in sectors_sdr_initial_pieces) or fallback to (ticket_epoch + 0).
+       You can replace that "0" with your actual fallback if needed.
+
+    2) Within the same query, we group the locked rows by (sp_id, reg_seal_proof),
+       chunk them into sub-batches of size up to p_max_batch. For each chunk/batch,
+       we record:
+         - sp_id, reg_seal_proof
+         - sector_nums: an array of sector_number
+         - batch_start_epoch: the MIN start_epoch in that chunk
+         - earliest_ready: the MIN precommit_ready_at in that chunk
+
+    3) We iterate over each batch (in ascending order), and for the first batch that
+       satisfies ANY of:
+         (a) (batch_start_epoch - p_slack_epoch - p_current_height) <= 0
+         (b) (earliest_ready + p_timeout_secs) > NOW()
+         (c) p_basefee_ok = TRUE
+       we update those sectors in sectors_sdr_pipeline => task_id_precommit_msg = p_new_task_id,
+       then return the number of rows updated.
+
+    4) If no batch meets the conditions, return 0. The locked rows will remain
+       without task_id_precommit_msg until the next polling iteration. Because
+       we do "FOR UPDATE SKIP LOCKED," other pollers can still operate on rows
+       that we haven't locked.
+
+  IMPORTANT:
+    - Call this function inside a single transaction.
+    - "FOR UPDATE SKIP LOCKED" ensures multiple pollers do not process the same
+      rows concurrently. Whichever poller locks them first "wins," while others
+      skip them.
+
+  Example usage:
+
+    SELECT poll_start_batch_precommit_msg(
+      randomnessLookBack,    -- p_randomnessLookBack
+      slack_epoch_value,     -- p_slack_epoch
+      current_height_value,  -- p_current_height
+      max_batch_size,        -- p_max_batch
+      new_task_id_value,     -- p_new_task_id
+      basefee_ok_boolean,    -- p_basefee_ok
+      timeout_secs           -- p_timeout_secs
+    );
+
+  Returns:
+    The number of sectors updated (i.e., assigned a precommit task) if a batch
+    is found that meets any condition. Otherwise, 0.
+*/
+
+CREATE OR REPLACE FUNCTION poll_start_batch_precommit_msg(
+    p_randomnessLookBack BIGINT, -- policy.MaxPreCommitRandomnessLookback
+    p_slack_epoch    BIGINT,  -- "Slack" epoch to compare against a sector's start_epoch
+    p_current_height BIGINT,  -- Current on-chain height
+    p_max_batch      INT,     -- Max number of sectors per batch
+    p_new_task_id    BIGINT,  -- Task ID to assign if a batch is chosen
+    p_basefee_ok     BOOLEAN, -- If TRUE, fee-based condition is considered met
+    p_timeout_secs   INT      -- Timeout in seconds for earliest_ready_at check
+)
+-- We return a TABLE of (updated_count BIGINT, reason TEXT),
+-- but in practice it will yield exactly one row.
+RETURNS TABLE (
+    updated_count BIGINT,
+    reason        TEXT
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    batch_rec RECORD;
+    cond_slack   BOOLEAN;
+    cond_timeout BOOLEAN;
+    cond_fee     BOOLEAN;
+BEGIN
+    -- Default outputs if we never find a batch
+    updated_count := 0;
+    reason        := 'NONE';
+    /*
+      We'll do all logic in a single CTE chain, which:
+        (1) Locks relevant rows in "sectors_sdr_pipeline".
+        (2) Computes each row's "start_epoch" by coalescing data from
+            sectors_sdr_initial_pieces or fallback.
+        (3) Numbers them per group, forming sub-batches of size p_max_batch.
+        (4) Groups by (sp_id, reg_seal_proof, batch_index).
+        (5) Finally selects sp_id, reg_seal_proof, an array of sector_numbers,
+            plus the min start_epoch and earliest_ready for each batch.
+      Then we loop over those grouped results in ascending order.
+    */
+
+    FOR batch_rec IN
+        WITH locked AS (
+            SELECT
+              p.sp_id,
+              p.sector_number,
+              -- Compute the precommit "start_epoch" via deal info or fallback:
+              COALESCE(
+                (
+                  SELECT MIN(LEAST(s.f05_deal_start_epoch, s.direct_start_epoch))
+                    FROM sectors_sdr_initial_pieces s
+                   WHERE s.sp_id = p.sp_id
+                     AND s.sector_number = p.sector_number
+                ),
+                p.ticket_epoch + p_randomnessLookBack
+              ) AS start_epoch,
+              p.precommit_ready_at,
+              p.reg_seal_proof
+            FROM sectors_sdr_pipeline p
+            WHERE p.after_synth = TRUE
+              AND p.task_id_precommit_msg IS NULL
+              AND p.after_precommit_msg = FALSE
+            ORDER BY p.sp_id, p.reg_seal_proof
+            FOR UPDATE SKIP LOCKED
+        ),
+        numbered AS (
+            SELECT
+              l.*,
+              ROW_NUMBER() OVER (
+                PARTITION BY l.sp_id, l.reg_seal_proof
+                ORDER BY l.start_epoch
+              ) AS rn
+            FROM locked l
+        ),
+        chunked AS (
+            SELECT
+              sp_id,
+              reg_seal_proof,
+              FLOOR((rn - 1)::NUMERIC / p_max_batch) AS batch_index,
+              start_epoch,
+              precommit_ready_at,
+              sector_number
+            FROM numbered
+        ),
+        grouped AS (
+            SELECT
+              sp_id,
+              reg_seal_proof,
+              batch_index,
+              MIN(start_epoch)               AS min_start_epoch,
+              MIN(precommit_ready_at)        AS earliest_ready,
+              ARRAY_AGG(sector_number)       AS sector_nums
+            FROM chunked
+            GROUP BY sp_id, reg_seal_proof, batch_index
+            ORDER BY sp_id, reg_seal_proof, batch_index
+        )
+        SELECT
+            sp_id,
+            reg_seal_proof,
+            sector_nums,
+            min_start_epoch,
+            earliest_ready
+        FROM grouped
+    LOOP
+         -- Evaluate each condition
+        cond_slack   := ((batch_rec.min_start_epoch - p_slack_epoch) <= p_current_height);
+        cond_timeout := ((batch_rec.earliest_ready + MAKE_INTERVAL(secs => p_timeout_secs)) < NOW() AT TIME ZONE 'UTC');
+        cond_fee     := p_basefee_ok;
+
+        IF (cond_slack OR cond_timeout OR cond_fee) THEN
+            -- Decide which reason triggered it (if multiple are true, pick priority order)
+            IF cond_slack THEN
+                reason := 'SLACK (min start epoch: ' || batch_rec.min_start_epoch || ')';
+            ELSIF cond_timeout THEN
+                reason := 'TIMEOUT (earliest_ready_at: ' || batch_rec.earliest_ready || ')';
+            ELSIF cond_fee THEN
+                reason := 'FEE';
+            END IF;
+
+            -- Update these sectors in sectors_sdr_pipeline
+            UPDATE sectors_sdr_pipeline t
+                SET task_id_precommit_msg = p_new_task_id
+            WHERE t.sp_id = batch_rec.sp_id
+                AND t.reg_seal_proof = batch_rec.reg_seal_proof
+                AND t.sector_number = ANY(batch_rec.sector_nums)
+                AND t.after_synth           = TRUE
+                AND t.task_id_precommit_msg IS NULL
+                AND t.after_precommit_msg   = FALSE;
+
+            GET DIAGNOSTICS updated_count = ROW_COUNT;
+            RETURN NEXT;
+            RETURN;  -- Return immediately with updated_count, reason
+        END IF;
+    END LOOP;
+
+    -- If we finish the loop with no triggered condition, we return updated_count=0, reason='NONE'
+    RETURN NEXT;
+    RETURN;
+END;
+$$;

--- a/tasks/seal/poller.go
+++ b/tasks/seal/poller.go
@@ -2,6 +2,7 @@ package seal
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -183,7 +184,7 @@ type pollTask struct {
 	Failed       bool   `db:"failed"`
 	FailedReason string `db:"failed_reason"`
 
-	StartEpoch abi.ChainEpoch `db:"smallest_start_epoch"`
+	StartEpoch sql.NullInt64 `db:"start_epoch"`
 }
 
 func (s *SealPoller) poll(ctx context.Context) error {
@@ -222,14 +223,7 @@ func (s *SealPoller) poll(ctx context.Context) error {
 												p.after_commit_msg_success,
 												p.failed, 
 												p.failed_reason,
-												COALESCE(
-													(SELECT 
-														MIN(LEAST(s.f05_deal_start_epoch, s.direct_start_epoch))
-													 FROM sectors_sdr_initial_pieces s
-													 WHERE s.sp_id = p.sp_id AND s.sector_number = p.sector_number
-													), 
-													0
-												) AS smallest_start_epoch
+												p.start_epoch
 											FROM 
 												sectors_sdr_pipeline p
 											WHERE 
@@ -257,14 +251,15 @@ func (s *SealPoller) poll(ctx context.Context) error {
 		s.pollStartSynth(ctx, task)
 		s.mustPoll(s.pollPrecommitMsgLanded(ctx, task))
 		s.pollStartPoRep(ctx, task, ts)
+		s.mustPoll(s.pollerAddStartEpoch(ctx, task))
 		s.pollStartFinalize(ctx, task, ts)
 		s.pollStartMoveStorage(ctx, task)
 		s.mustPoll(s.pollCommitMsgLanded(ctx, task))
 	}
 
 	// Aggregate/Batch PreCommit and Commit
-	s.pollStartBatchPrecommitMsg(ctx, tasks)
-	s.pollStartBatchCommitMsg(ctx, tasks)
+	s.pollStartBatchPrecommitMsg(ctx)
+	s.pollStartBatchCommitMsg(ctx)
 
 	return nil
 }

--- a/tasks/seal/poller_commit_msg.go
+++ b/tasks/seal/poller_commit_msg.go
@@ -2,8 +2,7 @@ package seal
 
 import (
 	"context"
-	"sort"
-	"time"
+	"math"
 
 	"golang.org/x/xerrors"
 
@@ -20,149 +19,104 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-func (s *SealPoller) pollStartBatchCommitMsg(ctx context.Context, tasks []pollTask) {
-	// Make batches based on Proof types
+func (s *SealPoller) pollerAddStartEpoch(ctx context.Context, task pollTask) error {
+	if !task.StartEpoch.Valid {
+		ts, err := s.api.ChainHead(ctx)
+		if err != nil {
+			return xerrors.Errorf("failed to get chain head: %w", err)
+		}
+
+		nv, err := s.api.StateNetworkVersion(ctx, ts.Key())
+		if err != nil {
+			return xerrors.Errorf("failed to get network version: %w", err)
+		}
+
+		av, err := actorstypes.VersionForNetwork(nv)
+		if err != nil {
+			return xerrors.Errorf("unsupported network version: %w", err)
+		}
+
+		maddr, err := address.NewIDAddress(uint64(task.SpID))
+		if err != nil {
+			return xerrors.Errorf("failed to create miner address: %w", err)
+		}
+		pci, err := s.api.StateSectorPreCommitInfo(ctx, maddr, abi.SectorNumber(task.SectorNumber), ts.Key())
+		if err != nil {
+			return xerrors.Errorf("failed to get precommit info: %w", err)
+		}
+		if pci == nil {
+			return xerrors.Errorf("precommit info not found for sp %s and sector %d", maddr.String(), task.SectorNumber)
+		}
+		mpcd, err := policy.GetMaxProveCommitDuration(av, task.RegisteredSealProof)
+		if err != nil {
+			return xerrors.Errorf("failed to get max prove commit duration: %w", err)
+		}
+		startEpoch := pci.PreCommitEpoch + mpcd
+		_, err = s.db.Exec(ctx, `UPDATE sectors_sdr_pipeline p
+										SET start_epoch = COALESCE(
+											(SELECT MIN(LEAST(s.f05_deal_start_epoch, s.direct_start_epoch))
+											 FROM sectors_sdr_initial_pieces s
+											 WHERE s.sp_id = $2 
+											   AND s.sector_number = $3
+											), 
+											$1
+										)
+										WHERE p.sp_id = $2
+										  AND p.sector_number = $3
+										  AND p.after_porep = TRUE 
+										  AND p.after_commit_msg = FALSE 
+										  AND p.start_epoch IS NULL`, startEpoch, task.SpID, task.SectorNumber)
+		if err != nil {
+			return xerrors.Errorf("failed to update start epoch: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *SealPoller) pollStartBatchCommitMsg(ctx context.Context) {
 	ts, err := s.api.ChainHead(ctx)
 	if err != nil {
 		log.Errorf("error getting chain head: %s", err)
 		return
 	}
 
-	nv, err := s.api.StateNetworkVersion(ctx, ts.Key())
-	if err != nil {
-		log.Errorf("getting network version: %s", err)
-		return
+	slackEpoch := int64(math.Ceil(s.cfg.commit.Slack.Seconds() / float64(build.BlockDelaySecs)))
+	feeOk := false
+	if ts.MinTicketBlock().ParentBaseFee.LessThan(s.cfg.commit.BaseFeeThreshold) {
+		feeOk = true
 	}
 
-	av, err := actorstypes.VersionForNetwork(nv)
-	if err != nil {
-		log.Errorf("unsupported network version: %s", err)
-		return
-	}
-
-	var tsks []pollTask
-
-	for i := range tasks {
-		if tasks[i].afterPoRep() && len(tasks[i].PoRepProof) > 0 && tasks[i].TaskCommitMsg == nil && !tasks[i].AfterCommitMsg && s.pollers[pollerCommitMsg].IsSet() {
-			// If CC sector set StartEpoch/CutOff
-			if tasks[i].StartEpoch == 0 {
-				maddr, err := address.NewIDAddress(uint64(tasks[i].SpID))
-				if err != nil {
-					log.Errorf("error creating miner address: %s", err)
-					return
-				}
-
-				pci, err := s.api.StateSectorPreCommitInfo(ctx, maddr, abi.SectorNumber(tasks[i].SectorNumber), ts.Key())
-				if err != nil {
-					log.Errorf("getting precommit info: %s", err)
-					return
-				}
-
-				if pci == nil {
-					log.Errorf("precommit info not found for sp %s and sector %d", maddr.String(), tasks[i].SectorNumber)
-					return
-				}
-
-				mpcd, err := policy.GetMaxProveCommitDuration(av, tasks[i].RegisteredSealProof)
-				if err != nil {
-					log.Errorf("getting max prove commit duration: %s", err)
-					return
-				}
-
-				tasks[i].StartEpoch = pci.PreCommitEpoch + mpcd
-			}
-			tsks = append(tsks, tasks[i])
-		}
-	}
-
-	sort.Slice(tsks, func(i, j int) bool {
-		return tsks[i].StartEpoch < tsks[j].StartEpoch
-	})
-
-	batchMap := make(map[int64]map[abi.RegisteredSealProof][]pollTask)
-	for i := range tsks {
-		// Check if SpID exists in batchMap
-		v, ok := batchMap[tsks[i].SpID]
-		if !ok {
-			// If not, initialize a new map for the RegisteredSealProof
-			v = make(map[abi.RegisteredSealProof][]pollTask)
-			batchMap[tsks[i].SpID] = v
-		}
-		// Append the task to the correct RegisteredSealProof
-		v[tsks[i].RegisteredSealProof] = append(v[tsks[i].RegisteredSealProof], tsks[i])
-	}
-
-	// Send batches per MinerID and per Proof type based on the following logic:
-	// 1. Check if Slack for any sector is reaching, if yes then send full batch
-	// 2. Check if timeout is reaching for any sector in the batch, if yes, then send the batch
-	// 3. Check if baseFee below set threshold. If yes then send all batches
-
-	for spid, sealProofMap := range batchMap {
-		for _, pts := range sealProofMap {
-			// Break into batches
-			var batches []sectorBatch
-			for i := 0; i < len(pts); i += s.cfg.commit.MaxCommitBatch {
-				// Create a batch of size `maxBatchSize` or smaller for the last batch
-				end := i + s.cfg.commit.MaxCommitBatch
-				if end > len(pts) {
-					end = len(pts)
-				}
-				var batch []int64
-				cutoff := abi.ChainEpoch(0)
-				earliest := time.Now()
-				for _, pt := range pts[i:end] {
-
-					if cutoff == 0 || pt.StartEpoch < cutoff {
-						cutoff = pt.StartEpoch
-					}
-
-					if pt.CommitReadyAt.Before(earliest) {
-						earliest = *pt.CommitReadyAt
-					}
-
-					batch = append(batch, pt.SectorNumber)
-				}
-
-				batches = append(batches, sectorBatch{
-					cutoff:  cutoff,
-					sectors: batch,
-				})
-			}
-
-			for i := range batches {
-				batch := batches[i]
-				//sectors := batch.sectors
-				// Process batch if slack has reached
-				if (time.Duration(batch.cutoff-ts.Height()) * time.Duration(build.BlockDelaySecs) * time.Second) < s.cfg.commit.Slack {
-					s.sendCommitBatch(ctx, spid, batch.sectors)
-					continue
-				}
-				// Process batch if timeout has reached
-				if batch.earliest.Add(s.cfg.commit.Timeout).After(time.Now()) {
-					s.sendCommitBatch(ctx, spid, batch.sectors)
-					continue
-				}
-				// Process batch if base fee is low enough for us to send
-				if ts.MinTicketBlock().ParentBaseFee.LessThan(s.cfg.commit.BaseFeeThreshold) {
-					s.sendCommitBatch(ctx, spid, batch.sectors)
-					continue
-				}
-			}
-		}
-	}
-}
-
-func (s *SealPoller) sendCommitBatch(ctx context.Context, spid int64, sectors []int64) {
 	s.pollers[pollerCommitMsg].Val(ctx)(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
-		n, err := tx.Exec(`UPDATE sectors_sdr_pipeline SET task_id_commit_msg = $1 WHERE sp_id = $2 AND sector_number = ANY($3) AND task_id_commit_msg IS NULL AND after_commit_msg = FALSE`, id, spid, sectors)
+		var updatedCount int64
+		var reason string
+
+		log.Infow("Trying to assign a commit batch",
+			"slack_epoch", slackEpoch,
+			"current_height", ts.Height(),
+			"max_batch", s.cfg.commit.MaxCommitBatch,
+			"new_task_id", id,
+			"basefee_ok", feeOk,
+			"timeout_secs", s.cfg.commit.Timeout.Seconds())
+
+		err = tx.QueryRow(`SELECT updated_count, reason FROM poll_start_batch_commit_msg($1, $2, $3, $4, $5, $6)`,
+			slackEpoch,                          // p_slack_epoch
+			ts.Height(),                         // p_current_height
+			s.cfg.commit.MaxCommitBatch,         // p_max_batch
+			id,                                  // p_new_task_id
+			feeOk,                               // p_basefee_ok
+			int(s.cfg.commit.Timeout.Seconds()), // p_timeout_secs
+		).Scan(&updatedCount, &reason)
 		if err != nil {
-			return false, xerrors.Errorf("update sectors_sdr_pipeline: %w", err)
-		}
-		if n > len(sectors) {
-			return false, xerrors.Errorf("expected to update at most %d rows, updated %d", len(sectors), n)
+			return false, err
 		}
 
-		return true, nil
+		if updatedCount > 0 {
+			log.Debugf("Assigned %d sectors to commit batch with taskID %d with reason %s", updatedCount, id, reason)
+			return true, nil
+		} else {
+			log.Debugf("No commit batch assigned")
+		}
+		return false, nil
 	})
 }
 

--- a/tasks/seal/poller_precommit_msg.go
+++ b/tasks/seal/poller_precommit_msg.go
@@ -3,7 +3,7 @@ package seal
 import (
 	"context"
 	"database/sql"
-	"sort"
+	"math"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -20,117 +20,55 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-type sectorBatch struct {
-	cutoff   abi.ChainEpoch
-	earliest time.Time
-	sectors  []int64
-}
-
-func (s *SealPoller) pollStartBatchPrecommitMsg(ctx context.Context, tasks []pollTask) {
-	// Make batches based on Proof types
-	var tsks []pollTask
-	for i := range tasks {
-		if tasks[i].TaskPrecommitMsg == nil && !tasks[i].AfterPrecommitMsg && tasks[i].afterSynth() && s.pollers[pollerPrecommitMsg].IsSet() {
-			// If CC sector set StartEpoch/CutOff
-			if tasks[i].StartEpoch == 0 {
-				tasks[i].StartEpoch = abi.ChainEpoch(*tasks[i].TicketEpoch) + policy.MaxPreCommitRandomnessLookback
-			}
-			tsks = append(tsks, tasks[i])
-		}
-	}
-
-	// Sort in ascending order to allow maximum time for sectors to wait for base free drop
-	sort.Slice(tsks, func(i, j int) bool {
-		return tsks[i].StartEpoch < tsks[j].StartEpoch
-	})
-
-	batchMap := make(map[int64]map[abi.RegisteredSealProof][]pollTask)
-	for i := range tsks {
-		// Check if SpID exists in batchMap
-		v, ok := batchMap[tsks[i].SpID]
-		if !ok {
-			// If not, initialize a new map for the RegisteredSealProof
-			v = make(map[abi.RegisteredSealProof][]pollTask)
-			batchMap[tsks[i].SpID] = v
-		}
-		// Append the task to the correct RegisteredSealProof
-		v[tsks[i].RegisteredSealProof] = append(v[tsks[i].RegisteredSealProof], tsks[i])
-	}
-
-	// Send batches per MinerID and per Proof type based on the following logic:
-	// 1. Check if Slack for any sector is reaching, if yes then send full batch
-	// 2. Check if timeout is reaching for any sector in the batch, if yes, then send the batch
-	// 3. Check if baseFee below set threshold. If yes then send all batches
-
+func (s *SealPoller) pollStartBatchPrecommitMsg(ctx context.Context) {
 	ts, err := s.api.ChainHead(ctx)
 	if err != nil {
 		log.Errorf("error getting chain head: %s", err)
 		return
 	}
 
-	for spid, sealProofMap := range batchMap {
-		for _, pts := range sealProofMap {
-			// Break into batches
-			var batches []sectorBatch
-			for i := 0; i < len(pts); i += s.cfg.preCommit.MaxPreCommitBatch {
-				// Create a batch of size `maxBatchSize` or smaller for the last batch
-				end := i + s.cfg.preCommit.MaxPreCommitBatch
-				if end > len(pts) {
-					end = len(pts)
-				}
-				var batch []int64
-				cutoff := abi.ChainEpoch(0)
-				earliest := time.Now()
-				for _, pt := range pts[i:end] {
-					batch = append(batch, pt.SectorNumber)
-					if cutoff == 0 || pt.StartEpoch < cutoff {
-						cutoff = pt.StartEpoch
-					}
-					if pt.PreCommitReadyAt.Before(earliest) {
-						earliest = *pt.PreCommitReadyAt
-					}
-				}
-
-				batches = append(batches, sectorBatch{
-					cutoff:  cutoff,
-					sectors: batch,
-				})
-			}
-
-			for i := range batches {
-				batch := batches[i]
-				//sectors := batch.sectors
-				// Process batch if slack has reached
-				if (time.Duration(batch.cutoff-ts.Height()) * time.Duration(build.BlockDelaySecs) * time.Second) < s.cfg.preCommit.Slack {
-					s.sendPreCommitBatch(ctx, spid, batch.sectors)
-					continue
-				}
-				// Process batch if timeout has reached
-				if batch.earliest.Add(s.cfg.preCommit.Timeout).After(time.Now()) {
-					s.sendPreCommitBatch(ctx, spid, batch.sectors)
-					continue
-				}
-				// Process batch if base fee is low enough for us to send
-				if ts.MinTicketBlock().ParentBaseFee.LessThan(s.cfg.preCommit.BaseFeeThreshold) {
-					s.sendPreCommitBatch(ctx, spid, batch.sectors)
-					continue
-				}
-			}
-		}
+	slackEpoch := int64(math.Ceil(s.cfg.preCommit.Slack.Seconds() / float64(build.BlockDelaySecs)))
+	feeOk := false
+	if ts.MinTicketBlock().ParentBaseFee.LessThan(s.cfg.preCommit.BaseFeeThreshold) {
+		feeOk = true
 	}
-}
 
-func (s *SealPoller) sendPreCommitBatch(ctx context.Context, spid int64, sectors []int64) {
 	s.pollers[pollerPrecommitMsg].Val(ctx)(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
-		n, err := tx.Exec(`UPDATE sectors_sdr_pipeline SET task_id_precommit_msg = $1 WHERE sp_id = $2 AND sector_number = ANY($3) AND task_id_precommit_msg IS NULL AND after_synth = TRUE AND after_precommit_msg = FALSE`, id, spid, sectors)
+		var updatedCount int64
+		var reason string
+
+		log.Infow("Trying to assign a precommit batch",
+			"slack_epoch", slackEpoch,
+			"current_height", ts.Height(),
+			"max_batch", s.cfg.preCommit.MaxPreCommitBatch,
+			"new_task_id", id,
+			"baseFee", ts.MinTicketBlock().ParentBaseFee.String(),
+			"basefee_ok", feeOk,
+			"timeout_secs", s.cfg.preCommit.Timeout.Seconds(),
+			"timeout_at", time.Now().Add(s.cfg.preCommit.Timeout).UTC().Format(time.RFC3339),
+			"randomness_lookback", policy.MaxPreCommitRandomnessLookback,
+		)
+
+		err = tx.QueryRow(`SELECT updated_count, reason FROM poll_start_batch_precommit_msg($1, $2, $3, $4, $5, $6, $7)`,
+			policy.MaxPreCommitRandomnessLookback,  // p_randomnessLookBack BIGINT,  -- policy.MaxPreCommitRandomnessLookback
+			slackEpoch,                             // p_slack_epoch        BIGINT,  -- "Slack" epoch to compare against a sector's start_epoch
+			ts.Height(),                            // p_current_height     BIGINT,  -- Current on-chain height
+			s.cfg.preCommit.MaxPreCommitBatch,      // p_max_batch          INT,     -- Max number of sectors per batch
+			id,                                     // p_new_task_id        BIGINT,  -- Task ID to assign if a batch is chosen
+			feeOk,                                  // p_basefee_ok 		   BOOLEAN, -- If TRUE, fee-based condition is considered met
+			int(s.cfg.preCommit.Timeout.Seconds()), // p_timeout_secs  	   INT      -- Timeout in seconds for earliest_ready_at check
+		).Scan(&updatedCount, &reason)
 		if err != nil {
-			return false, xerrors.Errorf("update sectors_sdr_pipeline: %w", err)
-		}
-		if n > len(sectors) {
-			return false, xerrors.Errorf("expected to update at most %d rows, updated %d", len(sectors), n)
+			return false, err
 		}
 
-		return true, nil
+		if updatedCount > 0 {
+			log.Debugf("Assigned %d sectors to precommit batch with taskID %d with reason %s", updatedCount, id, reason)
+			return true, nil
+		} else {
+			log.Debugf("No precommit batch assigned")
+		}
+		return false, nil
 	})
 }
 


### PR DESCRIPTION
This PR moved the batch creation logic from Go to SQL for preCommit and Commit messages.

Tested Following:

- [x] preCommit timeout trigger
- [x] preCommit slack trigger
- [x] preCommit fee trigger
- [x] Commit timeout trigger
- [x] Commit slack trigger
- [x] Commit fee trigger
