### PR TITLE
fix gc page with missing paths

### DIFF
--- a/web/api/webrpc/storage_stats.go
+++ b/web/api/webrpc/storage_stats.go
@@ -316,10 +316,10 @@ func (a *WebRPC) StorageGCMarks(ctx context.Context, miner *string, sectorNum *i
 								    sl.can_store, 
 								    sl.urls
 								FROM storage_removal_marks m 
-								    LEFT JOIN storage_path sl ON m.storage_id = sl.storage_id
+								    INNER JOIN storage_path sl ON m.storage_id = sl.storage_id
 								WHERE 
 								    ($1::BIGINT IS NULL OR m.sp_id = $1)
-    								AND ($2::BIGINT IS NULL OR m.sector_num = $2) 
+    								AND ($2::BIGINT IS NULL OR m.sector_num = $2)
 								ORDER BY created_at 
 								DESC LIMIT $3 
 								OFFSET $4`, spID, sectorNum, limit, offset)

--- a/web/static/pages/sector/sector-info.mjs
+++ b/web/static/pages/sector/sector-info.mjs
@@ -2,6 +2,7 @@ import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/al
 import RPCCall from '/lib/jsonrpc.mjs';
 import { renderSectorPipeline, pipelineStyles } from '/pages/pipeline_porep/pipeline-porep-sectors.mjs';
 import { renderSectorSnapPipeline, snapPipelineStyles} from '/snap/upgrade-sectors.mjs';
+import '/ux/epoch.mjs';
 
 customElements.define('sector-info',class SectorInfo extends LitElement {
     constructor() {
@@ -61,8 +62,8 @@ customElements.define('sector-info',class SectorInfo extends LitElement {
                         <tr><td>Sector Number</td><td>${this.data.SectorNumber}</td></tr>
                         <tr><td>PreCommit Message</td><td>${this.data.PreCommitMsg}</td></tr>
                         <tr><td>Commit Message</td><td>${this.data.CommitMsg}</td></tr>
-                        <tr><td>Activation Epoch</td><td>${this.data.ActivationEpoch}</td></tr>
-                        <tr><td>Expiration Epoch</td><td>${this.data.ExpirationEpoch}</td></tr>
+                        <tr><td>Activation Epoch</td><td><pretty-epoch epoch=${this.data.ActivationEpoch}></pretty-epoch></td></tr>
+                        <tr><td>Expiration Epoch</td><td><pretty-epoch epoch=${this.data.ExpirationEpoch}></pretty-epoch></td></tr>
                         <tr><td>Deal Weight</td><td>${this.data.DealWeight}</td></tr>
                         <tr><td>Deadline</td><td>${this.data.Deadline}</td></tr>
                         <tr><td>Partition</td><td>${this.data.Partition}</td></tr>


### PR DESCRIPTION
There's a bug in the RPC when there was a GC mark on a path which was removed (e.g. failed drive) the page wouldn't render - which was because left join caused `sl.can_store` to be null, which then we tried to scan into `bool` which obviously failed.