### PR TITLE
Fix/miner premium

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -152,7 +152,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 			}
 
 			var ethSenderTask *message.SendTaskETH
-			senderEth, ethSenderTask = message.NewSenderETH(ec, db)
+			senderEth, ethSenderTask = message.NewSenderETH(ec, full, db)
 			activeTasks = append(activeTasks, ethSenderTask)
 		})
 		return senderEth

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -152,7 +152,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 			}
 
 			var ethSenderTask *message.SendTaskETH
-			senderEth, ethSenderTask = message.NewSenderETH(ec, full, db)
+			senderEth, ethSenderTask = message.NewSenderETH(ec, db)
 			activeTasks = append(activeTasks, ethSenderTask)
 		})
 		return senderEth

--- a/tasks/message/sender_eth.go
+++ b/tasks/message/sender_eth.go
@@ -257,7 +257,7 @@ var _ harmonytask.TaskInterface = &SendTaskETH{}
 var _ = harmonytask.Reg(&SendTaskETH{})
 
 // NewSenderETH creates a new SenderETH.
-func NewSenderETH(client *ethclient.Client, db *harmonydb.DB) (*SenderETH, *SendTaskETH) {
+func NewSenderETH(client *ethclient.Client, fil SenderETHLotusAPI, db *harmonydb.DB) (*SenderETH, *SendTaskETH) {
 	st := &SendTaskETH{
 		client: client,
 		db:     db,
@@ -266,6 +266,7 @@ func NewSenderETH(client *ethclient.Client, db *harmonydb.DB) (*SenderETH, *Send
 	return &SenderETH{
 		client:   client,
 		db:       db,
+		fil:      fil,
 		sendTask: st,
 	}, st
 }


### PR DESCRIPTION
So I think this fixes the premium bug well enough without moving ethclient over to the curio internal shared api.  

One funny thing is that it only reduces premium on calibnet by 10x instead of 100 - 1000x because so many people are running 1nFIL premiums that the median as returned by lotus api is really high.