### PR TITLE
fix(pdptool): rename --recordkeeper to --pdp-service-contract in crea…

### DIFF
--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -853,8 +853,8 @@ var createProofSetCmd = &cli.Command{
 			Required: true,
 		},
 		&cli.StringFlag{
-			Name:     "recordkeeper",
-			Usage:    "Address of the record keeper contract",
+			Name:     "pdp-service-contract",
+			Usage:    "Address of the pdp service contract",
 			Required: true,
 		},
 		&cli.StringFlag{
@@ -871,7 +871,7 @@ var createProofSetCmd = &cli.Command{
 	Action: func(cctx *cli.Context) error {
 		serviceURL := cctx.String("service-url")
 		serviceName := cctx.String("service-name")
-		recordKeeper := cctx.String("recordkeeper")
+		recordKeeper := cctx.String("pdp-service-contract")
 		extraDataHexStr := cctx.String("extra-data")
 
 		// Validate extraData hex string and its decoded length


### PR DESCRIPTION
Closes: #507

Renames the `--recordkeeper` flag to `--pdp-service-contract` in the `create-proof-set` command for better UX.