### PR TITLE
feat: Option to specify custom client address in mk12 deal proposals

### DIFF
--- a/documentation/en/curio-cli/sptool.md
+++ b/documentation/en/curio-cli/sptool.md
@@ -601,7 +601,8 @@ OPTIONS:
    --storage-price value                          storage price in attoFIL per epoch per GiB (default: 1)
    --verified                                     whether the deal funds should come from verified client data-cap (default: false)
    --remove-unsealed-copy                         indicates that an unsealed copy of the sector in not required for fast retrieval (default: false)
-   --wallet value                                 wallet address to be used to initiate the deal
+   --wallet value                                 wallet address to be used to sign the deal
+   --client-address value                         address to be used to initiate the deal; if empty, the signing wallet will be used
    --skip-ipni-announce                           indicates that deal index should not be announced to the IPNI(Network Indexer) (default: false)
    --http                                         make the deal over HTTP instead of libp2p (default: false)
    --help, -h                                     show help
@@ -643,7 +644,8 @@ OPTIONS:
    --storage-price value            storage price in attoFIL per epoch per GiB (default: 1)
    --verified                       whether the deal funds should come from verified client data-cap (default: false)
    --remove-unsealed-copy           indicates that an unsealed copy of the sector in not required for fast retrieval (default: false)
-   --wallet value                   wallet address to be used to initiate the deal
+   --wallet value                   wallet address to be used to sign the deal
+   --client-address value           address to be used to initiate the deal; if empty, the signing wallet will be used
    --skip-ipni-announce             indicates that deal index should not be announced to the IPNI(Network Indexer) (default: false)
    --http                           make the deal over HTTP instead of libp2p (default: false)
    --help, -h                       show help


### PR DESCRIPTION
## Context

FIDL has introduced client smart contracts for use in Fil+. Instead of assigning DataCap directly to clients, it's now assigned to a smart contract. This provides more control over how the DataCap is used and allows allocators to revoke it from clients without needing to involve RKH. This system is already live on mainnet for DDO.

However, this introduces a challenge: from the perspective of the Market actor, the smart contract is the client. The Market actor will call the smart contract to authenticate the deal, but the contract still needs a way to verify that the *actual* client (the one using the DataCap) initiated the deal, so it can correctly deduct their allowance.

## This PR

This pull request proposes a general solution: a new option that allows specifying the client address in the deal proposal separately from the wallet used to sign it.

This means a client can sign the proposal with their own wallet, but set the `clientAddress` field to point to the smart contract.

The change is fully backwards compatible. If the `client-address` option is not provided, the system will default to using the signing wallet address, which is the current behavior.