### PR TITLE
Do the correct thing

### DIFF
--- a/pdp/contract/addresses.go
+++ b/pdp/contract/addresses.go
@@ -19,6 +19,10 @@ func ContractAddresses() PDPContracts {
 	switch build.BuildType {
 	case build.BuildCalibnet:
 		return PDPContracts{
+			PDPVerifier: common.HexToAddress("0x5A23b7df87f59A291C26A2A1d684AD03Ce9B68DC"),
+		}
+	case build.BuildMainnet:
+		return PDPContracts{
 			PDPVerifier: common.HexToAddress("0x9C65E8E57C98cCc040A3d825556832EA1e9f4Df6"),
 		}
 	default:


### PR DESCRIPTION
I ignored the nice build flag stuff earlier, now curio will work with correct contract immediately -- nice