### PR TITLE
sptool: batch sector extensions, set default --max-sectors=500, clamp to network limit

### DIFF
--- a/cmd/sptool/sector.go
+++ b/cmd/sptool/sector.go
@@ -433,6 +433,7 @@ Extensions will be clamped at either the maximum sector extension of 3.5 years/1
 		&cli.Int64Flag{
 			Name:  "max-sectors",
 			Usage: "the maximum number of sectors contained in each message",
+			Value: 500,
 		},
 		&cli.BoolFlag{
 			Name:  "really-do-it",
@@ -716,12 +717,12 @@ Extensions will be clamped at either the maximum sector extension of 3.5 years/1
 		}
 
 		addrSectors := sectorsMax
-		if cctx.Int("max-sectors") != 0 {
-			addrSectors = cctx.Int("max-sectors")
-			if addrSectors > sectorsMax {
-				return xerrors.Errorf("the specified max-sectors exceeds the maximum limit")
-			}
-		}
+        if cctx.Int("max-sectors") > 0 {
+            addrSectors = cctx.Int("max-sectors")
+        }
+        if addrSectors > sectorsMax {
+            addrSectors = sectorsMax
+        }
 
 		var params []miner.ExtendSectorExpiration2Params
 


### PR DESCRIPTION
### Summary
This PR adapts the fix from [Lotus PR #11928](https://github.com/filecoin-project/lotus/pull/11928) to Curio’s `sptool sectors extend` command.

- Set a default value of **500** for `--max-sectors` (instead of 0).  
- Clamp any user-specified value above the network maximum (`policy.GetAddressedSectorsMax`) instead of returning an error.  
- Ensure large extension runs are split into multiple smaller `ExtendSectorExpiration2` messages.  
- Prevents out-of-gas failures when extending many sectors.  

### References
- Mirrors [Lotus PR #11928](https://github.com/filecoin-project/lotus/pull/11928).  
- Fixes Curio issue [#587](https://github.com/filecoin-project/curio/issues/587).  

### Testing
⚠️ **Testing is ongoing, do not merge**.  
- Initial build and review confirm batching logic and flag wiring match Lotus.  
- Extended sector runs and `--really-do-it` mode are still pending live testing.  

---