### PR TITLE
Fix panic in allocateToExisting

### DIFF
--- a/market/storageingest/deal_ingest_seal.go
+++ b/market/storageingest/deal_ingest_seal.go
@@ -374,7 +374,7 @@ func (p *PieceIngester) allocateToExisting(tx *harmonydb.Tx, maddr address.Addre
 		// Check that each sector has unique pieces
 		var nextSector bool
 		for i := range sec.pieces {
-			if sec.pieces[i].cid == piece.DealProposal.PieceCID.String() && sec.pieces[i].size == piece.DealProposal.PieceSize {
+			if sec.pieces[i].cid == piece.PieceCID().String() && sec.pieces[i].size == piece.Size() {
 				nextSector = true
 				break
 			}


### PR DESCRIPTION
Fixed the nil panic issue that occurs when using ddo, where accessing piece.DealProposal leads to a null pointer dereference.