### PR TITLE
fix(pdp): s/piece_cid/pieceCid to make JSON response casing consistent

### DIFF
--- a/pdp/handlers_upload.go
+++ b/pdp/handlers_upload.go
@@ -497,7 +497,7 @@ func (p *PDPService) handleFindPiece(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := struct {
-		PieceCID string `json:"piece_cid"`
+		PieceCID string `json:"pieceCid"`
 	}{
 		PieceCID: pieceCid.String(),
 	}


### PR DESCRIPTION
This is the only place in the pdp handlers where we have _'s. This is probably good to fix earlier than later. On the client side, in my code at least, I'll make it accept both forms for now and remove the older form when we think we have it rolled out properly.