### PR TITLE
fix: use SourceOffset to support CarV2

### DIFF
--- a/tasks/indexing/task_indexing.go
+++ b/tasks/indexing/task_indexing.go
@@ -458,7 +458,7 @@ func IndexCAR(r io.Reader, buffSize int, recs chan<- indexstore.Record, addFail 
 		select {
 		case recs <- indexstore.Record{
 			Cid:    blockMetadata.Cid,
-			Offset: blockMetadata.Offset,
+			Offset: blockMetadata.SourceOffset,
 			Size:   blockMetadata.Size,
 		}:
 		case <-addFail:


### PR DESCRIPTION
The changes are based on below definition. Most deals are carV1 so we never hit this till now.

```
BlockMetadata contains metadata about a block's section in a CAR file/stream.
There are two offsets for the block section which will be the same if the original CAR is a CARv1, but will differ if the original CAR is a CARv2.
The block section offset is position where the CAR section begins; that is, the begining of the length prefix (varint) prior to the CID and the block data. Reading the varint at the offset will give the length of the rest of the section (CID+data).
In the case of a CARv2, SourceOffset will be the offset from the beginning of the file/steam, and Offset will be the offset from the beginning of the CARv1 payload container within the CARv2.
Offset is useful for index generation which requires an offset from the CARv1 payload; while SourceOffset is useful for direct section reads out of the source file/stream regardless of version.
```