### PR TITLE
Alert on older-than-head failures

### DIFF
--- a/alertmanager/alerts.go
+++ b/alertmanager/alerts.go
@@ -443,7 +443,12 @@ func wdPostCheck(al *alerts) {
 		return
 	}
 
-	h := head
+	// Start from the newest finalized tipset.
+	h, err := al.api.ChainGetTipSet(al.ctx, head.Parents())
+	if err != nil {
+		al.alertMap[Name].err = err
+		return
+	}
 
 	// Map[Miner Address]Map[DeadlineIdx][]Partitions
 	msgCheck := make(map[address.Address]map[uint64][]bool)


### PR DESCRIPTION
Fix for https://github.com/filecoin-project/curio/issues/603

It appears that over-eager reporting is causing false negatives. Reporting on the previous will solve that with a minimal loss of timeliness. 