### PR TITLE
fix: align address decoding with Solidity canonical behavior

### DIFF
--- a/pdp/contract/utils.go
+++ b/pdp/contract/utils.go
@@ -209,7 +209,7 @@ func FSRegister(ctx context.Context, db *harmonydb.DB, full api.FullNode, ethCli
 			}
 
 			// Compare that event log contains the correct payee
-			payee := common.BytesToAddress(vLog.Topics[1].Bytes())
+			payee := DecodeAddressCanonical(vLog.Topics[1].Bytes())
 			if payee != sender {
 				continue
 			}
@@ -408,4 +408,18 @@ func FSUpdatePDPService(ctx context.Context, db *harmonydb.DB, ethClient *ethcli
 	}
 
 	return signedTx.Hash().String(), nil
+}
+
+// DecodeAddressCanonical decodes a []byte into canonical Ethereum address:
+// - Uses last 20 bytes if len >= 20
+// - Left-pads with zero if shorter
+func DecodeAddressCanonical(input []byte) common.Address {
+    b := make([]byte, 20)
+    inLen := len(input)
+    if inLen >= 20 {
+        copy(b, input[inLen-20:])
+    } else {
+        copy(b[20-inLen:], input)
+    }
+    return common.BytesToAddress(b)
 }


### PR DESCRIPTION
### Description
This PR fixes inconsistent decoding of Ethereum addresses from byte slices in the ServiceProviderRegistry and related code, addressing issue #758.

- Implements `DecodeAddressCanonical` function matching Solidity's `address(uint160(BigEndian.decode(bytes)))`.
- Replaces all relevant decoding sites to use this new canonical decoding.
- Unit testing has been performed locally covering edge cases for the decode function.
### Issue
Fixes [https://github.com/filecoin-project/curio/issues/758](https://github.com/filecoin-project/curio/issues/758)

Please review the decoding logic and scope of changes. Happy to include tests or make adjustments as needed.
