### PR TITLE
Update Makefile for Non-CUDA Installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,12 @@ build/.update-modules:
 # Conditional execution block for Linux
 OS := $(shell uname)
 ifeq ($(OS), Linux)
-    $(eval CUDA_PATH := $(shell dirname $$(dirname $$(which nvcc))))
-    $(eval CUDA_LIB_PATH := $(CUDA_PATH)/lib64)
-    export LIBRARY_PATH := $(LIBRARY_PATH):$(CUDA_LIB_PATH)
+    NVCC_PATH := $(shell which nvcc 2>/dev/null)
+    ifneq ($(NVCC_PATH),)
+        $(eval CUDA_PATH := $(shell dirname $$(dirname $$(which nvcc))))
+        $(eval CUDA_LIB_PATH := $(CUDA_PATH)/lib64)
+        export LIBRARY_PATH := $(LIBRARY_PATH):$(CUDA_LIB_PATH)
+    endif
 endif
 
 ## MAIN BINARIES


### PR DESCRIPTION
Users installing Curio for PDP-only operations do not need to have CUDA libraries installed.

Running `sudo make install` without CUDA libraries installed results in the following error:

```
dirname: missing operand
Try 'dirname --help' for more information.
dirname: missing operand
Try 'dirname --help' for more information.
install -C ./curio /usr/local/bin/curio
install -C ./sptool /usr/local/bin/sptool
```

Tested with `curio version 1.25.0+mainnet+git_90cd136_2025-04-14T12:54:07-04:00`