### PR TITLE
fix: chain scheduler should update message execution first

### DIFF
--- a/tasks/message/watch.go
+++ b/tasks/message/watch.go
@@ -49,7 +49,7 @@ func NewMessageWatcher(db *harmonydb.DB, ht *harmonytask.TaskEngine, pcs *chains
 		updateCh: make(chan struct{}),
 	}
 	go mw.run()
-	if err := pcs.AddHandler(mw.processHeadChange); err != nil {
+	if err := pcs.AddWatcher(mw.processHeadChange); err != nil {
 		return nil, err
 	}
 	return mw, nil

--- a/tasks/message/watch_eth.go
+++ b/tasks/message/watch_eth.go
@@ -65,7 +65,7 @@ func NewMessageWatcherEth(db *harmonydb.DB, ht *harmonytask.TaskEngine, pcs *cha
 		ethCallTimeout: defaultEthCallTimeout,
 	}
 	go mw.run()
-	if err := pcs.AddHandler(mw.processHeadChange); err != nil {
+	if err := pcs.AddWatcher(mw.processHeadChange); err != nil {
 		return nil, err
 	}
 	return mw, nil


### PR DESCRIPTION
This PR updates the chain scheduler to execute message and eth watcher first. All the message executions from the tipset will be recorded in DB first. After that when handlers are executed, they will find the message results from the current tipset already updated in DB. This will allow handlers to apply changes from the current tipset immediately regardless of the order of the execution of the handlers. 