### PR TITLE
chore(pdp): use DEV_CURIO_EXTERNAL_URL for non-standard port announcements 

### DIFF
--- a/cuhttp/server.go
+++ b/cuhttp/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -156,7 +157,11 @@ func StartHTTPServer(ctx context.Context, d *deps.Deps, sd *ServiceDeps, dm *sto
 	chiRouter.Use(corsHeaders)
 
 	if cfg.EnableCORS {
-		chiRouter.Use(handlers.CORS(handlers.AllowedOrigins([]string{"https://" + cfg.DomainName})))
+		corsOrigin := "https://" + cfg.DomainName
+		if devURL := os.Getenv("DEV_CURIO_EXTERNAL_URL"); devURL != "" {
+			corsOrigin = devURL
+		}
+		chiRouter.Use(handlers.CORS(handlers.AllowedOrigins([]string{corsOrigin})))
 	}
 
 	// Set up the compression middleware with custom compression levels

--- a/lib/urlhelper/external.go
+++ b/lib/urlhelper/external.go
@@ -1,0 +1,86 @@
+package urlhelper
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/multiformats/go-multiaddr"
+
+	"github.com/filecoin-project/curio/build"
+	"github.com/filecoin-project/curio/deps/config"
+)
+
+// GetExternalURL returns the external URL for IPNI announcements based on HTTPConfig.
+// If the DEV_CURIO_EXTERNAL_URL environment variable is set, it is used as the external URL.
+// Otherwise, constructs URL from DomainName using default port based on build type.
+func GetExternalURL(c *config.HTTPConfig) (*url.URL, error) {
+	if devURL := os.Getenv("DEV_CURIO_EXTERNAL_URL"); devURL != "" {
+		u, err := url.Parse(devURL)
+		if err != nil {
+			return nil, fmt.Errorf("parsing DEV_CURIO_EXTERNAL_URL: %w", err)
+		}
+		return u, nil
+	}
+
+	// Fallback to existing logic
+	if build.BuildType == build.BuildMainnet || build.BuildType == build.BuildCalibnet {
+		return url.Parse(fmt.Sprintf("https://%s", c.DomainName))
+	}
+
+	// Devnet: use ListenAddress port
+	ls := strings.Split(c.ListenAddress, ":")
+	if len(ls) != 2 {
+		return nil, fmt.Errorf("invalid ListenAddress format: %s", c.ListenAddress)
+	}
+	return url.Parse(fmt.Sprintf("http://%s:%s", c.DomainName, ls[1]))
+}
+
+// GetExternalLibp2pAddr returns the multiaddr for libp2p WebSocket announcements.
+func GetExternalLibp2pAddr(c *config.HTTPConfig) (multiaddr.Multiaddr, error) {
+	u, err := GetExternalURL(c)
+	if err != nil {
+		return nil, err
+	}
+
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+
+	protocol := "wss"
+	if u.Scheme == "http" {
+		protocol = "ws"
+	}
+
+	return multiaddr.NewMultiaddr(fmt.Sprintf("/dns/%s/tcp/%s/%s", u.Hostname(), port, protocol))
+}
+
+// GetExternalHTTPAddr returns the multiaddr for HTTP announcements.
+func GetExternalHTTPAddr(c *config.HTTPConfig) (multiaddr.Multiaddr, error) {
+	u, err := GetExternalURL(c)
+	if err != nil {
+		return nil, err
+	}
+
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+
+	protocol := "https"
+	if u.Scheme == "http" {
+		protocol = "http"
+	}
+
+	return multiaddr.NewMultiaddr(fmt.Sprintf("/dns/%s/tcp/%s/%s", u.Hostname(), port, protocol))
+}

