### PR TITLE
feat: pending messages in UI

### DIFF
--- a/alertmanager/alerts.go
+++ b/alertmanager/alerts.go
@@ -717,3 +717,35 @@ func chainSyncCheck(al *alerts) {
 		}
 	}
 }
+
+func pendingMessagesCheck(al *alerts) {
+	Name := "PendingMessages"
+	al.alertMap[Name] = &alertOut{}
+
+	var messages []struct {
+		MessageCid string    `db:"signed_message_cid"`
+		AddedAt    time.Time `db:"added_at"`
+	}
+
+	err := al.db.Select(al.ctx, &messages, `SELECT signed_message_cid, added_at FROM message_waits WHERE executed_tsk_cid IS NULL ORDER BY added_at DESC`)
+	if err != nil {
+		al.alertMap[Name].err = xerrors.Errorf("getting pending messages: %w", err)
+	}
+
+	if len(messages) == 0 {
+		return
+	}
+
+	var msgs []string
+
+	for _, msg := range messages {
+		if time.Since(msg.AddedAt) > time.Hour {
+			msgs = append(msgs, msg.MessageCid)
+		}
+	}
+
+	if len(msgs) > 0 {
+		al.alertMap[Name].alertString += fmt.Sprintf("Messages pending for more than 1 hour: %s", strings.Join(msgs, ", "))
+	}
+
+}

