### PR TITLE
Use original PieceCID in download filename

### DIFF
--- a/market/retrieval/piecehandler.go
+++ b/market/retrieval/piecehandler.go
@@ -47,6 +47,7 @@ func (rp *Provider) handleByPieceCid(w http.ResponseWriter, r *http.Request) {
 		stats.Record(ctx, remoteblockstore.HttpPieceByCid400ResponseCount.M(1))
 		return
 	}
+	originalPieceCid := pieceCid
 	if multicodec.Code(pieceCid.Type()) != multicodec.FilCommitmentUnsealed {
 		pieceCid, _, err = commcid.PieceCidV1FromV2(pieceCid)
 		if err != nil {
@@ -84,7 +85,7 @@ func (rp *Provider) handleByPieceCid(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setHeaders(w, pieceCid, contentType)
+	setHeaders(w, originalPieceCid, contentType)
 	serveContent(w, r, size, reader)
 
 	stats.Record(ctx, remoteblockstore.HttpPieceByCid200ResponseCount.M(1))


### PR DESCRIPTION
Preserve the original PieceCID from the URL and use it for the Content-Disposition header filename instead of a converted version.

This ensures the downloaded filename matches the CID in the request URL.

Fixes #824