### PR TITLE
pdp browser rendering

### DIFF
--- a/market/retrieval/piecehandler.go
+++ b/market/retrieval/piecehandler.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -58,19 +60,42 @@ func (rp *Provider) handleByPieceCid(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setHeaders(w, pieceCid)
+	buf := make([]byte, 512)
+	n, _ := reader.Read(buf)
+	contentType := http.DetectContentType(buf[:n])
+
+	// rewind reader before sending
+	_, err = reader.Seek(0, io.SeekStart)
+	if err != nil {
+		log.Errorf("error rewinding reader for piece CID %s: %s", pieceCid, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		stats.Record(ctx, remoteblockstore.HttpPieceByCid500ResponseCount.M(1))
+		return
+	}
+
+	setHeaders(w, pieceCid, contentType)
 	serveContent(w, r, size, reader)
 
 	stats.Record(ctx, remoteblockstore.HttpPieceByCid200ResponseCount.M(1))
 	stats.Record(ctx, remoteblockstore.HttpPieceByCidRequestDuration.M(float64(time.Since(startTime).Milliseconds())))
 }
 
-func setHeaders(w http.ResponseWriter, pieceCid cid.Cid) {
+func setHeaders(w http.ResponseWriter, pieceCid cid.Cid, contentType string) {
 	w.Header().Set("Vary", "Accept-Encoding")
-	etag := `"` + pieceCid.String() + `.gz"` // must be quoted
-	w.Header().Set("Etag", etag)
-	w.Header().Set("Content-Type", "application/piece")
 	w.Header().Set("Cache-Control", "public, max-age=29030400, immutable")
+	w.Header().Set("Content-Type", contentType)
+	if contentType != "application/octet-stream" {
+		if exts, err := mime.ExtensionsByType(contentType); err == nil && len(exts) > 0 {
+			ext := exts[0]
+			filename := pieceCid.String() + ext
+			encoded := url.PathEscape(filename)
+
+			w.Header().Set("Content-Disposition",
+				fmt.Sprintf(`inline; filename="%s"; filename*=UTF-8''%s`, filename, encoded))
+		}
+	}
+	w.Header().Set("Etag", pieceCid.String())
+
 }
 
 func serveContent(res http.ResponseWriter, req *http.Request, size abi.UnpaddedPieceSize, content io.ReadSeeker) {


### PR DESCRIPTION
## DO NOT MERGE
- [x] Explore client side security considerations
1. Allows malicious builders to use PDP provider has host to malicious content
2. If malicious script is flagged, PDP provider's domain will be hit
3. Locking down CORS will mean external builders cannot serve directly from PDP provider
4. How do we find a balance? Where do we draw the line?

Added server side sniffing and only do "inline" if a valid MIME type is detected. This handles the security risks upto some degree. 