### PR TITLE
Enhance node info page with detailed fields

### DIFF
--- a/web/api/webrpc/cluster.go
+++ b/web/api/webrpc/cluster.go
@@ -141,21 +141,26 @@ func (a *WebRPC) ClusterTaskHistory(ctx context.Context) ([]TaskHistorySummary, 
 
 type MachineInfo struct {
 	Info struct {
-		Name          string
-		Host          string
-		ID            int64
-		LastContact   string
-		CPU           int64
-		Memory        int64
-		GPU           int64
-		Layers        string
-		Unschedulable bool
-		RunningTasks  int
+		Name           string
+		Host           string
+		ID             int64
+		LastContact    string
+		CPU            int64
+		Memory         int64
+		GPU            float64
+		Layers         string
+		Unschedulable  bool
+		RunningTasks   int
+		Tasks          string
+		Miners         string
+		StartupTime    *time.Time
+		RestartRequest *time.Time
 	}
 
 	// Storage
 	Storage []struct {
 		ID            string
+		URLs          string
 		Weight        int64
 		MaxStorage    int64
 		CanSeal       bool
@@ -178,22 +183,45 @@ type MachineInfo struct {
 		ReservedPercent float64
 	}
 
-	/*TotalStorage struct {
-		MaxStorage  int64
-		UsedStorage int64
+	// Storage URL Liveness
+	StorageURLs []struct {
+		StorageID       string
+		URL            string
+		LastChecked    time.Time
+		LastLive       *time.Time
+		LastDead       *time.Time
+		LastDeadReason *string
+	}
 
-		MaxSealStorage  int64
-		UsedSealStorage int64
 
-		MaxStoreStorage  int64
-		UsedStoreStorage int64
-	}*/
+	// Message Waits
+	MessageWaits []struct {
+		SignedMessageCID string
+		ExecutedTskCID   *string
+		ExecutedTskEpoch *int64
+		ExecutedMsgCID   *string
+		CreatedAt        time.Time
+		Status           string
+	}
+
+	MessageWaitsEth []struct {
+		SignedTxHash         string
+		ConfirmedBlockNumber *int64
+		TxStatus             *string
+		TxSuccess            *bool
+		Status               string
+	}
 
 	// Tasks
 	RunningTasks []struct {
-		ID     int64
-		Task   string
-		Posted string
+		ID           int64
+		Task         string
+		Posted       string
+		UpdateTime   string
+		InitiatedBy  *int64
+		AddedBy      int64
+		PreviousTask *int64
+		Retries      int64
 
 		PoRepSector, PoRepSectorSP *int64
 		PoRepSectorMiner           string
@@ -201,11 +229,14 @@ type MachineInfo struct {
 
 	FinishedTasks []struct {
 		ID      int64
+		TaskID  int64
 		Task    string
 		Posted  string
 		Start   string
+		End     string
 		Queued  string
 		Took    string
+		Result  bool
 		Outcome string
 		Message string
 	}
@@ -221,8 +252,12 @@ func (a *WebRPC) ClusterNodeInfo(ctx context.Context, id int64) (*MachineInfo, e
 							hm.ram,
 							hm.gpu,
 							hm.unschedulable,
+							hm.restart_request,
 							hmd.machine_name,
-							hmd.layers
+							hmd.layers,
+							hmd.tasks,
+							hmd.miners,
+							hmd.startup_time
 						FROM 
 							harmony_machines hm
 						LEFT JOIN 
@@ -242,7 +277,7 @@ func (a *WebRPC) ClusterNodeInfo(ctx context.Context, id int64) (*MachineInfo, e
 		var m MachineInfo
 		var lastContact time.Time
 
-		if err := rows.Scan(&m.Info.ID, &m.Info.Host, &lastContact, &m.Info.CPU, &m.Info.Memory, &m.Info.GPU, &m.Info.Unschedulable, &m.Info.Name, &m.Info.Layers); err != nil {
+		if err := rows.Scan(&m.Info.ID, &m.Info.Host, &lastContact, &m.Info.CPU, &m.Info.Memory, &m.Info.GPU, &m.Info.Unschedulable, &m.Info.RestartRequest, &m.Info.Name, &m.Info.Layers, &m.Info.Tasks, &m.Info.Miners, &m.Info.StartupTime); err != nil {
 			return nil, err
 		}
 
@@ -256,7 +291,7 @@ func (a *WebRPC) ClusterNodeInfo(ctx context.Context, id int64) (*MachineInfo, e
 	}
 
 	// query storage info
-	rows2, err := a.deps.DB.Query(ctx, "SELECT storage_id, weight, max_storage, can_seal, can_store, groups, allow_to, allow_types, deny_types, capacity, available, fs_available, reserved, used, allow_miners, deny_miners, last_heartbeat, heartbeat_err FROM storage_path WHERE urls LIKE '%' || $1 || '%'", summaries[0].Info.Host)
+	rows2, err := a.deps.DB.Query(ctx, "SELECT storage_id, urls, weight, max_storage, can_seal, can_store, groups, allow_to, allow_types, deny_types, capacity, available, fs_available, reserved, used, allow_miners, deny_miners, last_heartbeat, heartbeat_err FROM storage_path WHERE urls LIKE '%' || $1 || '%'", summaries[0].Info.Host)
 	if err != nil {
 		return nil, err
 	}
@@ -266,6 +301,7 @@ func (a *WebRPC) ClusterNodeInfo(ctx context.Context, id int64) (*MachineInfo, e
 	for rows2.Next() {
 		var s struct {
 			ID            string
+			URLs          string
 			Weight        int64
 			MaxStorage    int64
 			CanSeal       bool
@@ -287,7 +323,7 @@ func (a *WebRPC) ClusterNodeInfo(ctx context.Context, id int64) (*MachineInfo, e
 			UsedPercent     float64
 			ReservedPercent float64
 		}
-		if err := rows2.Scan(&s.ID, &s.Weight, &s.MaxStorage, &s.CanSeal, &s.CanStore, &s.Groups, &s.AllowTo, &s.AllowTypes, &s.DenyTypes, &s.Capacity, &s.Available, &s.FSAvailable, &s.Reserved, &s.Used, &s.AllowMiners, &s.DenyMiners, &s.LastHeartbeat, &s.HeartbeatErr); err != nil {
+		if err := rows2.Scan(&s.ID, &s.URLs, &s.Weight, &s.MaxStorage, &s.CanSeal, &s.CanStore, &s.Groups, &s.AllowTo, &s.AllowTypes, &s.DenyTypes, &s.Capacity, &s.Available, &s.FSAvailable, &s.Reserved, &s.Used, &s.AllowMiners, &s.DenyMiners, &s.LastHeartbeat, &s.HeartbeatErr); err != nil {
 			return nil, err
 		}
 
@@ -298,8 +334,99 @@ func (a *WebRPC) ClusterNodeInfo(ctx context.Context, id int64) (*MachineInfo, e
 		summaries[0].Storage = append(summaries[0].Storage, s)
 	}
 
+	// query storage URL liveness
+	rowsURL, err := a.deps.DB.Query(ctx, `SELECT sp.storage_id, spul.url, spul.last_checked, spul.last_live, spul.last_dead, spul.last_dead_reason 
+		FROM storage_path sp 
+		INNER JOIN sector_path_url_liveness spul ON sp.storage_id = spul.storage_id 
+		WHERE sp.urls LIKE '%' || $1 || '%'`, summaries[0].Info.Host)
+	if err != nil {
+		return nil, err
+	}
+	defer rowsURL.Close()
+
+	for rowsURL.Next() {
+		var sul struct {
+			StorageID       string
+			URL            string
+			LastChecked    time.Time
+			LastLive       *time.Time
+			LastDead       *time.Time
+			LastDeadReason *string
+		}
+		if err := rowsURL.Scan(&sul.StorageID, &sul.URL, &sul.LastChecked, &sul.LastLive, &sul.LastDead, &sul.LastDeadReason); err != nil {
+			return nil, err
+		}
+		summaries[0].StorageURLs = append(summaries[0].StorageURLs, sul)
+	}
+
+
+	// query message waits
+	rowsMsg, err := a.deps.DB.Query(ctx, "SELECT signed_message_cid, executed_tsk_cid, executed_tsk_epoch, executed_msg_cid, created_at FROM message_waits WHERE waiter_machine_id=$1 ORDER BY created_at DESC LIMIT 10", summaries[0].Info.ID)
+	if err != nil {
+		return nil, err
+	}
+	defer rowsMsg.Close()
+
+	for rowsMsg.Next() {
+		var msg struct {
+			SignedMessageCID string
+			ExecutedTskCID   *string
+			ExecutedTskEpoch *int64
+			ExecutedMsgCID   *string
+			CreatedAt        time.Time
+			Status           string
+		}
+		if err := rowsMsg.Scan(&msg.SignedMessageCID, &msg.ExecutedTskCID, &msg.ExecutedTskEpoch, &msg.ExecutedMsgCID, &msg.CreatedAt); err != nil {
+			return nil, err
+		}
+		
+		// Determine status
+		if msg.ExecutedTskCID != nil {
+			msg.Status = "Executed"
+		} else {
+			msg.Status = "Waiting"
+		}
+		
+		summaries[0].MessageWaits = append(summaries[0].MessageWaits, msg)
+	}
+
+	// query message waits eth
+	rowsMsgEth, err := a.deps.DB.Query(ctx, "SELECT signed_tx_hash, confirmed_block_number, tx_status, tx_success FROM message_waits_eth WHERE waiter_machine_id=$1 ORDER BY signed_tx_hash DESC LIMIT 10", summaries[0].Info.ID)
+	if err != nil {
+		return nil, err
+	}
+	defer rowsMsgEth.Close()
+
+	for rowsMsgEth.Next() {
+		var msgEth struct {
+			SignedTxHash         string
+			ConfirmedBlockNumber *int64
+			TxStatus             *string
+			TxSuccess            *bool
+			Status               string
+		}
+		if err := rowsMsgEth.Scan(&msgEth.SignedTxHash, &msgEth.ConfirmedBlockNumber, &msgEth.TxStatus, &msgEth.TxSuccess); err != nil {
+			return nil, err
+		}
+		
+		// Determine status
+		if msgEth.TxStatus != nil {
+			if msgEth.TxSuccess != nil && *msgEth.TxSuccess {
+				msgEth.Status = "Success"
+			} else if msgEth.TxSuccess != nil && !*msgEth.TxSuccess {
+				msgEth.Status = "Failed"
+			} else {
+				msgEth.Status = *msgEth.TxStatus
+			}
+		} else {
+			msgEth.Status = "Pending"
+		}
+		
+		summaries[0].MessageWaitsEth = append(summaries[0].MessageWaitsEth, msgEth)
+	}
+
 	// tasks
-	rows3, err := a.deps.DB.Query(ctx, "SELECT id, name, posted_time FROM harmony_task WHERE owner_id=$1", summaries[0].Info.ID)
+	rows3, err := a.deps.DB.Query(ctx, "SELECT id, name, posted_time, update_time, initiated_by, added_by, previous_task, retries FROM harmony_task WHERE owner_id=$1", summaries[0].Info.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -308,20 +435,26 @@ func (a *WebRPC) ClusterNodeInfo(ctx context.Context, id int64) (*MachineInfo, e
 
 	for rows3.Next() {
 		var t struct {
-			ID     int64
-			Task   string
-			Posted string
+			ID           int64
+			Task         string
+			Posted       string
+			UpdateTime   string
+			InitiatedBy  *int64
+			AddedBy      int64
+			PreviousTask *int64
+			Retries      int64
 
 			PoRepSector      *int64
 			PoRepSectorSP    *int64
 			PoRepSectorMiner string
 		}
 
-		var posted time.Time
-		if err := rows3.Scan(&t.ID, &t.Task, &posted); err != nil {
+		var posted, updateTime time.Time
+		if err := rows3.Scan(&t.ID, &t.Task, &posted, &updateTime, &t.InitiatedBy, &t.AddedBy, &t.PreviousTask, &t.Retries); err != nil {
 			return nil, err
 		}
 		t.Posted = time.Since(posted).Round(time.Second).String()
+		t.UpdateTime = time.Since(updateTime).Round(time.Second).String()
 
 		{
 			// try to find in the porep pipeline
@@ -362,7 +495,7 @@ func (a *WebRPC) ClusterNodeInfo(ctx context.Context, id int64) (*MachineInfo, e
 		summaries[0].Info.RunningTasks++
 	}
 
-	rows5, err := a.deps.DB.Query(ctx, `SELECT name, task_id, posted, work_start, work_end, result, err FROM harmony_task_history WHERE completed_by_host_and_port = $1 ORDER BY work_end DESC LIMIT 15`, summaries[0].Info.Host)
+	rows5, err := a.deps.DB.Query(ctx, `SELECT id, name, task_id, posted, work_start, work_end, result, err FROM harmony_task_history WHERE completed_by_host_and_port = $1 ORDER BY work_end DESC LIMIT 15`, summaries[0].Info.Host)
 	if err != nil {
 		return nil, err
 	}
@@ -371,30 +504,32 @@ func (a *WebRPC) ClusterNodeInfo(ctx context.Context, id int64) (*MachineInfo, e
 	for rows5.Next() {
 		var ft struct {
 			ID      int64
+			TaskID  int64
 			Task    string
 			Posted  string
 			Start   string
+			End     string
 			Queued  string
 			Took    string
+			Result  bool
 			Outcome string
-
 			Message string
 		}
 
 		var posted, start, end time.Time
-		var result bool
-		if err := rows5.Scan(&ft.Task, &ft.ID, &posted, &start, &end, &result, &ft.Message); err != nil {
+		if err := rows5.Scan(&ft.ID, &ft.Task, &ft.TaskID, &posted, &start, &end, &ft.Result, &ft.Message); err != nil {
 			return nil, err
 		}
 
 		ft.Outcome = "Success"
-		if !result {
+		if !ft.Result {
 			ft.Outcome = "Failed"
 		}
 
 		// Format the times and durations
 		ft.Posted = posted.Format("02 Jan 06 15:04 MST")
 		ft.Start = start.Format("02 Jan 06 15:04 MST")
+		ft.End = end.Format("02 Jan 06 15:04 MST")
 		ft.Queued = start.Sub(posted).Round(time.Second).String()
 		ft.Took = end.Sub(start).Round(time.Second).String()
 

--- a/web/static/pages/node_info/node-info.mjs
+++ b/web/static/pages/node_info/node-info.mjs
@@ -55,27 +55,29 @@ customElements.define('node-info',class NodeInfoElement extends LitElement {
             
             ${this.data.Info.Tasks || this.data.Info.Miners || this.data.Info.StartupTime || this.data.Info.RestartRequest ? html`
             <h3>Additional Info</h3>
-            <table class="table table-dark table-borderless">
-                ${this.data.Info.Tasks ? html`
-                <tr>
-                    <td>Supported Tasks</td>
-                    <td>${this.data.Info.Tasks.split(',').map(task => task.trim()).join(', ')}</td>
-                </tr>` : ''}
-                ${this.data.Info.Miners ? html`
-                <tr>
-                    <td>Miners</td>
-                    <td>${this.data.Info.Miners.split(',').map(miner => miner.trim()).join(', ')}</td>
-                </tr>` : ''}
-                ${this.data.Info.StartupTime ? html`
-                <tr>
-                    <td>Startup Time</td>
-                    <td>${this.formatTime(this.data.Info.StartupTime)}</td>
-                </tr>` : ''}
-                ${this.data.Info.RestartRequest ? html`
-                <tr>
-                    <td>Restart Request</td>
-                    <td><span class="warning">${this.formatTime(this.data.Info.RestartRequest)}</span></td>
-                </tr>` : ''}
+            <table class="table table-dark">
+                <tbody>
+                    ${this.data.Info.Tasks ? html`
+                    <tr>
+                        <td>Supported Tasks</td>
+                        <td>${this.data.Info.Tasks.split(',').map(task => task.trim()).join(', ')}</td>
+                    </tr>` : ''}
+                    ${this.data.Info.Miners ? html`
+                    <tr>
+                        <td>Miners</td>
+                        <td>${this.data.Info.Miners.split(',').map(miner => miner.trim()).join(', ')}</td>
+                    </tr>` : ''}
+                    ${this.data.Info.StartupTime ? html`
+                    <tr>
+                        <td>Startup Time</td>
+                        <td>${this.formatTime(this.data.Info.StartupTime)}</td>
+                    </tr>` : ''}
+                    ${this.data.Info.RestartRequest ? html`
+                    <tr>
+                        <td>Restart Request</td>
+                        <td><span class="warning">${this.formatTime(this.data.Info.RestartRequest)}</span></td>
+                    </tr>` : ''}
+                </tbody>
             </table>` : ''}
             <hr>
             <h2>Configuration</h2>


### PR DESCRIPTION
## Changes
- Add supported tasks, miners, startup time, restart requests to node info page
- Add message wait status for Filecoin/Ethereum transactions
- Add storage URL health monitoring
- Enhance task tables with retries and execution details

## Purpose
Improve node visibility for better cluster management and troubleshooting.

<img width="1450" height="1027" alt="iShot_2025-09-09_15 23 54" src="https://github.com/user-attachments/assets/2263ef8e-8e01-4f59-82f4-275152b04f72" />