--- a/alertmanager/task_alert.go
+++ b/alertmanager/task_alert.go
@@ -70,6 +70,7 @@ var AlertFuncs = []AlertFunc{
 	wnPostCheck,
 	NowCheck,
 	chainSyncCheck,
+	pendingMessagesCheck,
 }
 
 func NewAlertTask(

--- a/harmony/harmonydb/sql/20231225-message-waits.sql
+++ b/harmony/harmonydb/sql/20231225-message-waits.sql
@@ -10,4 +10,6 @@ create table message_waits (
     executed_rcpt_exitcode bigint,
     executed_rcpt_return bytea,
     executed_rcpt_gas_used bigint
+
+    -- created_at timestampz (added in 20250422-msg-wait-timestamp.sql)
 )

--- a/harmony/harmonydb/sql/20250422-msg-wait-timestamp.sql
+++ b/harmony/harmonydb/sql/20250422-msg-wait-timestamp.sql
@@ -1,0 +1,2 @@
+ALTER TABLE message_waits
+    ADD COLUMN added_at timestamptz NOT NULL DEFAULT TIMEZONE('UTC', NOW());

--- a/web/static/pages/wallet/index.html
+++ b/web/static/pages/wallet/index.html
@@ -5,6 +5,7 @@
     <script type="module" src="/ux/curio-ux.mjs"></script>
     <script type="module" src="/ux/components/Drawer.mjs"></script>
     <script type="module" src="wallet.mjs"></script>
+    <script type="module" src="messages.mjs"></script>
 </head>
 <body style="visibility:hidden; background:rgb(11, 22, 34)" data-bs-theme="dark">
 <curio-ux>
@@ -16,6 +17,11 @@
             <div class="row">
                 <div class="col-md-auto" style="max-width: 95%">
                     <wallet-names></wallet-names>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-auto" style="max-width: 95%">
+                    <pending-messages></pending-messages>
                 </div>
             </div>
         </section>

--- a/web/static/pages/wallet/messages.mjs
+++ b/web/static/pages/wallet/messages.mjs
@@ -1,0 +1,168 @@
+import { css, html, LitElement } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
+import RPCCall from '/lib/jsonrpc.mjs';
+import { formatDate } from '/lib/dateutil.mjs';
+import '/ux/yesno.mjs';
+import {timeSince} from "../../lib/dateutil.mjs";
+
+class PendingMessages extends LitElement {
+    static properties = {
+        messages: { type: Array },
+        totalCount: { type: Number },
+        pageSize: { type: Number },
+        currentPage: { type: Number },
+        totalPages: { type: Number }
+    };
+
+    constructor() {
+        super();
+        this.messages = [];
+        this.totalCount = 0;
+        this.pageSize = 10;
+        this.currentPage = 1;
+        this.totalPages = 0;
+        this.loadData();
+    }
+
+    async loadData() {
+        try {
+            const data = await RPCCall('PendingMessages');
+            this.messages = data.messages || [];
+            this.totalCount = this.messages.length;
+            this.totalPages = Math.ceil(this.totalCount / this.pageSize);
+            this.currentPage = 1;
+            this.requestUpdate();
+        } catch (error) {
+            console.error('Failed to load pending messages:', error);
+            alert('Failed to load pending messages: ' + error.message);
+        }
+    }
+
+    get pagedMessages() {
+        const start = (this.currentPage - 1) * this.pageSize;
+        const end = start + this.pageSize;
+        return this.messages.slice(start, end);
+    }
+
+    nextPage() {
+        if (this.currentPage < this.totalPages) {
+            this.currentPage++;
+        }
+    }
+
+    prevPage() {
+        if (this.currentPage > 1) {
+            this.currentPage--;
+        }
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this.loadData();
+    }
+
+    render() {
+        return html`
+      <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        crossorigin="anonymous"
+      />
+      <link rel="stylesheet" href="/ux/main.css" />
+
+      <div>
+        <h2>
+          Pending Messages List
+          <button class="info-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+              class="bi bi-info-circle" viewBox="0 0 16 16">
+              <path
+                d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
+              <path
+                d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 
+                3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 
+                1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 
+                0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
+            </svg>
+            <span class="tooltip-text">
+              List of all pending messages. Certain messages may have been executed, but cannot be found on the connected chain node.
+            </span>
+          </button>
+        </h2>
+        <table class="table table-dark table-striped table-sm">
+          <thead>
+            <tr>
+              <th>Created At</th>
+              <th>Message / Txn ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${this.pagedMessages.map(
+            (msg) => html`
+                <tr>
+                    <td>${new Date(msg.added_at).toLocaleString()}</td>
+                    <td>${(() => {
+                        const ageMinutes = (Date.now() - new Date(msg.added_at).getTime()) / 60000;
+                        const color = ageMinutes < 30 ? 'limegreen' : ageMinutes < 60 ? 'goldenrod' : 'crimson';
+                        return html`<span style="color: ${color}">${msg.message}</span>`;
+                    })()}</td>
+                </tr>
+            `)}
+          </tbody>
+        </table>
+
+        <div class="pagination-controls">
+          <button class="btn btn-secondary" @click="${this.prevPage}" ?disabled="${this.currentPage <= 1}">
+            Previous
+          </button>
+          <span>Page ${this.currentPage} of ${this.totalPages}</span>
+          <button class="btn btn-secondary" @click="${this.nextPage}" ?disabled="${this.currentPage >= this.totalPages}">
+            Next
+          </button>
+        </div>
+      </div>
+    `;
+    }
+
+    static styles = css`
+    .pagination-controls {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-top: 1rem;
+    }
+
+    .info-btn {
+      position: relative;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      color: #17a2b8;
+      font-size: 1em;
+      margin-left: 8px;
+    }
+
+    .tooltip-text {
+      display: none;
+      position: absolute;
+      top: 50%;
+      left: 120%;
+      transform: translateY(-50%);
+      min-width: 440px;
+      max-width: 600px;
+      background-color: #333;
+      color: #fff;
+      padding: 8px;
+      border-radius: 4px;
+      font-size: 0.8em;
+      text-align: left;
+      white-space: normal;
+      z-index: 10;
+    }
+
+    .info-btn:hover .tooltip-text {
+      display: block;
+    }
+  `;
+}
+
+customElements.define('pending-messages', PendingMessages);


### PR DESCRIPTION
This PR adds pending message table to wallets page.

The color of the message string changes based on following:
1. < 30 minutes: Green
2. > 30 and < 60 minutes: Yellow
3. > 60 minutes: Red

Alert is also generates for messages > 60 minutes.

Once this PR is merged, I merge main into PDP and extend the functionality.

<img width="898" alt="Screenshot 2025-04-22 at 4 40 41 PM" src="https://github.com/user-attachments/assets/28f3a300-9556-49c6-82d3-c03b9bf29eea" />
<img width="823" alt="Screenshot 2025-04-22 at 4 44 51 PM" src="https://github.com/user-attachments/assets/b4d99ac3-25fd-41ad-86e8-f82aa3610098" />
<img width="948" alt="Screenshot 2025-04-22 at 5 33 45 PM" src="https://github.com/user-attachments/assets/12bbcfdd-0c4d-4b80-848d-891f30a93fab" />
