### PR TITLE
fix(pdp): cleanup query selects on wrong column name

### DIFF
--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -1610,7 +1610,7 @@ func (p *PDPService) cleanup(ctx context.Context) {
 
 		var RefIDs []int64
 
-		err := db.QueryRow(ctx, `SELECT COALESCE(array_agg(ref_id), '{}') AS ref_ids
+		err := db.QueryRow(ctx, `SELECT COALESCE(array_agg(piece_ref), '{}') AS ref_ids
 												FROM pdp_piece_streaming_uploads
 												WHERE complete = TRUE
 												  AND completed_at <= TIMEZONE('UTC', NOW()) - INTERVAL '60 minutes';`).Scan(&RefIDs)


### PR DESCRIPTION
Deals with:

```
2025-10-11T08:15:16.135+0200    ERROR   pdp     pdp/handlers.go:1618    failed to get non-finalized uploads     {"error": "ERROR: column \"ref_id\" does not exist (SQLSTATE 42703)"}
```