### PR TITLE
fix: phantom IPNI tasks

### DIFF
--- a/tasks/indexing/task_check_indexes.go
+++ b/tasks/indexing/task_check_indexes.go
@@ -279,7 +279,7 @@ func (c *CheckIndexesTask) checkIPNI(ctx context.Context, taskID harmonytask.Tas
 	}
 	err = c.db.Select(ctx, &toCheck, `SELECT DISTINCT piece_cid, sp_id, piece_size,
                 uuid, offline, url, url_headers, created_at
-                FROM market_mk12_deals WHERE announce_to_ipni=true`)
+                FROM market_mk12_deals WHERE fast_retrieval=true AND announce_to_ipni=true`)
 	if err != nil {
 		return xerrors.Errorf("getting ipni tasks: %w", err)
 	}


### PR DESCRIPTION
It was observed that IPNI tasks were being executed for deals which were not indexed. In Curio, we treat this as no go. Both fast_retrieval and announce_to_ipni must be true for deal to be indexed. Otherwise, we will announce a deal which cannot be retrieved due to missing local indexes. 
This PR fixes the condition to check which deals should be consider for repairing IPNI.