### PR TITLE
fix(pdptool): Skip JWT auth for public service

### DIFF
--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -185,14 +185,9 @@ var pingCmd = &cli.Command{
 		if serviceName == "" {
 			return fmt.Errorf("either --jwt-token or --service-name must be provided")
 		}
-		privKey, err := loadPrivateKey()
+		jwtToken, err := getJWTTokenForService(serviceName)
 		if err != nil {
 			return err
-		}
-		var errCreateToken error
-		jwtToken, errCreateToken := createJWTToken(serviceName, privKey)
-		if errCreateToken != nil {
-			return errCreateToken
 		}
 
 		// Append /pdp/ping to the service URL
@@ -203,7 +198,9 @@ var pingCmd = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create request: %v", err)
 		}
-		req.Header.Set("Authorization", "Bearer "+jwtToken)
+		if jwtToken != "" {
+			req.Header.Set("Authorization", "Bearer "+jwtToken)
+		}
 
 		// Send the request
 		client := &http.Client{}
@@ -242,6 +239,19 @@ func createJWTToken(serviceName string, privateKey *ecdsa.PrivateKey) (string, e
 	}
 
 	return tokenString, nil
+}
+
+func getJWTTokenForService(serviceName string) (string, error) {
+	if serviceName == "public" {
+		return "", nil // No JWT needed for public service
+	}
+
+	privKey, err := loadPrivateKey()
+	if err != nil {
+		return "", err
+	}
+
+	return createJWTToken(serviceName, privKey)
 }
 
 func loadPrivateKey() (*ecdsa.PrivateKey, error) {
@@ -401,7 +411,9 @@ func uploadOnePiece(client *http.Client, serviceURL string, reqBody []byte, jwtT
 	if err != nil {
 		return fmt.Errorf("failed to create request: %v", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+jwtToken)
+	if jwtToken != "" {
+		req.Header.Set("Authorization", "Bearer "+jwtToken)
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
@@ -522,14 +534,10 @@ var pieceUploadCmd = &cli.Command{
 			if serviceName == "" {
 				return fmt.Errorf("either --jwt-token or --service-name must be provided")
 			}
-			privKey, err := loadPrivateKey()
+			var err error
+			jwtToken, err = getJWTTokenForService(serviceName)
 			if err != nil {
 				return err
-			}
-			var errCreateToken error
-			jwtToken, errCreateToken = createJWTToken(serviceName, privKey)
-			if errCreateToken != nil {
-				return errCreateToken
 			}
 		}
 
@@ -690,14 +698,10 @@ var uploadFileCmd = &cli.Command{
 			if serviceName == "" {
 				return fmt.Errorf("either --jwt-token or --service-name must be provided")
 			}
-			privKey, err := loadPrivateKey()
+			var err error
+			jwtToken, err = getJWTTokenForService(serviceName)
 			if err != nil {
 				return err
-			}
-			var errCreateToken error
-			jwtToken, errCreateToken = createJWTToken(serviceName, privKey)
-			if errCreateToken != nil {
-				return errCreateToken
 			}
 		}
 
@@ -875,14 +879,8 @@ var createProofSetCmd = &cli.Command{
 			return err
 		}
 
-		// Load the private key
-		privKey, err := loadPrivateKey()
-		if err != nil {
-			return fmt.Errorf("failed to load private key: %v", err)
-		}
-
 		// Create the JWT token
-		jwtToken, err := createJWTToken(serviceName, privKey)
+		jwtToken, err := getJWTTokenForService(serviceName)
 		if err != nil {
 			return fmt.Errorf("failed to create JWT token: %v", err)
 		}
@@ -908,7 +906,9 @@ var createProofSetCmd = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create request: %v", err)
 		}
-		req.Header.Set("Authorization", "Bearer "+jwtToken)
+		if jwtToken != "" {
+			req.Header.Set("Authorization", "Bearer "+jwtToken)
+		}
 		req.Header.Set("Content-Type", "application/json")
 
 		// Send the request
@@ -964,14 +964,8 @@ var getProofSetStatusCmd = &cli.Command{
 		serviceName := cctx.String("service-name")
 		txHash := cctx.String("tx-hash")
 
-		// Load the private key
-		privKey, err := loadPrivateKey()
-		if err != nil {
-			return fmt.Errorf("failed to load private key: %v", err)
-		}
-
 		// Create the JWT token
-		jwtToken, err := createJWTToken(serviceName, privKey)
+		jwtToken, err := getJWTTokenForService(serviceName)
 		if err != nil {
 			return fmt.Errorf("failed to create JWT token: %v", err)
 		}
@@ -990,7 +984,9 @@ var getProofSetStatusCmd = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create request: %v", err)
 		}
-		req.Header.Set("Authorization", "Bearer "+jwtToken)
+		if jwtToken != "" {
+			req.Header.Set("Authorization", "Bearer "+jwtToken)
+		}
 
 		// Send the request
 		client := &http.Client{}
@@ -1074,14 +1070,8 @@ var getProofSetCmd = &cli.Command{
 		serviceURL := cctx.String("service-url")
 		serviceName := cctx.String("service-name")
 
-		// Load the private key
-		privKey, err := loadPrivateKey()
-		if err != nil {
-			return fmt.Errorf("failed to load private key: %v", err)
-		}
-
 		// Create the JWT token
-		jwtToken, err := createJWTToken(serviceName, privKey)
+		jwtToken, err := getJWTTokenForService(serviceName)
 		if err != nil {
 			return fmt.Errorf("failed to create JWT token: %v", err)
 		}
@@ -1094,7 +1084,9 @@ var getProofSetCmd = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create request: %v", err)
 		}
-		req.Header.Set("Authorization", "Bearer "+jwtToken)
+		if jwtToken != "" {
+			req.Header.Set("Authorization", "Bearer "+jwtToken)
+		}
 
 		// Send the request
 		client := &http.Client{}
@@ -1188,14 +1180,8 @@ var addRootsCmd = &cli.Command{
 			return err
 		}
 
-		// Load the private key
-		privKey, err := loadPrivateKey()
-		if err != nil {
-			return fmt.Errorf("failed to load private key: %v", err)
-		}
-
 		// Create the JWT token
-		jwtToken, err := createJWTToken(serviceName, privKey)
+		jwtToken, err := getJWTTokenForService(serviceName)
 		if err != nil {
 			return fmt.Errorf("failed to create JWT token: %v", err)
 		}
@@ -1264,7 +1250,9 @@ var addRootsCmd = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create request: %v", err)
 		}
-		req.Header.Set("Authorization", "Bearer "+jwtToken)
+		if jwtToken != "" {
+			req.Header.Set("Authorization", "Bearer "+jwtToken)
+		}
 		req.Header.Set("Content-Type", "application/json")
 
 		// Send the request
@@ -1426,14 +1414,8 @@ var removeRootsCmd = &cli.Command{
 		proofSetID := cctx.Uint64("proof-set-id")
 		rootID := cctx.Uint64("root-id")
 
-		// Load the private key (implement `loadPrivateKey` according to your setup)
-		privKey, err := loadPrivateKey()
-		if err != nil {
-			return fmt.Errorf("failed to load private key: %v", err)
-		}
-
-		// Create the JWT token (implement `createJWTToken` according to your setup)
-		jwtToken, err := createJWTToken(serviceName, privKey)
+		// Create the JWT token
+		jwtToken, err := getJWTTokenForService(serviceName)
 		if err != nil {
 			return fmt.Errorf("failed to create JWT token: %v", err)
 		}
@@ -1447,7 +1429,9 @@ var removeRootsCmd = &cli.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create request: %v", err)
 		}
-		req.Header.Set("Authorization", "Bearer "+jwtToken)
+		if jwtToken != "" {
+			req.Header.Set("Authorization", "Bearer "+jwtToken)
+		}
 		req.Header.Set("Content-Type", "application/json")
 
 		// Send the request


### PR DESCRIPTION
- Add getJWTTokenForService() wrapper that returns empty token for 'public' service
- Update all commands to use the wrapper instead of direct JWT creation
- Only set Authorization header when JWT token is not empty
- Allows pdptool to work with public services without requiring pdpservice.json

Fixes #558