### PR TITLE
fix: batch build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,14 +108,14 @@ batchdep: $(BUILD_DEPS)
 
 batch: CURIO_TAGS+= supraseal
 batch: CGO_LDFLAGS_ALLOW='.*'
-batch: batchdep build
+batch: batchdep batch-build
 .PHONY: batch
 
 
 batch-calibnet: CURIO_TAGS+= supraseal
 batch-calibnet: CURIO_TAGS+= calibnet
 batch-calibnet: CGO_LDFLAGS_ALLOW='.*'
-batch-calibnet: batchdep build
+batch-calibnet: batchdep batch-build
 .PHONY: batch-calibnet
 
 else
@@ -145,6 +145,12 @@ build: curio sptool
 an existing curio binary in your PATH. This may cause problems if you don't run 'sudo make install'" || true
 
 .PHONY: build
+
+batch-build: curio
+.PHONY: batch-build
+
+calibnet-sptool: CURIO_TAGS+= calibnet
+calibnet-sptool: sptool
 
 install: install-curio install-sptool
 .PHONY: install

--- a/documentation/en/supraseal.md
+++ b/documentation/en/supraseal.md
@@ -128,20 +128,36 @@ CUDA 12.x is required, 11.x won't work. The build process depends on GCC 11.x sy
 * On Arch install https://aur.archlinux.org/packages/gcc11
 * Ubuntu 22.04 has GCC 11.x by default
 * On newer Ubuntu install `gcc-11` and `g++-11` packages
+    ```shell
+    sudo apt install gcc-11 g++-11
+    ```
 * In addtion to general build dependencies (listed on the [installation page](installation.md)), you need `libgmp-dev` and `libconfig++-dev`
+    ```shell
+    sudo apt install libgmp-dev libconfig++-dev
+    ```
 
 ### Building
 
-Build the batch-capable Curio binary:
+Build and install the batch-capable Curio binary:
 
 ```bash
 make batch
+make sptool
+```
+
+```shell
+make install
 ```
 
 For calibnet
 
 ```bash
 make batch-calibnet
+make batch-sptool
+```
+
+```shell
+make install
 ```
 
 {% hint style="warning" %}


### PR DESCRIPTION
This PR separates the `sptool` build from `make batch` and updates the documentation for the same.