### PR TITLE
sender: load signeddata

### DIFF
--- a/tasks/message/sender.go
+++ b/tasks/message/sender.go
@@ -81,10 +81,10 @@ func (s *SendTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done b
 	}
 
 	err = s.db.QueryRow(ctx, `
-		SELECT from_key, nonce, to_addr, unsigned_data, unsigned_cid 
+		SELECT from_key, nonce, to_addr, unsigned_data, unsigned_cid, signed_data
 		FROM message_sends 
 		WHERE send_task_id = $1`, taskID).Scan(
-		&dbMsg.FromKey, &dbMsg.Nonce, &dbMsg.ToAddr, &dbMsg.UnsignedData, &dbMsg.UnsignedCid)
+		&dbMsg.FromKey, &dbMsg.Nonce, &dbMsg.ToAddr, &dbMsg.UnsignedData, &dbMsg.UnsignedCid, &dbMsg.SignedData)
 	if err != nil {
 		return false, xerrors.Errorf("getting message from db: %w", err)
 	}


### PR DESCRIPTION
This fixes handling for the edgecase where sending fails, e.g. when a node is forcibly restarted in the middle of a send, or when yugabyte errors on a transaction in some exotic way (e.g. under extreme io pressure).

signed_data is used below in `if dbMsg.Nonce == nil .. else { [here]`