### PR TITLE
Wallet Balance Manager

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -35,6 +35,7 @@ import (
 	"github.com/filecoin-project/curio/lib/slotmgr"
 	"github.com/filecoin-project/curio/lib/storiface"
 	"github.com/filecoin-project/curio/market/libp2p"
+	"github.com/filecoin-project/curio/tasks/balancemgr"
 	"github.com/filecoin-project/curio/tasks/f3"
 	"github.com/filecoin-project/curio/tasks/gc"
 	"github.com/filecoin-project/curio/tasks/indexing"
@@ -101,12 +102,13 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 	iStore := dependencies.IndexStore
 	pp := dependencies.SectorReader
 
+	chainSched := chainsched.New(full)
+
 	var activeTasks []harmonytask.TaskInterface
 
 	sender, sendTask := message.NewSender(full, full, db)
-	activeTasks = append(activeTasks, sendTask)
-
-	chainSched := chainsched.New(full)
+	balanceMgrTask := balancemgr.NewBalanceMgrTask(db, full, chainSched, sender)
+	activeTasks = append(activeTasks, sendTask, balanceMgrTask)
 
 	// paramfetch
 	var fetchOnce sync.Once

--- a/harmony/harmonydb/sql/20250727-balancemgr.sql
+++ b/harmony/harmonydb/sql/20250727-balancemgr.sql
@@ -1,0 +1,47 @@
+-- Balance Manager
+
+CREATE TABLE balance_manager_addresses (
+    id SERIAL PRIMARY KEY,
+    
+    subject_address TEXT NOT NULL, -- f0 address
+    second_address TEXT NOT NULL, -- f0 address
+
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_action TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    -- "requester" - if subject below low watermark, send fil from second address to subject up to high watermark
+    -- "active-provider" - if subject above high watermark, send fil from subject to second address up to low watermark
+    action_type TEXT NOT NULL, -- "requester", "active-provider"
+
+    low_watermark_fil_balance TEXT NOT NULL DEFAULT '0',
+    high_watermark_fil_balance TEXT NOT NULL DEFAULT '0',
+
+    active_task_id BIGINT,
+
+    last_msg_cid TEXT,
+    last_msg_sent_at TIMESTAMP,
+    last_msg_landed_at TIMESTAMP
+);
+
+CREATE INDEX balance_manager_addresses_last_msg_cid_idx ON balance_manager_addresses (last_msg_cid);
+
+ALTER TABLE balance_manager_addresses ADD CONSTRAINT subject_not_equal_second CHECK (subject_address != second_address);
+ALTER TABLE balance_manager_addresses ADD CONSTRAINT balance_manager_addresses_subject_address_second_address_unique UNIQUE (subject_address, second_address, action_type);
+
+CREATE OR REPLACE FUNCTION update_balance_manager_from_message_waits()
+RETURNS trigger AS $$
+BEGIN
+  IF OLD.executed_tsk_epoch IS NULL AND NEW.executed_tsk_epoch IS NOT NULL THEN
+    UPDATE balance_manager_addresses
+      SET last_msg_landed_at = current_timestamp
+    WHERE last_msg_cid = NEW.signed_message_cid;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER tr_update_balance_manager_from_message_waits
+AFTER UPDATE ON message_waits
+FOR EACH ROW
+WHEN (OLD.executed_tsk_epoch IS NULL AND NEW.executed_tsk_epoch IS NOT NULL)
+EXECUTE FUNCTION update_balance_manager_from_message_waits();

--- a/tasks/balancemgr/task_balancemgr.go
+++ b/tasks/balancemgr/task_balancemgr.go
@@ -4,19 +4,22 @@ import (
 	"context"
 	"fmt"
 
+	logging "github.com/ipfs/go-log/v2"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/harmony/resources"
 	"github.com/filecoin-project/curio/lib/chainsched"
 	"github.com/filecoin-project/curio/lib/promise"
 	"github.com/filecoin-project/curio/tasks/message"
-	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-state-types/abi"
+
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/types"
-	logging "github.com/ipfs/go-log/v2"
-	"golang.org/x/xerrors"
 )
 
 var log = logging.Logger("balancemgr")
@@ -299,7 +302,7 @@ func (b *BalanceMgrTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (
 	}
 
 	mss := &api.MessageSendSpec{
-		MaxFee: abi.TokenAmount(MaxSendFee),
+		MaxFee:         abi.TokenAmount(MaxSendFee),
 		MaximizeFeeCap: true,
 	}
 

--- a/tasks/balancemgr/task_balancemgr.go
+++ b/tasks/balancemgr/task_balancemgr.go
@@ -1,0 +1,354 @@
+package balancemgr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+	"github.com/filecoin-project/curio/harmony/resources"
+	"github.com/filecoin-project/curio/lib/chainsched"
+	"github.com/filecoin-project/curio/lib/promise"
+	"github.com/filecoin-project/curio/tasks/message"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	"github.com/filecoin-project/lotus/chain/types"
+	logging "github.com/ipfs/go-log/v2"
+	"golang.org/x/xerrors"
+)
+
+var log = logging.Logger("balancemgr")
+
+var MaxSendFee = types.MustParseFIL("0.05 FIL")
+
+type BalanceMgrTask struct {
+	db     *harmonydb.DB
+	chain  api.FullNode
+	sender *message.Sender
+	adder  promise.Promise[harmonytask.AddTaskFunc]
+}
+
+func NewBalanceMgrTask(db *harmonydb.DB, chain api.FullNode, pcs *chainsched.CurioChainSched, sender *message.Sender) *BalanceMgrTask {
+	t := &BalanceMgrTask{
+		db:     db,
+		chain:  chain,
+		sender: sender,
+	}
+
+	pcs.AddHandler(func(ctx context.Context, revert, apply *types.TipSet) error {
+		if !t.adder.IsSet() {
+			return nil
+		}
+
+		taskFunc := t.adder.Val(ctx)
+
+		// select all addrs, where active_task_id = null, last_msg_cid is null OR last_msg_landed_at is NOT null
+		rows, err := t.db.Query(ctx, `
+			SELECT id, subject_address, second_address, action_type, low_watermark_fil_balance, high_watermark_fil_balance
+			FROM balance_manager_addresses
+			WHERE active_task_id IS NULL AND (last_msg_cid IS NULL OR last_msg_landed_at IS NOT NULL)
+		`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		type balanceManagerAddress struct {
+			ID                      int64
+			SubjectAddress          address.Address
+			SecondAddress           address.Address
+			ActionType              string
+			LowWatermarkFilBalance  types.BigInt
+			HighWatermarkFilBalance types.BigInt
+
+			// chain data
+			SubjectBalance types.BigInt
+			SecondBalance  types.BigInt
+		}
+		addresses := make([]*balanceManagerAddress, 0)
+
+		for rows.Next() {
+			var id int64
+			var subjectAddressStr string
+			var secondAddressStr string
+			var actionType string
+			var lowWatermarkFilBalanceStr string
+			var highWatermarkFilBalanceStr string
+
+			err = rows.Scan(&id, &subjectAddressStr, &secondAddressStr, &actionType, &lowWatermarkFilBalanceStr, &highWatermarkFilBalanceStr)
+			if err != nil {
+				return xerrors.Errorf("scanning balance manager address: %w", err)
+			}
+
+			subjectAddr, err := address.NewFromString(subjectAddressStr)
+			if err != nil {
+				return xerrors.Errorf("parsing subject address: %w", err)
+			}
+
+			secondAddr, err := address.NewFromString(secondAddressStr)
+			if err != nil {
+				return xerrors.Errorf("parsing second address: %w", err)
+			}
+
+			lowWatermark, err := types.ParseFIL(lowWatermarkFilBalanceStr)
+			if err != nil {
+				return xerrors.Errorf("parsing low watermark: %w", err)
+			}
+
+			highWatermark, err := types.ParseFIL(highWatermarkFilBalanceStr)
+			if err != nil {
+				return xerrors.Errorf("parsing high watermark: %w", err)
+			}
+
+			addr := &balanceManagerAddress{
+				ID:                      id,
+				SubjectAddress:          subjectAddr,
+				SecondAddress:           secondAddr,
+				ActionType:              actionType,
+				LowWatermarkFilBalance:  abi.TokenAmount(lowWatermark),
+				HighWatermarkFilBalance: abi.TokenAmount(highWatermark),
+			}
+
+			addresses = append(addresses, addr)
+		}
+
+		for _, addr := range addresses {
+			// get balances
+			subjectBalance, err := t.chain.WalletBalance(ctx, addr.SubjectAddress)
+			if err != nil {
+				return xerrors.Errorf("getting subject balance: %w", err)
+			}
+
+			secondBalance, err := t.chain.WalletBalance(ctx, addr.SecondAddress)
+			if err != nil {
+				return xerrors.Errorf("getting second balance: %w", err)
+			}
+
+			addr.SubjectBalance = subjectBalance
+			addr.SecondBalance = secondBalance
+
+			var shouldCreateTask bool
+			switch addr.ActionType {
+			case "requester":
+				shouldCreateTask = addr.SubjectBalance.LessThan(addr.LowWatermarkFilBalance)
+			case "active-provider":
+				shouldCreateTask = addr.SubjectBalance.GreaterThan(addr.HighWatermarkFilBalance)
+			}
+
+			if shouldCreateTask {
+				taskFunc(func(taskID harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
+					// check that address.ID has active_task_id = null, set the task ID, set last_ to null
+					n, err := tx.Exec(`
+						UPDATE balance_manager_addresses
+						SET active_task_id = $1, last_msg_cid = NULL, last_msg_sent_at = NULL, last_msg_landed_at = NULL
+						WHERE id = $2 AND active_task_id IS NULL AND (last_msg_cid IS NULL OR last_msg_landed_at IS NOT NULL)
+					`, taskID, addr.ID)
+					if err != nil {
+						return false, xerrors.Errorf("updating balance manager address: %w", err)
+					}
+
+					return n > 0, nil
+				})
+			}
+		}
+		return nil
+	})
+
+	return t
+}
+
+// Adder implements harmonytask.TaskInterface.
+func (b *BalanceMgrTask) Adder(taskFunc harmonytask.AddTaskFunc) {
+	b.adder.Set(taskFunc)
+}
+
+// CanAccept implements harmonytask.TaskInterface.
+func (b *BalanceMgrTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+	return &ids[0], nil
+}
+
+// Do implements harmonytask.TaskInterface.
+func (b *BalanceMgrTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+	ctx := context.Background()
+
+	// select task info
+	var id int64
+	var subjectAddressStr string
+	var secondAddressStr string
+	var actionType string
+	var lowWatermarkStr string
+	var highWatermarkStr string
+
+	err = b.db.QueryRow(ctx, `
+		SELECT id, subject_address, second_address, action_type, 
+		       low_watermark_fil_balance, high_watermark_fil_balance
+		FROM balance_manager_addresses
+		WHERE active_task_id = $1
+	`, taskID).Scan(&id, &subjectAddressStr, &secondAddressStr, &actionType,
+		&lowWatermarkStr, &highWatermarkStr)
+	if err != nil {
+		return false, xerrors.Errorf("failed to get balance manager address: %w", err)
+	}
+
+	// Parse addresses and watermarks
+	subjectAddr, err := address.NewFromString(subjectAddressStr)
+	if err != nil {
+		return false, xerrors.Errorf("parsing subject address: %w", err)
+	}
+
+	secondAddr, err := address.NewFromString(secondAddressStr)
+	if err != nil {
+		return false, xerrors.Errorf("parsing second address: %w", err)
+	}
+
+	lowWatermark, err := types.ParseFIL(lowWatermarkStr)
+	if err != nil {
+		return false, xerrors.Errorf("parsing low watermark: %w", err)
+	}
+
+	highWatermark, err := types.ParseFIL(highWatermarkStr)
+	if err != nil {
+		return false, xerrors.Errorf("parsing high watermark: %w", err)
+	}
+
+	// Get current balances
+	subjectBalance, err := b.chain.WalletBalance(ctx, subjectAddr)
+	if err != nil {
+		return false, xerrors.Errorf("getting subject balance: %w", err)
+	}
+
+	secondBalance, err := b.chain.WalletBalance(ctx, secondAddr)
+	if err != nil {
+		return false, xerrors.Errorf("getting second balance: %w", err)
+	}
+
+	// calculate amount to send (based on latest chain balance)
+	var amount types.BigInt
+	var from, to address.Address
+	var shouldSend bool
+
+	switch actionType {
+	case "requester":
+		// If subject below low watermark, send from second to subject up to high watermark
+		if subjectBalance.LessThan(abi.TokenAmount(lowWatermark)) {
+			targetAmount := types.BigSub(abi.TokenAmount(highWatermark), subjectBalance)
+			// Make sure we don't send more than second address has
+			if targetAmount.GreaterThan(secondBalance) {
+				log.Warnw("second address has insufficient balance",
+					"needed", types.FIL(targetAmount),
+					"available", types.FIL(secondBalance))
+
+				// clear the task
+				_, err = b.db.Exec(ctx, `
+					UPDATE balance_manager_addresses 
+					SET active_task_id = NULL, last_action = NOW()
+					WHERE id = $1
+				`, id)
+				if err != nil {
+					return false, xerrors.Errorf("clearing task id: %w", err)
+				}
+
+				return true, nil
+			}
+			amount = targetAmount
+			from = secondAddr
+			to = subjectAddr
+			shouldSend = true
+		}
+
+	case "active-provider":
+		// If subject above high watermark, send from subject to second down to low watermark
+		if subjectBalance.GreaterThan(abi.TokenAmount(highWatermark)) {
+			amount = types.BigSub(subjectBalance, abi.TokenAmount(lowWatermark))
+			from = subjectAddr
+			to = secondAddr
+			shouldSend = true
+		}
+
+	default:
+		return false, xerrors.Errorf("unknown action type: %s", actionType)
+	}
+
+	// If no need to send, clear the task and return
+	if !shouldSend {
+		log.Infow("balance within watermarks, no action needed",
+			"subject", subjectAddr,
+			"balance", types.FIL(subjectBalance),
+			"low", types.FIL(lowWatermark),
+			"high", types.FIL(highWatermark))
+
+		_, err = b.db.Exec(ctx, `
+			UPDATE balance_manager_addresses 
+			SET active_task_id = NULL, last_action = NOW()
+			WHERE id = $1
+		`, id)
+		if err != nil {
+			return false, xerrors.Errorf("clearing task id: %w", err)
+		}
+		return true, nil
+	}
+
+	// send msg
+	msg := &types.Message{
+		From:   from,
+		To:     to,
+		Value:  amount,
+		Method: builtin.MethodSend,
+	}
+
+	mss := &api.MessageSendSpec{
+		MaxFee: abi.TokenAmount(MaxSendFee),
+		MaximizeFeeCap: true,
+	}
+
+	// Send the message - sender will handle message_wait insertion
+	msgCid, err := b.sender.Send(ctx, msg, mss, fmt.Sprintf("balancemgr-%s", actionType))
+	if err != nil {
+		return false, xerrors.Errorf("sending message: %w", err)
+	}
+
+	_, err = b.db.Exec(ctx, `INSERT INTO message_waits (signed_message_cid) VALUES ($1)`, msgCid)
+	if err != nil {
+		return false, xerrors.Errorf("inserting into message_waits: %w", err)
+	}
+
+	// Update the database with message info
+	_, err = b.db.Exec(ctx, `
+		UPDATE balance_manager_addresses 
+		SET last_msg_cid = $2, 
+		    last_msg_sent_at = NOW(), 
+		    last_msg_landed_at = NULL,
+			active_task_id = NULL
+		WHERE id = $1
+	`, id, msgCid.String())
+	if err != nil {
+		return false, xerrors.Errorf("updating message cid: %w", err)
+	}
+
+	log.Infow("sent balance management message",
+		"from", from,
+		"to", to,
+		"amount", types.FIL(amount),
+		"msgCid", msgCid,
+		"actionType", actionType)
+
+	// Task complete - chain handler will clear active_task_id when message lands
+	return true, nil
+}
+
+// TypeDetails implements harmonytask.TaskInterface.
+func (b *BalanceMgrTask) TypeDetails() harmonytask.TaskTypeDetails {
+	return harmonytask.TaskTypeDetails{
+		Name: "BalanceMgr",
+		Cost: resources.Resources{
+			Cpu: 0,
+			Gpu: 0,
+			Ram: 10 << 20,
+		},
+		MaxFailures: 2,
+	}
+}
+
+var _ = harmonytask.Reg(&BalanceMgrTask{})

--- a/tasks/balancemgr/task_balancemgr.go
+++ b/tasks/balancemgr/task_balancemgr.go
@@ -40,7 +40,7 @@ func NewBalanceMgrTask(db *harmonydb.DB, chain api.FullNode, pcs *chainsched.Cur
 		sender: sender,
 	}
 
-	pcs.AddHandler(func(ctx context.Context, revert, apply *types.TipSet) error {
+	err := pcs.AddHandler(func(ctx context.Context, revert, apply *types.TipSet) error {
 		if !t.adder.IsSet() {
 			return nil
 		}
@@ -158,6 +158,9 @@ func NewBalanceMgrTask(db *harmonydb.DB, chain api.FullNode, pcs *chainsched.Cur
 		}
 		return nil
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	return t
 }

--- a/web/api/webrpc/balance_manager.go
+++ b/web/api/webrpc/balance_manager.go
@@ -1,0 +1,144 @@
+package webrpc
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/chain/types"
+	"golang.org/x/xerrors"
+)
+
+// BalanceMgrRule represents a balance manager rule with display-friendly fields.
+// Watermark values are returned as short FIL strings (e.g. "0.25 FIL").
+// Nullable DB fields are returned as pointers so JSON omits them when nil.
+// Time values are formatted on the JS side – we simply expose RFC3339 strings.
+//
+// NOTE: Any new columns that should be exposed can be trivially added here.
+type BalanceMgrRule struct {
+	ID              int64   `json:"id"`
+	SubjectAddress  string  `json:"subject_address"`
+	SecondAddress   string  `json:"second_address"`
+	ActionType      string  `json:"action_type"`
+	LowWatermark    string  `json:"low_watermark"`
+	HighWatermark   string  `json:"high_watermark"`
+	TaskID          *int64  `json:"task_id,omitempty"`
+	LastMsgCID      *string `json:"last_msg_cid,omitempty"`
+	LastMsgSentAt   *string `json:"last_msg_sent_at,omitempty"`
+	LastMsgLandedAt *string `json:"last_msg_landed_at,omitempty"`
+}
+
+// BalanceMgrRules returns all balance-manager rules.
+func (a *WebRPC) BalanceMgrRules(ctx context.Context) ([]BalanceMgrRule, error) {
+	const q = `SELECT id, subject_address, second_address, action_type, low_watermark_fil_balance, high_watermark_fil_balance,
+        last_msg_cid, last_msg_sent_at, last_msg_landed_at, active_task_id FROM balance_manager_addresses ORDER BY id`
+
+	rows, err := a.deps.DB.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []BalanceMgrRule
+	for rows.Next() {
+		var (
+			id                                                   int64
+			subjectAddr, secondAddr, actionType, lowStr, highStr string
+			lastMsgCID                                           sql.NullString
+			lastMsgSentAt, lastMsgLandedAt                       sql.NullTime
+			taskID                                               sql.NullInt64
+		)
+		if err := rows.Scan(&id, &subjectAddr, &secondAddr, &actionType, &lowStr, &highStr, &lastMsgCID, &lastMsgSentAt, &lastMsgLandedAt, &taskID); err != nil {
+			return nil, err
+		}
+
+		// Convert watermarks to short FIL strings.
+		lowBig, err := types.ParseFIL(lowStr)
+		if err != nil {
+			return nil, err
+		}
+		highBig, err := types.ParseFIL(highStr)
+		if err != nil {
+			return nil, err
+		}
+
+		rule := BalanceMgrRule{
+			ID:             id,
+			SubjectAddress: subjectAddr,
+			SecondAddress:  secondAddr,
+			ActionType:     actionType,
+			LowWatermark:   types.FIL(lowBig).Short(),
+			HighWatermark:  types.FIL(highBig).Short(),
+		}
+		if lastMsgCID.Valid {
+			rule.LastMsgCID = &lastMsgCID.String
+		}
+		if lastMsgSentAt.Valid {
+			s := lastMsgSentAt.Time.Format(time.RFC3339)
+			rule.LastMsgSentAt = &s
+		}
+		if lastMsgLandedAt.Valid {
+			s := lastMsgLandedAt.Time.Format(time.RFC3339)
+			rule.LastMsgLandedAt = &s
+		}
+		if taskID.Valid {
+			rule.TaskID = &taskID.Int64
+		}
+		out = append(out, rule)
+	}
+	return out, nil
+}
+
+// BalanceMgrRuleUpdate updates the low / high watermark thresholds for a rule.
+// Values should be provided as strings parsable by types.ParseFIL (e.g. "0.5" or "0.5 FIL").
+func (a *WebRPC) BalanceMgrRuleUpdate(ctx context.Context, id int64, lowWatermark, highWatermark string) error {
+	lowAmt, err := types.ParseFIL(lowWatermark)
+	if err != nil {
+		return err
+	}
+	highAmt, err := types.ParseFIL(highWatermark)
+	if err != nil {
+		return err
+	}
+
+	_, err = a.deps.DB.Exec(ctx, `UPDATE balance_manager_addresses SET low_watermark_fil_balance = $1, high_watermark_fil_balance = $2 WHERE id = $3`, lowAmt.String(), highAmt.String(), id)
+	return err
+}
+
+// BalanceMgrRuleRemove deletes a balance-manager rule.
+func (a *WebRPC) BalanceMgrRuleRemove(ctx context.Context, id int64) error {
+	_, err := a.deps.DB.Exec(ctx, `DELETE FROM balance_manager_addresses WHERE id = $1`, id)
+	return err
+}
+
+// BalanceMgrRuleAdd creates a new balance-manager rule.
+// Watermarks are provided as FIL strings. Addresses use Fil/ID strings.
+func (a *WebRPC) BalanceMgrRuleAdd(ctx context.Context, subject, second, actionType, lowWatermark, highWatermark string) error {
+	// Basic sanity – ensure addresses parse but keep original text for insertion.
+	if _, err := address.NewFromString(subject); err != nil {
+		return xerrors.Errorf("invalid subject address: %w", err)
+	}
+	if _, err := address.NewFromString(second); err != nil {
+		return xerrors.Errorf("invalid second address: %w", err)
+	}
+
+	switch actionType {
+	case "requester":
+	case "active-provider":
+	default:
+		return xerrors.Errorf("invalid action type: %s", actionType)
+	}
+
+	lowAmt, err := types.ParseFIL(lowWatermark)
+	if err != nil {
+		return xerrors.Errorf("invalid low watermark: %w", err)
+	}
+	highAmt, err := types.ParseFIL(highWatermark)
+	if err != nil {
+		return xerrors.Errorf("invalid high watermark: %w", err)
+	}
+
+	_, err = a.deps.DB.Exec(ctx, `INSERT INTO balance_manager_addresses (subject_address, second_address, action_type, low_watermark_fil_balance, high_watermark_fil_balance) VALUES ($1,$2,$3,$4,$5)`, subject, second, actionType, lowAmt.String(), highAmt.String())
+	return err
+}

--- a/web/api/webrpc/balance_manager.go
+++ b/web/api/webrpc/balance_manager.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/lotus/chain/types"
 	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+
+	"github.com/filecoin-project/lotus/chain/types"
 )
 
 // BalanceMgrRule represents a balance manager rule with display-friendly fields.

--- a/web/static/pages/wallet/balance-manager.mjs
+++ b/web/static/pages/wallet/balance-manager.mjs
@@ -1,0 +1,255 @@
+import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
+import RPCCall from '/lib/jsonrpc.mjs';
+import '/ux/task.mjs';
+import '/ux/message.mjs';
+
+class BalanceManager extends LitElement {
+  static properties = {
+    rules: { type: Array },
+    editingId: { type: Number },
+    editLow: { type: String },
+    editHigh: { type: String },
+    adding: { type: Boolean },
+    newSubject: { type: String },
+    newSecond: { type: String },
+    newAction: { type: String },
+    newLow: { type: String },
+    newHigh: { type: String },
+    _refreshHandle: { state: false }
+  };
+
+  constructor() {
+    super();
+    this.rules = [];
+    this.editingId = null;
+    this.editLow = '';
+    this.editHigh = '';
+    this.adding = false;
+    this.newSubject = '';
+    this.newSecond = '';
+    this.newAction = 'transfer';
+    this.newLow = '';
+    this.newHigh = '';
+    this.loadRules();
+    this._refreshHandle = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._refreshHandle = setInterval(() => this.loadRules(), 5000);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._refreshHandle) {
+      clearInterval(this._refreshHandle);
+      this._refreshHandle = null;
+    }
+  }
+
+  async loadRules() {
+    try {
+      const data = await RPCCall('BalanceMgrRules', []);
+      this.rules = data || [];
+    } catch (err) {
+      console.error('Failed to fetch balance-manager rules:', err);
+      alert('Failed to fetch balance-manager rules: ' + err.message);
+    }
+  }
+
+  startEdit(rule) {
+    this.editingId = rule.id;
+    // Strip possible " FIL" suffix for easier editing
+    this.editLow = (rule.low_watermark || '').replace(/\s*FIL$/i, '').trim();
+    this.editHigh = (rule.high_watermark || '').replace(/\s*FIL$/i, '').trim();
+  }
+
+  cancelEdit() {
+    this.editingId = null;
+    this.editLow = '';
+    this.editHigh = '';
+  }
+
+  startAdd() {
+    this.adding = true;
+    this.newSubject = '';
+    this.newSecond = '';
+    this.newAction = 'transfer';
+    this.newLow = '';
+    this.newHigh = '';
+  }
+
+  cancelAdd() {
+    this.adding = false;
+  }
+
+  async saveAdd() {
+    try {
+      await RPCCall('BalanceMgrRuleAdd', [
+        this.newSubject,
+        this.newSecond,
+        this.newAction,
+        this.newLow,
+        this.newHigh,
+      ]);
+      this.cancelAdd();
+      await this.loadRules();
+    } catch (err) {
+      console.error('Failed to add rule:', err);
+      alert('Failed to add rule: ' + err.message);
+    }
+  }
+
+  async saveEdit() {
+    try {
+      await RPCCall('BalanceMgrRuleUpdate', [this.editingId, this.editLow, this.editHigh]);
+      this.cancelEdit();
+      await this.loadRules();
+    } catch (err) {
+      console.error('Failed to update rule:', err);
+      alert('Failed to update rule: ' + err.message);
+    }
+  }
+
+  async deleteRule(id) {
+    if (!confirm('Delete this rule?')) return;
+    try {
+      await RPCCall('BalanceMgrRuleRemove', [id]);
+      await this.loadRules();
+    } catch (err) {
+      console.error('Failed to delete rule:', err);
+      alert('Failed to delete rule: ' + err.message);
+    }
+  }
+
+  render() {
+    return html`
+      <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        crossorigin="anonymous"
+      />
+      <link rel="stylesheet" href="/ux/main.css" />
+
+      <div class="container py-3">
+        <h2>Balance-Manager Rules</h2>
+        <button class="btn btn-primary btn-sm mb-2" @click=${this.startAdd}>Add Rule</button>
+        ${this.adding
+          ? html`
+              <div class="card card-body bg-dark text-light mb-3">
+                <div class="row g-2 align-items-end">
+                  <div class="col-md-2">
+                    <label class="form-label mb-0">Subject</label>
+                    <input class="form-control form-control-sm" .value=${this.newSubject} @input=${(e) => (this.newSubject = e.target.value)} />
+                  </div>
+                  <div class="col-md-2">
+                    <label class="form-label mb-0">Second</label>
+                    <input class="form-control form-control-sm" .value=${this.newSecond} @input=${(e) => (this.newSecond = e.target.value)} />
+                  </div>
+                  <div class="col-md-3">
+                    <label class="form-label mb-0">Action</label>
+                    <select class="form-select form-select-sm" .value=${this.newAction} @change=${(e) => (this.newAction = e.target.value)}>
+                      <option value="requester">Keep Subject Above Low</option>
+                      <option value="active-provider">Keep Subject Below High</option>
+                    </select>
+                  </div>
+                  <div class="col-md-1">
+                    <label class="form-label mb-0">Low WM (FIL)</label>
+                    <input class="form-control form-control-sm" .value=${this.newLow} @input=${(e) => (this.newLow = e.target.value)} />
+                  </div>
+                  <div class="col-md-1">
+                    <label class="form-label mb-0">High WM (FIL)</label>
+                    <input class="form-control form-control-sm" .value=${this.newHigh} @input=${(e) => (this.newHigh = e.target.value)} />
+                  </div>
+                  <div class="col-md-2 d-flex gap-2">
+                    <button class="btn btn-success btn-sm" @click=${this.saveAdd}>Save</button>
+                    <button class="btn btn-secondary btn-sm" @click=${this.cancelAdd}>Cancel</button>
+                  </div>
+                </div>
+              </div>`
+          : ''}
+        ${this.rules.length === 0
+          ? html`<p class="text-muted">No balance-manager rules found.</p>`
+          : html`
+              <table class="table table-dark table-striped table-sm">
+                <thead>
+                  <tr>
+                    <th style="white-space: nowrap;">ID</th>
+                    <th style="white-space: nowrap;">Subject</th>
+                    <th style="white-space: nowrap;">Second</th>
+                    <th style="white-space: nowrap;">Action</th>
+                    <th style="white-space: nowrap;">Low&nbsp;WM</th>
+                    <th style="white-space: nowrap;">High&nbsp;WM</th>
+                    <th style="white-space: nowrap;">Last&nbsp;Msg</th>
+                    <th style="white-space: nowrap;">Task</th>
+                    <th style="white-space: nowrap;">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${this.rules.map((rule) => {
+                    return html`
+                      <tr>
+                        <td style="white-space: nowrap;">${rule.id}</td>
+                        <td style="white-space: nowrap;"><cu-wallet wallet_id="${rule.subject_address}"></cu-wallet></td>
+                        <td style="white-space: nowrap;"><cu-wallet wallet_id="${rule.second_address}"></cu-wallet></td>
+                        <td style="white-space: nowrap;">${rule.action_type === 'requester' ? 'Keep Subject Above Low' : rule.action_type === 'active-provider' ? 'Keep Subject Below High' : rule.action_type}</td>
+                        <td style="white-space: nowrap;">
+                          ${this.editingId === rule.id
+                            ? html`<input
+                                class="form-control form-control-sm"
+                                .value=${this.editLow}
+                                @input=${(e) => (this.editLow = e.target.value)}
+                              />`
+                            : rule.low_watermark}
+                        </td>
+                        <td style="white-space: nowrap;">
+                          ${this.editingId === rule.id
+                            ? html`<input
+                                class="form-control form-control-sm"
+                                .value=${this.editHigh}
+                                @input=${(e) => (this.editHigh = e.target.value)}
+                              />`
+                            : rule.high_watermark}
+                        </td>
+                        <td style="white-space: nowrap;">
+                          ${rule.last_msg_cid
+                            ? html`<fil-message cid="${rule.last_msg_cid}"></fil-message>`
+                            : '-'}
+                        </td>
+                        <td style="white-space: nowrap;">
+                            ${rule.task_id ? html`<task-status taskId=${rule.task_id}></task-status>` : '-'}
+                        </td>
+                        <td style="white-space: nowrap;">
+                          ${this.editingId === rule.id
+                            ? html`<div class="d-flex gap-2">
+                                  <button class="btn btn-sm btn-success" @click=${this.saveEdit}>Save</button>
+                                  <button class="btn btn-sm btn-secondary" @click=${this.cancelEdit}>Cancel</button>
+                                </div>`
+                            : html`<div class="d-flex gap-2">
+                                  <button class="btn btn-sm btn-secondary" @click=${() => this.startEdit(rule)}>Edit</button>
+                                  <button class="btn btn-danger btn-sm" @click=${() => this.deleteRule(rule.id)}>
+                                    Delete
+                                  </button>
+                                </div>`}
+                        </td>
+                      </tr>
+                    `;
+                  })}
+                </tbody>
+              </table>
+            `}
+      </div>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    .gap-2 {
+      gap: 0.5rem;
+    }
+  `;
+}
+
+customElements.define('balance-manager', BalanceManager);

--- a/web/static/pages/wallet/index.html
+++ b/web/static/pages/wallet/index.html
@@ -6,17 +6,23 @@
     <script type="module" src="/ux/components/Drawer.mjs"></script>
     <script type="module" src="wallet.mjs"></script>
     <script type="module" src="messages.mjs"></script>
+    <script type="module" src="balance-manager.mjs"></script>
 </head>
 <body style="visibility:hidden; background:rgb(11, 22, 34)" data-bs-theme="dark">
 <curio-ux>
     <div class="page" style="margin-left: 20px; margin-right: 10px">
         <section class="section">
             <div class="row">
-                <h1>Friendly Wallet Names</h1>
+                <h1>Wallet Management</h1>
             </div>
             <div class="row">
                 <div class="col-md-auto" style="max-width: 95%">
                     <wallet-names></wallet-names>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-auto" style="max-width: 95%">
+                    <balance-manager></balance-manager>
                 </div>
             </div>
             <div class="row">

--- a/web/static/pages/wallet/messages.mjs
+++ b/web/static/pages/wallet/messages.mjs
@@ -2,7 +2,8 @@ import { css, html, LitElement } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/al
 import RPCCall from '/lib/jsonrpc.mjs';
 import { formatDate } from '/lib/dateutil.mjs';
 import '/ux/yesno.mjs';
-import {timeSince} from "../../lib/dateutil.mjs";
+import '/ux/message.mjs';
+import { timeSince } from '/lib/dateutil.mjs';
 
 class PendingMessages extends LitElement {
     static properties = {
@@ -21,6 +22,7 @@ class PendingMessages extends LitElement {
         this.currentPage = 1;
         this.totalPages = 0;
         this.loadData();
+        this._refreshHandle = null;
     }
 
     async loadData() {
@@ -57,7 +59,15 @@ class PendingMessages extends LitElement {
 
     connectedCallback() {
         super.connectedCallback();
-        this.loadData();
+        this._refreshHandle = setInterval(() => this.loadData(), 5000);
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        if (this._refreshHandle) {
+            clearInterval(this._refreshHandle);
+            this._refreshHandle = null;
+        }
     }
 
     render() {
@@ -69,7 +79,7 @@ class PendingMessages extends LitElement {
       />
       <link rel="stylesheet" href="/ux/main.css" />
 
-      <div>
+      <div class="container py-3">
         <h2>
           Pending Messages List
           <button class="info-btn">
@@ -100,11 +110,13 @@ class PendingMessages extends LitElement {
             (msg) => html`
                 <tr>
                     <td>${new Date(msg.added_at).toLocaleString()}</td>
-                    <td>${(() => {
+                    <td>
+                      ${(() => {
                         const ageMinutes = (Date.now() - new Date(msg.added_at).getTime()) / 60000;
-                        const color = ageMinutes < 30 ? 'limegreen' : ageMinutes < 60 ? 'goldenrod' : 'crimson';
-                        return html`<span style="color: ${color}">${msg.message}</span>`;
-                    })()}</td>
+                        const color = ageMinutes < 30 ? '' : ageMinutes < 60 ? 'goldenrod' : 'crimson';
+                        return html`<span style="color: ${color}"><fil-message cid="${msg.message}"></fil-message></span>`;
+                      })()}
+                    </td>
                 </tr>
             `)}
           </tbody>

--- a/web/static/ux/message.mjs
+++ b/web/static/ux/message.mjs
@@ -1,15 +1,25 @@
 import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
 import RPCCall from '/lib/jsonrpc.mjs';
+import '/lib/cu-wallet.mjs';
 
 class FilMessage extends LitElement {
     static properties = {
         cid: { type: String },
-        message: { type: Object }
+        message: { type: Object },
+        // Info-box state
+        _showInfoBox: { state: true },
+        _epochPretty: { state: true }
     };
 
     constructor() {
         super();
         this.message = null;
+        // Info-box state handling
+        this._showInfoBox = false;
+        this._epochPretty = '';
+        this._mouseOverComponent = false;
+        this._mouseOverInfoBox = false;
+        this._hideTimeout = null;
     }
 
     updated(changedProperties) {
@@ -22,8 +32,50 @@ class FilMessage extends LitElement {
         if (this.cid) {
             let message = await RPCCall('MessageByCid', [this.cid]);
             this.message = message;
+            // Fetch pretty epoch string if available
+            if (message && message.executed_tsk_epoch !== null && message.executed_tsk_epoch !== undefined) {
+                try {
+                    this._epochPretty = await RPCCall('EpochPretty', [message.executed_tsk_epoch]);
+                } catch (err) {
+                    console.error('Failed to fetch pretty epoch:', err);
+                    this._epochPretty = message.executed_tsk_epoch?.toString() || '';
+                }
+            } else {
+                this._epochPretty = '';
+            }
             this.requestUpdate();
         }
+    }
+
+    // Hover helpers
+    _handleComponentMouseEnter() {
+        this._mouseOverComponent = true;
+        if (this._hideTimeout) clearTimeout(this._hideTimeout);
+        this._showInfoBox = true;
+    }
+
+    _handleComponentMouseLeave() {
+        this._mouseOverComponent = false;
+        this._scheduleHideInfoBox();
+    }
+
+    _handleInfoBoxMouseEnter() {
+        this._mouseOverInfoBox = true;
+        if (this._hideTimeout) clearTimeout(this._hideTimeout);
+    }
+
+    _handleInfoBoxMouseLeave() {
+        this._mouseOverInfoBox = false;
+        this._scheduleHideInfoBox();
+    }
+
+    _scheduleHideInfoBox() {
+        if (this._hideTimeout) clearTimeout(this._hideTimeout);
+        this._hideTimeout = setTimeout(() => {
+            if (!this._mouseOverComponent && !this._mouseOverInfoBox) {
+                this._showInfoBox = false;
+            }
+        }, 100);
     }
 
     render() {
@@ -38,16 +90,65 @@ class FilMessage extends LitElement {
         const method = md.Method || '';
         const value = msg.value_str || '';
         const fee = msg.fee_str || '';
-        const gas = md.GasLimit || '';
-        const status = msg.executed_rcpt_exitcode !== null ? html`Executed(<abbr title="Exit Code">E:${msg.executed_rcpt_exitcode}</abbr>${msg.executed_rcpt_exitcode===0?' ✅':' ❌'})` : 'Pending';
+        const gasLimitValue = md.GasLimit;
+        const gas = (typeof gasLimitValue === 'number' && gasLimitValue > 1000000)
+            ? `${Math.round(gasLimitValue / 1000000)}M`
+            : (gasLimitValue || '');
+        const status = msg.executed_rcpt_exitcode !== null
+            ? (msg.executed_rcpt_exitcode === 0
+                ? html`<span style="color: var(--color-success-main);">Executed</span>(<abbr title="Exit Code">E:${msg.executed_rcpt_exitcode}</abbr> ✅)`
+                : html`<span style="color: var(--color-danger-main);">Executed</span>(<abbr title="Exit Code">E:${msg.executed_rcpt_exitcode}</abbr> ❌)`)
+            : html`<span style="color: var(--color-info-main);">Pending</span>`;
         const epoch = msg.executed_tsk_epoch || '';
 
         return html`
-          <div>
-            <div><strong>MSG:</strong>${this.cid}</div>
-            <div>
-                <abbr title=${from}>${this.formatAddr(from)}</abbr>→${to} M${method} <abbr title="Value">${value}</abbr> <abbr title="Max Fee">F:${fee}</abbr> G:${gas} ${status}${epoch ? ' @' + epoch : ''}
-            </div>
+          <style>
+            .fil-message-parent-container {
+              position: relative;
+              display: inline-block;
+              white-space: nowrap;
+            }
+            .message-info-box-details {
+              position: absolute;
+              top: 100%;
+              left: 0;
+              background-color: var(--color-form-group-1);
+              border: 1px solid #ccc;
+              padding: 10px;
+              z-index: 1000;
+              min-width: 450px;
+              box-shadow: 0 2px 5px rgba(0,0,0,0.15);
+              font-size: 0.9em;
+            }
+            .message-info-box-details p {
+              margin: 4px 0;
+            }
+            .message-info-box-details .label {
+              font-weight: bold;
+            }
+          </style>
+          <div class="fil-message-parent-container">
+            <span @mouseenter=${this._handleComponentMouseEnter} @mouseleave=${this._handleComponentMouseLeave}>
+              <div style="white-space: nowrap;"><strong>MSG:</strong>${this.cid}</div>
+              <div style="white-space: nowrap;">
+                  <span style="font-size: 0.8em;">
+                    <abbr title=${from}>${this.formatAddr(from)}</abbr>→<abbr title=${to}>${this.formatAddr(to)}</abbr>
+                    M${method}
+                    <abbr title="Value"><strong>${value}</strong></abbr>
+                    <span style="color: var(--color-form-default);"><abbr title="Max Fee">F:${fee}</abbr></span>
+                    <abbr title="Gas">G:${gas}</abbr>
+                    ${status}${epoch ? ' @' + epoch : ''}
+                  </span>
+              </div>
+            </span>
+            ${this._showInfoBox ? html`
+              <div class="message-info-box-details" @mouseenter=${this._handleInfoBoxMouseEnter} @mouseleave=${this._handleInfoBoxMouseLeave}>
+                <p><span class="label">From:</span> <cu-wallet wallet_id="${from}"></cu-wallet></p>
+                <p><span class="label">To:</span> <cu-wallet wallet_id="${to}"></cu-wallet></p>
+                <p><span class="label">FilFox:</span> <a href="https://filfox.info/en/message/${this.cid}" target="_blank">${this.cid}</a></p>
+                ${this._epochPretty ? html`<p><span class="label">Time:</span> ${this._epochPretty}</p>` : ''}
+              </div>
+            ` : ''}
           </div>
         `;
     }


### PR DESCRIPTION
Small weekend project, and massive quality of life improvement when managing too many wallets.

Initially intended to have this be a part of the snark market PR, where it is pretty nice for auto-withdrawing market income from a separate wallet into a main one, but this got a little big, and also is entirely independent, soo here is.

This PR:
* Adds a new "balance manager" feature
  * Automatically send from wallet A to B when B is BELOW some balance
  * Automatically send from wallet A to B when B is ABOVE some balance
  * In both cases bounds are set as Low/High watermark to limit frequency of message sends
* Also:
  * Cleans up the wallet page quite a bit, adding some more info to it
  * Improves the Message component, adding more complete, possible to copy on-hover info
  * Small UX tweaks here and there in the wallet page, e.g. more auto-refresh, wrapping fixes, etc.

Overall look now:
<img width="1480" height="947" alt="2025-07-27-212639_1480x947_scrot" src="https://github.com/user-attachments/assets/2e2ae619-4ad4-4121-8b44-687447b83645" />

Message on-hover:
<img width="1111" height="453" alt="2025-07-27-212520_1111x453_scrot" src="https://github.com/user-attachments/assets/4703f079-2cc1-4c23-a640-c3a481845712" />

Message on-hover shows the also-hoverable wallet, which works very well together:
<img width="749" height="330" alt="2025-07-27-212537_749x330_scrot" src="https://github.com/user-attachments/assets/d0c2cbe4-5013-4c6f-aaa7-820cf0cbd214" />
