### PR TITLE
park: don't declare nonexistent parked pieces

### DIFF
--- a/lib/ffi/piece_funcs.go
+++ b/lib/ffi/piece_funcs.go
@@ -18,7 +18,11 @@ func (sb *SealCalls) WritePiece(ctx context.Context, taskID *harmonytask.TaskID,
 	if err != nil {
 		return err
 	}
-	defer done()
+
+	skipDeclare := storiface.FTPiece
+	defer func() {
+		done(skipDeclare)
+	}()
 
 	dest := paths.Piece
 	tempDest := dest + storiface.TempSuffix
@@ -62,6 +66,7 @@ func (sb *SealCalls) WritePiece(ctx context.Context, taskID *harmonytask.TaskID,
 		return xerrors.Errorf("rename temp piece to dest %s -> %s: %w", tempDest, dest, err)
 	}
 
+	skipDeclare = storiface.FTNone
 	removeTemp = false
 	return nil
 }


### PR DESCRIPTION
This is mainly only annoying when multiple machines are configured to ingest data - when a piece fails to fetch once and succeeds on another try, then later tasks have a 50/50 change of trying to read the piece where the task has failed - that's because the WritePiece call will improperly declare a piece file in storage even when it wasn't written properly and the process has failed.