### PR TITLE
fix: Handle OPTIONS requests for CORS preflight

### DIFF
--- a/web/srv.go
+++ b/web/srv.go
@@ -42,6 +42,11 @@ var webDev = os.Getenv("CURIO_WEB_DEV") == "1"
 func GetSrv(ctx context.Context, deps *deps.Deps, devMode bool) (*http.Server, error) {
 	mx := mux.NewRouter()
 	mx.Use(corsMiddleware)
+	mx.Methods(http.MethodOptions).PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Register OPTIONS routes for CORS preflight requests.
+		// Actual handling is done by corsMiddleware which intercepts
+		// all OPTIONS requests before they reach this handler.
+	})
 
 	if !devMode {
 		api.Routes(mx.PathPrefix("/api").Subrouter(), deps, webDev)


### PR DESCRIPTION
Fixes CORS preflight OPTIONS requests returning 404 for API endpoints.

The previous CORS middleware in #629 worked fine for registered routes, but I missed that OPTIONS requests were hitting 404 before the middleware could handle them. This happens because Gorilla Mux returns 404 when no route matches the HTTP method.

Added a catch-all OPTIONS handler so all API endpoints can receive CORS preflight requests properly.

My bad for not testing this thoroughly in the first PR!