### PR TITLE
Remove unpadding transformation from root size

### DIFF
--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -803,7 +803,7 @@ func (p *PDPService) handleAddRootToProofSet(w http.ResponseWriter, r *http.Requ
 			}
 
 			prevSubrootSize = subrootInfo.PieceInfo.Size
-			totalSize += uint64(subrootInfo.PieceInfo.Size.Unpadded())
+			totalSize += uint64(subrootInfo.PieceInfo.Size)
 		}
 
 		// Prepare RootData for Ethereum transaction


### PR DESCRIPTION
It turns out we shouldn't need to do anything with proving.  Prove tasks ask the contract to find the root id and offset and this is not validated against any of the database's state on piece sizes.  However when we generate the proving tree we use the correct padded piece size of subroots from the database.  This means that the proving task

a) always generates correct trees 
b) today will never challenge the leaves at the last 1/128 th of the root since the contract doesn't consider them part of the data
c) does not need any new information from chain or in state to handle the true padded piece size -- it delegates everything to pdpVerifiers `findRootIds` which will always be correct for the root values provided during addRoots.