### PR TITLE
feat: test post cli: Vanilla Proof test command

### DIFF
--- a/cmd/curio/internal/translations/catalog.go
+++ b/cmd/curio/internal/translations/catalog.go
@@ -47,16 +47,16 @@ var messageKeyToIndex = map[string]int{
 	"(for init) use path for sealing":           143,
 	"--machine flag in cli command should point to the node where storage to redeclare is attached": 155,
 	"1278 (3.5 years)":                127,
-	"2 KiB":                           254,
-	"32 GiB":                          252,
-	"64 GiB":                          251,
-	"8 MiB":                           253,
+	"2 KiB":                           255,
+	"32 GiB":                          253,
+	"64 GiB":                          252,
+	"8 MiB":                           254,
 	"<sector>":                        97,
-	"Aborting migration.":             205,
-	"Aborting remaining steps.":       202,
+	"Aborting migration.":             206,
+	"Aborting remaining steps.":       203,
 	"Accept a proposed service actor": 71,
 	"Add URL to fetch data for offline deals":                98,
-	"Additional info is at http://docs.curiostorage.org":     210,
+	"Additional info is at http://docs.curiostorage.org":     211,
 	"Address to listen for the GUI on":                       120,
 	"Amount in FIL":                                          41,
 	"Amount to deposit (FIL)":                                60,
@@ -66,139 +66,140 @@ var messageKeyToIndex = map[string]int{
 	"CSV file location to use for multiple deal input. Each line in the file should be in the format 'uuid,raw size,url,header1,header2...'":                                                                                                 99,
 	"Cancel a pending client withdrawal request":                            46,
 	"Cancel a pending service withdrawal request":                           58,
-	"Cannot reach the DB: %s":                                               259,
-	"Cannot read the config.toml file in the provided directory, Error: %s": 233,
-	"Check data integrity in unsealed sector files":                         188,
+	"Cannot reach the DB: %s":                                               260,
+	"Cannot read the config.toml file in the provided directory, Error: %s": 234,
+	"Check data integrity in unsealed sector files":                         189,
 	"Client actor":                      49,
 	"Client actor address":              62,
 	"Client sender address":             43,
-	"Collection of debugging utilities": 165,
+	"Collection of debugging utilities": 166,
 	"Command separated list of hostnames for yugabyte cluster": 84,
-	"Compare the configurations %s to %s. Changes between the miner IDs other than wallet addreses should be a new, minimal layer for runners that need it.": 295,
+	"Compare the configurations %s to %s. Changes between the miner IDs other than wallet addreses should be a new, minimal layer for runners that need it.": 296,
 	"Complete a pending client withdrawal after the withdrawal window elapses":                                                                               45,
 	"Complete a pending service withdrawal after the withdrawal window elapses":                                                                              57,
 	"Compute WindowPoSt for performance and configuration testing.":                                                                                          161,
+	"Compute WindowPoSt vanilla proofs and verify them.":                                                                                                     165,
 	"Compute a proof-of-spacetime for a sector (requires the sector to be pre-sealed). These will not send to the chain.":                                    157,
-	"Configuration 'base' was created to resemble this lotus-miner's config.toml .":                                                                          296,
-	"Configuration 'base' was updated to include this miner's address":                                                                                       271,
-	"Configuration 'base' was updated to include this miner's address (%s) and its wallet setup.":                                                            294,
-	"Connected to Yugabyte":                                                          227,
-	"Connected to Yugabyte. Schema is current.":                                      226,
-	"Continue to connect and update schema.":                                         286,
-	"Continue to verify the addresses and create a new miner actor.":                 244,
+	"Configuration 'base' was created to resemble this lotus-miner's config.toml .":                                                                          297,
+	"Configuration 'base' was updated to include this miner's address":                                                                                       272,
+	"Configuration 'base' was updated to include this miner's address (%s) and its wallet setup.":                                                            295,
+	"Connected to Yugabyte":                                                          228,
+	"Connected to Yugabyte. Schema is current.":                                      227,
+	"Continue to connect and update schema.":                                         287,
+	"Continue to verify the addresses and create a new miner actor.":                 245,
 	"Cordon a machine, set it to maintenance mode":                                   36,
-	"Could not create repo from directory: %s. Aborting migration":                   234,
-	"Could not lock miner repo. Your miner must be stopped: %s\n Aborting migration": 235,
-	"Create a check task for a specific sector, wait for its completion, and output the result.\n   <miner-id>: The storage provider ID\n   <sector-number>: The sector number": 189,
+	"Could not create repo from directory: %s. Aborting migration":                   235,
+	"Could not lock miner repo. Your miner must be stopped: %s\n Aborting migration": 236,
+	"Create a check task for a specific sector, wait for its completion, and output the result.\n   <miner-id>: The storage provider ID\n   <sector-number>: The sector number": 190,
 	"Create a client voucher":                                   66,
-	"Create a new miner":                                        200,
+	"Create a new miner":                                        201,
 	"Create a new offline verified DDO deal for Curio":          105,
 	"Create a provider voucher":                                 68,
 	"Create new configuration for a new cluster":                34,
-	"Ctrl+C pressed in Terminal":                                197,
+	"Ctrl+C pressed in Terminal":                                198,
 	"Cumulative amount (FIL)":                                   50,
 	"Custom `HEADER` to include in the HTTP request":            100,
-	"Database config error occurred, abandoning migration: %s ": 287,
-	"Database: %s":                                              285,
+	"Database config error occurred, abandoning migration: %s ": 288,
+	"Database: %s":                                              286,
 	"Deposit FIL into the Router contract (client)":             39,
 	"Deposit funds into the service pool (service role)":        59,
-	"Documentation: ":                                           220,
-	"Each step needs your confirmation and can be reversed. Press Ctrl+C to exit at any time.": 196,
+	"Documentation: ":                                           221,
+	"Each step needs your confirmation and can be reversed. Press Ctrl+C to exit at any time.": 197,
 	"Enable load balancing for connecting to the Postgres database in Yugabyte cluster":        90,
-	"Enter %s address":                    249,
-	"Enter the Yugabyte database %s":      290,
-	"Enter the Yugabyte database host(s)": 288,
-	"Enter the info to connect to your Yugabyte database installation (https://download.yugabyte.com/)": 280,
-	"Enter the info to create a new miner":                             239,
-	"Enter the owner address":                                          246,
-	"Enter the path to the configuration directory used by %s":         231,
-	"Error connecting to Yugabyte database: %s":                        292,
-	"Error connecting to full node API: %s":                            260,
-	"Error getting API: %s":                                            213,
-	"Error getting token: %s":                                          215,
-	"Error saving config to layer: %s. Aborting Migration":             219,
-	"Error writing file: %s":                                           206,
+	"Enter %s address":                    250,
+	"Enter the Yugabyte database %s":      291,
+	"Enter the Yugabyte database host(s)": 289,
+	"Enter the info to connect to your Yugabyte database installation (https://download.yugabyte.com/)": 281,
+	"Enter the info to create a new miner":                             240,
+	"Enter the owner address":                                          247,
+	"Enter the path to the configuration directory used by %s":         232,
+	"Error connecting to Yugabyte database: %s":                        293,
+	"Error connecting to full node API: %s":                            261,
+	"Error getting API: %s":                                            214,
+	"Error getting token: %s":                                          216,
+	"Error saving config to layer: %s. Aborting Migration":             220,
+	"Error writing file: %s":                                           207,
 	"Execute cli commands":                                             6,
-	"Failed to create auth token: %s":                                  266,
-	"Failed to create the miner actor: %s":                             257,
-	"Failed to generate default config: %s":                            267,
-	"Failed to generate random bytes for secret: %s":                   262,
-	"Failed to get API info for FullNode: %s":                          265,
-	"Failed to insert 'base' config layer in database: %s":             275,
-	"Failed to insert config into database: %s":                        268,
-	"Failed to load base config from database: %s":                     272,
-	"Failed to parse base config: %s":                                  273,
-	"Failed to parse sector size: %s":                                  256,
-	"Failed to parse the address: %s":                                  248,
-	"Failed to regenerate base config: %s":                             274,
+	"Failed to create auth token: %s":                                  267,
+	"Failed to create the miner actor: %s":                             258,
+	"Failed to generate default config: %s":                            268,
+	"Failed to generate random bytes for secret: %s":                   263,
+	"Failed to get API info for FullNode: %s":                          266,
+	"Failed to insert 'base' config layer in database: %s":             276,
+	"Failed to insert config into database: %s":                        269,
+	"Failed to load base config from database: %s":                     273,
+	"Failed to parse base config: %s":                                  274,
+	"Failed to parse sector size: %s":                                  257,
+	"Failed to parse the address: %s":                                  249,
+	"Failed to regenerate base config: %s":                             275,
 	"Fetch proving parameters":                                         92,
-	"Filecoin %s channels: %s and %s":                                  223,
+	"Filecoin %s channels: %s and %s":                                  224,
 	"Filecoin decentralized storage network provider":                  81,
-	"Filter by storage provider ID":                                    184,
+	"Filter by storage provider ID":                                    185,
 	"Filter events by actor address; lists all if not specified":       132,
 	"Filter events by sector number; requires --actor to be specified": 133,
-	"For more servers, make /etc/curio.env with the curio.env database env and add the CURIO_LAYERS env to assign purposes.": 208,
+	"For more servers, make /etc/curio.env with the curio.env database env and add the CURIO_LAYERS env to assign purposes.": 209,
 	"Generate a supra_seal configuration": 3,
 	"Generate a supra_seal configuration for a given batch size.\n\nThis command outputs a configuration expected by SupraSeal. Main purpose of this command is for debugging and testing.\nThe config can be used directly with SupraSeal binaries to test it without involving Curio.": 4,
 	"Get Curio node info": 74,
 	"Get a config layer by name. You may want to pipe the output to a file, or use 'less'": 19,
-	"Get information about unsealed data":                                                  182,
-	"Host: %s":                                                                             281,
+	"Get information about unsealed data":                                                  183,
+	"Host: %s":                                                                             282,
 	"How long to commit sectors for":                                                       126,
-	"I want to:":                                                                           198,
+	"I want to:":                                                                           199,
 	"Ignore sectors that cannot be migrated":                                               130,
-	"Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'": 224,
-	"Initializing a new miner actor.":                                                           238,
+	"Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'": 225,
+	"Initializing a new miner actor.":                                                           239,
 	"Initiate a withdrawal request from the client's deposit":                                   42,
 	"Initiate a withdrawal request from the service pool":                                       56,
 	"Interpret stacked config layers by this version of curio, with system-generated comments.": 23,
-	"Layer %s created. ":                                                 297,
+	"Layer %s created. ":                                                 298,
 	"Limit output to the last N events":                                  134,
 	"List config layers present in the DB.":                              21,
-	"List data from the sectors_unseal_pipeline and sectors_meta tables": 183,
+	"List data from the sectors_unseal_pipeline and sectors_meta tables": 184,
 	"List log systems":                                                   76,
 	"List pipeline events":                                               131,
-	"Location of the service provider":                                   179,
-	"Lotus-Miner to Curio Migration.":                                    203,
+	"Location of the service provider":                                   180,
+	"Lotus-Miner to Curio Migration.":                                    204,
 	"Manage logging":                                                     75,
 	"Manage node config by layers. The layer 'base' will always be applied at Curio start-up.": 13,
 	"Manage the sealing pipeline":       121,
-	"Manage unsealed data":              181,
+	"Manage unsealed data":              182,
 	"Math Utils":                        0,
-	"Maximum piece size":                174,
-	"Migrate from existing Lotus-Miner": 199,
-	"Migrating lotus-miner config.toml to Curio in-database configuration.":                 212,
-	"Migrating metadata for %d sectors.":                                                    293,
-	"Miner %s created successfully":                                                         258,
-	"Miner creation error occurred: %s ":                                                    245,
-	"Minimum piece size":                                                                    173,
+	"Maximum piece size":                175,
+	"Migrate from existing Lotus-Miner": 200,
+	"Migrating lotus-miner config.toml to Curio in-database configuration.":                 213,
+	"Migrating metadata for %d sectors.":                                                    294,
+	"Miner %s created successfully":                                                         259,
+	"Miner creation error occurred: %s ":                                                    246,
+	"Minimum piece size":                                                                    174,
 	"Moves funds from the deal collateral wallet into escrow with the storage market actor": 102,
 	"Name of the Postgres database in Yugabyte cluster":                                     85,
-	"New Miner initialization complete.":                                                    211,
+	"New Miner initialization complete.":                                                    212,
 	"New service actor address":                                                             70,
-	"No address provided":                                                                   247,
-	"No host provided":                                                                      289,
-	"No path provided, abandoning migration ":                                               232,
-	"No value provided":                                                                     291,
-	"No, abort":                                                                             218,
-	"Non-SP cluster configuration complete":                                                 270,
-	"Non-SP cluster configuration created successfully":                                     269,
-	"Non-SP cluster setup complete!":                                                        276,
+	"No address provided":                                                                   248,
+	"No host provided":                                                                      290,
+	"No path provided, abandoning migration ":                                               233,
+	"No value provided":                                                                     292,
+	"No, abort":                                                                             219,
+	"Non-SP cluster configuration complete":                                                 271,
+	"Non-SP cluster configuration created successfully":                                     270,
+	"Non-SP cluster setup complete!":                                                        277,
 	"Note: This command is intended to be used to verify PoSt compute performance.\nIt will not send any messages to the chain. Since it can compute any deadline, output may be incorrectly timed for the chain.": 162,
 	"Number of sectors to start": 125,
-	"One database can serve multiple miner IDs: Run a migration for each lotus-miner.": 225,
-	"Other":                              230,
-	"Output file path (default: stdout)": 185,
-	"Owner Wallet: %s":                   240,
+	"One database can serve multiple miner IDs: Run a migration for each lotus-miner.": 226,
+	"Other":                              231,
+	"Output file path (default: stdout)": 186,
+	"Owner Wallet: %s":                   241,
 	"Password for connecting to the Postgres database in Yugabyte cluster": 87,
-	"Password: %s":       284,
+	"Password: %s":       285,
 	"Path to miner repo": 129,
-	"Please do not run guided-setup again as miner creation is not idempotent. You need to run 'curio config new-cluster %s' to finish the configuration": 263,
-	"Please do not run guided-setup again. You need to run 'curio config new-cluster' manually to finish the configuration":                               264,
+	"Please do not run guided-setup again as miner creation is not idempotent. You need to run 'curio config new-cluster %s' to finish the configuration": 264,
+	"Please do not run guided-setup again. You need to run 'curio config new-cluster' manually to finish the configuration":                               265,
 	"Port for connecting to the Cassandra database in Yugabyte cluster":                                                                                   89,
 	"Port for connecting to the Postgres database in Yugabyte cluster":                                                                                    88,
-	"Port: %s":                                        282,
-	"Pre-initialization steps complete":               261,
+	"Port: %s":                                        283,
+	"Pre-initialization steps complete":               262,
 	"Print default node config":                       14,
 	"Propose a new service actor":                     69,
 	"Provider actor":                                  55,
@@ -208,30 +209,30 @@ var messageKeyToIndex = map[string]int{
 	"Query the service state":                         65,
 	"Query the state of a client":                     61,
 	"Query the state of a provider":                   63,
-	"Read Miner Config":                               236,
+	"Read Miner Config":                               237,
 	"Redeem a client voucher (service role)":          47,
 	"Redeem a provider voucher (provider role)":       53,
-	"Register a PDP service provider with Filecoin Service Registry Contract": 169,
+	"Register a PDP service provider with Filecoin Service Registry Contract": 170,
 	"Remove a named config layer.":                                            22,
 	"Remove unsealed copies of sector containing this deal":                   107,
 	"SP ID to compute WindowPoSt for":                                         160,
-	"Sector Size: %s":                                                         243,
-	"Sector selection failed: %s ":                                            255,
+	"Sector Size: %s":                                                         244,
+	"Sector selection failed: %s ":                                            256,
 	"Sectors can be stored across many filesystem paths. These\ncommands provide ways to manage the storage a Curio node will use to store sectors\nlong term for proving (references as 'store') as well as how sectors will be\nstored while moving through the sealing pipeline (references as 'seal').": 137,
-	"Select the Sector Size":                                    250,
-	"Select the location of your lotus-miner config directory?": 229,
-	"Sender Wallet: %s":                                         242,
+	"Select the Sector Size":                                    251,
+	"Select the location of your lotus-miner config directory?": 230,
+	"Sender Wallet: %s":                                         243,
 	"Sender address":                                            40,
-	"Service provider description":                              171,
-	"Service provider name":                                     170,
+	"Service provider description":                              172,
+	"Service provider name":                                     171,
 	"Service sender address":                                    48,
 	"Set a config layer or the base by providing a filename or stdin.": 16,
 	"Set log level": 77,
 	"Set the log level for logging systems:\n\n   The system flag can be specified multiple times.\n\n   eg) log set-level --system chain --system chainxchg debug\n\n   Available Levels:\n   debug\n   info\n   warn\n   error\n\n   Environment Variables:\n   GOLOG_LOG_LEVEL - Default log level for all log systems\n   GOLOG_LOG_FMT   - Change output log format (json, nocolor)\n   GOLOG_FILE      - Write logs to file\n   GOLOG_OUTPUT    - Specify whether to output to file, stderr, stdout or a combination, i.e. file+stderr\n": 79,
-	"Set the target unseal state for a sector": 186,
-	"Set the target unseal state for a specific sector.\n   <miner-id>: The storage provider ID\n   <sector-number>: The sector number\n   <target-state>: The target state (true, false, or none)\n\n   The unseal target state indicates to curio how an unsealed copy of the sector should be maintained.\n\t   If the target state is true, curio will ensure that the sector is unsealed.\n\t   If the target state is false, curio will ensure that there is no unsealed copy of the sector.\n\t   If the target state is none, curio will not change the current state of the sector.\n\n   Currently when the curio will only start new unseal processes when the target state changes from another state to true.\n\n   When the target state is false, and an unsealed sector file exists, the GC mark step will create a removal mark\n   for the unsealed sector file. The file will only be removed after the removal mark is accepted.\n": 187,
-	"Setup non-Storage Provider cluster": 201,
-	"Shortest frequency interval in epochs at which the SP is willing to prove access to the stored dataset": 178,
+	"Set the target unseal state for a sector": 187,
+	"Set the target unseal state for a specific sector.\n   <miner-id>: The storage provider ID\n   <sector-number>: The sector number\n   <target-state>: The target state (true, false, or none)\n\n   The unseal target state indicates to curio how an unsealed copy of the sector should be maintained.\n\t   If the target state is true, curio will ensure that the sector is unsealed.\n\t   If the target state is false, curio will ensure that there is no unsealed copy of the sector.\n\t   If the target state is none, curio will not change the current state of the sector.\n\n   Currently when the curio will only start new unseal processes when the target state changes from another state to true.\n\n   When the target state is false, and an unsealed sector file exists, the GC mark step will create a removal mark\n   for the unsealed sector file. The file will only be removed after the removal mark is accepted.\n": 188,
+	"Setup non-Storage Provider cluster": 202,
+	"Shortest frequency interval in epochs at which the SP is willing to prove access to the stored dataset": 179,
 	"Specify actor address for the deal":                 106,
 	"Specify actor address to start sealing sectors for": 95,
 	"Specify wallet address to send the funds from":      104,
@@ -241,49 +242,49 @@ var messageKeyToIndex = map[string]int{
 	"Start new sealing operations manually":                      122,
 	"Start sealing new CC sectors":                               124,
 	"Start sealing sectors for all actors now (not on schedule)": 123,
-	"Step Complete: %s\n":                                        237,
+	"Step Complete: %s\n":                                        238,
 	"Stop a running Curio process":                               135,
 	"Storage can be attached to a Curio node using this command. The storage volume\nlist is stored local to the Curio node in storage.json set in curio run. We do not\nrecommend manually modifying this value without further understanding of the\nstorage system.\n\nEach storage volume contains a configuration file which describes the\ncapabilities of the volume. When the '--init' flag is provided, this file will\nbe created using the additional flags.\n\nWeight\nA high weight value means data will be more likely to be stored in this path\n\nSeal\nData for the sealing process will be stored here\n\nStore\nFinalized sectors that will be moved here for long term storage and be proven\nover time\n   ": 140,
-	"Storage price per TiB per month in USDFC, Default is 1 USDFC.": 177,
-	"Supports IPNI IPFS CID indexing":                               176,
-	"Supports IPNI piece CID indexing":                              175,
+	"Storage price per TiB per month in USDFC, Default is 1 USDFC.": 178,
+	"Supports IPNI IPFS CID indexing":                               177,
+	"Supports IPNI piece CID indexing":                              176,
 	"Test the windowpost scheduler by running it on the next available curio. If tasks fail all retries, you will need to ctrl+c to exit.":                                                               158,
-	"The '%s' layer stores common configuration. All curio instances can include it in their %s argument.":                                                                                               221,
-	"This interactive tool creates a new miner actor and creates the basic configuration layer for it.":                                                                                                  191,
-	"This interactive tool migrates lotus-miner to Curio in 5 minutes.":                                                                                                                                  195,
-	"This interactive tool sets up a non-Storage Provider cluster for protocols like PDP, Snark market, and others.":                                                                                     193,
-	"This process is partially idempotent. Once a new miner actor has been created and subsequent steps fail, the user need to run 'curio config new-cluster < miner ID >' to finish the configuration.": 192,
-	"This setup does not create or migrate a Filecoin SP actor.":                                                                                                                                         194,
-	"To run Curio: With machine or cgroup isolation, use the command (with example layer selection):":                                                                                                    299,
-	"To start the cluster, run: curio run --layers basic-cluster":                                                                                                                                        279,
-	"To start, ensure your sealing pipeline is drained and shut-down lotus-miner.":                                                                                                                       228,
-	"To work with the config: ":                                            298,
-	"Token contract for payment (IERC20(address(0)) for FIL)":              180,
-	"Tool Box for Curio":                                                   166,
-	"Try the web interface with %s ":                                       207,
-	"URL of the service provider":                                          172,
+	"The '%s' layer stores common configuration. All curio instances can include it in their %s argument.":                                                                                               222,
+	"This interactive tool creates a new miner actor and creates the basic configuration layer for it.":                                                                                                  192,
+	"This interactive tool migrates lotus-miner to Curio in 5 minutes.":                                                                                                                                  196,
+	"This interactive tool sets up a non-Storage Provider cluster for protocols like PDP, Snark market, and others.":                                                                                     194,
+	"This process is partially idempotent. Once a new miner actor has been created and subsequent steps fail, the user need to run 'curio config new-cluster < miner ID >' to finish the configuration.": 193,
+	"This setup does not create or migrate a Filecoin SP actor.":                                                                                                                                         195,
+	"To run Curio: With machine or cgroup isolation, use the command (with example layer selection):":                                                                                                    300,
+	"To start the cluster, run: curio run --layers basic-cluster":                                                                                                                                        280,
+	"To start, ensure your sealing pipeline is drained and shut-down lotus-miner.":                                                                                                                       229,
+	"To work with the config: ":                                            299,
+	"Token contract for payment (IERC20(address(0)) for FIL)":              181,
+	"Tool Box for Curio":                                                   167,
+	"Try the web interface with %s ":                                       208,
+	"URL of the service provider":                                          173,
 	"Uncordon a machine, resume scheduling":                                37,
-	"Unmigratable sectors found. Do you want to continue?":                 216,
-	"Update data for messages in wait queue":                               168,
-	"Updated DB with message data missing from chain node":                 167,
+	"Unmigratable sectors found. Do you want to continue?":                 217,
+	"Update data for messages in wait queue":                               169,
+	"Updated DB with message data missing from chain node":                 168,
 	"Use synthetic PoRep":                                                  96,
-	"Use the arrow keys to navigate: ↓ ↑ → ← ":                             190,
+	"Use the arrow keys to navigate: ↓ ↑ → ← ":                             191,
 	"Username for connecting to the Postgres database in Yugabyte cluster": 86,
-	"Username: %s":                                    283,
+	"Username: %s":                                    284,
 	"Utility functions for testing":                   156,
 	"Validate a client voucher signature":             72,
 	"Validate a provider voucher signature":           73,
 	"Voucher nonce":                                   51,
 	"Voucher signature (hex)":                         52,
 	"Wait for Curio api to come online":               8,
-	"Where should we save your database config file?": 204,
+	"Where should we save your database config file?": 205,
 	"Withdrawal amount (in FIL)":                      44,
-	"Worker Wallet: %s":                               241,
-	"Yes, continue":                                   217,
-	"You can add other layers for per-machine configuration changes.":                  222,
-	"You can now migrate your market node (%s), if applicable.":                        209,
-	"You can now start using Curio for protocols like PDP, Snark markets, and others.": 278,
-	"Your non-SP cluster has been configured successfully.":                            277,
+	"Worker Wallet: %s":                               242,
+	"Yes, continue":                                   218,
+	"You can add other layers for per-machine configuration changes.":                  223,
+	"You can now migrate your market node (%s), if applicable.":                        210,
+	"You can now start using Curio for protocols like PDP, Snark markets, and others.": 279,
+	"Your non-SP cluster has been configured successfully.":                            278,
 	"Zen3 and later supports two sectors per thread, set to false for older CPUs":      5,
 	"[SP actor address...]":           35,
 	"[deadline index]":                163,
@@ -298,7 +299,7 @@ var messageKeyToIndex = map[string]int{
 	"allow overwrite of existing layer if source is a different layer":                   30,
 	"attach local storage path":                                                          138,
 	"comma or space separated list of layers to be interpreted (base is always applied)": 25,
-	"could not get API info for FullNode: %w":                                            214,
+	"could not get API info for FullNode: %w":                                            215,
 	"custom node name":                                                117,
 	"deadline to compute WindowPoSt for ":                             159,
 	"depends on output being a TTY":                                   83,
@@ -342,7 +343,7 @@ var messageKeyToIndex = map[string]int{
 	"use color in display output":                 82,
 }
 
-var enIndex = []uint32{ // 301 elements
+var enIndex = []uint32{ // 302 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000b, 0x00000042, 0x00000126,
 	0x0000014a, 0x0000025a, 0x000002a6, 0x000002bb,
@@ -390,48 +391,48 @@ var enIndex = []uint32{ // 301 elements
 	0x00001ebb, 0x00001ed9, 0x00001f4d, 0x00001fd2,
 	// Entry A0 - BF
 	0x00001ffa, 0x0000201a, 0x00002058, 0x00002124,
-	0x00002135, 0x00002159, 0x0000217b, 0x0000218e,
-	0x000021c3, 0x000021ea, 0x00002232, 0x00002248,
-	0x00002265, 0x00002281, 0x00002294, 0x000022a7,
-	0x000022c8, 0x000022e8, 0x00002326, 0x0000238d,
-	0x000023ae, 0x000023e6, 0x000023fb, 0x0000241f,
-	0x00002462, 0x00002480, 0x000024a3, 0x000024cc,
-	0x00002852, 0x00002880, 0x00002928, 0x0000295d,
+	0x00002135, 0x00002159, 0x0000218c, 0x000021ae,
+	0x000021c1, 0x000021f6, 0x0000221d, 0x00002265,
+	0x0000227b, 0x00002298, 0x000022b4, 0x000022c7,
+	0x000022da, 0x000022fb, 0x0000231b, 0x00002359,
+	0x000023c0, 0x000023e1, 0x00002419, 0x0000242e,
+	0x00002452, 0x00002495, 0x000024b3, 0x000024d6,
+	0x000024ff, 0x00002885, 0x000028b3, 0x0000295b,
 	// Entry C0 - DF
-	0x000029bf, 0x00002a82, 0x00002af1, 0x00002b2c,
-	0x00002b6e, 0x00002bc7, 0x00002be2, 0x00002bed,
-	0x00002c0f, 0x00002c22, 0x00002c45, 0x00002c5f,
-	0x00002c7f, 0x00002caf, 0x00002cc3, 0x00002cdd,
-	0x00002d03, 0x00002d7a, 0x00002db7, 0x00002dea,
-	0x00002e0d, 0x00002e53, 0x00002e6c, 0x00002e97,
-	0x00002eb2, 0x00002ee7, 0x00002ef5, 0x00002eff,
-	0x00002f37, 0x00002f4b, 0x00002fb6, 0x00002ff6,
+	0x00002990, 0x000029f2, 0x00002ab5, 0x00002b24,
+	0x00002b5f, 0x00002ba1, 0x00002bfa, 0x00002c15,
+	0x00002c20, 0x00002c42, 0x00002c55, 0x00002c78,
+	0x00002c92, 0x00002cb2, 0x00002ce2, 0x00002cf6,
+	0x00002d10, 0x00002d36, 0x00002dad, 0x00002dea,
+	0x00002e1d, 0x00002e40, 0x00002e86, 0x00002e9f,
+	0x00002eca, 0x00002ee5, 0x00002f1a, 0x00002f28,
+	0x00002f32, 0x00002f6a, 0x00002f7e, 0x00002fe9,
 	// Entry E0 - FF
-	0x0000301f, 0x00003096, 0x000030e7, 0x00003111,
-	0x00003127, 0x00003174, 0x000031ae, 0x000031b4,
-	0x000031f0, 0x0000321c, 0x00003265, 0x000032a5,
-	0x000032f6, 0x00003308, 0x00003322, 0x00003342,
-	0x00003367, 0x0000337b, 0x00003390, 0x000033a5,
-	0x000033b8, 0x000033f7, 0x00003421, 0x00003439,
-	0x0000344d, 0x00003470, 0x00003484, 0x0000349b,
-	0x000034a2, 0x000034a9, 0x000034af, 0x000034b5,
+	0x00003029, 0x00003052, 0x000030c9, 0x0000311a,
+	0x00003144, 0x0000315a, 0x000031a7, 0x000031e1,
+	0x000031e7, 0x00003223, 0x0000324f, 0x00003298,
+	0x000032d8, 0x00003329, 0x0000333b, 0x00003355,
+	0x00003375, 0x0000339a, 0x000033ae, 0x000033c3,
+	0x000033d8, 0x000033eb, 0x0000342a, 0x00003454,
+	0x0000346c, 0x00003480, 0x000034a3, 0x000034b7,
+	0x000034ce, 0x000034d5, 0x000034dc, 0x000034e2,
 	// Entry 100 - 11F
-	0x000034d9, 0x000034fc, 0x00003524, 0x00003545,
-	0x00003560, 0x00003589, 0x000035ab, 0x000035dd,
-	0x00003674, 0x000036ea, 0x00003715, 0x00003738,
-	0x00003761, 0x0000378e, 0x000037c0, 0x000037e6,
-	0x00003827, 0x00003857, 0x0000387a, 0x000038a2,
-	0x000038da, 0x000038f9, 0x0000392f, 0x00003980,
-	0x000039bc, 0x00003a1e, 0x00003a2a, 0x00003a36,
-	0x00003a46, 0x00003a56, 0x00003a66, 0x00003a8d,
+	0x000034e8, 0x0000350c, 0x0000352f, 0x00003557,
+	0x00003578, 0x00003593, 0x000035bc, 0x000035de,
+	0x00003610, 0x000036a7, 0x0000371d, 0x00003748,
+	0x0000376b, 0x00003794, 0x000037c1, 0x000037f3,
+	0x00003819, 0x0000385a, 0x0000388a, 0x000038ad,
+	0x000038d5, 0x0000390d, 0x0000392c, 0x00003962,
+	0x000039b3, 0x000039ef, 0x00003a51, 0x00003a5d,
+	0x00003a69, 0x00003a79, 0x00003a89, 0x00003a99,
 	// Entry 120 - 13F
-	0x00003ace, 0x00003af2, 0x00003b03, 0x00003b25,
-	0x00003b37, 0x00003b64, 0x00003b8a, 0x00003be9,
-	0x00003c86, 0x00003cd4, 0x00003cee, 0x00003d0c,
-	0x00003d6c,
-} // Size: 1228 bytes
+	0x00003ac0, 0x00003b01, 0x00003b25, 0x00003b36,
+	0x00003b58, 0x00003b6a, 0x00003b97, 0x00003bbd,
+	0x00003c1c, 0x00003cb9, 0x00003d07, 0x00003d21,
+	0x00003d3f, 0x00003d9f,
+} // Size: 1232 bytes
 
-const enData string = "" + // Size: 15724 bytes
+const enData string = "" + // Size: 15775 bytes
 	"\x02Math Utils\x02Analyze and display the layout of batch sealer threads" +
 	"\x02Analyze and display the layout of batch sealer threads on your CPU." +
 	"\x0a\x0aIt provides detailed information about CPU utilization for batch" +
@@ -560,117 +561,118 @@ const enData string = "" + // Size: 15724 bytes
 	"ded to be used to verify PoSt compute performance.\x0aIt will not send a" +
 	"ny messages to the chain. Since it can compute any deadline, output may " +
 	"be incorrectly timed for the chain.\x02[deadline index]\x02partition to " +
-	"compute WindowPoSt for\x02Collection of debugging utilities\x02Tool Box " +
-	"for Curio\x02Updated DB with message data missing from chain node\x02Upd" +
-	"ate data for messages in wait queue\x02Register a PDP service provider w" +
-	"ith Filecoin Service Registry Contract\x02Service provider name\x02Servi" +
-	"ce provider description\x02URL of the service provider\x02Minimum piece " +
-	"size\x02Maximum piece size\x02Supports IPNI piece CID indexing\x02Suppor" +
-	"ts IPNI IPFS CID indexing\x02Storage price per TiB per month in USDFC, D" +
-	"efault is 1 USDFC.\x02Shortest frequency interval in epochs at which the" +
-	" SP is willing to prove access to the stored dataset\x02Location of the " +
-	"service provider\x02Token contract for payment (IERC20(address(0)) for F" +
-	"IL)\x02Manage unsealed data\x02Get information about unsealed data\x02Li" +
-	"st data from the sectors_unseal_pipeline and sectors_meta tables\x02Filt" +
-	"er by storage provider ID\x02Output file path (default: stdout)\x02Set t" +
-	"he target unseal state for a sector\x04\x00\x01\x0a\x80\x07\x02Set the t" +
-	"arget unseal state for a specific sector.\x0a   <miner-id>: The storage " +
-	"provider ID\x0a   <sector-number>: The sector number\x0a   <target-state" +
-	">: The target state (true, false, or none)\x0a\x0a   The unseal target s" +
-	"tate indicates to curio how an unsealed copy of the sector should be mai" +
-	"ntained.\x0a\x09   If the target state is true, curio will ensure that t" +
-	"he sector is unsealed.\x0a\x09   If the target state is false, curio wil" +
-	"l ensure that there is no unsealed copy of the sector.\x0a\x09   If the " +
-	"target state is none, curio will not change the current state of the sec" +
-	"tor.\x0a\x0a   Currently when the curio will only start new unseal proce" +
-	"sses when the target state changes from another state to true.\x0a\x0a  " +
-	" When the target state is false, and an unsealed sector file exists, the" +
-	" GC mark step will create a removal mark\x0a   for the unsealed sector f" +
-	"ile. The file will only be removed after the removal mark is accepted." +
-	"\x02Check data integrity in unsealed sector files\x02Create a check task" +
-	" for a specific sector, wait for its completion, and output the result." +
-	"\x0a   <miner-id>: The storage provider ID\x0a   <sector-number>: The se" +
-	"ctor number\x04\x00\x01 0\x02Use the arrow keys to navigate: ↓ ↑ → ←\x02" +
-	"This interactive tool creates a new miner actor and creates the basic co" +
-	"nfiguration layer for it.\x02This process is partially idempotent. Once " +
-	"a new miner actor has been created and subsequent steps fail, the user n" +
-	"eed to run 'curio config new-cluster < miner ID >' to finish the configu" +
-	"ration.\x02This interactive tool sets up a non-Storage Provider cluster " +
-	"for protocols like PDP, Snark market, and others.\x02This setup does not" +
-	" create or migrate a Filecoin SP actor.\x02This interactive tool migrate" +
-	"s lotus-miner to Curio in 5 minutes.\x02Each step needs your confirmatio" +
-	"n and can be reversed. Press Ctrl+C to exit at any time.\x02Ctrl+C press" +
-	"ed in Terminal\x02I want to:\x02Migrate from existing Lotus-Miner\x02Cre" +
-	"ate a new miner\x02Setup non-Storage Provider cluster\x02Aborting remain" +
-	"ing steps.\x02Lotus-Miner to Curio Migration.\x02Where should we save yo" +
-	"ur database config file?\x02Aborting migration.\x02Error writing file: %" +
-	"[1]s\x04\x00\x01 !\x02Try the web interface with %[1]s\x02For more serve" +
-	"rs, make /etc/curio.env with the curio.env database env and add the CURI" +
-	"O_LAYERS env to assign purposes.\x02You can now migrate your market node" +
-	" (%[1]s), if applicable.\x02Additional info is at http://docs.curiostora" +
-	"ge.org\x02New Miner initialization complete.\x02Migrating lotus-miner co" +
-	"nfig.toml to Curio in-database configuration.\x02Error getting API: %[1]" +
-	"s\x02could not get API info for FullNode: %[1]w\x02Error getting token: " +
-	"%[1]s\x02Unmigratable sectors found. Do you want to continue?\x02Yes, co" +
-	"ntinue\x02No, abort\x02Error saving config to layer: %[1]s. Aborting Mig" +
-	"ration\x04\x00\x01 \x0f\x02Documentation:\x02The '%[1]s' layer stores co" +
-	"mmon configuration. All curio instances can include it in their %[2]s ar" +
-	"gument.\x02You can add other layers for per-machine configuration change" +
-	"s.\x02Filecoin %[1]s channels: %[2]s and %[3]s\x02Increase reliability u" +
-	"sing redundancy: start multiple machines with at-least the post layer: '" +
-	"curio run --layers=post'\x02One database can serve multiple miner IDs: R" +
-	"un a migration for each lotus-miner.\x02Connected to Yugabyte. Schema is" +
-	" current.\x02Connected to Yugabyte\x02To start, ensure your sealing pipe" +
-	"line is drained and shut-down lotus-miner.\x02Select the location of you" +
-	"r lotus-miner config directory?\x02Other\x02Enter the path to the config" +
-	"uration directory used by %[1]s\x04\x00\x01 '\x02No path provided, aband" +
-	"oning migration\x02Cannot read the config.toml file in the provided dire" +
-	"ctory, Error: %[1]s\x02Could not create repo from directory: %[1]s. Abor" +
-	"ting migration\x02Could not lock miner repo. Your miner must be stopped:" +
-	" %[1]s\x0a Aborting migration\x02Read Miner Config\x04\x00\x01\x0a\x15" +
-	"\x02Step Complete: %[1]s\x02Initializing a new miner actor.\x02Enter the" +
-	" info to create a new miner\x02Owner Wallet: %[1]s\x02Worker Wallet: %[1" +
-	"]s\x02Sender Wallet: %[1]s\x02Sector Size: %[1]s\x02Continue to verify t" +
-	"he addresses and create a new miner actor.\x04\x00\x01 %\x02Miner creati" +
-	"on error occurred: %[1]s\x02Enter the owner address\x02No address provid" +
-	"ed\x02Failed to parse the address: %[1]s\x02Enter %[1]s address\x02Selec" +
-	"t the Sector Size\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1f" +
-	"\x02Sector selection failed: %[1]s\x02Failed to parse sector size: %[1]s" +
-	"\x02Failed to create the miner actor: %[1]s\x02Miner %[1]s created succe" +
-	"ssfully\x02Cannot reach the DB: %[1]s\x02Error connecting to full node A" +
-	"PI: %[1]s\x02Pre-initialization steps complete\x02Failed to generate ran" +
-	"dom bytes for secret: %[1]s\x02Please do not run guided-setup again as m" +
-	"iner creation is not idempotent. You need to run 'curio config new-clust" +
-	"er %[1]s' to finish the configuration\x02Please do not run guided-setup " +
-	"again. You need to run 'curio config new-cluster' manually to finish the" +
-	" configuration\x02Failed to get API info for FullNode: %[1]s\x02Failed t" +
-	"o create auth token: %[1]s\x02Failed to generate default config: %[1]s" +
-	"\x02Failed to insert config into database: %[1]s\x02Non-SP cluster confi" +
-	"guration created successfully\x02Non-SP cluster configuration complete" +
-	"\x02Configuration 'base' was updated to include this miner's address\x02" +
-	"Failed to load base config from database: %[1]s\x02Failed to parse base " +
-	"config: %[1]s\x02Failed to regenerate base config: %[1]s\x02Failed to in" +
-	"sert 'base' config layer in database: %[1]s\x02Non-SP cluster setup comp" +
-	"lete!\x02Your non-SP cluster has been configured successfully.\x02You ca" +
-	"n now start using Curio for protocols like PDP, Snark markets, and other" +
-	"s.\x02To start the cluster, run: curio run --layers basic-cluster\x02Ent" +
-	"er the info to connect to your Yugabyte database installation (https://d" +
-	"ownload.yugabyte.com/)\x02Host: %[1]s\x02Port: %[1]s\x02Username: %[1]s" +
-	"\x02Password: %[1]s\x02Database: %[1]s\x02Continue to connect and update" +
-	" schema.\x04\x00\x01 <\x02Database config error occurred, abandoning mig" +
-	"ration: %[1]s\x02Enter the Yugabyte database host(s)\x02No host provided" +
-	"\x02Enter the Yugabyte database %[1]s\x02No value provided\x02Error conn" +
-	"ecting to Yugabyte database: %[1]s\x02Migrating metadata for %[1]d secto" +
-	"rs.\x02Configuration 'base' was updated to include this miner's address " +
-	"(%[1]s) and its wallet setup.\x02Compare the configurations %[1]s to %[2" +
-	"]s. Changes between the miner IDs other than wallet addreses should be a" +
-	" new, minimal layer for runners that need it.\x02Configuration 'base' wa" +
-	"s created to resemble this lotus-miner's config.toml .\x04\x00\x01 \x15" +
-	"\x02Layer %[1]s created.\x04\x00\x01 \x19\x02To work with the config:" +
-	"\x02To run Curio: With machine or cgroup isolation, use the command (wit" +
-	"h example layer selection):"
+	"compute WindowPoSt for\x02Compute WindowPoSt vanilla proofs and verify t" +
+	"hem.\x02Collection of debugging utilities\x02Tool Box for Curio\x02Updat" +
+	"ed DB with message data missing from chain node\x02Update data for messa" +
+	"ges in wait queue\x02Register a PDP service provider with Filecoin Servi" +
+	"ce Registry Contract\x02Service provider name\x02Service provider descri" +
+	"ption\x02URL of the service provider\x02Minimum piece size\x02Maximum pi" +
+	"ece size\x02Supports IPNI piece CID indexing\x02Supports IPNI IPFS CID i" +
+	"ndexing\x02Storage price per TiB per month in USDFC, Default is 1 USDFC." +
+	"\x02Shortest frequency interval in epochs at which the SP is willing to " +
+	"prove access to the stored dataset\x02Location of the service provider" +
+	"\x02Token contract for payment (IERC20(address(0)) for FIL)\x02Manage un" +
+	"sealed data\x02Get information about unsealed data\x02List data from the" +
+	" sectors_unseal_pipeline and sectors_meta tables\x02Filter by storage pr" +
+	"ovider ID\x02Output file path (default: stdout)\x02Set the target unseal" +
+	" state for a sector\x04\x00\x01\x0a\x80\x07\x02Set the target unseal sta" +
+	"te for a specific sector.\x0a   <miner-id>: The storage provider ID\x0a " +
+	"  <sector-number>: The sector number\x0a   <target-state>: The target st" +
+	"ate (true, false, or none)\x0a\x0a   The unseal target state indicates t" +
+	"o curio how an unsealed copy of the sector should be maintained.\x0a\x09" +
+	"   If the target state is true, curio will ensure that the sector is uns" +
+	"ealed.\x0a\x09   If the target state is false, curio will ensure that th" +
+	"ere is no unsealed copy of the sector.\x0a\x09   If the target state is " +
+	"none, curio will not change the current state of the sector.\x0a\x0a   C" +
+	"urrently when the curio will only start new unseal processes when the ta" +
+	"rget state changes from another state to true.\x0a\x0a   When the target" +
+	" state is false, and an unsealed sector file exists, the GC mark step wi" +
+	"ll create a removal mark\x0a   for the unsealed sector file. The file wi" +
+	"ll only be removed after the removal mark is accepted.\x02Check data int" +
+	"egrity in unsealed sector files\x02Create a check task for a specific se" +
+	"ctor, wait for its completion, and output the result.\x0a   <miner-id>: " +
+	"The storage provider ID\x0a   <sector-number>: The sector number\x04\x00" +
+	"\x01 0\x02Use the arrow keys to navigate: ↓ ↑ → ←\x02This interactive to" +
+	"ol creates a new miner actor and creates the basic configuration layer f" +
+	"or it.\x02This process is partially idempotent. Once a new miner actor h" +
+	"as been created and subsequent steps fail, the user need to run 'curio c" +
+	"onfig new-cluster < miner ID >' to finish the configuration.\x02This int" +
+	"eractive tool sets up a non-Storage Provider cluster for protocols like " +
+	"PDP, Snark market, and others.\x02This setup does not create or migrate " +
+	"a Filecoin SP actor.\x02This interactive tool migrates lotus-miner to Cu" +
+	"rio in 5 minutes.\x02Each step needs your confirmation and can be revers" +
+	"ed. Press Ctrl+C to exit at any time.\x02Ctrl+C pressed in Terminal\x02I" +
+	" want to:\x02Migrate from existing Lotus-Miner\x02Create a new miner\x02" +
+	"Setup non-Storage Provider cluster\x02Aborting remaining steps.\x02Lotus" +
+	"-Miner to Curio Migration.\x02Where should we save your database config " +
+	"file?\x02Aborting migration.\x02Error writing file: %[1]s\x04\x00\x01 !" +
+	"\x02Try the web interface with %[1]s\x02For more servers, make /etc/curi" +
+	"o.env with the curio.env database env and add the CURIO_LAYERS env to as" +
+	"sign purposes.\x02You can now migrate your market node (%[1]s), if appli" +
+	"cable.\x02Additional info is at http://docs.curiostorage.org\x02New Mine" +
+	"r initialization complete.\x02Migrating lotus-miner config.toml to Curio" +
+	" in-database configuration.\x02Error getting API: %[1]s\x02could not get" +
+	" API info for FullNode: %[1]w\x02Error getting token: %[1]s\x02Unmigrata" +
+	"ble sectors found. Do you want to continue?\x02Yes, continue\x02No, abor" +
+	"t\x02Error saving config to layer: %[1]s. Aborting Migration\x04\x00\x01" +
+	" \x0f\x02Documentation:\x02The '%[1]s' layer stores common configuration" +
+	". All curio instances can include it in their %[2]s argument.\x02You can" +
+	" add other layers for per-machine configuration changes.\x02Filecoin %[1" +
+	"]s channels: %[2]s and %[3]s\x02Increase reliability using redundancy: s" +
+	"tart multiple machines with at-least the post layer: 'curio run --layers" +
+	"=post'\x02One database can serve multiple miner IDs: Run a migration for" +
+	" each lotus-miner.\x02Connected to Yugabyte. Schema is current.\x02Conne" +
+	"cted to Yugabyte\x02To start, ensure your sealing pipeline is drained an" +
+	"d shut-down lotus-miner.\x02Select the location of your lotus-miner conf" +
+	"ig directory?\x02Other\x02Enter the path to the configuration directory " +
+	"used by %[1]s\x04\x00\x01 '\x02No path provided, abandoning migration" +
+	"\x02Cannot read the config.toml file in the provided directory, Error: %" +
+	"[1]s\x02Could not create repo from directory: %[1]s. Aborting migration" +
+	"\x02Could not lock miner repo. Your miner must be stopped: %[1]s\x0a Abo" +
+	"rting migration\x02Read Miner Config\x04\x00\x01\x0a\x15\x02Step Complet" +
+	"e: %[1]s\x02Initializing a new miner actor.\x02Enter the info to create " +
+	"a new miner\x02Owner Wallet: %[1]s\x02Worker Wallet: %[1]s\x02Sender Wal" +
+	"let: %[1]s\x02Sector Size: %[1]s\x02Continue to verify the addresses and" +
+	" create a new miner actor.\x04\x00\x01 %\x02Miner creation error occurre" +
+	"d: %[1]s\x02Enter the owner address\x02No address provided\x02Failed to " +
+	"parse the address: %[1]s\x02Enter %[1]s address\x02Select the Sector Siz" +
+	"e\x0264 GiB\x0232 GiB\x028 MiB\x022 KiB\x04\x00\x01 \x1f\x02Sector selec" +
+	"tion failed: %[1]s\x02Failed to parse sector size: %[1]s\x02Failed to cr" +
+	"eate the miner actor: %[1]s\x02Miner %[1]s created successfully\x02Canno" +
+	"t reach the DB: %[1]s\x02Error connecting to full node API: %[1]s\x02Pre" +
+	"-initialization steps complete\x02Failed to generate random bytes for se" +
+	"cret: %[1]s\x02Please do not run guided-setup again as miner creation is" +
+	" not idempotent. You need to run 'curio config new-cluster %[1]s' to fin" +
+	"ish the configuration\x02Please do not run guided-setup again. You need " +
+	"to run 'curio config new-cluster' manually to finish the configuration" +
+	"\x02Failed to get API info for FullNode: %[1]s\x02Failed to create auth " +
+	"token: %[1]s\x02Failed to generate default config: %[1]s\x02Failed to in" +
+	"sert config into database: %[1]s\x02Non-SP cluster configuration created" +
+	" successfully\x02Non-SP cluster configuration complete\x02Configuration " +
+	"'base' was updated to include this miner's address\x02Failed to load bas" +
+	"e config from database: %[1]s\x02Failed to parse base config: %[1]s\x02F" +
+	"ailed to regenerate base config: %[1]s\x02Failed to insert 'base' config" +
+	" layer in database: %[1]s\x02Non-SP cluster setup complete!\x02Your non-" +
+	"SP cluster has been configured successfully.\x02You can now start using " +
+	"Curio for protocols like PDP, Snark markets, and others.\x02To start the" +
+	" cluster, run: curio run --layers basic-cluster\x02Enter the info to con" +
+	"nect to your Yugabyte database installation (https://download.yugabyte.c" +
+	"om/)\x02Host: %[1]s\x02Port: %[1]s\x02Username: %[1]s\x02Password: %[1]s" +
+	"\x02Database: %[1]s\x02Continue to connect and update schema.\x04\x00" +
+	"\x01 <\x02Database config error occurred, abandoning migration: %[1]s" +
+	"\x02Enter the Yugabyte database host(s)\x02No host provided\x02Enter the" +
+	" Yugabyte database %[1]s\x02No value provided\x02Error connecting to Yug" +
+	"abyte database: %[1]s\x02Migrating metadata for %[1]d sectors.\x02Config" +
+	"uration 'base' was updated to include this miner's address (%[1]s) and i" +
+	"ts wallet setup.\x02Compare the configurations %[1]s to %[2]s. Changes b" +
+	"etween the miner IDs other than wallet addreses should be a new, minimal" +
+	" layer for runners that need it.\x02Configuration 'base' was created to " +
+	"resemble this lotus-miner's config.toml .\x04\x00\x01 \x15\x02Layer %[1]" +
+	"s created.\x04\x00\x01 \x19\x02To work with the config:\x02To run Curio:" +
+	" With machine or cgroup isolation, use the command (with example layer s" +
+	"election):"
 
-var koIndex = []uint32{ // 301 elements
+var koIndex = []uint32{ // 302 elements
 	// Entry 0 - 1F
 	0x00000000, 0x00000014, 0x0000004e, 0x00000168,
 	0x00000181, 0x000002b1, 0x00000328, 0x0000033a,
@@ -718,46 +720,46 @@ var koIndex = []uint32{ // 301 elements
 	0x00002455, 0x00002476, 0x000024ec, 0x00002596,
 	// Entry A0 - BF
 	0x000025ba, 0x000025dc, 0x00002615, 0x00002707,
-	0x0000271a, 0x0000273c, 0x0000275a, 0x0000276e,
-	0x000027d6, 0x00002812, 0x00002855, 0x00002870,
-	0x0000288b, 0x000028a3, 0x000028b8, 0x000028cd,
-	0x000028ee, 0x0000290d, 0x0000295b, 0x000029d5,
-	0x000029f0, 0x00002a32, 0x00002a50, 0x00002a82,
-	0x00002ac9, 0x00002af0, 0x00002b20, 0x00002b49,
-	0x00002f29, 0x00002f5f, 0x00003013, 0x00003057,
+	0x0000271a, 0x0000273c, 0x0000273c, 0x0000275a,
+	0x0000276e, 0x000027d6, 0x00002812, 0x00002855,
+	0x00002870, 0x0000288b, 0x000028a3, 0x000028b8,
+	0x000028cd, 0x000028ee, 0x0000290d, 0x0000295b,
+	0x000029d5, 0x000029f0, 0x00002a32, 0x00002a50,
+	0x00002a82, 0x00002ac9, 0x00002af0, 0x00002b20,
+	0x00002b49, 0x00002f29, 0x00002f5f, 0x00003013,
 	// Entry C0 - DF
-	0x000030d4, 0x000031d4, 0x0000324b, 0x000032a6,
-	0x000032f3, 0x0000336e, 0x0000338f, 0x000033a1,
-	0x000033ca, 0x000033e5, 0x00003400, 0x00003425,
-	0x00003448, 0x0000348e, 0x000034a9, 0x000034c5,
-	0x00003504, 0x000035ba, 0x0000360a, 0x0000364a,
-	0x00003670, 0x000036c9, 0x000036e8, 0x00003724,
-	0x00003754, 0x000037a4, 0x000037b0, 0x000037c2,
-	0x0000381a, 0x00003827, 0x000038ad, 0x000038ff,
+	0x00003057, 0x000030d4, 0x000031d4, 0x0000324b,
+	0x000032a6, 0x000032f3, 0x0000336e, 0x0000338f,
+	0x000033a1, 0x000033ca, 0x000033e5, 0x00003400,
+	0x00003425, 0x00003448, 0x0000348e, 0x000034a9,
+	0x000034c5, 0x00003504, 0x000035ba, 0x0000360a,
+	0x0000364a, 0x00003670, 0x000036c9, 0x000036e8,
+	0x00003724, 0x00003754, 0x000037a4, 0x000037b0,
+	0x000037c2, 0x0000381a, 0x00003827, 0x000038ad,
 	// Entry E0 - FF
-	0x00003926, 0x000039c2, 0x00003a54, 0x00003a95,
-	0x00003aab, 0x00003b16, 0x00003b65, 0x00003b6c,
-	0x00003bb4, 0x00003c06, 0x00003c60, 0x00003cca,
-	0x00003d5b, 0x00003d73, 0x00003d8d, 0x00003db1,
-	0x00003de4, 0x00003dfc, 0x00003e14, 0x00003e2c,
-	0x00003e41, 0x00003e98, 0x00003ec3, 0x00003edb,
-	0x00003f02, 0x00003f25, 0x00003f39, 0x00003f4e,
-	0x00003f55, 0x00003f5c, 0x00003f62, 0x00003f68,
+	0x000038ff, 0x00003926, 0x000039c2, 0x00003a54,
+	0x00003a95, 0x00003aab, 0x00003b16, 0x00003b65,
+	0x00003b6c, 0x00003bb4, 0x00003c06, 0x00003c60,
+	0x00003cca, 0x00003d5b, 0x00003d73, 0x00003d8d,
+	0x00003db1, 0x00003de4, 0x00003dfc, 0x00003e14,
+	0x00003e2c, 0x00003e41, 0x00003e98, 0x00003ec3,
+	0x00003edb, 0x00003f02, 0x00003f25, 0x00003f39,
+	0x00003f4e, 0x00003f55, 0x00003f5c, 0x00003f62,
 	// Entry 100 - 11F
-	0x00003f89, 0x00003fb3, 0x00003fd9, 0x00004012,
-	0x0000404a, 0x00004082, 0x000040a1, 0x000040ed,
-	0x000041ab, 0x0000423e, 0x0000427c, 0x000042b1,
-	0x000042d4, 0x0000431f, 0x00004363, 0x00004385,
-	0x000043d5, 0x0000442a, 0x0000446d, 0x000044ac,
-	0x00004508, 0x0000452b, 0x00004569, 0x000045c8,
-	0x0000461a, 0x00004688, 0x00004699, 0x000046a7,
-	0x000046bf, 0x000046d3, 0x000046ed, 0x00004717,
+	0x00003f68, 0x00003f89, 0x00003fb3, 0x00003fd9,
+	0x00004012, 0x0000404a, 0x00004082, 0x000040a1,
+	0x000040ed, 0x000041ab, 0x0000423e, 0x0000427c,
+	0x000042b1, 0x000042d4, 0x0000431f, 0x00004363,
+	0x00004385, 0x000043d5, 0x0000442a, 0x0000446d,
+	0x000044ac, 0x00004508, 0x0000452b, 0x00004569,
+	0x000045c8, 0x0000461a, 0x00004688, 0x00004699,
+	0x000046a7, 0x000046bf, 0x000046d3, 0x000046ed,
 	// Entry 120 - 13F
-	0x0000477a, 0x000047b6, 0x000047e0, 0x00004818,
-	0x0000483c, 0x00004890, 0x000048c8, 0x00004941,
-	0x000049fb, 0x00004a52, 0x00004a81, 0x00004aa8,
-	0x00004b34,
-} // Size: 1228 bytes
+	0x00004717, 0x0000477a, 0x000047b6, 0x000047e0,
+	0x00004818, 0x0000483c, 0x00004890, 0x000048c8,
+	0x00004941, 0x000049fb, 0x00004a52, 0x00004a81,
+	0x00004aa8, 0x00004b34,
+} // Size: 1232 bytes
 
 const koData string = "" + // Size: 19252 bytes
 	"\x02수학 유틸리티\x02배치 실러 스레드의 레이아웃 분석 및 표시\x02CPU에서 배치 실러 스레드의 레이아웃을 분석하고 표시" +
@@ -910,7 +912,7 @@ const koData string = "" + // Size: 19252 bytes
 	"구성 파일을 사용하려면:\x02Curio를 실행하려면: 기계 또는 cgroup 격리를 사용하여 다음 명령을 사용하세요 (예제 " +
 	"레이어 선택과 함께):"
 
-var zhIndex = []uint32{ // 301 elements
+var zhIndex = []uint32{ // 302 elements
 	// Entry 0 - 1F
 	0x00000000, 0x0000000d, 0x00000038, 0x000000e6,
 	0x000000ff, 0x000001d8, 0x00000229, 0x0000023b,
@@ -958,46 +960,46 @@ var zhIndex = []uint32{ // 301 elements
 	0x00001bcf, 0x00001be5, 0x00001c43, 0x00001cc8,
 	// Entry A0 - BF
 	0x00001cef, 0x00001d1d, 0x00001d51, 0x00001dfe,
-	0x00001e13, 0x00001e2f, 0x00001e42, 0x00001e52,
-	0x00001e8c, 0x00001eb1, 0x00001eee, 0x00001f04,
-	0x00001f1a, 0x00001f31, 0x00001f44, 0x00001f57,
-	0x00001f75, 0x00001f91, 0x00001fdb, 0x00002043,
-	0x00002059, 0x00002095, 0x000020ae, 0x000020cd,
-	0x00002110, 0x0000212d, 0x0000215b, 0x0000217d,
-	0x0000247e, 0x000024af, 0x00002535, 0x00002568,
+	0x00001e13, 0x00001e2f, 0x00001e2f, 0x00001e42,
+	0x00001e52, 0x00001e8c, 0x00001eb1, 0x00001eee,
+	0x00001f04, 0x00001f1a, 0x00001f31, 0x00001f44,
+	0x00001f57, 0x00001f75, 0x00001f91, 0x00001fdb,
+	0x00002043, 0x00002059, 0x00002095, 0x000020ae,
+	0x000020cd, 0x00002110, 0x0000212d, 0x0000215b,
+	0x0000217d, 0x0000247e, 0x000024af, 0x00002535,
 	// Entry C0 - DF
-	0x000025c0, 0x00002669, 0x000026bc, 0x00002708,
-	0x00002750, 0x0000279f, 0x000027b8, 0x000027c5,
-	0x000027e5, 0x000027fe, 0x0000281d, 0x00002833,
-	0x00002850, 0x0000288d, 0x0000289d, 0x000028b7,
-	0x000028dd, 0x00002964, 0x000029a5, 0x000029d8,
-	0x000029f4, 0x00002a39, 0x00002a56, 0x00002a7f,
-	0x00002a9d, 0x00002ad1, 0x00002ae1, 0x00002aee,
-	0x00002b27, 0x00002b36, 0x00002b90, 0x00002bcd,
+	0x00002568, 0x000025c0, 0x00002669, 0x000026bc,
+	0x00002708, 0x00002750, 0x0000279f, 0x000027b8,
+	0x000027c5, 0x000027e5, 0x000027fe, 0x0000281d,
+	0x00002833, 0x00002850, 0x0000288d, 0x0000289d,
+	0x000028b7, 0x000028dd, 0x00002964, 0x000029a5,
+	0x000029d8, 0x000029f4, 0x00002a39, 0x00002a56,
+	0x00002a7f, 0x00002a9d, 0x00002ad1, 0x00002ae1,
+	0x00002aee, 0x00002b27, 0x00002b36, 0x00002b90,
 	// Entry E0 - FF
-	0x00002bf5, 0x00002c54, 0x00002ca4, 0x00002cd1,
-	0x00002ce6, 0x00002d31, 0x00002d61, 0x00002d68,
-	0x00002d92, 0x00002db6, 0x00002dfa, 0x00002e2c,
-	0x00002e75, 0x00002e88, 0x00002ea2, 0x00002ec1,
-	0x00002ee6, 0x00002efd, 0x00002f11, 0x00002f28,
-	0x00002f3c, 0x00002f6d, 0x00002f92, 0x00002fa8,
-	0x00002fb8, 0x00002fd2, 0x00002fe6, 0x00002ff9,
-	0x00003000, 0x00003007, 0x0000300d, 0x00003013,
+	0x00002bcd, 0x00002bf5, 0x00002c54, 0x00002ca4,
+	0x00002cd1, 0x00002ce6, 0x00002d31, 0x00002d61,
+	0x00002d68, 0x00002d92, 0x00002db6, 0x00002dfa,
+	0x00002e2c, 0x00002e75, 0x00002e88, 0x00002ea2,
+	0x00002ec1, 0x00002ee6, 0x00002efd, 0x00002f11,
+	0x00002f28, 0x00002f3c, 0x00002f6d, 0x00002f92,
+	0x00002fa8, 0x00002fb8, 0x00002fd2, 0x00002fe6,
+	0x00002ff9, 0x00003000, 0x00003007, 0x0000300d,
 	// Entry 100 - 11F
-	0x00003032, 0x00003052, 0x00003072, 0x0000308c,
-	0x000030a9, 0x000030da, 0x000030f3, 0x0000311c,
-	0x000031a9, 0x0000320e, 0x0000323a, 0x0000325a,
-	0x0000327a, 0x000032a0, 0x000032c0, 0x000032da,
-	0x0000330d, 0x0000333a, 0x0000335b, 0x00003381,
-	0x000033b2, 0x000033cf, 0x000033f5, 0x0000343c,
-	0x0000347b, 0x000034d5, 0x000034e4, 0x000034f3,
-	0x00003505, 0x00003514, 0x00003526, 0x00003545,
+	0x00003013, 0x00003032, 0x00003052, 0x00003072,
+	0x0000308c, 0x000030a9, 0x000030da, 0x000030f3,
+	0x0000311c, 0x000031a9, 0x0000320e, 0x0000323a,
+	0x0000325a, 0x0000327a, 0x000032a0, 0x000032c0,
+	0x000032da, 0x0000330d, 0x0000333a, 0x0000335b,
+	0x00003381, 0x000033b2, 0x000033cf, 0x000033f5,
+	0x0000343c, 0x0000347b, 0x000034d5, 0x000034e4,
+	0x000034f3, 0x00003505, 0x00003514, 0x00003526,
 	// Entry 120 - 13F
-	0x0000357d, 0x000035a2, 0x000035b2, 0x000035d0,
-	0x000035dd, 0x00003609, 0x00003633, 0x00003684,
-	0x00003706, 0x0000374d, 0x00003767, 0x0000377f,
-	0x000037d6,
-} // Size: 1228 bytes
+	0x00003545, 0x0000357d, 0x000035a2, 0x000035b2,
+	0x000035d0, 0x000035dd, 0x00003609, 0x00003633,
+	0x00003684, 0x00003706, 0x0000374d, 0x00003767,
+	0x0000377f, 0x000037d6,
+} // Size: 1232 bytes
 
 const zhData string = "" + // Size: 14294 bytes
 	"\x02数学工具\x02分析并显示批量封装线程的布局\x02分析并显示CPU上批量封装线程的布局。\x0a\x0a提供有关批量封装操作的CPU利" +
@@ -1111,4 +1113,4 @@ const zhData string = "" + // Size: 14294 bytes
 	"s-miner的config.toml。\x04\x00\x01 \x15\x02层%[1]s已创建。\x04\x00\x01 \x13\x02" +
 	"要使用配置：\x02运行Curio：使用机器或cgroup隔离，使用命令（附带示例层选择）："
 
-	// Total table size 52954 bytes (51KiB); checksum: E23B27E1
+	// Total table size 53017 bytes (51KiB); checksum: E3D70A16

--- a/cmd/curio/internal/translations/locales/en/out.gotext.json
+++ b/cmd/curio/internal/translations/locales/en/out.gotext.json
@@ -1157,6 +1157,13 @@
             "fuzzy": true
         },
         {
+            "id": "Compute WindowPoSt vanilla proofs and verify them.",
+            "message": "Compute WindowPoSt vanilla proofs and verify them.",
+            "translation": "Compute WindowPoSt vanilla proofs and verify them.",
+            "translatorComment": "Copied from source.",
+            "fuzzy": true
+        },
+        {
             "id": "Collection of debugging utilities",
             "message": "Collection of debugging utilities",
             "translation": "Collection of debugging utilities",

--- a/cmd/curio/internal/translations/locales/ko/out.gotext.json
+++ b/cmd/curio/internal/translations/locales/ko/out.gotext.json
@@ -1,4 +1,11 @@
 {
     "language": "ko",
-    "messages": []
+    "messages": [
+      {
+        "id": "Compute WindowPoSt vanilla proofs and verify them.",
+        "translation": "",
+        "message": "Compute WindowPoSt vanilla proofs and verify them.",
+        "placeholder": null
+      }
+    ]
   }

--- a/cmd/curio/internal/translations/locales/zh/out.gotext.json
+++ b/cmd/curio/internal/translations/locales/zh/out.gotext.json
@@ -1,4 +1,11 @@
 {
     "language": "zh",
-    "messages": []
+    "messages": [
+      {
+        "id": "Compute WindowPoSt vanilla proofs and verify them.",
+        "translation": "",
+        "message": "Compute WindowPoSt vanilla proofs and verify them.",
+        "placeholder": null
+      }
+    ]
   }

--- a/cmd/curio/test-cli.go
+++ b/cmd/curio/test-cli.go
@@ -1,26 +1,37 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
+	"sync"
 	"time"
 
 	"github.com/samber/lo"
+	"github.com/snadrus/must"
 	"github.com/urfave/cli/v2"
 	"github.com/yugabyte/pgx/v5"
 	"golang.org/x/xerrors"
 
+	ffi "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/builtin"
+	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/dline"
+	"github.com/filecoin-project/go-state-types/proof"
 
 	"github.com/filecoin-project/curio/cmd/curio/internal/translations"
 	"github.com/filecoin-project/curio/cmd/curio/tasks"
 	"github.com/filecoin-project/curio/deps"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
+	cuproof "github.com/filecoin-project/curio/lib/proof"
+	"github.com/filecoin-project/curio/lib/storiface"
 )
 
 var testCmd = &cli.Command{
@@ -43,6 +54,7 @@ var wdPostCmd = &cli.Command{
 	Subcommands: []*cli.Command{
 		wdPostHereCmd,
 		wdPostTaskCmd,
+		wdPostVanillaCmd,
 	},
 }
 
@@ -216,6 +228,10 @@ It will not send any messages to the chain. Since it can compute any deadline, o
 			Usage: translations.T("partition to compute WindowPoSt for"),
 			Value: 0,
 		},
+		&cli.StringFlag{
+			Name:  "addr",
+			Usage: translations.T("SP ID to compute WindowPoSt for"),
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 
@@ -223,6 +239,14 @@ It will not send any messages to the chain. Since it can compute any deadline, o
 		deps, err := deps.GetDeps(ctx, cctx)
 		if err != nil {
 			return err
+		}
+
+		var spAddr address.Address
+		if cctx.IsSet("addr") {
+			spAddr, err = address.NewFromString(cctx.String("addr"))
+			if err != nil {
+				return xerrors.Errorf("invalid sp address: %w", err)
+			}
 		}
 
 		wdPostTask, wdPoStSubmitTask, derlareRecoverTask, err := tasks.WindowPostScheduler(
@@ -244,6 +268,10 @@ It will not send any messages to the chain. Since it can compute any deadline, o
 		di := dline.NewInfo(head.Height(), cctx.Uint64("deadline"), 0, 0, 0, 10 /*challenge window*/, 0, 0)
 
 		for maddr := range deps.Maddrs {
+			if spAddr != address.Undef && address.Address(maddr) != spAddr {
+				continue
+			}
+
 			out, err := wdPostTask.DoPartition(ctx, head, address.Address(maddr), di, cctx.Uint64("partition"), true)
 			if err != nil {
 				fmt.Println("Error computing WindowPoSt for miner", maddr, err)
@@ -255,6 +283,226 @@ It will not send any messages to the chain. Since it can compute any deadline, o
 				fmt.Println("Could not encode WindowPoSt output for miner", maddr, err)
 				continue
 			}
+		}
+
+		return nil
+	},
+}
+
+var wdPostVanillaCmd = &cli.Command{
+	Name:  "vanilla",
+	Usage: translations.T("Compute WindowPoSt vanilla proofs and verify them."),
+	Flags: []cli.Flag{
+		&cli.Uint64Flag{
+			Name:  "deadline",
+			Usage: translations.T("deadline to compute WindowPoSt for "),
+			Value: 0,
+		},
+		&cli.StringSliceFlag{
+			Name:  "layers",
+			Usage: translations.T("list of layers to be interpreted (atop defaults). Default: base"),
+		},
+		&cli.Uint64Flag{
+			Name:  "partition",
+			Usage: translations.T("partition to compute WindowPoSt for"),
+			Value: 0,
+		},
+		&cli.StringFlag{
+			Name:  "addr",
+			Usage: translations.T("SP ID to compute WindowPoSt for"),
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		start := time.Now()
+
+		ctx := context.Background()
+		deps, err := deps.GetDeps(ctx, cctx)
+		if err != nil {
+			return err
+		}
+
+		var spAddr address.Address
+		if cctx.IsSet("addr") {
+			spAddr, err = address.NewFromString(cctx.String("addr"))
+			if err != nil {
+				return xerrors.Errorf("invalid sp address: %w", err)
+			}
+		}
+
+		wdPostTask, wdPoStSubmitTask, derlareRecoverTask, err := tasks.WindowPostScheduler(
+			ctx, deps.Cfg.Fees, deps.Cfg.Proving, deps.Chain, deps.Verif, nil, nil, nil,
+			deps.As, deps.Maddrs, deps.DB, deps.Stor, deps.Si, deps.Cfg.Subsystems.WindowPostMaxTasks)
+		if err != nil {
+			return err
+		}
+		_, _ = wdPoStSubmitTask, derlareRecoverTask
+
+		if len(deps.Maddrs) == 0 {
+			return errors.New("no miners to compute WindowPoSt for")
+		}
+		head, err := deps.Chain.ChainHead(ctx)
+		if err != nil {
+			return xerrors.Errorf("failed to get chain head: %w", err)
+		}
+
+		di := dline.NewInfo(head.Height(), cctx.Uint64("deadline"), 0, 0, 0, 10 /*challenge window*/, 0, 0)
+
+		for maddr := range deps.Maddrs {
+			if spAddr != address.Undef && address.Address(maddr) != spAddr {
+				continue
+			}
+
+			maddr := address.Address(maddr)
+			mid, err := address.IDFromAddress(maddr)
+			if err != nil {
+				return xerrors.Errorf("failed to get miner id: %w", err)
+			}
+
+			buf := new(bytes.Buffer)
+			if err := maddr.MarshalCBOR(buf); err != nil {
+				return xerrors.Errorf("failed to marshal address to cbor: %w", err)
+			}
+
+			headTs, err := deps.Chain.ChainHead(ctx)
+			if err != nil {
+				return xerrors.Errorf("getting current head: %w", err)
+			}
+
+			rand, err := deps.Chain.StateGetRandomnessFromBeacon(ctx, crypto.DomainSeparationTag_WindowedPoStChallengeSeed, di.Challenge, buf.Bytes(), headTs.Key())
+			if err != nil {
+				return xerrors.Errorf("failed to get chain randomness from beacon for window post (ts=%d; deadline=%d): %w", headTs.Height(), di, err)
+			}
+			rand[31] &= 0x3f
+
+			parts, err := deps.Chain.StateMinerPartitions(ctx, maddr, di.Index, headTs.Key())
+			if err != nil {
+				return xerrors.Errorf("getting partitions: %w", err)
+			}
+
+			if cctx.Uint64("partition") >= uint64(len(parts)) {
+				return xerrors.Errorf("invalid partition: %d", cctx.Uint64("partition"))
+			}
+
+			partition := parts[cctx.Uint64("partition")]
+
+			log.Infow("Getting sectors for proof", "partition", cctx.Uint64("partition"), "liveSectors", must.One(partition.LiveSectors.Count()), "allSectors", must.One(partition.AllSectors.Count()))
+
+			xsinfos, err := wdPostTask.SectorsForProof(ctx, maddr, partition.LiveSectors, partition.AllSectors, headTs)
+			if err != nil {
+				return xerrors.Errorf("getting sectors for proof: %w", err)
+			}
+
+			if len(xsinfos) == 0 {
+				return xerrors.Errorf("no sectors to prove")
+			}
+
+			nv, err := deps.Chain.StateNetworkVersion(ctx, headTs.Key())
+			if err != nil {
+				return xerrors.Errorf("getting network version: %w", err)
+			}
+
+			ppt, err := xsinfos[0].SealProof.RegisteredWindowPoStProofByNetworkVersion(nv)
+			if err != nil {
+				return xerrors.Errorf("failed to get window post type: %w", err)
+			}
+
+			sectorNums := make([]abi.SectorNumber, len(xsinfos))
+			sectorMap := make(map[abi.SectorNumber]proof.ExtendedSectorInfo)
+			for i, s := range xsinfos {
+				sectorNums[i] = s.SectorNumber
+				sectorMap[s.SectorNumber] = s
+			}
+
+			postChallenges, err := ffi.GeneratePoStFallbackSectorChallenges(ppt, abi.ActorID(mid), abi.PoStRandomness(rand), sectorNums)
+			if err != nil {
+				return xerrors.Errorf("generating fallback challenges: %w", err)
+			}
+
+			maxPartitionSize, err := builtin.PoStProofWindowPoStPartitionSectors(ppt)
+			if err != nil {
+				return xerrors.Errorf("get sectors count of partition failed:%+v", err)
+			}
+
+			sectors := make([]storiface.PostSectorChallenge, 0)
+			for i := range postChallenges.Sectors {
+				snum := postChallenges.Sectors[i]
+				sinfo := sectorMap[snum]
+
+				sectors = append(sectors, storiface.PostSectorChallenge{
+					SealProof:    sinfo.SealProof,
+					SectorNumber: snum,
+					SealedCID:    sinfo.SealedCID,
+					Challenge:    postChallenges.Challenges[snum],
+					Update:       sinfo.SectorKey != nil,
+				})
+			}
+			elapsed := time.Since(start)
+			log.Infow("Generated fallback challenges", "error", err, "elapsed", elapsed, "sectors", len(sectors), "maxPartitionSize", maxPartitionSize, "postChallenges", len(postChallenges.Challenges))
+
+			var outLk sync.Mutex
+
+			wg := sync.WaitGroup{}
+			wg.Add(len(sectors))
+			throttle := make(chan struct{}, runtime.NumCPU())
+
+			for i, s := range sectors {
+				go func(i int, s storiface.PostSectorChallenge) {
+
+					throttle <- struct{}{}
+					defer func() {
+						<-throttle
+					}()
+					defer wg.Done()
+
+					start := time.Now()
+					vanilla, err := deps.Stor.GenerateSingleVanillaProof(ctx, abi.ActorID(mid), s, ppt)
+					elapsed := time.Since(start)
+
+					if err != nil || vanilla == nil {
+						outLk.Lock()
+						log.Errorw("Generated vanilla proof for sector", "sector", s.SectorNumber, "of", fmt.Sprintf("%d/%d", i+1, len(sectors)), "error", err, "elapsed", elapsed)
+						log.Errorw("reading PoSt challenge for sector", "sector", s.SectorNumber, "vlen", len(vanilla), "error", err)
+						outLk.Unlock()
+						return
+					}
+
+					// verify vproofs
+					pvi := proof.WindowPoStVerifyInfo{
+						Randomness:        abi.PoStRandomness(rand),
+						Proofs:            []proof.PoStProof{},
+						ChallengedSectors: []proof.SectorInfo{},
+					}
+					pvi.Proofs = append(pvi.Proofs, proof.PoStProof{
+						PoStProof:  ppt,
+						ProofBytes: vanilla,
+					})
+					for _, s := range sectors {
+						pvi.ChallengedSectors = append(pvi.ChallengedSectors, proof.SectorInfo{
+							SealProof:    s.SealProof,
+							SectorNumber: s.SectorNumber,
+							SealedCID:    s.SealedCID,
+						})
+					}
+
+					verifyStart := time.Now()
+					ok, err := cuproof.VerifyWindowPoStVanilla(pvi)
+					verifyElapsed := time.Since(verifyStart)
+
+					outLk.Lock()
+					if elapsed.Seconds() > 2 {
+						log.Warnw("Generated vanilla proof for sector (slow)", "sector", s.SectorNumber, "of", fmt.Sprintf("%d/%d", i+1, len(sectors)), "elapsed", elapsed)
+					} else {
+						log.Debugw("Generated vanilla proof for sector", "sector", s.SectorNumber, "of", fmt.Sprintf("%d/%d", i+1, len(sectors)), "elapsed", elapsed)
+					}
+					if err != nil || !ok {
+						log.Errorw("Verified window post vanilla proofs", "error", err, "elapsed", verifyElapsed, "ok", ok)
+					} else {
+						log.Debugw("Verified window post vanilla proofs", "elapsed", verifyElapsed, "ok", ok)
+					}
+					outLk.Unlock()
+				}(i, s)
+			}
+			wg.Wait()
 		}
 
 		return nil

--- a/documentation/en/curio-cli/curio.md
+++ b/documentation/en/curio-cli/curio.md
@@ -510,6 +510,7 @@ USAGE:
 COMMANDS:
    here, cli                                       Compute WindowPoSt for performance and configuration testing.
    task, scheduled, schedule, async, asynchronous  Test the windowpost scheduler by running it on the next available curio. If tasks fail all retries, you will need to ctrl+c to exit.
+   vanilla                                         Compute WindowPoSt vanilla proofs and verify them.
    help, h                                         Shows a list of commands or help for one command
 
 OPTIONS:
@@ -532,6 +533,7 @@ OPTIONS:
    --deadline value                   deadline to compute WindowPoSt for  (default: 0)
    --layers value [ --layers value ]  list of layers to be interpreted (atop defaults). Default: base
    --partition value                  partition to compute WindowPoSt for (default: 0)
+   --addr value                       SP ID to compute WindowPoSt for
    --help, -h                         show help
 ```
 
@@ -546,6 +548,22 @@ USAGE:
 OPTIONS:
    --deadline value                   deadline to compute WindowPoSt for  (default: 0)
    --layers value [ --layers value ]  list of layers to be interpreted (atop defaults). Default: base
+   --addr value                       SP ID to compute WindowPoSt for
+   --help, -h                         show help
+```
+
+#### curio test window-post vanilla
+```
+NAME:
+   curio test window-post vanilla - Compute WindowPoSt vanilla proofs and verify them.
+
+USAGE:
+   curio test window-post vanilla [command options]
+
+OPTIONS:
+   --deadline value                   deadline to compute WindowPoSt for  (default: 0)
+   --layers value [ --layers value ]  list of layers to be interpreted (atop defaults). Default: base
+   --partition value                  partition to compute WindowPoSt for (default: 0)
    --addr value                       SP ID to compute WindowPoSt for
    --help, -h                         show help
 ```

--- a/lib/proof/post_vproof_verify.go
+++ b/lib/proof/post_vproof_verify.go
@@ -74,16 +74,20 @@ func verifyWindowPoStVanilla(
 	}
 
 	// Partition if the number of sectors is large
-	partitions, err := partitionFallbackPoStSectorProofs(cfg, sectorProofs)
+	/* partitions, err := partitionFallbackPoStSectorProofs(cfg, sectorProofs)
 	if err != nil {
 		return false, xerrors.Errorf("failed partitioning: %w", err)
+	} */
+	if len(sectorProofs) != 1 {
+		return false, xerrors.Errorf("expected 1 proof, multi-sector support todo, got %d", len(sectorProofs))
 	}
+	partitions := [][]FallbackPoStSectorProof{sectorProofs}
 
 	for pIndex, partition := range partitions {
 		var eg errgroup.Group
 
-		for i, sec := range partition {
-			i := i
+		for _, sec := range partition {
+			//i := i
 			sec := sec
 
 			eg.Go(func() error {
@@ -115,7 +119,6 @@ func verifyWindowPoStVanilla(
 					}
 				}
 
-				fmt.Println(i)
 				return nil
 			})
 		}
@@ -136,6 +139,7 @@ func partitionFallbackPoStSectorProofs(cfg *PoStConfig, all []FallbackPoStSector
 	}
 
 	out := make([][]FallbackPoStSectorProof, 0, partitionCount)
+	partSizes := make([]int, partitionCount)
 	start := 0
 	for i := 0; i < partitionCount; i++ {
 		end := start + cfg.SectorCount
@@ -155,7 +159,11 @@ func partitionFallbackPoStSectorProofs(cfg *PoStConfig, all []FallbackPoStSector
 			chunk = append(chunk, pad...)
 		}
 		out = append(out, chunk)
+		partSizes[i] = len(chunk)
 	}
+
+	log.Infow("partitioned fallback PoSt sector proofs", "partitionCount", partitionCount, "partSizes", partSizes)
+
 	return out, nil
 }
 

--- a/lib/proof/post_vproof_verify.go
+++ b/lib/proof/post_vproof_verify.go
@@ -3,7 +3,6 @@ package proof
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"math/big"
 	"sync"
 
@@ -131,6 +130,7 @@ func verifyWindowPoStVanilla(
 	return true, nil
 }
 
+/*
 // partitionFallbackPoStSectorProofs splits sector proofs into chunks of length cfg.SectorCount.
 func partitionFallbackPoStSectorProofs(cfg *PoStConfig, all []FallbackPoStSectorProof) ([][]FallbackPoStSectorProof, error) {
 	partitionCount := int(math.Ceil(float64(len(all)) / float64(cfg.SectorCount)))
@@ -166,6 +166,7 @@ func partitionFallbackPoStSectorProofs(cfg *PoStConfig, all []FallbackPoStSector
 
 	return out, nil
 }
+*/
 
 // checkCommR is the fallback post condition: comm_r = PoseidonHash2(comm_c, comm_r_last).
 func checkCommR(commC, commRLast, claimed PoseidonDomain) bool {

--- a/tasks/window/compute_do.go
+++ b/tasks/window/compute_do.go
@@ -103,7 +103,7 @@ func (t *WdPostTask) DoPartition(ctx context.Context, ts *types.TipSet, maddr ad
 			return nil, xerrors.Errorf("copy toProve: %w", err)
 		}
 
-		xsinfos, err := t.sectorsForProof(ctx, maddr, good, partition.AllSectors, ts)
+		xsinfos, err := t.SectorsForProof(ctx, maddr, good, partition.AllSectors, ts)
 		if err != nil {
 			return nil, xerrors.Errorf("getting sorted sector info: %w", err)
 		}
@@ -313,7 +313,7 @@ func checkSectors(ctx context.Context, api CheckSectorsAPI, ft FaultTracker,
 	return sbf, nil
 }
 
-func (t *WdPostTask) sectorsForProof(ctx context.Context, maddr address.Address, goodSectors, allSectors bitfield.BitField, ts *types.TipSet) ([]proof7.ExtendedSectorInfo, error) {
+func (t *WdPostTask) SectorsForProof(ctx context.Context, maddr address.Address, goodSectors, allSectors bitfield.BitField, ts *types.TipSet) ([]proof7.ExtendedSectorInfo, error) {
 	sset, err := t.api.StateMinerSectors(ctx, maddr, &goodSectors, ts.Key())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We had a pure-Go vanilla PoSt proof verifier for a while now, that never got used. Wrapped it into a tool to debug particularly confusing PoSt failures of the `failed to generate window post`+ no other information flavor.

This tool will show which specific vanilla proofs contained errors which for whatever reason don't get checked on the rust side until the actual proof is computed.

```
GOLOG_LOG_LEVEL=error ./curio-cu test wd vanilla --addr f0... --deadline 1

2025-10-06T12:20:53.913+0200	ERROR	main	curio/test-cli.go:499	Verified window post vanilla proofs	{"error": "comm_r invalid: sector 3245, partition 0", "elapsed": 0.001823394, "ok": false}
2025-10-06T12:20:54.168+0200	ERROR	main	curio/test-cli.go:499	Verified window post vanilla proofs	{"error": "comm_r invalid: sector 4567, partition 0", "elapsed": 0.005112741, "ok": false}
```