### PR TITLE
Update PDP contract address for mainnet

### DIFF
--- a/pdp/contract/addresses.go
+++ b/pdp/contract/addresses.go
@@ -26,8 +26,9 @@ func ContractAddresses() PDPContracts {
 			},
 		}
 	case build.BuildMainnet:
-		// Compatible contract not yet deployed
-		panic("compatible PDP contract not available on mainnet")
+		return PDPContracts{
+			PDPVerifier: common.HexToAddress("0x1790d465d1FABE85b530B116f385091d52a12a3b"),
+		}
 	default:
 		panic("PDP contract unknown for this network")
 	}


### PR DESCRIPTION
- Update PDPVerifier address to use the proxy contract (0x1790d465d1FABE85b530B116f385091d52a12a3b)
- This enables PDP functionality on mainnet network