### PR TITLE
fix(pdp): move setting pdp_data_sets.init_ready to add message handler

### DIFF
--- a/pdp/handlers_add.go
+++ b/pdp/handlers_add.go
@@ -421,15 +421,6 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 			return false, err // Return false to rollback the transaction
 		}
 
-		// Update data set for initialization upon first add
-		_, err = txdb.Exec(`
-			UPDATE pdp_data_sets SET init_ready = true
-			WHERE id = $1 AND prev_challenge_request_epoch IS NULL AND challenge_request_msg_hash IS NULL AND prove_at_epoch IS NULL
-			`, dataSetIdUint64)
-		if err != nil {
-			return false, err
-		}
-
 		// Insert into pdp_data_set_pieces
 		err = p.insertPieceAdds(txdb, &dataSetIdUint64, txHashLower, payload.Pieces, subPieceInfoMap)
 		if err != nil {

--- a/tasks/pdp/proofset_addroot_watch.go
+++ b/tasks/pdp/proofset_addroot_watch.go
@@ -179,6 +179,15 @@ func extractAndInsertPiecesFromReceipt(ctx context.Context, db *harmonydb.DB, re
 
 	// Begin a database transaction
 	_, err = db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		// Update data set for initialization upon first add
+		_, err = tx.Exec(`
+			UPDATE pdp_data_sets SET init_ready = true
+			WHERE id = $1 AND prev_challenge_request_epoch IS NULL AND challenge_request_msg_hash IS NULL AND prove_at_epoch IS NULL
+			`, pieceAdd.DataSet)
+		if err != nil {
+			return false, err
+		}
+
 		// Fetch the entries from pdp_data_set_piece_adds
 		var pieceAddEntries []PieceAddEntry
 		err := tx.Select(&pieceAddEntries, `


### PR DESCRIPTION
this resolves two issues:
- initpp task firing too early while the data set is still empty
- initpp taks now firing when using combined create-and-add flow