### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @filecoin-project/curio


### PR DESCRIPTION
Specifying @filecoin-project/curio as the codeowners so that branch protection rules / rulesets against `main` that "Require review from Code Owners" actually has enforcement.

This is so something like https://github.com/filecoin-project/curio/settings/branch_protection_rules/50732051 has teeth:
<img width="785" height="652" alt="image" src="https://github.com/user-attachments/assets/61b462e2-8ae0-4459-bf69-e18fcd9f0e63" />

This came to mind for me as FilOz has been adding more individuals with push access to the repo so they can work on feature/development branches.  I want to be able to safely do that and ensure that `main` still stays protected.