### PR TITLE
fix proofshare log spam

### DIFF
--- a/lib/proofsvc/clientctl.go
+++ b/lib/proofsvc/clientctl.go
@@ -277,9 +277,9 @@ func GetProofStatus(requestCid cid.Cid) (common.ProofResponse, error) {
 			return common.ProofResponse{}, xerrors.Errorf("failed to unmarshal response body: %w", err)
 		}
 
-		// If the proof is not ready yet, return an error to trigger retry
+		// not ready yet, return empty response to the poller above
 		if proofResp.Proof == nil && proofResp.Error == "" {
-			return common.ProofResponse{}, xerrors.Errorf("proof not ready yet")
+			return common.ProofResponse{}, nil
 		}
 
 		// If there's an error in the proof generation, return it

--- a/tasks/proofshare/task_client_poll.go
+++ b/tasks/proofshare/task_client_poll.go
@@ -145,7 +145,7 @@ func (t *TaskClientPoll) Do(taskID harmonytask.TaskID, stillOwned func() bool) (
 	}
 	if err != nil && errors.Is(err, pgx.ErrNoRows) {
 		log.Infow("client request not found", "taskID", taskID)
-		return false, nil
+		return true, nil
 	}
 
 	var proof []byte

--- a/tasks/proofshare/task_client_poll.go
+++ b/tasks/proofshare/task_client_poll.go
@@ -166,7 +166,7 @@ func (t *TaskClientPoll) Do(taskID harmonytask.TaskID, stillOwned func() bool) (
 
 		// check if the task is still owned
 		if !stillOwned() {
-			return false, nil
+			return false, xerrors.Errorf("yield")
 		}
 	}
 
@@ -216,7 +216,6 @@ func NewTaskClientPoll(db *harmonydb.DB, api ClientServiceAPI) *TaskClientPoll {
 
 // pollForProof polls for the proof status
 func pollForProof(ctx context.Context, db *harmonydb.DB, taskID harmonytask.TaskID, clientRequest *ClientRequest) (bool, []byte, error) {
-	log.Infow("pollForProof", "taskID", taskID, "requestCID", clientRequest.RequestCID)
 	// Parse the request CID
 	requestCid, err := cid.Parse(*clientRequest.RequestCID)
 	if err != nil {
@@ -226,7 +225,6 @@ func pollForProof(ctx context.Context, db *harmonydb.DB, taskID harmonytask.Task
 	// Get proof status by CID
 	proofResp, err := proofsvc.GetProofStatus(requestCid)
 	if err != nil || proofResp.Proof == nil {
-		log.Infow("proof not ready", "taskID", taskID, "spID", clientRequest.SpID, "sectorNumber", clientRequest.SectorNumber)
 		// Not ready yet, continue polling
 		return false, nil, nil
 	}

--- a/tasks/proofshare/task_client_upload.go
+++ b/tasks/proofshare/task_client_upload.go
@@ -63,6 +63,10 @@ func (t *TaskClientUpload) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return false, xerrors.Errorf("failed to get client request: %w", err)
 	}
+	if err != nil && errors.Is(err, pgx.ErrNoRows) {
+		log.Infow("client upload not found", "taskID", taskID)
+		return true, nil
+	}
 
 	if clientRequest.RequestSent && len(clientRequest.ResponseData) > 0 {
 		// special case: pipeline was done but re-entered due to the retry button on the PrRep page being clicked


### PR DESCRIPTION
Those logs don't really say anything useful and are extreeeemely spammy, GBs per day.