### PR TITLE
Lower MinConfidence to a value of 1

### DIFF
--- a/tasks/message/watch.go
+++ b/tasks/message/watch.go
@@ -18,7 +18,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
-const MinConfidence = 6
+const MinConfidence = 1
 
 type MessageWaiterApi interface {
 	StateGetActor(ctx context.Context, actor address.Address, tsk types.TipSetKey) (*types.Actor, error)


### PR DESCRIPTION
To optimise testing, this PR temporarily lowers the MinConfidence value from 6 to 1.