### PR TITLE
fix(pdp): remove unpadding transformation from root size

### DIFF
--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -801,7 +801,7 @@ func (p *PDPService) handleAddRootToProofSet(w http.ResponseWriter, r *http.Requ
 			}
 
 			prevSubrootSize = subrootInfo.PieceInfo.Size
-			totalSize += uint64(subrootInfo.PieceInfo.Size.Unpadded())
+			totalSize += uint64(subrootInfo.PieceInfo.Size)
 		}
 
 		// Prepare RootData for Ethereum transaction


### PR DESCRIPTION
From the `synapse` branch. A bugfix that allowed us to get smaller pieces onboarded. The current reporting of the raw->padded->unpadded size is a bit off, and this is one of the side effects. Due to the way it gets calculated, pieces less than 2048 bytes get reported badly.

This isn't _quite_ the final fix here, because what this does is tell PDP to prove the whole, padded piece, which is not what the user really wants, but Curio can deal with it, it'll just be proving fake-zeros on the end of the piece sometimes. The ideal is to report the raw size, but PDP needs it to be multiples of 32. I think the final fix here would be to take the raw size, pad it to 32 and report that. But that's not as easy as just fixing this for now.