--- a/market/ipni/ipni-provider/ipni-provider.go
+++ b/market/ipni/ipni-provider/ipni-provider.go
@@ -38,6 +38,7 @@ import (
 	"github.com/filecoin-project/curio/deps"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/lib/pieceprovider"
+	"github.com/filecoin-project/curio/lib/urlhelper"
 	"github.com/filecoin-project/curio/market/indexstore"
 	"github.com/filecoin-project/curio/market/ipni/chunker"
 	"github.com/filecoin-project/curio/market/ipni/ipniculib"
@@ -164,17 +165,9 @@ func NewProvider(d *deps.Deps) (*Provider, error) {
 	httpServerAddresses := map[string]multiaddr.Multiaddr{}
 
 	{
-		u, err := url.Parse(fmt.Sprintf("https://%s", d.Cfg.HTTP.DomainName))
+		u, err := urlhelper.GetExternalURL(&d.Cfg.HTTP)
 		if err != nil {
-			return nil, xerrors.Errorf("parsing announce address domain: %w", err)
-		}
-
-		if build.BuildType != build.BuildMainnet && build.BuildType != build.BuildCalibnet {
-			ls := strings.Split(d.Cfg.HTTP.ListenAddress, ":")
-			u, err = url.Parse(fmt.Sprintf("http://%s:%s", d.Cfg.HTTP.DomainName, ls[1]))
-			if err != nil {
-				return nil, xerrors.Errorf("parsing announce address domain: %w", err)
-			}
+			return nil, xerrors.Errorf("getting external URL for IPNI: %w", err)
 		}
 
 		u.Path = path.Join(u.Path, IPNIRoutePath)

--- a/tasks/indexing/task_ipni.go
+++ b/tasks/indexing/task_ipni.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"strings"
 	"time"
 
@@ -26,7 +25,6 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 
-	"github.com/filecoin-project/curio/build"
 	"github.com/filecoin-project/curio/deps/config"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"
@@ -36,6 +34,7 @@ import (
 	"github.com/filecoin-project/curio/lib/passcall"
 	"github.com/filecoin-project/curio/lib/pieceprovider"
 	"github.com/filecoin-project/curio/lib/storiface"
+	"github.com/filecoin-project/curio/lib/urlhelper"
 	"github.com/filecoin-project/curio/market/indexstore"
 	"github.com/filecoin-project/curio/market/ipni/chunker"
 	"github.com/filecoin-project/curio/market/ipni/ipniculib"
@@ -192,16 +191,9 @@ func (I *IPNITask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done b
 		}
 
 		{
-			u, err := url.Parse(fmt.Sprintf("https://%s", I.cfg.HTTP.DomainName))
+			u, err := urlhelper.GetExternalURL(&I.cfg.HTTP)
 			if err != nil {
-				return false, xerrors.Errorf("parsing announce address domain: %w", err)
-			}
-			if build.BuildType != build.BuildMainnet && build.BuildType != build.BuildCalibnet {
-				ls := strings.Split(I.cfg.HTTP.ListenAddress, ":")
-				u, err = url.Parse(fmt.Sprintf("http://%s:%s", I.cfg.HTTP.DomainName, ls[1]))
-				if err != nil {
-					return false, xerrors.Errorf("parsing announce address domain: %w", err)
-				}
+				return false, xerrors.Errorf("getting external URL for IPNI: %w", err)
 			}
 
 			addr, err := maurl.FromURL(u)

--- a/tasks/indexing/task_pdp_v0_ipni.go
+++ b/tasks/indexing/task_pdp_v0_ipni.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"strings"
 	"time"
 
@@ -25,7 +24,6 @@ import (
 
 	commcid "github.com/filecoin-project/go-fil-commcid"
 
-	"github.com/filecoin-project/curio/build"
 	"github.com/filecoin-project/curio/deps/config"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"
@@ -34,6 +32,7 @@ import (
 	"github.com/filecoin-project/curio/lib/cachedreader"
 	"github.com/filecoin-project/curio/lib/ffi"
 	"github.com/filecoin-project/curio/lib/passcall"
+	"github.com/filecoin-project/curio/lib/urlhelper"
 	"github.com/filecoin-project/curio/market/ipni/chunker"
 	"github.com/filecoin-project/curio/market/ipni/ipniculib"
 )
@@ -207,16 +206,9 @@ func (P *PDPV0IPNITask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 		}
 
 		{
-			u, err := url.Parse(fmt.Sprintf("https://%s:443", P.cfg.HTTP.DomainName))
+			u, err := urlhelper.GetExternalURL(&P.cfg.HTTP)
 			if err != nil {
-				return false, xerrors.Errorf("parsing announce address domain: %w", err)
-			}
-			if build.BuildType != build.BuildMainnet && build.BuildType != build.BuildCalibnet {
-				ls := strings.Split(P.cfg.HTTP.ListenAddress, ":")
-				u, err = url.Parse(fmt.Sprintf("http://%s:%s", P.cfg.HTTP.DomainName, ls[1]))
-				if err != nil {
-					return false, xerrors.Errorf("parsing announce address domain: %w", err)
-				}
+				return false, xerrors.Errorf("getting external URL for IPNI: %w", err)
 			}
 
 			addr, err := maurl.FromURL(u)

--- a/tasks/pdpv0/watch_piece_delete.go
+++ b/tasks/pdpv0/watch_piece_delete.go
@@ -3,9 +3,7 @@ package pdpv0
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
-	"net/url"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -18,10 +16,10 @@ import (
 	"github.com/yugabyte/pgx/v5"
 	"golang.org/x/xerrors"
 
-	"github.com/filecoin-project/curio/build"
 	"github.com/filecoin-project/curio/deps/config"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/lib/chainsched"
+	"github.com/filecoin-project/curio/lib/urlhelper"
 	"github.com/filecoin-project/curio/market/indexstore"
 	"github.com/filecoin-project/curio/market/ipni/ipniculib"
 	"github.com/filecoin-project/curio/pdp/contract"
@@ -224,16 +222,9 @@ func processIndexingAndIPNICleanup(ctx context.Context, db *harmonydb.DB, cfg *c
 			}
 
 			{
-				u, err := url.Parse(fmt.Sprintf("https://%s:443", cfg.DomainName))
+				u, err := urlhelper.GetExternalURL(cfg)
 				if err != nil {
-					return false, xerrors.Errorf("parsing announce address domain: %w", err)
-				}
-				if build.BuildType != build.BuildMainnet && build.BuildType != build.BuildCalibnet {
-					ls := strings.Split(cfg.ListenAddress, ":")
-					u, err = url.Parse(fmt.Sprintf("http://%s:%s", cfg.DomainName, ls[1]))
-					if err != nil {
-						return false, xerrors.Errorf("parsing announce address domain: %w", err)
-					}
+					return false, xerrors.Errorf("getting external URL for IPNI: %w", err)
 				}
 
 				addr, err := maurl.FromURL(u)

--- a/web/api/webrpc/pdp.go
+++ b/web/api/webrpc/pdp.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/lib/urlhelper"
 	"github.com/filecoin-project/curio/pdp/contract"
 	"github.com/filecoin-project/curio/tasks/indexing"
 )
@@ -436,9 +437,9 @@ func (a *WebRPC) FSRegister(ctx context.Context, name, description, location str
 		return xerrors.Errorf("provider is already registered")
 	}
 
-	serviceURL := url.URL{
-		Scheme: "https",
-		Host:   a.deps.Cfg.HTTP.DomainName,
+	serviceURL, err := urlhelper.GetExternalURL(&a.deps.Cfg.HTTP)
+	if err != nil {
+		return xerrors.Errorf("getting external URL: %w", err)
 	}
 
 	tokenAddress, err := contract.USDFCAddress()


### PR DESCRIPTION
https://github.com/filecoin-project/curio/issues/786

<img width="1588" height="748" alt="image" src="https://github.com/user-attachments/assets/d85777af-d749-4790-bc5a-0c626a92f4cb" />


```
2025-11-20T21:27:13.578+0800    INFO    ipni-provider   ipni-provider/ipni-provider.go:147      ipni peer ID    {"peerID": "12D3KooWPRuubsz8p49yAFBZGwsKVEF9MqxN1CQ1QRMeaDE4VCZu"}
2025-11-20T21:27:13.578+0800    INFO    ipni-provider   ipni-provider/ipni-provider.go:197      Announce address        {"address": "/dns/pdp.660688.xyz/tcp/8880/http/http-path/%2Fipni-provider%2F12D3KooWPRuubsz8p49yAFBZGwsKVEF9MqxN1CQ1QRMeaDE4VCZu", "pid": "12D3KooWPRuubsz8p49yAFBZGwsKVEF9MqxN1CQ1QRMeaDE4VCZu", "url": "http://pdp.660688.xyz:8880/ipni-provider/12D3KooWPRuubsz8p49yAFBZGwsKVEF9MqxN1CQ1QRMeaDE4VCZu"}
2025-11-20T21:27:13.578+0800    INFO    ipni-provider   ipni-provider/ipni-provider.go:527      Starting IPNI provider publishing for testnet build
```