### PR TITLE
fix: store log debug, seal poller log, batching, itest

### DIFF
--- a/.github/image/Dockerfile
+++ b/.github/image/Dockerfile
@@ -23,7 +23,7 @@ RUN git submodule update --init
 RUN go mod download
 
 # Stage 2: Install Lotus binary
-FROM ghcr.io/filecoin-shipyard/lotus-containers:lotus-v1.32.0-rc1-devnet AS lotus-test
+FROM ghcr.io/filecoin-shipyard/lotus-containers:lotus-v1.32.0-rc3-devnet AS lotus-test
 
 # Stage 3: Build the final image
 FROM myoung34/github-runner AS curio-github-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN go install github.com/ipld/go-car/cmd/car@latest \
 RUN go install github.com/LexLuthr/piece-server@latest \
  && cp $GOPATH/bin/piece-server /usr/local/bin/
 
-RUN go install github.com/ipni/storetheindex@latest \
+RUN go install github.com/ipni/storetheindex@v0.8.38 \
  && cp $GOPATH/bin/storetheindex /usr/local/bin/
 
 #####################################

--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ build_lotus?=0
 curio_docker_user?=curio
 curio_base_image=$(curio_docker_user)/curio-all-in-one:latest-debug
 ffi_from_source?=0
-lotus_version?=v1.32.0-rc1
+lotus_version?=v1.32.0-rc3
 
 ifeq ($(build_lotus),1)
 # v1: building lotus image with provided lotus version

