### PR TITLE
Rvagg/eth client timeout and log

### DIFF
--- a/deps/deps.go
+++ b/deps/deps.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/ethereum/go-ethereum/ethclient"
+	ethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/gbrlsnchs/jwt/v3"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/samber/lo"
@@ -263,6 +264,7 @@ func (deps *Deps) PopulateRemainingDeps(ctx context.Context, cctx *cli.Context, 
 			if v := os.Getenv("FULLNODE_API_INFO"); v != "" {
 				cfgApiInfo = []string{v}
 			}
+			ethlog.SetDefault(ethlog.NewLogger(ethlog.NewTerminalHandlerWithLevel(os.Stdout, ethlog.LevelDebug, false)))
 			return GetEthClient(cctx, cfgApiInfo)
 		})
 	}

--- a/lib/chainsched/chain_sched.go
+++ b/lib/chainsched/chain_sched.go
@@ -2,6 +2,7 @@ package chainsched
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -25,8 +26,9 @@ type NodeAPI interface {
 type CurioChainSched struct {
 	api NodeAPI
 
-	callbacks []UpdateFunc
-	started   bool
+	callbacks   []UpdateFunc
+	callbacksLk sync.RWMutex
+	started     bool
 }
 
 func New(api NodeAPI) *CurioChainSched {
@@ -41,7 +43,8 @@ func (s *CurioChainSched) AddHandler(ch UpdateFunc) error {
 	if s.started {
 		return xerrors.Errorf("cannot add handler after start")
 	}
-
+	s.callbacksLk.Lock()
+	defer s.callbacksLk.Unlock()
 	s.callbacks = append(s.callbacks, ch)
 	return nil
 }
@@ -56,7 +59,7 @@ func (s *CurioChainSched) Run(ctx context.Context) {
 	)
 
 	// not fine to panic after this point
-	for {
+	for ctx.Err() == nil {
 		if notifs == nil {
 			notifs, err = s.api.ChainNotify(ctx)
 			if err != nil {
@@ -129,7 +132,12 @@ func (s *CurioChainSched) update(ctx context.Context, revert, apply *types.TipSe
 		return
 	}
 
-	for _, ch := range s.callbacks {
+	s.callbacksLk.RLock()
+	callbacksCopy := make([]UpdateFunc, len(s.callbacks))
+	copy(callbacksCopy, s.callbacks)
+	s.callbacksLk.RUnlock()
+
+	for _, ch := range callbacksCopy {
 		if err := ch(ctx, revert, apply); err != nil {
 			log.Errorf("handling head updates in curio chain sched: %+v", err)
 		}

--- a/lib/chainsched/chain_sched.go
+++ b/lib/chainsched/chain_sched.go
@@ -2,6 +2,7 @@ package chainsched
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -17,6 +18,10 @@ import (
 )
 
 var log = logging.Logger("curio/chainsched")
+
+// Notification timeout for chain updates, if we don't get a notification within this time frame
+// then something must be wrong so we'll attempt to restart
+const notificationTimeout = 60 * time.Second
 
 type NodeAPI interface {
 	ChainHead(context.Context) (*types.TipSet, error)
@@ -53,51 +58,69 @@ func (s *CurioChainSched) Run(ctx context.Context) {
 	s.started = true
 
 	var (
-		notifs <-chan []*api.HeadChange
-		err    error
-		gotCur bool
+		notificationCh       <-chan []*api.HeadChange
+		err                  error
+		gotFirstNotification bool
 	)
+
+	ticker := build.Clock.Ticker(notificationTimeout)
+	defer ticker.Stop()
+	lastNotif := build.Clock.Now()
 
 	// not fine to panic after this point
 	for ctx.Err() == nil {
-		if notifs == nil {
-			notifs, err = s.api.ChainNotify(ctx)
+		if notificationCh == nil {
+			notificationCh, err = s.api.ChainNotify(ctx)
 			if err != nil {
-				log.Errorf("ChainNotify error: %+v", err)
-
-				build.Clock.Sleep(10 * time.Second)
+				log.Errorw("ChainNotify", "error", err)
+				build.Clock.Sleep(10 * time.Second) // Retry after 10 second wait
 				continue
 			}
-
-			gotCur = false
-			log.Info("restarting chain scheduler")
+			gotFirstNotification = false
+			log.Info("Restarting chain scheduler with new notification channel")
+			lastNotif = build.Clock.Now()
 		}
 
 		select {
-		case changes, ok := <-notifs:
+		case changes, ok := <-notificationCh:
 			if !ok {
-				log.Warn("chain notifs channel closed")
-				notifs = nil
+				log.Warn("Chain notification channel closed")
+				notificationCh = nil
 				continue
 			}
 
-			if !gotCur {
+			notifSummaries := make([]string, len(changes))
+			for i, chg := range changes {
+				var height int64 = -1
+				if chg.Val != nil {
+					height = int64(chg.Val.Height())
+				}
+				notifSummaries[i] = fmt.Sprintf("[%d:%v:h=%d]", i, chg.Type, height)
+			}
+			log.Debugf("Received notification: %d changes %v", len(changes), notifSummaries)
+
+			lastNotif = build.Clock.Now()
+
+			if !gotFirstNotification {
 				if len(changes) != 1 {
-					log.Errorf("expected first notif to have len = 1")
+					log.Errorf("Expected first chain notification to have a single change")
+					notificationCh = nil
+					build.Clock.Sleep(10 * time.Second) // Retry after 10 second wait
 					continue
 				}
 				chg := changes[0]
 				if chg.Type != store.HCCurrent {
-					log.Errorf("expected first notif to tell current ts")
+					log.Errorf(`Expected first chain notification to tell "current" TipSet`)
+					notificationCh = nil
+					build.Clock.Sleep(10 * time.Second) // Retry after 10 second wait
 					continue
 				}
 
 				ctx, span := trace.StartSpan(ctx, "CurioChainSched.headChange")
-
 				s.update(ctx, nil, chg.Val)
-
 				span.End()
-				gotCur = true
+
+				gotFirstNotification = true
 				continue
 			}
 
@@ -120,6 +143,13 @@ func (s *CurioChainSched) Run(ctx context.Context) {
 			s.update(ctx, lowest, highest)
 
 			span.End()
+		case <-ticker.C:
+			since := build.Clock.Since(lastNotif)
+			log.Debugf("ChainSched ticker: %s since last notification", since)
+			if since > notificationTimeout {
+				log.Warnf("No notifications received in %s, resubscribing to ChainNotify", notificationTimeout)
+				notificationCh = nil
+			}
 		case <-ctx.Done():
 			return
 		}
@@ -128,7 +158,7 @@ func (s *CurioChainSched) Run(ctx context.Context) {
 
 func (s *CurioChainSched) update(ctx context.Context, revert, apply *types.TipSet) {
 	if apply == nil {
-		log.Error("no new tipset in CurioChainSched.update")
+		log.Error("No new tipset in CurioChainSched.update")
 		return
 	}
 
@@ -139,7 +169,7 @@ func (s *CurioChainSched) update(ctx context.Context, revert, apply *types.TipSe
 
 	for _, ch := range callbacksCopy {
 		if err := ch(ctx, revert, apply); err != nil {
-			log.Errorf("handling head updates in curio chain sched: %+v", err)
+			log.Errorf("Handling head updates in curio chain sched: %+v", err)
 		}
 	}
 }

--- a/tasks/message/watch_eth.go
+++ b/tasks/message/watch_eth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -17,6 +18,12 @@ import (
 	"github.com/filecoin-project/curio/lib/chainsched"
 
 	types2 "github.com/filecoin-project/lotus/chain/types"
+)
+
+const (
+	// ethCallTimeout is the timeout for sets of Ethereum client calls per transaction
+	// (i.e. receipt and transaction data)
+	ethCallTimeout = time.Second
 )
 
 type MessageWatcherEth struct {
@@ -111,12 +118,21 @@ func (mw *MessageWatcherEth) update() {
 		txHash := common.HexToHash(tx.TxHash)
 		log.Debugw("Checking transaction", "txHash", txHash.Hex())
 
-		receipt, err := mw.api.TransactionReceipt(ctx, txHash)
+		ethCtx, ethCancel := context.WithTimeout(ctx, ethCallTimeout)
+
+		receipt, err := mw.api.TransactionReceipt(ethCtx, txHash)
 		if err != nil {
+			ethCancel()
 			if errors.Is(err, ethereum.NotFound) {
 				// Transaction is still pending
 				stillPending++
 				log.Debugw("Transaction still pending", "txHash", txHash.Hex())
+				continue
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				errorCount++
+				log.Debugw("Eth calls timed out - continuing with next tx",
+					"txHash", txHash.Hex())
 				continue
 			}
 			errorCount++
@@ -124,7 +140,6 @@ func (mw *MessageWatcherEth) update() {
 				"txHash", txHash.Hex(),
 				"error", err,
 				"errorType", fmt.Sprintf("%T", err))
-			// Continue processing other transactions instead of returning
 			continue
 		}
 
@@ -137,6 +152,7 @@ func (mw *MessageWatcherEth) update() {
 		// Check if the transaction has enough confirmations
 		confirmations := new(big.Int).Sub(bestBlockNumber, receipt.BlockNumber)
 		if confirmations.Cmp(big.NewInt(MinConfidence)) < 0 {
+			ethCancel()
 			// Not enough confirmations yet
 			waitingConfirmations++
 			log.Debugw("Transaction waiting for confirmations",
@@ -147,12 +163,20 @@ func (mw *MessageWatcherEth) update() {
 			continue
 		}
 
-		// Get the transaction data
-		txData, _, err := mw.api.TransactionByHash(ctx, txHash)
+		// Get the transaction data using same timeout context
+		txData, _, err := mw.api.TransactionByHash(ethCtx, txHash)
+		ethCancel()
+
 		if err != nil {
 			if errors.Is(err, ethereum.NotFound) {
 				errorCount++
 				log.Errorw("Transaction data not found - continuing", "txHash", txHash.Hex())
+				continue
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				errorCount++
+				log.Debugw("Eth calls timed out - continuing with next tx",
+					"txHash", txHash.Hex())
 				continue
 			}
 			errorCount++


### PR DESCRIPTION
Still failing in watch_eth.go, but I have a little bit more information with additional logging turned on.

Last output for watch_eth.go working on stuff is:

```
2025-06-30T13:11:00.927Z        INFO    curio/message   message/watch_eth.go:104        Processing pending transactions {"count": 12, "machineID": 1}
2025-06-30T13:11:00.927Z        DEBUG   curio/message   message/watch_eth.go:112        Checking transaction    {"txHash": "0x0ee2d4acfb636e314a0a544a84e60873aebaa39c607f500e5ac0b4d009953f6e"}
2025-06-30T13:11:00.928Z        DEBUG   curio/message   message/watch_eth.go:119        Transaction still pending       {"txHash": "0x0ee2d4acfb636e314a0a544a84e60873aebaa39c607f500e5ac0b4d009953f6e"}
2025-06-30T13:11:00.928Z        DEBUG   curio/message   message/watch_eth.go:112        Checking transaction    {"txHash": "0x6a04975f33972c2d7a0977ba88bae36c6123a292b5ba512dc086b09de2c0acc4"}
```

After that we just have this:

```
2025-07-01T01:54:30.072Z        DEBUG   curio/message   message/watch_eth.go:246        Head change received    {"newHeight": "2800283"}
2025-07-01T01:54:30.072Z        DEBUG   curio/message   message/watch_eth.go:251        Update channel full, skipping   {"height": "2800283"}
2025-07-01T01:55:00.080Z        DEBUG   curio/message   message/watch_eth.go:246        Head change received    {"newHeight": "2800284"}
2025-07-01T01:55:00.080Z        DEBUG   curio/message   message/watch_eth.go:251        Update channel full, skipping   {"height": "2800284"}
```

Which looks to me like a lock-up here since either return path should log something: https://github.com/filecoin-project/curio/blob/289b2db01d4f5ab3bae8677762965d2dfd149291/tasks/message/watch_eth.go#L114

At the same time, Lotus shows us:

```
{"level":"error","ts":"2025-06-30T13:11:00.929Z","logger":"node/eth","caller":"eth/transaction.go:414","msg":"failed to lookup transaction hash 0x6a04975f33972c2d7a0977ba88bae36c6123a292b5ba512dc086b09de2c0acc4 in chain indexer: failed to read data from index: context canceled"}
{"level":"warn","ts":"2025-06-30T13:11:00.929Z","logger":"rpc","caller":"go-jsonrpc@v0.7.0/handler.go:421","msg":"error in RPC call to 'eth_getTransactionReceipt': failed to lookup transaction hash 0x6a04975f33972c2d7a0977ba88bae36c6123a292b5ba512dc086b09de2c0acc4 in chain indexer:\n    github.com/filecoin-project/lotus/node/impl/eth.(*ethTransaction).getCidForTransaction\n        /root/repos/lotus/node/impl/eth/transaction.go:415\n  - failed to read data from index:\n    github.com/filecoin-project/lotus/chain/index.(*SqliteIndexer).readWithHeadIndexWait\n        /root/repos/lotus/chain/index/read.go:88\n  - context canceled"}
{"level":"error","ts":"2025-06-30T13:11:00.929Z","logger":"rpc","caller":"go-jsonrpc@v0.7.0/websocket.go:145","msg":"handle me:write tcp4 127.0.0.1:1234->127.0.0.1:37802: use of closed network connection"}
```

That path suggests that we hit the moment in the Lotus ChainIndexer where it had a new chain head but it wasn't quite indexed, so it had to wait a little while to see it be indexed, which should be pretty quick but there's a 5 second timeout on the wait. That particular timeout isn't what's returned here though, it's a timeout from somewhere up the stack, I believe go-jsonrpc, maybe a deadline in the websocket handler, although I can't figure out exactly where. I _think_ it might be the generic timeout that go-jsonrpc sets up for listening for responses which is 30 seconds, but that seems far too long to be relevant here. The timing says Curio asked Lotus at `13:11:00.928` for an `eth_getTransactionReceipt` and Lotus experienced a timeout error at `13:11:00.929`!

The fact that we don't progress further than this might suggest that go-ethereum/ethclient doesn't know how to deal with the error that comes out of Lotus for this event, or maybe one of the websocket handlers (on either side) doesn't know. So my strategy here is to put a 1s timeout per transaction in the processing loop and move on if we don't get a response after that. Hopefully whatever part of the stack is pausing will respond to a context kick.