### PR TITLE
fix: Snark Market: Unbrick client setup

### DIFF
--- a/tasks/proofshare/task_client_send.go
+++ b/tasks/proofshare/task_client_send.go
@@ -134,7 +134,7 @@ func (t *TaskClientSend) Do(taskID harmonytask.TaskID, stillOwned func() bool) (
 			return false, xerrors.Errorf("failed to check for unconsumed payments: %w", err)
 		}
 
-		if lastPayment.Consumed {
+		if lastPayment.Consumed || errors.Is(err, pgx.ErrNoRows) {
 			// it was, create a new payment
 			// Note: Payment Consumed == it was sent and is now being processed in the market
 			match, err := t.doCreatePayment(ctx, taskID, walletID)

--- a/web/static/pages/proofshare/proofshare-client.mjs
+++ b/web/static/pages/proofshare/proofshare-client.mjs
@@ -256,6 +256,22 @@ class ProofShareClient extends LitElement {
   }
 
   /**
+   * Remove an SP row.
+   */
+  async removeRow(spId, address) {
+    if (!confirm(`Are you sure you want to remove the SP configuration for ${address}?`)) return;
+
+    try {
+      await RPCCall('PSClientRemove', [spId]);
+      console.log(`Removed SP configuration for ${address}`);
+      await this.loadAllSettings();
+    } catch (err) {
+      console.error(`Error removing SP configuration for ${address}:`, err);
+      alert(`Failed to remove ${address}. See console for details.`);
+    }
+  }
+
+  /**
    * Render a sub-table of requests for a given SP.
    */
   renderRequestsFor(spId, address) {

--- a/web/static/pages/proofshare/proofshare-client.mjs
+++ b/web/static/pages/proofshare/proofshare-client.mjs
@@ -175,10 +175,13 @@ class ProofShareClient extends LitElement {
     const address = prompt('Enter new SP address:');
     if (!address) return; // cancelled
 
+    const wallet = prompt('Enter client wallet address (f1.. for payments, must be added to wallets first):');
+    if (!wallet) return;
+
     const newRow = {
       address,
       enabled: false,
-      wallet: null,
+      wallet,
       minimum_pending_seconds: 0,
       do_porep: false,
       do_snap: false,


### PR DESCRIPTION
Currently setting up as a client in Snark Market apparently doesn't work very well due to a few regressions, this PR fixes the onboarding flow:
* UI wasn't able to create client entries because address can't be null
* Even if the client entry was manually inserted into the database, the refactored payment logic wasn't capable of creating a payment with nonce=0
* Also wasn't possible to remove client entries from the UI