### PR TITLE
fix: yield in PSClientPoll correctly

### DIFF
--- a/cmd/curio/debug-proofsvc.go
+++ b/cmd/curio/debug-proofsvc.go
@@ -202,7 +202,7 @@ var proofsvcStatusCmd = &cli.Command{
 		if err != nil {
 			return err
 		}
-		resp, err := proofsvc.GetProofStatus(rcid)
+		resp, err := proofsvc.GetProofStatus(context.Background(), rcid)
 		if err != nil {
 			return err
 		}

--- a/lib/proofsvc/clientctl.go
+++ b/lib/proofsvc/clientctl.go
@@ -296,7 +296,7 @@ func WaitForProof(request common.ProofRequest) ([]byte, error) {
 	start := time.Now()
 	defer recordClientctlDuration("WaitForProof", start)
 	// Wait for the proof
-	proofResp, err := GetProofStatus(request.Data)
+	proofResp, err := GetProofStatus(context.Background(), request.Data)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get proof: %w", err)
 	}

--- a/lib/proofsvc/clientctl.go
+++ b/lib/proofsvc/clientctl.go
@@ -249,10 +249,10 @@ func RequestProof(request common.ProofRequest) (bool, error) {
 }
 
 // GetProofStatus checks the status of a proof request by ID
-func GetProofStatus(requestCid cid.Cid) (common.ProofResponse, error) {
+func GetProofStatus(ctx context.Context, requestCid cid.Cid) (common.ProofResponse, error) {
 	start := time.Now()
 	defer recordClientctlDuration("GetProofStatus", start)
-	ctx, cancel := context.WithTimeout(context.Background(), MaxRetryTime)
+	ctx, cancel := context.WithTimeout(ctx, MaxRetryTime)
 	defer cancel()
 
 	return retryWithBackoff(ctx, func() (common.ProofResponse, error) {


### PR DESCRIPTION
Needs to propagate through a context because of the use of the retryWithBackoff helper.