### PR TITLE
feat: config for maximized feecap

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -108,7 +108,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 
 	var activeTasks []harmonytask.TaskInterface
 
-	sender, sendTask := message.NewSender(full, full, db)
+	sender, sendTask := message.NewSender(full, full, db, cfg.Fees.MaximizeFeeCap)
 	balanceMgrTask := balancemgr.NewBalanceMgrTask(db, full, chainSched, sender)
 	activeTasks = append(activeTasks, sendTask, balanceMgrTask)
 	dependencies.Sender = sender

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -300,6 +300,14 @@ Accepts a decimal string (e.g., "123.45") with optional "fil" or "attofil" suffi
 
 			Comment: `Don't send collateral with messages even if there is no available balance in the miner actor (Default: false)`,
 		},
+		{
+			Name: "MaximizeFeeCap",
+			Type: "bool",
+
+			Comment: `MaximizeFeeCap makes the sender set maximum allowed FeeCap on all sent messages.
+This generally doesn't increase message cost, but in highly congested network messages
+are much less likely to get stuck in mempool. (Default: true)`,
+		},
 	},
 	"CurioIngestConfig": {
 		{

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -36,6 +36,7 @@ func DefaultCurioConfig() *CurioConfig {
 			MaxWindowPoStGasFee:        types.MustParseFIL("5"),
 			CollateralFromMinerBalance: false,
 			DisableCollateralFallback:  false,
+			MaximizeFeeCap:             true,
 		},
 		Addresses: []CurioAddresses{{
 			PreCommitControl:   []string{},
@@ -439,6 +440,11 @@ type CurioFees struct {
 
 	// Don't send collateral with messages even if there is no available balance in the miner actor (Default: false)
 	DisableCollateralFallback bool
+
+	// MaximizeFeeCap makes the sender set maximum allowed FeeCap on all sent messages.
+	// This generally doesn't increase message cost, but in highly congested network messages
+	// are much less likely to get stuck in mempool. (Default: true)
+	MaximizeFeeCap bool
 }
 
 type CurioAddresses struct {

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -342,6 +342,13 @@ description: The default curio configuration
   # type: bool
   #DisableCollateralFallback = false
 
+  # MaximizeFeeCap makes the sender set maximum allowed FeeCap on all sent messages.
+  # This generally doesn't increase message cost, but in highly congested network messages
+  # are much less likely to get stuck in mempool. (Default: true)
+  #
+  # type: bool
+  #MaximizeFeeCap = true
+
   # maxBatchFee = maxBase + maxPerSector * nSectors
   # (Default: #Base = "0 FIL" and #PerSector = "0.02 FIL")
   #


### PR DESCRIPTION
There is generally no reason not to set MaximizeFeeCap on message send spec. We somehow didn't have a config for this all this time, so this PR fixes that.

This setting just sets basefee limit - it doesn't touch gas premium - so all messages are always sent with maximum FeeCap we're willing to pay, which is much better than the lotus default of 'up to 10x current network basefee rate' that's guaranteed to get messages stuck in the mempool when there is any sort of congestion.