### PR TITLE
fix gc mark snapdeal sector query

### DIFF
--- a/tasks/gc/storage_gc_mark.go
+++ b/tasks/gc/storage_gc_mark.go
@@ -331,7 +331,7 @@ func (s *StorageGCMark) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 	}
 
 	var minerIDs []int64
-	if err = s.db.Select(ctx, &minerIDs, `SELECT DISTINCT sp_id FROM sectors_meta WHERE orig_unsealed_cid != cur_sealed_cid`); err != nil {
+	if err = s.db.Select(ctx, &minerIDs, `SELECT DISTINCT sp_id FROM sectors_meta WHERE orig_sealed_cid != cur_sealed_cid`); err != nil {
 		return false, xerrors.Errorf("distinct miners from snap sectors: %w", err)
 	}
 
@@ -355,12 +355,12 @@ func (s *StorageGCMark) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 		finalityMinerStates[abi.ActorID(mID)] = mState
 	}
 
-	// SELECT sp_id, sector_num FROM sectors_meta WHERE orig_unsealed_cid != cur_sealed_cid
+	// SELECT sp_id, sector_num FROM sectors_meta WHERE orig_sealed_cid != cur_sealed_cid
 	var snapSectors []struct {
 		SpID      int64 `db:"sp_id"`
 		SectorNum int64 `db:"sector_num"`
 	}
-	err = s.db.Select(ctx, &snapSectors, `SELECT sp_id, sector_num FROM sectors_meta WHERE orig_unsealed_cid != cur_sealed_cid ORDER BY sp_id, sector_num`)
+	err = s.db.Select(ctx, &snapSectors, `SELECT sp_id, sector_num FROM sectors_meta WHERE orig_sealed_cid != cur_sealed_cid ORDER BY sp_id, sector_num`)
 	if err != nil {
 		return false, xerrors.Errorf("select snap sectors: %w", err)
 	}


### PR DESCRIPTION
We were basically comparing apples to oranges. Every sector was considered as snapped - this was still mostly safe as for correct files to be removed there was still the separate check that update files existed, but this would have caused us to mark too many files for GC in some scenarios.