### PR TITLE
pdp (rename): use errors.Is(err, pgx.ErrNoRows)

### DIFF
--- a/pdp/contract/addresses.go
+++ b/pdp/contract/addresses.go
@@ -19,7 +19,7 @@ func ContractAddresses() PDPContracts {
 	switch build.BuildType {
 	case build.BuildCalibnet:
 		return PDPContracts{
-			PDPVerifier: common.HexToAddress("0x86E3bBb5c2f9c70F5d4f66dD23864623B1f34f63"),
+			PDPVerifier: common.HexToAddress("0x07074aDd0364e79a1fEC01c128c1EFfa19C184E9"),
 		}
 	case build.BuildMainnet:
 		// Compatible contract not yet deployed

--- a/tasks/pdp/task_next_pp.go
+++ b/tasks/pdp/task_next_pp.go
@@ -2,11 +2,12 @@ package pdp
 
 import (
 	"context"
-	"database/sql"
+	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/yugabyte/pgx/v5"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
@@ -58,7 +59,7 @@ func NewNextProvingPeriodTask(db *harmonydb.DB, ethClient *ethclient.Client, fil
                 WHERE challenge_request_task_id IS NULL
                 AND (prove_at_epoch + challenge_window) <= $1
             `, apply.Height())
-		if err != nil && err != sql.ErrNoRows {
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return xerrors.Errorf("failed to select data sets needing nextProvingPeriod: %w", err)
 		}
 
@@ -98,7 +99,7 @@ func (n *NextProvingPeriodTask) Do(taskID harmonytask.TaskID, stillOwned func() 
         FROM pdp_data_sets
         WHERE challenge_request_task_id = $1 AND prove_at_epoch IS NOT NULL
     `, taskID).Scan(&dataSetId)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		// No matching data set, task is done (something weird happened, and e.g another task was spawned in place of this one)
 		return true, nil
 	}

--- a/tasks/pdp/task_prove.go
+++ b/tasks/pdp/task_prove.go
@@ -2,7 +2,6 @@ package pdp
 
 import (
 	"context"
-	"database/sql"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -20,6 +19,7 @@ import (
 	pool "github.com/libp2p/go-buffer-pool"
 	"github.com/minio/sha256-simd"
 	"github.com/samber/lo"
+	"github.com/yugabyte/pgx/v5"
 	"golang.org/x/crypto/sha3"
 	"golang.org/x/xerrors"
 
@@ -677,7 +677,7 @@ func (p *ProveTask) getSenderAddress(ctx context.Context, match common.Address) 
 	var addressStr string
 	err := p.db.QueryRow(ctx, `SELECT address FROM eth_keys WHERE role = 'pdp' AND address = $1 LIMIT 1`, match.Hex()).Scan(&addressStr)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return common.Address{}, errors.New("no sender address with role 'pdp' found")
 		}
 		return common.Address{}, err
@@ -704,7 +704,7 @@ func (p *ProveTask) cleanupDeletedPieces(ctx context.Context, dataSetId int64, p
                 WHERE data_set = $1 AND piece_id = $2
             `, dataSetId, removeID.Int64()).Scan(&pdpPieceRefID)
 			if err != nil {
-				if errors.Is(err, sql.ErrNoRows) {
+				if errors.Is(err, pgx.ErrNoRows) {
 					// Piece already deleted, skip
 					continue
 				}


### PR DESCRIPTION
Not sure why I encountered the errant `== sql.ErrNoRows` on the rename branch, maybe a fluke, but I've done a search and replace of all instances of ErrNoRows checking in the PDP code and am using errors.Is and pgx.ErrNoRows.