--- a/harmony/harmonytask/harmonytask.go
+++ b/harmony/harmonytask/harmonytask.go
@@ -388,7 +388,7 @@ func (e *TaskEngine) pollerTryAllWork() bool {
 		}
 
 		unownedTasks := lo.FlatMap(allUnownedTasks, func(t task, _ int) []TaskID {
-			if v.RetryWait == nil {
+			if v.RetryWait == nil || t.Retries == 0 {
 				return []TaskID{t.ID}
 			}
 			if time.Since(t.UpdateTime) > v.RetryWait(t.Retries) {

--- a/itests/curio_test.go
+++ b/itests/curio_test.go
@@ -2,6 +2,7 @@ package itests
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"flag"
 	"fmt"
@@ -44,56 +45,6 @@ import (
 	"github.com/filecoin-project/lotus/node"
 )
 
-func TestCurioNewActor(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	full, miner, ensemble := kit.EnsembleMinimal(t,
-		kit.LatestActorsAt(-1),
-		kit.MockProofs(),
-	)
-
-	ensemble.Start()
-	blockTime := 100 * time.Millisecond
-	ensemble.BeginMiningMustPost(blockTime)
-
-	addr := miner.OwnerKey.Address
-	sectorSizeInt, err := units.RAMInBytes("8MiB")
-	require.NoError(t, err)
-
-	sharedITestID := harmonydb.ITestNewID()
-	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID)
-	require.NoError(t, err)
-
-	var titles []string
-	err = db.Select(ctx, &titles, `SELECT title FROM harmony_config WHERE LENGTH(config) > 0`)
-	require.NoError(t, err)
-	require.NotEmpty(t, titles)
-	require.NotContains(t, titles, "base")
-
-	maddr, err := createminer.CreateStorageMiner(ctx, full, addr, addr, addr, abi.SectorSize(sectorSizeInt), 0)
-	require.NoError(t, err)
-
-	err = deps.CreateMinerConfig(ctx, full, db, []string{maddr.String()}, "FULL NODE API STRING")
-	require.NoError(t, err)
-
-	err = db.Select(ctx, &titles, `SELECT title FROM harmony_config WHERE LENGTH(config) > 0`)
-	require.NoError(t, err)
-	require.Contains(t, titles, "base")
-	baseCfg := config.DefaultCurioConfig()
-	var baseText string
-
-	err = db.QueryRow(ctx, "SELECT config FROM harmony_config WHERE title='base'").Scan(&baseText)
-	require.NoError(t, err)
-	_, err = deps.LoadConfigWithUpgrades(baseText, baseCfg)
-	require.NoError(t, err)
-
-	require.NotNil(t, baseCfg.Addresses)
-	require.GreaterOrEqual(t, len(baseCfg.Addresses), 1)
-
-	require.Contains(t, baseCfg.Addresses[0].MinerAddresses, maddr.String())
-}
-
 func TestCurioHappyPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -122,6 +73,7 @@ func TestCurioHappyPath(t *testing.T) {
 	fapi := fmt.Sprintf("%s:%s", string(token), full.ListenAddr)
 
 	sharedITestID := harmonydb.ITestNewID()
+	t.Logf("sharedITestID: %s", sharedITestID)
 
 	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID)
 	require.NoError(t, err)
@@ -240,9 +192,57 @@ func TestCurioHappyPath(t *testing.T) {
 
 	// TODO: add DDO deal, f05 deal 2 MiB each in the sector
 
-	var sectorParamsArr []struct {
-		SpID         int64 `db:"sp_id"`
-		SectorNumber int64 `db:"sector_number"`
+	var pollTask []struct {
+		SpID                int64                   `db:"sp_id"`
+		SectorNumber        int64                   `db:"sector_number"`
+		RegisteredSealProof abi.RegisteredSealProof `db:"reg_seal_proof"`
+
+		TicketEpoch *int64 `db:"ticket_epoch"`
+
+		TaskSDR  *int64 `db:"task_id_sdr"`
+		AfterSDR bool   `db:"after_sdr"`
+
+		TaskTreeD  *int64 `db:"task_id_tree_d"`
+		AfterTreeD bool   `db:"after_tree_d"`
+
+		TaskTreeC  *int64 `db:"task_id_tree_c"`
+		AfterTreeC bool   `db:"after_tree_c"`
+
+		TaskTreeR  *int64 `db:"task_id_tree_r"`
+		AfterTreeR bool   `db:"after_tree_r"`
+
+		TaskSynth  *int64 `db:"task_id_synth"`
+		AfterSynth bool   `db:"after_synth"`
+
+		PreCommitReadyAt *time.Time `db:"precommit_ready_at"`
+
+		TaskPrecommitMsg  *int64 `db:"task_id_precommit_msg"`
+		AfterPrecommitMsg bool   `db:"after_precommit_msg"`
+
+		AfterPrecommitMsgSuccess bool   `db:"after_precommit_msg_success"`
+		SeedEpoch                *int64 `db:"seed_epoch"`
+
+		TaskPoRep  *int64 `db:"task_id_porep"`
+		PoRepProof []byte `db:"porep_proof"`
+		AfterPoRep bool   `db:"after_porep"`
+
+		TaskFinalize  *int64 `db:"task_id_finalize"`
+		AfterFinalize bool   `db:"after_finalize"`
+
+		TaskMoveStorage  *int64 `db:"task_id_move_storage"`
+		AfterMoveStorage bool   `db:"after_move_storage"`
+
+		CommitReadyAt *time.Time `db:"commit_ready_at"`
+
+		TaskCommitMsg  *int64 `db:"task_id_commit_msg"`
+		AfterCommitMsg bool   `db:"after_commit_msg"`
+
+		AfterCommitMsgSuccess bool `db:"after_commit_msg_success"`
+
+		Failed       bool   `db:"failed"`
+		FailedReason string `db:"failed_reason"`
+
+		StartEpoch sql.NullInt64 `db:"start_epoch"`
 	}
 
 	require.Eventuallyf(t, func() bool {
@@ -250,18 +250,89 @@ func TestCurioHappyPath(t *testing.T) {
 		require.NoError(t, err)
 		t.Logf("head: %d", h.Height())
 
-		err = db.Select(ctx, &sectorParamsArr, `
-		SELECT sp_id, sector_number
-		FROM sectors_sdr_pipeline
-		WHERE after_commit_msg_success = True`)
+		err = db.Select(ctx, &pollTask, `
+											SELECT 
+												sp_id, 
+												sector_number, 
+												reg_seal_proof, 
+												ticket_epoch,
+												task_id_sdr, 
+												after_sdr,
+												task_id_tree_d, 
+												after_tree_d,
+												task_id_tree_c, 
+												after_tree_c,
+												task_id_tree_r, 
+												after_tree_r,
+												task_id_synth, 
+												after_synth,
+												precommit_ready_at,
+												task_id_precommit_msg, 
+												after_precommit_msg,
+												after_precommit_msg_success, 
+												seed_epoch,
+												task_id_porep, 
+												porep_proof, 
+												after_porep,
+												task_id_finalize, 
+												after_finalize,
+												task_id_move_storage, 
+												after_move_storage,
+												commit_ready_at,
+												task_id_commit_msg, 
+												after_commit_msg,
+												after_commit_msg_success,
+												failed, 
+												failed_reason,
+												start_epoch
+											FROM 
+												sectors_sdr_pipeline;`)
 		require.NoError(t, err)
-		return len(sectorParamsArr) == 2
-	}, 10*time.Minute, 1*time.Second, "sector did not finish sealing in 5 minutes")
+		for i, task := range pollTask {
+			t.Logf("Task %d: SpID=%d, SectorNumber=%d, RegisteredSealProof=%d, TicketEpoch=%s, TaskSDR=%s, AfterSDR=%t, TaskTreeD=%s, AfterTreeD=%t, TaskTreeC=%s, AfterTreeC=%t, TaskTreeR=%s, AfterTreeR=%t, TaskSynth=%s, AfterSynth=%t, PreCommitReadyAt=%s, TaskPrecommitMsg=%s, AfterPrecommitMsg=%t, AfterPrecommitMsgSuccess=%t, SeedEpoch=%s, TaskPoRep=%s, PoRepProof=%v, AfterPoRep=%t, TaskFinalize=%s, AfterFinalize=%t, TaskMoveStorage=%s, AfterMoveStorage=%t, CommitReadyAt=%s, TaskCommitMsg=%s, AfterCommitMsg=%t, AfterCommitMsgSuccess=%t, Failed=%t, FailedReason=%s, StartEpoch=%s",
+				i,
+				task.SpID,
+				task.SectorNumber,
+				task.RegisteredSealProof,
+				valueOrNA(task.TicketEpoch),
+				valueOrNA(task.TaskSDR),
+				task.AfterSDR,
+				valueOrNA(task.TaskTreeD),
+				task.AfterTreeD,
+				valueOrNA(task.TaskTreeC),
+				task.AfterTreeC,
+				valueOrNA(task.TaskTreeR),
+				task.AfterTreeR,
+				valueOrNA(task.TaskSynth),
+				task.AfterSynth,
+				timeValueOrNA(task.PreCommitReadyAt),
+				valueOrNA(task.TaskPrecommitMsg),
+				task.AfterPrecommitMsg,
+				task.AfterPrecommitMsgSuccess,
+				valueOrNA(task.SeedEpoch),
+				valueOrNA(task.TaskPoRep),
+				task.PoRepProof,
+				task.AfterPoRep,
+				valueOrNA(task.TaskFinalize),
+				task.AfterFinalize,
+				valueOrNA(task.TaskMoveStorage),
+				task.AfterMoveStorage,
+				timeValueOrNA(task.CommitReadyAt),
+				valueOrNA(task.TaskCommitMsg),
+				task.AfterCommitMsg,
+				task.AfterCommitMsgSuccess,
+				task.Failed,
+				task.FailedReason,
+				nullInt64OrNA(task.StartEpoch),
+			)
+		}
+		return pollTask[0].AfterCommitMsgSuccess && pollTask[1].AfterCommitMsgSuccess
+	}, 10*time.Minute, 1*time.Second, "sector did not finish sealing in 10 minutes")
 
-	require.Equal(t, sectorParamsArr[0].SectorNumber, int64(0))
-	require.Equal(t, sectorParamsArr[0].SpID, int64(mid))
-	require.Equal(t, sectorParamsArr[1].SectorNumber, int64(1))
-	require.Equal(t, sectorParamsArr[1].SpID, int64(mid))
+	require.Equal(t, pollTask[0].SectorNumber, int64(0))
+	require.Equal(t, pollTask[0].SpID, int64(mid))
+	require.Equal(t, pollTask[1].SectorNumber, int64(1))
+	require.Equal(t, pollTask[1].SpID, int64(mid))
 
 	_ = capi.Shutdown(ctx)
 
@@ -448,4 +519,26 @@ func envElse(env, els string) string {
 		return v
 	}
 	return els
+}
+
+// Helper functions to handle nil or null values
+func valueOrNA(ptr *int64) string {
+	if ptr == nil {
+		return "NA"
+	}
+	return fmt.Sprintf("%d", *ptr)
+}
+
+func timeValueOrNA(t *time.Time) string {
+	if t == nil {
+		return "NA"
+	}
+	return t.Format(time.RFC3339)
+}
+
+func nullInt64OrNA(nullInt sql.NullInt64) string {
+	if !nullInt.Valid {
+		return "NA"
+	}
+	return fmt.Sprintf("%d", nullInt.Int64)
 }

--- a/lib/paths/http_handler.go
+++ b/lib/paths/http_handler.go
@@ -77,7 +77,7 @@ func (handler *FetchHandler) remoteStatFs(w http.ResponseWriter, r *http.Request
 		break
 	default:
 		w.WriteHeader(500)
-		log.Errorf("%+v", err)
+		log.Errorf("error getting stat for ID %s: %s", id, err.Error())
 		return
 	}
 
@@ -93,14 +93,14 @@ func (handler *FetchHandler) remoteGetSector(w http.ResponseWriter, r *http.Requ
 
 	id, err := storiface.ParseSectorID(vars["id"])
 	if err != nil {
-		log.Errorf("%+v", err)
+		log.Errorf("parsing sectorID: %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
 
 	ft, err := FileTypeFromString(vars["type"])
 	if err != nil {
-		log.Errorf("%+v", err)
+		log.Errorf("parsing fileType: %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
@@ -114,7 +114,7 @@ func (handler *FetchHandler) remoteGetSector(w http.ResponseWriter, r *http.Requ
 
 	paths, _, err := handler.Local.AcquireSector(r.Context(), si, ft, storiface.FTNone, storiface.PathStorage, storiface.AcquireMove)
 	if err != nil {
-		log.Errorf("AcquireSector: %+v", err)
+		log.Errorf("acquiring sector from local storage: %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
@@ -130,7 +130,7 @@ func (handler *FetchHandler) remoteGetSector(w http.ResponseWriter, r *http.Requ
 
 	stat, err := os.Stat(path)
 	if err != nil {
-		log.Errorf("os.Stat: %+v", err)
+		log.Errorf("failed to stat path %s: %s", path, err.Error())
 		w.WriteHeader(500)
 		return
 	}
@@ -152,7 +152,7 @@ func (handler *FetchHandler) remoteGetSector(w http.ResponseWriter, r *http.Requ
 
 		err := tarutil.TarDirectory(constraints, path, w, make([]byte, CopyBuf))
 		if err != nil {
-			log.Errorf("send tar: %+v", err)
+			log.Errorf("failed to tar and send the directory %s: %s", path, err.Error())
 			return
 		}
 	} else {
@@ -161,7 +161,7 @@ func (handler *FetchHandler) remoteGetSector(w http.ResponseWriter, r *http.Requ
 		http.ServeFile(w, r, path)
 	}
 
-	log.Debugf("served sector file/dir, sectorID=%+v, fileType=%s, path=%s", id, ft, path)
+	log.Debugw("served sector file/dir", "sectorID", id, "fileType", ft, "path", path)
 }
 
 func (handler *FetchHandler) remoteDeleteSector(w http.ResponseWriter, r *http.Request) {
@@ -170,20 +170,20 @@ func (handler *FetchHandler) remoteDeleteSector(w http.ResponseWriter, r *http.R
 
 	id, err := storiface.ParseSectorID(vars["id"])
 	if err != nil {
-		log.Errorf("%+v", err)
+		log.Errorf("parsing sectorID: %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
 
 	ft, err := FileTypeFromString(vars["type"])
 	if err != nil {
-		log.Errorf("%+v", err)
+		log.Errorf("parsing fileType: %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
 
 	if err := handler.Local.Remove(r.Context(), id, ft, false, storiface.ParseIDList(r.FormValue("keep"))); err != nil {
-		log.Errorf("%+v", err)
+		log.Errorf("removing sector: %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
@@ -205,7 +205,7 @@ func (handler *FetchHandler) remoteGetAllocated(w http.ResponseWriter, r *http.R
 
 	ft, err := FileTypeFromString(vars["type"])
 	if err != nil {
-		log.Errorf("FileTypeFromString: %+v", err)
+		log.Errorf("parsing fileType: %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
@@ -217,27 +217,27 @@ func (handler *FetchHandler) remoteGetAllocated(w http.ResponseWriter, r *http.R
 
 	spti, err := strconv.ParseInt(vars["spt"], 10, 64)
 	if err != nil {
-		log.Errorf("parsing spt: %+v", err)
+		log.Errorf("parsing registered seal proof type: %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
 	spt := abi.RegisteredSealProof(spti)
 	ssize, err := spt.SectorSize()
 	if err != nil {
-		log.Errorf("spt.SectorSize(): %+v", err)
+		log.Errorf("spt.SectorSize(): %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
 
 	offi, err := strconv.ParseInt(vars["offset"], 10, 64)
 	if err != nil {
-		log.Errorf("parsing offset: %+v", err)
+		log.Errorf("parsing offset: %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
 	szi, err := strconv.ParseInt(vars["size"], 10, 64)
 	if err != nil {
-		log.Errorf("parsing size: %+v", err)
+		log.Errorf("parsing size: %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
@@ -254,7 +254,7 @@ func (handler *FetchHandler) remoteGetAllocated(w http.ResponseWriter, r *http.R
 	// return error if we do NOT have it.
 	paths, _, err := handler.Local.AcquireSector(r.Context(), si, ft, storiface.FTNone, storiface.PathStorage, storiface.AcquireMove)
 	if err != nil {
-		log.Errorf("AcquireSector: %+v", err)
+		log.Errorf("acquiring sector on local storage: %s", err.Error())
 		w.WriteHeader(500)
 		return
 	}
@@ -311,6 +311,7 @@ func (handler *FetchHandler) generateSingleVanillaProof(w http.ResponseWriter, r
 
 	vanilla, err := handler.Local.GenerateSingleVanillaProof(r.Context(), params.Miner, params.Sector, params.ProofType)
 	if err != nil {
+		log.Errorw("failed to generate single vanilla proof:", "miner", params.Miner, "sector", params.Sector, "proofType", params.ProofType, "err", err)
 		http.Error(w, err.Error(), 500)
 		return
 	}
@@ -336,6 +337,14 @@ func (handler *FetchHandler) generatePoRepVanillaProof(w http.ResponseWriter, r 
 
 	vanilla, err := handler.Local.GeneratePoRepVanillaProof(r.Context(), params.Sector, params.Sealed, params.Unsealed, params.Ticket, params.Seed)
 	if err != nil {
+		log.Errorw(
+			"failed to generate porep vanilla proof",
+			"sector", params.Sector,
+			"sealed", params.Sealed,
+			"unsealed", params.Unsealed,
+			"ticket", params.Ticket,
+			"seed", params.Seed,
+			"err", err)
 		http.Error(w, err.Error(), 500)
 		return
 	}
@@ -357,6 +366,7 @@ func (handler *FetchHandler) readSnapVanillaProof(w http.ResponseWriter, r *http
 
 	vanilla, err := handler.Local.ReadSnapVanillaProof(r.Context(), params.Sector)
 	if err != nil {
+		log.Errorw("failed to read snap vanilla proof", "sector", params.Sector, "err", err)
 		http.Error(w, err.Error(), 500)
 		return
 	}

--- a/lib/paths/local.go
+++ b/lib/paths/local.go
@@ -708,10 +708,11 @@ func (st *Local) AcquireSector(ctx context.Context, sid storiface.SectorRef, exi
 			if allocate.Has(fileType) {
 				ok, err := allocPathOk(info.CanSeal, info.CanStore, info.AllowTypes, info.DenyTypes, info.AllowMiners, info.DenyMiners, fileType, sid.ID.Miner)
 				if err != nil {
-					log.Debug(err)
+					log.Warnw("checking path eligibility failed", "id", sid, "type", fileType, "pathType", pathType, "op", op, "info", info, "err", err)
 					continue
 				}
 				if !ok {
+					log.Debugw("cannot allocate for", "id", sid, "type", fileType, "pathType", pathType, "op", op, "info", info)
 					continue // allocate request for a path of different type
 				}
 			}
@@ -753,11 +754,12 @@ func (st *Local) AcquireSector(ctx context.Context, sid storiface.SectorRef, exi
 			alloc, err := allocPathOk(si.CanSeal, si.CanStore, si.AllowTypes, si.DenyTypes, si.AllowMiners, si.DenyMiners, fileType, sid.ID.Miner)
 
 			if err != nil {
-				log.Debug(err)
+				log.Warnw("checking path eligibility failed", "id", sid, "type", fileType, "pathType", pathType, "op", op, "info", si, "err", err)
 				continue
 			}
 
 			if !alloc {
+				log.Debugw("cannot allocate for", "id", sid, "type", fileType, "pathType", pathType, "op", op, "info", si)
 				continue
 			}
 

--- a/tasks/message/sender.go
+++ b/tasks/message/sender.go
@@ -247,10 +247,7 @@ func (s *SendTask) TypeDetails() harmonytask.TaskTypeDetails {
 		MaxFailures: 1000,
 		Follows:     nil,
 		RetryWait: func(retries int) time.Duration {
-			if retries < 10 {
-				return time.Second * time.Duration(retries)
-			}
-			return time.Second * 10
+			return min(time.Second*time.Duration(retries), time.Second*10)
 		},
 	}
 }

--- a/tasks/piece/task_park_piece.go
+++ b/tasks/piece/task_park_piece.go
@@ -213,17 +213,9 @@ func (p *ParkPieceTask) TypeDetails() harmonytask.TaskTypeDetails {
 		},
 		MaxFailures: 10,
 		RetryWait: func(retries int) time.Duration {
-			baseWait, maxWait := 5*time.Second, time.Minute
-			mul := 1.5
-
+			const baseWait, maxWait, factor = 5 * time.Second, time.Minute, 1.5
 			// Use math.Pow for exponential backoff
-			wait := time.Duration(float64(baseWait) * math.Pow(mul, float64(retries)))
-
-			// Ensure the wait time doesn't exceed maxWait
-			if wait > maxWait {
-				return maxWait
-			}
-			return wait
+			return min(time.Duration(float64(baseWait)*math.Pow(factor, float64(retries))), maxWait)
 		},
 	}
 }

--- a/tasks/seal/poller_commit_msg.go
+++ b/tasks/seal/poller_commit_msg.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (s *SealPoller) pollerAddStartEpoch(ctx context.Context, task pollTask) error {
-	if !task.StartEpoch.Valid {
+	if task.AfterPrecommitMsgSuccess && !task.StartEpoch.Valid {
 		ts, err := s.api.ChainHead(ctx)
 		if err != nil {
 			return xerrors.Errorf("failed to get chain head: %w", err)
@@ -69,7 +69,9 @@ func (s *SealPoller) pollerAddStartEpoch(ctx context.Context, task pollTask) err
 		if err != nil {
 			return xerrors.Errorf("failed to update start epoch: %w", err)
 		}
+		log.Debugw("updated start epoch", "sp", task.SpID, "sector", task.SectorNumber, "start_epoch", startEpoch)
 	}
+
 	return nil
 }
 

--- a/tasks/seal/poller_commit_msg.go
+++ b/tasks/seal/poller_commit_msg.go
@@ -74,6 +74,10 @@ func (s *SealPoller) pollerAddStartEpoch(ctx context.Context, task pollTask) err
 }
 
 func (s *SealPoller) pollStartBatchCommitMsg(ctx context.Context) {
+	if !s.pollers[pollerCommitMsg].IsSet() {
+		return
+	}
+
 	ts, err := s.api.ChainHead(ctx)
 	if err != nil {
 		log.Errorf("error getting chain head: %s", err)
@@ -90,7 +94,7 @@ func (s *SealPoller) pollStartBatchCommitMsg(ctx context.Context) {
 		var updatedCount int64
 		var reason string
 
-		log.Infow("Trying to assign a commit batch",
+		log.Debugw("Trying to assign a commit batch",
 			"slack_epoch", slackEpoch,
 			"current_height", ts.Height(),
 			"max_batch", s.cfg.commit.MaxCommitBatch,
@@ -114,7 +118,7 @@ func (s *SealPoller) pollStartBatchCommitMsg(ctx context.Context) {
 			log.Debugf("Assigned %d sectors to commit batch with taskID %d with reason %s", updatedCount, id, reason)
 			return true, nil
 		} else {
-			log.Debugf("No commit batch assigned")
+			log.Debugf("No commit batch assigned for ID %d", id)
 		}
 		return false, nil
 	})

--- a/tasks/seal/poller_commit_msg.go
+++ b/tasks/seal/poller_commit_msg.go
@@ -68,6 +68,7 @@ func (s *SealPoller) pollerAddStartEpoch(ctx context.Context, task pollTask) err
 }
 
 func (s *SealPoller) pollStartBatchCommitMsg(ctx context.Context) {
+	// Exit early if the poller is set i.e. Commit task is not enabled on the node
 	if !s.pollers[pollerCommitMsg].IsSet() {
 		return
 	}

--- a/tasks/seal/poller_commit_msg.go
+++ b/tasks/seal/poller_commit_msg.go
@@ -52,20 +52,12 @@ func (s *SealPoller) pollerAddStartEpoch(ctx context.Context, task pollTask) err
 			return xerrors.Errorf("failed to get max prove commit duration: %w", err)
 		}
 		startEpoch := pci.PreCommitEpoch + mpcd
-		_, err = s.db.Exec(ctx, `UPDATE sectors_sdr_pipeline p
-										SET start_epoch = COALESCE(
-											(SELECT MIN(LEAST(s.f05_deal_start_epoch, s.direct_start_epoch))
-											 FROM sectors_sdr_initial_pieces s
-											 WHERE s.sp_id = $2 
-											   AND s.sector_number = $3
-											), 
-											$1
-										)
-										WHERE p.sp_id = $2
-										  AND p.sector_number = $3
-										  AND p.after_porep = TRUE 
-										  AND p.after_commit_msg = FALSE 
-										  AND p.start_epoch IS NULL`, startEpoch, task.SpID, task.SectorNumber)
+		_, err = s.db.Exec(ctx, `UPDATE sectors_sdr_pipeline SET start_epoch =  $1
+										WHERE sp_id = $2
+										  AND sector_number = $3
+										  AND after_precommit_msg_success = TRUE 
+										  AND after_commit_msg = FALSE 
+										  AND start_epoch IS NULL`, startEpoch, task.SpID, task.SectorNumber)
 		if err != nil {
 			return xerrors.Errorf("failed to update start epoch: %w", err)
 		}

--- a/tasks/seal/poller_precommit_msg.go
+++ b/tasks/seal/poller_precommit_msg.go
@@ -21,6 +21,10 @@ import (
 )
 
 func (s *SealPoller) pollStartBatchPrecommitMsg(ctx context.Context) {
+	if !s.pollers[pollerPrecommitMsg].IsSet() {
+		return
+	}
+
 	ts, err := s.api.ChainHead(ctx)
 	if err != nil {
 		log.Errorf("error getting chain head: %s", err)
@@ -37,7 +41,7 @@ func (s *SealPoller) pollStartBatchPrecommitMsg(ctx context.Context) {
 		var updatedCount int64
 		var reason string
 
-		log.Infow("Trying to assign a precommit batch",
+		log.Debugw("Trying to assign a precommit batch",
 			"slack_epoch", slackEpoch,
 			"current_height", ts.Height(),
 			"max_batch", s.cfg.preCommit.MaxPreCommitBatch,
@@ -66,7 +70,7 @@ func (s *SealPoller) pollStartBatchPrecommitMsg(ctx context.Context) {
 			log.Debugf("Assigned %d sectors to precommit batch with taskID %d with reason %s", updatedCount, id, reason)
 			return true, nil
 		} else {
-			log.Debugf("No precommit batch assigned")
+			log.Debugf("No precommit batch assigned for ID %d", id)
 		}
 		return false, nil
 	})

--- a/tasks/seal/poller_precommit_msg.go
+++ b/tasks/seal/poller_precommit_msg.go
@@ -21,6 +21,7 @@ import (
 )
 
 func (s *SealPoller) pollStartBatchPrecommitMsg(ctx context.Context) {
+	// Exit early if the poller is set i.e. precommit task is not enabled on the node
 	if !s.pollers[pollerPrecommitMsg].IsSet() {
 		return
 	}

--- a/tasks/seal/task_porep.go
+++ b/tasks/seal/task_porep.go
@@ -174,7 +174,7 @@ func (p *PoRepTask) TypeDetails() harmonytask.TaskTypeDetails {
 		},
 		MaxFailures: 10,
 		RetryWait: func(retries int) time.Duration {
-			return max(time.Second<<retries, 2*time.Minute)
+			return min(time.Second<<retries, 2*time.Minute)
 		},
 		Follows: nil,
 	}

--- a/tasks/seal/task_submit_precommit.go
+++ b/tasks/seal/task_submit_precommit.go
@@ -111,14 +111,6 @@ func (s *SubmitPrecommitTask) Do(taskID harmonytask.TaskID, stillOwned func() bo
 		return false, xerrors.Errorf("expected at least 1 sector params, got 0")
 	}
 
-	//if s.batching {
-	//	if len(sectorParamsArr) != 1 {
-	//		return false, xerrors.Errorf("expected 1 sector params, got %d", len(sectorParamsArr))
-	//	}
-	//} else {
-	//
-	//}
-
 	head, err := s.api.ChainHead(ctx)
 	if err != nil {
 		return false, xerrors.Errorf("getting chain head: %w", err)


### PR DESCRIPTION
This PR mostly have small fixes.
1. Fix Commit and Precommit batch condition
2. Update StartEpoch poller condition
3. Improve storage logging
4. Improve seal poller logging
5. Drops TestCurioNewActor from itest. We already cover this in TestCurioHappyPath
6. Improves the harmonyTak retry logic. 