### PR TITLE
fix(pdp): commit removal transaction when we don't have IPNI ads

### DIFF
--- a/tasks/pdp/watch_piece_delete.go
+++ b/tasks/pdp/watch_piece_delete.go
@@ -195,7 +195,7 @@ func processIndexingAndIPNICleanup(ctx context.Context, db *harmonydb.DB, cfg *c
 		return nil
 	}
 
-	log.Infof("Cleaning up Indexing and IPNI for %d pieces", len(pieces))
+	log.Infof("Cleaning up %d pieces not referenced by any datasets", len(pieces))
 
 	var peerID string
 	var privKeyBytes []byte


### PR DESCRIPTION
Currently the transaction will be rolled back when there are no IPNI ads
for the pieces.