### PR TITLE
PDP service contract whitelist

### DIFF
--- a/pdp/contract/addresses.go
+++ b/pdp/contract/addresses.go
@@ -12,7 +12,8 @@ import (
 )
 
 type PDPContracts struct {
-	PDPVerifier common.Address
+	PDPVerifier                common.Address
+	AllowedPublicRecordKeepers []common.Address
 }
 
 func ContractAddresses() PDPContracts {
@@ -20,6 +21,9 @@ func ContractAddresses() PDPContracts {
 	case build.BuildCalibnet:
 		return PDPContracts{
 			PDPVerifier: common.HexToAddress("0x445238Eca6c6aB8Dff1Aa6087d9c05734D22f137"),
+			AllowedPublicRecordKeepers: []common.Address{
+				common.HexToAddress("0x80617b65FD2EEa1D7fDe2B4F85977670690ed348"), // FilecoinWarmStorageService
+			},
 		}
 	case build.BuildMainnet:
 		// Compatible contract not yet deployed
@@ -33,4 +37,21 @@ const NumChallenges = 5
 
 func SybilFee() *big.Int {
 	return must.One(types.ParseFIL("0.1")).Int
+}
+
+// IsPublicService checks if a service label indicates a public service
+func IsPublicService(serviceLabel string) bool {
+	return serviceLabel == "public"
+}
+
+// IsRecordKeeperAllowed checks if a recordkeeper address is in the whitelist
+// Returns true if the address is allowed, or if there's no whitelist for the network
+func IsRecordKeeperAllowed(recordKeeper common.Address) bool {
+	// Check if the recordkeeper is in the whitelist
+	for _, allowed := range ContractAddresses().AllowedPublicRecordKeepers {
+		if recordKeeper == allowed {
+			return true
+		}
+	}
+	return false
 }

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -170,6 +170,12 @@ func (p *PDPService) handleCreateDataSet(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Check if the recordkeeper is in the whitelist for public services
+	if contract.IsPublicService(serviceLabel) && !contract.IsRecordKeeperAllowed(recordKeeperAddr) {
+		http.Error(w, "recordKeeper address not allowed for public service", http.StatusForbidden)
+		return
+	}
+
 	// Decode extraData if provided
 	extraDataBytes := []byte{}
 	if reqBody.ExtraData != nil {


### PR DESCRIPTION
This provides some protection for curio PDP operators running publically accessible PDP services.  Only the pandora PDP service contract is allowed upon proofset creation over the publically available PDP service.  

The whitelist is network dependent -- only calibnet specified as pandora only launched on calibnet.

Closes https://github.com/FilOzone/synapse-sdk/issues/34