### PR TITLE
pdp: fix multi-piece upload

### DIFF
--- a/harmony/harmonydb/sql/20251010-pdp-fix-add-piece-constraints.sql
+++ b/harmony/harmonydb/sql/20251010-pdp-fix-add-piece-constraints.sql
@@ -1,0 +1,8 @@
+-- changes an errand constraint from (data_set, add_message_hash, sub_piece_offset) to (data_set, add_message_hash, add_message_index)
+
+ALTER TABLE pdp_data_set_piece_adds
+  DROP CONSTRAINT pdp_data_set_piece_adds_piece_id_unique;
+
+ALTER TABLE pdp_data_set_piece_adds
+  ADD CONSTRAINT pdp_data_set_piece_adds_pk
+  PRIMARY KEY (data_set HASH, add_message_hash ASC, add_message_index ASC);


### PR DESCRIPTION
Resolves a constraint issue with multipiece upload:
```
Failed to insert into database  {"error": "ERROR: duplicate key value violates unique constraint \"pdp_data_set_piece_adds_piece_id_unique\"
```