### PR TITLE
fix(pdp,ipni): use PieceCIDv2 for PDP IPNI ContextID

### DIFF
--- a/tasks/indexing/task_pdp_ipni.go
+++ b/tasks/indexing/task_pdp_ipni.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/ipfs/go-cid"
 	carv2 "github.com/ipld/go-car/v2"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipni/go-libipni/ingest/schema"
 	"github.com/ipni/go-libipni/maurl"
@@ -63,6 +65,7 @@ func (P *PDPIPNITask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 		ID       int64  `db:"id"`
 		PieceCID string `db:"piece_cid"`
 		Size     int64  `db:"piece_padded_size"`
+		RawSize  int64  `db:"piece_raw_size"`
 		Prov     string `db:"peer_id"`
 	}
 
@@ -71,6 +74,7 @@ func (P *PDPIPNITask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 										pr.id,
 										pr.piece_cid,
 										pp.piece_padded_size,
+										pp.piece_raw_size,
 										ipni_peer.peer_id
 									FROM
 										pdp_piecerefs pr
@@ -107,6 +111,12 @@ func (P *PDPIPNITask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 		return false, xerrors.Errorf("parsing piece CID: %w", err)
 	}
 
+	// Convert to PieceCIDv2 for IPNI ContextID
+	pcidV2, err := commcid.PieceCidV2FromV1(pcid, uint64(task.RawSize))
+	if err != nil {
+		return false, xerrors.Errorf("converting piece CID to v2: %w", err)
+	}
+
 	mds := metadata.IpfsGatewayHttp{}
 	md, err := mds.MarshalBinary()
 	if err != nil {
@@ -114,7 +124,7 @@ func (P *PDPIPNITask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 	}
 
 	pi := &PdpIpniContext{
-		PieceCID: pcid,
+		PieceCID: pcidV2,
 		Payload:  true,
 	}
 


### PR DESCRIPTION
Fetch piece_raw_size from parked_pieces to convert v1 to v2.

Fixes: https://github.com/filecoin-project/curio/issues/735

---

This is one of those things where it took me 2 minutes more to write the code after investigating it.