### PR TITLE
Feat/download file

### DIFF
--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -786,7 +786,9 @@ var uploadFileCmd = &cli.Command{
 				}
 			}
 			if chunkFile != nil {
-				chunkFile.Write([]byte(fmt.Sprintf("%s\n", commP)))
+				if _, err := chunkFile.Write([]byte(fmt.Sprintf("%s\n", commP))); err != nil {
+					return fmt.Errorf("failed to write chunk to file: %v", err)
+				}
 			}
 			if rootSize+paddedPieceSize > uint64(maxRootSize) {
 				rootSets = append(rootSets, rootSetInfo{

--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -682,7 +682,10 @@ var uploadFileCmd = &cli.Command{
 		chunkSize := int64((paddedChunkSize * 127) / 128) // make room for padding
 
 		// Progress bar
-		bar := progressbar.NewOptions(int(fileSize/chunkSize), progressbar.OptionSetDescription("Uploading..."))
+		bar := progressbar.NewOptions(1, progressbar.OptionSetDescription("Uploading..."))
+		if int(fileSize/chunkSize) >= 0 {
+			bar = progressbar.NewOptions(int(fileSize/chunkSize), progressbar.OptionSetDescription("Uploading..."))
+		}
 
 		// Setup local server if needed
 		var notifyReceived chan struct{}

--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -683,7 +683,7 @@ var uploadFileCmd = &cli.Command{
 
 		// Progress bar
 		bar := progressbar.NewOptions(1, progressbar.OptionSetDescription("Uploading..."))
-		if int(fileSize/chunkSize) >= 0 {
+		if int(fileSize/chunkSize) > 0 {
 			bar = progressbar.NewOptions(int(fileSize/chunkSize), progressbar.OptionSetDescription("Uploading..."))
 		}
 

--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -679,7 +679,7 @@ var uploadFileCmd = &cli.Command{
 		fileSize := fi.Size()
 		// Make padded chunk size as big as allowed
 		paddedChunkSize := curioproof.MaxMemtreeSize
-		chunkSize := int64(paddedChunkSize * (127 / 128)) // make room for padding
+		chunkSize := int64((paddedChunkSize * 127) / 128)) // make room for padding
 
 		// Progress bar
 		bar := progressbar.NewOptions(int(fileSize/chunkSize), progressbar.OptionSetDescription("Uploading..."))

--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -679,7 +679,7 @@ var uploadFileCmd = &cli.Command{
 		fileSize := fi.Size()
 		// Make padded chunk size as big as allowed
 		paddedChunkSize := curioproof.MaxMemtreeSize
-		chunkSize := int64((paddedChunkSize * 127) / 128)) // make room for padding
+		chunkSize := int64((paddedChunkSize * 127) / 128) // make room for padding
 
 		// Progress bar
 		bar := progressbar.NewOptions(int(fileSize/chunkSize), progressbar.OptionSetDescription("Uploading..."))

--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 
 	curiobuild "github.com/filecoin-project/curio/build"
+	curioproof "github.com/filecoin-project/curio/lib/proof"
 )
 
 func main() {
@@ -676,7 +677,9 @@ var uploadFileCmd = &cli.Command{
 			return fmt.Errorf("failed to stat input file: %v", err)
 		}
 		fileSize := fi.Size()
-		chunkSize := int64(1024 * 1024 * 100) // 100 MiB chunks
+		// Make padded chunk size as big as allowed
+		paddedChunkSize := curioproof.MaxMemtreeSize
+		chunkSize := int64(paddedChunkSize * (127 / 128)) // make room for padding
 
 		// Progress bar
 		bar := progressbar.NewOptions(int(fileSize/chunkSize), progressbar.OptionSetDescription("Uploading..."))


### PR DESCRIPTION
This PR handles a few related file upload and download issues

## Bugs
- [x] fix a progress bar related bug which made upload-file fail on files that fit into one piece
- [x] fix a wasteful parameter setting chunk size to exactly 100MiB which always forces 200MiB padded piece sizes due to padding overflow
- [x] set padded chunk size to 200MiB to use the maximum allowed piece size on curio pdp upload api

## Features
- [x] chunk-file output with ordered list of cids added to upload-file so we can record them for easy retrieval
- [x] dry-run flag added to upload-file so we can easily do data prep and regen chunk files / add-cid output without uploading to curio
- [x] download-file command reading chunk-file, hitting curio piece retrieval http api and reconstructing file from chunks

Tested all of this out on my setup so will be merging as soon as CI is passing 
