### PR TITLE
feat: allow clients to pass extra-data for proof set creation and adding roots

### DIFF
--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -35,6 +35,21 @@ import (
 	curioproof "github.com/filecoin-project/curio/lib/proof"
 )
 
+// validateExtraData checks if the provided hex string is valid and within the size limit.
+func validateExtraData(extraDataHexStr string) error {
+	if extraDataHexStr == "" {
+		return nil // No data to validate
+	}
+	decoded, err := hex.DecodeString(strings.TrimPrefix(extraDataHexStr, "0x"))
+	if err != nil {
+		return fmt.Errorf("failed to decode hex in extra-data: %w", err)
+	}
+	if len(decoded) > 2048 {
+		return fmt.Errorf("decoded extra-data exceeds maximum size of 2048 bytes (decoded length: %d)", len(decoded))
+	}
+	return nil
+}
+
 func main() {
 	app := &cli.App{
 		Name:    "pdptool",
@@ -856,14 +871,8 @@ var createProofSetCmd = &cli.Command{
 		extraDataHexStr := cctx.String("extra-data")
 
 		// Validate extraData hex string and its decoded length
-		if extraDataHexStr != "" {
-			decoded, err := hex.DecodeString(strings.TrimPrefix(extraDataHexStr, "0x"))
-			if err != nil {
-				return fmt.Errorf("failed to decode hex in --extra-data: %v", err)
-			}
-			if len(decoded) > 2048 {
-				return fmt.Errorf("decoded extra-data exceeds maximum size of 2048 bytes (decoded length: %d)", len(decoded))
-			}
+		if err := validateExtraData(extraDataHexStr); err != nil {
+			return err
 		}
 
 		// Load the private key
@@ -1175,14 +1184,8 @@ var addRootsCmd = &cli.Command{
 		extraDataHexStr := cctx.String("extra-data")
 
 		// Validate extraData hex string and its decoded length
-		if extraDataHexStr != "" {
-			decoded, err := hex.DecodeString(strings.TrimPrefix(extraDataHexStr, "0x"))
-			if err != nil {
-				return fmt.Errorf("invalid hex format for --extra-data (after removing 0x prefix): %v", err)
-			}
-			if len(decoded) > 2048 {
-				return fmt.Errorf("decoded extra-data exceeds maximum size of 2048 bytes (decoded length: %d)", len(decoded))
-			}
+		if err := validateExtraData(extraDataHexStr); err != nil {
+			return err
 		}
 
 		// Load the private key

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -167,7 +167,7 @@ func (p *PDPService) handleCreateProofSet(w http.ResponseWriter, r *http.Request
 	}
 
 	// Decode extraData if provided
-	var extraDataBytes []byte
+	var extraDataBytes = []byte{}
 	if reqBody.ExtraData != nil {
 		extraDataHexStr := *reqBody.ExtraData
 		decodedBytes, err := hex.DecodeString(strings.TrimPrefix(extraDataHexStr, "0x"))
@@ -177,8 +177,6 @@ func (p *PDPService) handleCreateProofSet(w http.ResponseWriter, r *http.Request
 			return
 		}
 		extraDataBytes = decodedBytes
-	} else {
-		extraDataBytes = []byte{}
 	}
 
 	// Step 3: Get the sender address from 'eth_keys' table where role = 'pdp' limit 1
@@ -610,7 +608,7 @@ func (p *PDPService) handleAddRootToProofSet(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	var extraDataBytes []byte
+	var extraDataBytes = []byte{}
 	if payload.ExtraData != nil {
 		extraDataHexStr := *payload.ExtraData
 		decodedBytes, err := hex.DecodeString(strings.TrimPrefix(extraDataHexStr, "0x"))
@@ -620,8 +618,6 @@ func (p *PDPService) handleAddRootToProofSet(w http.ResponseWriter, r *http.Requ
 			return
 		}
 		extraDataBytes = decodedBytes
-	} else {
-		extraDataBytes = []byte{} // Ensure it's an empty byte slice if not provided
 	}
 
 	// Collect all subrootCIDs to fetch their info in a batch


### PR DESCRIPTION
The `PDPVerifier` contract allows passing an opaque byte array as "extradata" that gets passed to the listener as is. This is needed for allowing the client/provider to pass in payer/payee addresses and proofset/root metadata to the listener to build payment flows/better explorer UX.
