### PR TITLE
feat!(ServiceProviderRegistry): Hex Capabilities

### DIFF
--- a/web/api/webrpc/pdp.go
+++ b/web/api/webrpc/pdp.go
@@ -292,8 +292,8 @@ func capabilitiesToOffering(keys []string, values [][]byte) (*FSPDPOffering, map
 		case contract.CapPaymentToken:
 			offering.PaymentTokenAddress = contract.DecodeAddressCapability(value).Hex()
 		default:
-			// Custom capability
-			customCaps[key] = string(value)
+			// Custom capability - encode for safe round-trip through JSON/browser
+			customCaps[key] = contract.EncodeCapabilityForDisplay(value)
 		}
 	}
 


### PR DESCRIPTION

Reviewer @rvagg
This allows the user to enter a hex string prefixed with `0x` and it will be encoded as bytes.
Hex encoding is good for:
* address
* encoded certificates (https://github.com/FilOzone/synapse-sdk/pull/443)
We can consider detecting and supporting other encodings.
#### Changes
If a capability value string is hex, encode the bytes directly rather than as utf8 