### PR TITLE
chore(cors): expose Location header to JS for PDP

### DIFF
--- a/cuhttp/server.go
+++ b/cuhttp/server.go
@@ -54,6 +54,8 @@ func corsHeaders(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Accept, Accept-Encoding")
+		// Expose Location header for PDP Piece upload
+		w.Header().Set("Access-Control-Expose-Headers", "Location")
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return


### PR DESCRIPTION
Can't access `Location` header from within a browser context and we need it for PDP uploads.