### PR TITLE
feat(pdp): add SP-to-SP piece pull endpoint

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -305,12 +305,13 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 			pdpNextProvingPeriodTask := pdp.NewNextProvingPeriodTask(db, must.One(dependencies.EthClient.Val()), dependencies.Chain, chainSched, es)
 			pdpInitProvingPeriodTask := pdp.NewInitProvingPeriodTask(db, must.One(dependencies.EthClient.Val()), dependencies.Chain, chainSched, es)
 			pdpNotifTask := pdp.NewPDPNotifyTask(ctx, db)
+			pdpPullPieceTask := pdp.NewPDPPullPieceTask(ctx, db, lstor, 4)
 			pdpIndexingTask := indexing.NewPDPIndexingTask(db, iStore, dependencies.CachedPieceReader, cfg, idxMax)
 			pdpIpniTask := indexing.NewPDPIPNITask(db, sc, dependencies.CachedPieceReader, cfg, idxMax)
 			pdpTerminate := pdp.NewTerminateServiceTask(db, must.One(dependencies.EthClient.Val()), senderEth)
 			pdpDelete := pdp.NewDeleteDataSetTask(db, must.One(dependencies.EthClient.Val()), senderEth)
 			payTask := pay.NewSettleTask(db, must.One(dependencies.EthClient.Val()), senderEth)
-			activeTasks = append(activeTasks, pdpProveTask, pdpNotifTask, pdpNextProvingPeriodTask, pdpInitProvingPeriodTask, pdpIndexingTask, pdpIpniTask, pdpTerminate, pdpDelete, payTask)
+			activeTasks = append(activeTasks, pdpProveTask, pdpNotifTask, pdpPullPieceTask, pdpNextProvingPeriodTask, pdpInitProvingPeriodTask, pdpIndexingTask, pdpIpniTask, pdpTerminate, pdpDelete, payTask)
 		}
 
 		indexingTask := indexing.NewIndexingTask(db, sc, iStore, pp, cfg, idxMax)

--- a/harmony/harmonydb/sql/20260109-pdpv0-pull.sql
+++ b/harmony/harmonydb/sql/20260109-pdpv0-pull.sql
@@ -1,0 +1,30 @@
+-- PDP piece pull tables for SP-to-SP transfer
+--
+-- Provides idempotency and piece tracking for pull requests.
+-- Status is derived dynamically from parked_pieces, not stored here.
+CREATE TABLE pdp_piece_pulls (
+    id BIGSERIAL PRIMARY KEY,
+    service TEXT NOT NULL REFERENCES pdp_services(service_label) ON DELETE CASCADE,
+    extra_data_hash BYTEA NOT NULL,  -- sha256(extraData) for idempotency
+    data_set_id BIGINT NOT NULL DEFAULT 0,  -- 0 = create new dataset
+    record_keeper TEXT NOT NULL DEFAULT '',  -- required when data_set_id is 0
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+
+    UNIQUE(service, extra_data_hash, data_set_id, record_keeper)
+);
+
+-- Tracks individual pieces within a pull request
+CREATE TABLE pdp_piece_pull_items (
+    fetch_id BIGINT NOT NULL REFERENCES pdp_piece_pulls(id) ON DELETE CASCADE,
+    piece_cid TEXT NOT NULL,        -- PieceCIDv1 (for joins with parked_pieces)
+    piece_raw_size BIGINT NOT NULL, -- raw size to reconstruct PieceCIDv2 for API
+    source_url TEXT NOT NULL,       -- external SP URL to fetch from
+    task_id BIGINT REFERENCES harmony_task(id) ON DELETE SET NULL,  -- pull task
+    failed BOOLEAN NOT NULL DEFAULT FALSE,  -- true if piece permanently failed
+    fail_reason TEXT,               -- error message when failed
+
+    PRIMARY KEY (fetch_id, piece_cid)
+);
+
+-- Index for cleanup queries
+CREATE INDEX idx_pdp_piece_pulls_created_at ON pdp_piece_pulls(created_at);

--- a/pdp/handlers_add.go
+++ b/pdp/handlers_add.go
@@ -69,11 +69,11 @@ func (p *PDPService) transformAddPiecesRequest(ctx context.Context, serviceLabel
 			if subPieceEntry.SubPieceCID == "" {
 				return nil, nil, nil, errors.New("subPieceCid is required for each subPiece")
 			}
-			pieceCid, err := asPieceCIDv1(subPieceEntry.SubPieceCID)
+			info, err := ParsePieceCid(subPieceEntry.SubPieceCID)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("invalid SubPiece: %w", err)
 			}
-			pieceCidString := pieceCid.String()
+			pieceCidString := info.CidV1.String()
 
 			addPieceReq.SubPieces[i].subPieceCIDv1 = pieceCidString // save it for to query subPieceInfoMap later
 
@@ -177,14 +177,14 @@ func (p *PDPService) transformAddPiecesRequest(ctx context.Context, serviceLabel
 			}
 
 			// Compare generated PieceCid with provided PieceCid
-			providedPieceCidv1, err := asPieceCIDv1(addPieceReq.PieceCID)
+			providedInfo, err := ParsePieceCid(addPieceReq.PieceCID)
 			if err != nil {
 				return false, fmt.Errorf("invalid provided PieceCid: %v", err)
 			}
-			pieces[i].pieceCIDv1 = providedPieceCidv1.String()
+			pieces[i].pieceCIDv1 = providedInfo.CidV1.String()
 
-			if !providedPieceCidv1.Equals(generatedPieceCid) {
-				return false, fmt.Errorf("provided PieceCid does not match generated PieceCid: %s != %s", providedPieceCidv1, generatedPieceCid)
+			if !providedInfo.CidV1.Equals(generatedPieceCid) {
+				return false, fmt.Errorf("provided PieceCid does not match generated PieceCid: %s != %s", providedInfo.CidV1, generatedPieceCid)
 			}
 		}
 

--- a/pdp/handlers_pull.go
+++ b/pdp/handlers_pull.go
@@ -1,0 +1,861 @@
+package pdp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ipfs/go-cid"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/pdp/contract"
+)
+
+// getPDPSenderAddress retrieves the PDP key address from the database
+func getPDPSenderAddress(ctx context.Context, db *harmonydb.DB) (common.Address, error) {
+	var privateKeyData []byte
+	err := db.QueryRow(ctx,
+		`SELECT private_key FROM eth_keys WHERE role = 'pdp'`).Scan(&privateKeyData)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("fetching pdp private key from db: %w", err)
+	}
+
+	privateKey, err := crypto.ToECDSA(privateKeyData)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("converting private key: %w", err)
+	}
+
+	return crypto.PubkeyToAddress(privateKey.PublicKey), nil
+}
+
+// PullRecord represents a pull request record from the database
+type PullRecord struct {
+	ID            int64
+	Service       string
+	ExtraDataHash []byte
+	DataSetId     uint64 // 0 = create new
+	RecordKeeper  string // address, required when DataSetId is 0
+}
+
+// PieceStatus represents the status of a piece in storage
+type PieceStatus struct {
+	PieceCid   string
+	Complete   bool
+	TaskID     *int64 // task_id from parked_pieces (may point to deleted task)
+	TaskExists bool   // true if task_id exists in harmony_task
+	Retries    int    // retry count from harmony_task (0 if task doesn't exist)
+}
+
+// ParkedPieceEntry represents the data needed to create a parked piece entry
+type ParkedPieceEntry struct {
+	PieceCid        string
+	PiecePaddedSize int64
+	PieceRawSize    int64
+	DataURL         string
+}
+
+// PullPiece represents a piece stored in a pull request (v1 CID + raw size for v2 reconstruction)
+type PullPiece struct {
+	CidV1      cid.Cid
+	RawSize    uint64
+	SourceURL  string // external SP URL to fetch from
+	Failed     bool   // true if piece permanently failed
+	FailReason string // error message when failed
+}
+
+// PullItemStatus represents the status of a pull item
+type PullItemStatus struct {
+	TaskID     *int64 // task_id from pdp_piece_pull_items
+	TaskExists bool   // true if task_id exists in harmony_task
+	Retries    int    // retry count from harmony_task (0 if task doesn't exist)
+	Failed     bool   // true if piece permanently failed
+}
+
+// PullStore abstracts database operations for the fetch handler
+type PullStore interface {
+	// GetPullByKey retrieves a pull record by its idempotency key
+	GetPullByKey(ctx context.Context, service string, hash []byte, dataSetId uint64, recordKeeper string) (*PullRecord, error)
+
+	// CreatePullWithPieces creates a pull record and its associated piece items in a transaction
+	// Returns the created fetch ID
+	CreatePullWithPieces(ctx context.Context, fetch *PullRecord, pieces []PullPiece) (int64, error)
+
+	// GetPieceStatuses retrieves the status of multiple pieces from parked_pieces (keyed by v1 CID string)
+	// This checks if pieces have been successfully stored (complete=true)
+	GetPieceStatuses(ctx context.Context, pieceCids []cid.Cid) (map[string]*PieceStatus, error)
+
+	// GetPullItemStatuses retrieves the status of pull items (keyed by v1 CID string)
+	// This checks the fetch task state (task_id, failed)
+	GetPullItemStatuses(ctx context.Context, pullID int64, pieceCids []cid.Cid) (map[string]*PullItemStatus, error)
+
+	// GetPullPieces retrieves all pieces associated with a pull record (includes failure info)
+	GetPullPieces(ctx context.Context, pullID int64) ([]PullPiece, error)
+
+	// MarkPieceFailed marks a piece as permanently failed in the pull items table
+	MarkPieceFailed(ctx context.Context, pullID int64, pieceCid string, reason string) error
+
+	// CheckTaskExhaustedRetries checks if a task exhausted its retries by looking at harmony_task_history
+	// Returns true if the task failed permanently, along with the error message
+	CheckTaskExhaustedRetries(ctx context.Context, taskID int64) (bool, string, error)
+}
+
+// AddPiecesValidatorParams contains parameters for eth_call validation
+type AddPiecesValidatorParams struct {
+	DataSetId    *big.Int // 0 for create-new
+	RecordKeeper common.Address
+	PieceData    []contract.CidsCid
+	ExtraData    []byte
+}
+
+// AddPiecesValidator validates extraData against the contract via eth_call
+type AddPiecesValidator interface {
+	// ValidateAddPieces performs an eth_call to validate the extraData
+	// Returns nil if validation passes, error otherwise
+	ValidateAddPieces(ctx context.Context, params *AddPiecesValidatorParams) error
+}
+
+// EthCallValidator validates via eth_call to PDPVerifier contract
+type EthCallValidator struct {
+	ethClient  *ethclient.Client
+	db         *harmonydb.DB
+	senderAddr common.Address // cached, lazily loaded
+}
+
+// NewEthCallValidator creates a validator that uses eth_call
+func NewEthCallValidator(ethClient *ethclient.Client, db *harmonydb.DB) *EthCallValidator {
+	return &EthCallValidator{ethClient: ethClient, db: db}
+}
+
+func (v *EthCallValidator) ValidateAddPieces(ctx context.Context, params *AddPiecesValidatorParams) error {
+	// Lazily load sender address if not cached
+	if v.senderAddr == (common.Address{}) && v.db != nil {
+		addr, err := getPDPSenderAddress(ctx, v.db)
+		if err != nil {
+			return fmt.Errorf("failed to get PDP sender address: %w", err)
+		}
+		v.senderAddr = addr
+	}
+
+	abiData, err := contract.PDPVerifierMetaData.GetAbi()
+	if err != nil {
+		return fmt.Errorf("failed to get contract ABI: %w", err)
+	}
+
+	// Build addPieces calldata
+	// When dataSetId is 0 (create new), use recordKeeper address and sybil fee
+	// When dataSetId > 0 (add to existing), use zero address and no fee
+	isCreateNew := params.DataSetId.Cmp(big.NewInt(0)) == 0
+	listenerAddr := common.Address{}
+	if isCreateNew {
+		listenerAddr = params.RecordKeeper
+	}
+
+	data, err := abiData.Pack("addPieces", params.DataSetId, listenerAddr, params.PieceData, params.ExtraData)
+	if err != nil {
+		return fmt.Errorf("failed to pack addPieces call: %w", err)
+	}
+
+	// eth_call to validate
+	contractAddr := contract.ContractAddresses().PDPVerifier
+	value := big.NewInt(0)
+	if isCreateNew {
+		// Sybil fee only required for create-new case
+		value = contract.SybilFee()
+	}
+	msg := ethereum.CallMsg{
+		From:  v.senderAddr,
+		To:    &contractAddr,
+		Data:  data,
+		Value: value,
+	}
+
+	_, err = v.ethClient.CallContract(ctx, msg, nil)
+	if err != nil {
+		return fmt.Errorf("addPieces validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// PullHandler handles piece pull requests
+type PullHandler struct {
+	auth      Auth
+	store     PullStore
+	validator AddPiecesValidator
+}
+
+// NewPullHandler creates a new PullHandler
+func NewPullHandler(auth Auth, store PullStore, validator AddPiecesValidator) *PullHandler {
+	return &PullHandler{
+		auth:      auth,
+		store:     store,
+		validator: validator,
+	}
+}
+
+// HandlePull handles POST /pdp/piece/pull requests for SP-to-SP piece pull.
+//
+// # Overview
+//
+// This endpoint allows a client to request that pieces be fetched from other storage
+// providers and stored locally. It is designed for scenarios where data already exists
+// on one SP and needs to be replicated to another, without requiring the client to
+// re-upload the data.
+//
+// # Request Format
+//
+// The request body is a JSON object with the following fields:
+//
+//   - extraData (required): Hex-encoded bytes that will be validated against the
+//     PDPVerifier contract via eth_call. This ensures the caller has authorization
+//     to add these pieces. See "ExtraData and Authorization" below.
+//
+//   - dataSetId (optional): The target dataset ID for the eth_call validation.
+//     If omitted or zero, validation simulates creating a new dataset.
+//
+//   - recordKeeper (required when creating new dataset): The contract address that
+//     will receive callbacks from PDPVerifier (typically FilecoinWarmStorageService).
+//     Must be in the allowed list for public services.
+//
+//   - pieces (required): Array of pieces to fetch, each containing:
+//
+//   - pieceCid: PieceCIDv2 format (encodes both CommP and raw size)
+//
+//   - sourceUrl: HTTPS URL ending in /piece/{pieceCid} on a public host
+//
+// # ExtraData and Authorization
+//
+// The extraData field serves two purposes:
+//
+//  1. Authorization: It is validated via eth_call to PDPVerifier.addPieces(), which
+//     forwards to the recordKeeper contract for validation. PDPVerifier itself only
+//     checks for valid input format; the recordKeeper (e.g., FilecoinWarmStorageService)
+//     performs the actual authorization checks such as signature verification and
+//     ensuring sufficient funds are available.
+//
+//  2. Idempotency key: Combined with service, dataSetId, and recordKeeper, a hash of
+//     extraData forms the idempotency key. Repeated requests with the same key return
+//     the status of the existing fetch rather than creating duplicates.
+//
+// The extraData used here does NOT need to match the extraData used in the subsequent
+// addPieces call to the contract. This allows for a two-phase flow where:
+//   - Phase 1 (this endpoint): Authorize and initiate piece pulling
+//   - Phase 2 (contract call): Add pieces to the dataset with potentially different extraData
+//
+// # Workflow
+//
+//  1. Client calls POST /pdp/piece/pull with piece CIDs and source URLs
+//  2. Server validates extraData via eth_call (ensures authorization)
+//  3. Server creates pull tracking record and queues pieces for download
+//  4. Background task (StorePiece) downloads pieces from source URLs
+//  5. Client polls the same endpoint to check status (idempotent)
+//  6. Once all pieces are "complete", client calls the contract to add pieces to dataset
+//
+// # Status Progression
+//
+// Each piece progresses through these statuses:
+//
+//   - pending: Piece is queued but download hasn't started
+//   - inProgress: Download task is actively running (first attempt)
+//   - retrying: Download task is running after one or more failures
+//   - complete: Piece successfully downloaded and verified
+//   - failed: Piece permanently failed after exhausting retries (currently 5 attempts)
+//
+// The overall response status reflects the worst-case across all pieces:
+// failed > retrying > inProgress > pending > complete
+//
+// # Safety and Verification
+//
+// Several safety measures protect against malicious sources:
+//
+//   - Source URL validation: Must be HTTPS, path must match /piece/{pieceCid},
+//     host must not be localhost/private IP/link-local
+//
+//   - Size limits: Piece size (encoded in PieceCIDv2) must not exceed PieceSizeLimit.
+//     Downloads are capped at the declared size to prevent abuse.
+//
+//   - CommP verification: After download, the CommP (piece commitment) is computed
+//     and verified against the expected value from PieceCIDv2. Mismatches are rejected.
+//
+//   - Size verification: Actual downloaded size must match the declared size.
+//     Both truncation and oversized data are rejected.
+//
+// # Response Format
+//
+// Returns JSON with overall status and per-piece status:
+//
+//	{
+//	  "status": "inProgress",
+//	  "pieces": [
+//	    {"pieceCid": "bafk...", "status": "complete"},
+//	    {"pieceCid": "bafk...", "status": "inProgress"}
+//	  ]
+//	}
+//
+// # Idempotency
+//
+// Requests are idempotent based on (service, sha256(extraData), dataSetId, recordKeeper).
+// Calling with the same parameters returns the current status without creating new work.
+// This allows safe retries and status polling using the same request.
+func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := r.Context()
+
+	// Auth check
+	service, err := h.auth.AuthService(r)
+	if err != nil {
+		http.Error(w, "Unauthorized: "+err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	// Parse request body
+	var req PullRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Validate request
+	if err := req.Validate(); err != nil {
+		http.Error(w, "Validation error: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Validate recordKeeper against allowed list (for create-new case)
+	var recordKeeperAddr common.Address
+	if req.IsCreateNew() {
+		recordKeeperAddr = common.HexToAddress(*req.RecordKeeper)
+		if recordKeeperAddr == (common.Address{}) {
+			http.Error(w, "Invalid recordKeeper address", http.StatusBadRequest)
+			return
+		}
+		// Check recordKeeper is allowed (prevents bypass via malicious contract)
+		if contract.IsPublicService(service) && !contract.IsRecordKeeperAllowed(recordKeeperAddr) {
+			http.Error(w, "recordKeeper address not allowed for public service", http.StatusForbidden)
+			return
+		}
+	}
+
+	// Compute extraData hash and prepare idempotency key components
+	extraDataBytes, err := decodeExtraData(&req.ExtraData)
+	if err != nil {
+		http.Error(w, "Invalid extraData: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if extraDataBytes == nil {
+		http.Error(w, "extraData is required", http.StatusBadRequest)
+		return
+	}
+	extraDataHash := sha256.Sum256(extraDataBytes)
+
+	// Build idempotency key components
+	var dataSetId uint64
+	if req.DataSetId != nil {
+		dataSetId = *req.DataSetId
+	}
+	recordKeeperStr := ""
+	if req.RecordKeeper != nil {
+		recordKeeperStr = *req.RecordKeeper
+	}
+
+	// If we've seen this request before, return current status
+	existingPull, err := h.store.GetPullByKey(ctx, service, extraDataHash[:], dataSetId, recordKeeperStr)
+	if err != nil {
+		log.Errorw("failed to check fetch idempotency", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if existingPull != nil {
+		// Return existing status
+		h.respondWithStatus(ctx, w, existingPull.ID)
+		return
+	}
+
+	// Parse all piece CIDs (validates PieceCIDv2 format, extracts v1, size info)
+	pieceInfos := make([]*PieceCidInfo, len(req.Pieces))
+	pieceData := make([]contract.CidsCid, len(req.Pieces))
+	for i, piece := range req.Pieces {
+		info, err := ParsePieceCidV2(piece.PieceCid)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid pieceCid[%d]: %s", i, err.Error()), http.StatusBadRequest)
+			return
+		}
+		if info.RawSize > uint64(PieceSizeLimit) {
+			http.Error(w, fmt.Sprintf("pieceCid[%d]: size %d exceeds maximum %d", i, info.RawSize, PieceSizeLimit), http.StatusBadRequest)
+			return
+		}
+		pieceInfos[i] = info
+		pieceData[i] = contract.CidsCid{Data: info.CidV2.Bytes()}
+	}
+
+	// Validate extraData via eth_call
+	validatorParams := &AddPiecesValidatorParams{
+		DataSetId:    big.NewInt(int64(dataSetId)),
+		RecordKeeper: recordKeeperAddr,
+		PieceData:    pieceData,
+		ExtraData:    extraDataBytes,
+	}
+	if err := h.validator.ValidateAddPieces(ctx, validatorParams); err != nil {
+		http.Error(w, "extraData validation failed: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Build pull pieces for database storage (v1 CID + raw size + source URL for task to pick up)
+	pullPieces := make([]PullPiece, len(pieceInfos))
+	for i, info := range pieceInfos {
+		pullPieces[i] = PullPiece{
+			CidV1:     info.CidV1,
+			RawSize:   info.RawSize,
+			SourceURL: req.Pieces[i].SourceURL,
+		}
+	}
+
+	// Create pull record
+	pullRecord := &PullRecord{
+		Service:       service,
+		ExtraDataHash: extraDataHash[:],
+		DataSetId:     dataSetId,
+		RecordKeeper:  recordKeeperStr,
+	}
+
+	pullID, err := h.store.CreatePullWithPieces(ctx, pullRecord, pullPieces)
+	if err != nil {
+		log.Errorw("failed to create pull record", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// PDPPullPieceTask will pick up items from pdp_piece_pull_items,
+	// download pieces, verify CommP, and create parked_pieces entries.
+
+	// Return status
+	h.respondWithStatus(ctx, w, pullID)
+}
+
+// respondWithStatus queries piece statuses and returns a JSON response
+func (h *PullHandler) respondWithStatus(ctx context.Context, w http.ResponseWriter, pullID int64) {
+	// Get pieces for this fetch
+	pieces, err := h.store.GetPullPieces(ctx, pullID)
+	if err != nil {
+		log.Errorw("failed to get pull pieces", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Extract v1 CIDs for status lookup
+	cidV1s := make([]cid.Cid, len(pieces))
+	for i, p := range pieces {
+		cidV1s[i] = p.CidV1
+	}
+
+	// Get parked_pieces statuses (keyed by v1 CID string)
+	pieceStatuses, err := h.store.GetPieceStatuses(ctx, cidV1s)
+	if err != nil {
+		log.Errorw("failed to get piece statuses", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Get pull item statuses (keyed by v1 CID string)
+	fetchItemStatuses, err := h.store.GetPullItemStatuses(ctx, pullID, cidV1s)
+	if err != nil {
+		log.Errorw("failed to get pull item statuses", "error", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Build response with v2 CIDs for API
+	resp := &PullResponse{
+		Pieces: make([]PullPieceStatus, len(pieces)),
+	}
+
+	for i, piece := range pieces {
+		// Determine status based on pull item and parked piece state
+		cidV1Str := piece.CidV1.String()
+		status := h.determinePieceStatus(ctx, pullID, piece, fetchItemStatuses[cidV1Str], pieceStatuses[cidV1Str])
+
+		// Reconstruct v2 CID for API response
+		cidV2, err := commcid.PieceCidV2FromV1(piece.CidV1, piece.RawSize)
+		if err != nil {
+			log.Errorw("failed to reconstruct v2 CID", "error", err, "cidV1", piece.CidV1.String())
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
+
+		resp.Pieces[i] = PullPieceStatus{
+			PieceCid: cidV2.String(),
+			Status:   status,
+		}
+	}
+
+	resp.ComputeOverallStatus()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Errorw("failed to encode response", "error", err)
+	}
+}
+
+// determinePieceStatus determines the status of a piece based on pull item and parked piece state.
+//
+// Status priority:
+// 1. Check pull item failed flag: if true, return failed
+// 2. Check pull item task_id: if not null, the fetch task is running
+// 3. Check parked_pieces complete: if true, return complete
+// 4. Check parked_pieces task_id: if not null, StorePiece is running
+// 5. Otherwise return pending (waiting for fetch task to pick up)
+func (h *PullHandler) determinePieceStatus(ctx context.Context, pullID int64, piece PullPiece, fis *PullItemStatus, ps *PieceStatus) PullStatus {
+	cidV1Str := piece.CidV1.String()
+
+	// Already marked failed in fetch_items (from PullPiece struct)
+	if piece.Failed {
+		return PullStatusFailed
+	}
+
+	// Check pull item status (PDPPullPieceTask)
+	if fis != nil {
+		if fis.Failed {
+			return PullStatusFailed
+		}
+
+		// Pull task is assigned
+		if fis.TaskID != nil {
+			if fis.TaskExists {
+				// Task is alive
+				if fis.Retries > 0 {
+					return PullStatusRetrying
+				}
+				return PullStatusInProgress
+			}
+
+			// Task was deleted (orphaned), check if it failed permanently
+			exhausted, reason, err := h.store.CheckTaskExhaustedRetries(ctx, *fis.TaskID)
+			if err != nil {
+				log.Errorw("failed to check task history", "error", err, "taskId", *fis.TaskID)
+				return PullStatusPending
+			}
+
+			if exhausted {
+				// Mark as failed in our tracking table
+				if err := h.store.MarkPieceFailed(ctx, pullID, cidV1Str, reason); err != nil {
+					log.Errorw("failed to mark piece as failed", "error", err, "pieceCid", cidV1Str)
+				}
+				return PullStatusFailed
+			}
+
+			// Task deleted but not due to exhausted retries, mark as failed
+			if err := h.store.MarkPieceFailed(ctx, pullID, cidV1Str, "fetch task orphaned without failure record"); err != nil {
+				log.Errorw("failed to mark piece as failed", "error", err, "pieceCid", cidV1Str)
+			}
+			return PullStatusFailed
+		}
+	}
+
+	// Pull task completed successfully, check parked_pieces status
+	if ps != nil {
+		// Complete
+		if ps.Complete {
+			return PullStatusComplete
+		}
+
+		// StorePiece task is assigned
+		if ps.TaskID != nil {
+			if ps.TaskExists {
+				// Task is alive
+				if ps.Retries > 0 {
+					return PullStatusRetrying
+				}
+				return PullStatusInProgress
+			}
+
+			// StorePiece task was deleted, check if it failed permanently
+			exhausted, reason, err := h.store.CheckTaskExhaustedRetries(ctx, *ps.TaskID)
+			if err != nil {
+				log.Errorw("failed to check task history", "error", err, "taskId", *ps.TaskID)
+				return PullStatusPending
+			}
+
+			if exhausted {
+				// Mark as failed
+				if err := h.store.MarkPieceFailed(ctx, pullID, cidV1Str, "StorePiece: "+reason); err != nil {
+					log.Errorw("failed to mark piece as failed", "error", err, "pieceCid", cidV1Str)
+				}
+				return PullStatusFailed
+			}
+
+			// StorePiece task orphaned, mark as failed
+			if err := h.store.MarkPieceFailed(ctx, pullID, cidV1Str, "StorePiece task orphaned without failure record"); err != nil {
+				log.Errorw("failed to mark piece as failed", "error", err, "pieceCid", cidV1Str)
+			}
+			return PullStatusFailed
+		}
+
+		// parked_pieces exists but task_id is NULL and not complete, waiting for StorePiece to pick up
+		return PullStatusInProgress
+	}
+
+	// No parked_pieces yet, waiting for fetch task to pick up
+	return PullStatusPending
+}
+
+// dbPullStore implements PullStore using harmonydb
+type dbPullStore struct {
+	db *harmonydb.DB
+}
+
+// NewDBPullStore creates a PullStore backed by harmonydb
+func NewDBPullStore(db *harmonydb.DB) PullStore {
+	return &dbPullStore{db: db}
+}
+
+func (s *dbPullStore) GetPullByKey(ctx context.Context, service string, hash []byte, dataSetId uint64, recordKeeper string) (*PullRecord, error) {
+	var records []struct {
+		ID            int64  `db:"id"`
+		Service       string `db:"service"`
+		ExtraDataHash []byte `db:"extra_data_hash"`
+		DataSetId     uint64 `db:"data_set_id"`
+		RecordKeeper  string `db:"record_keeper"`
+	}
+
+	err := s.db.Select(ctx, &records, `
+		SELECT id, service, extra_data_hash, data_set_id, record_keeper
+		FROM pdp_piece_pulls
+		WHERE service = $1 AND extra_data_hash = $2 AND data_set_id = $3 AND record_keeper = $4
+	`, service, hash, dataSetId, recordKeeper)
+	if err != nil {
+		return nil, fmt.Errorf("query fetch by key: %w", err)
+	}
+
+	if len(records) == 0 {
+		return nil, nil
+	}
+
+	return &PullRecord{
+		ID:            records[0].ID,
+		Service:       records[0].Service,
+		ExtraDataHash: records[0].ExtraDataHash,
+		DataSetId:     records[0].DataSetId,
+		RecordKeeper:  records[0].RecordKeeper,
+	}, nil
+}
+
+func (s *dbPullStore) CreatePullWithPieces(ctx context.Context, fetch *PullRecord, pieces []PullPiece) (int64, error) {
+	var pullID int64
+
+	_, err := s.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		// Insert pull record and get the auto-generated ID
+		err := tx.QueryRow(`
+			INSERT INTO pdp_piece_pulls (service, extra_data_hash, data_set_id, record_keeper)
+			VALUES ($1, $2, $3, $4)
+			RETURNING id
+		`, fetch.Service, fetch.ExtraDataHash, fetch.DataSetId, fetch.RecordKeeper).Scan(&pullID)
+		if err != nil {
+			return false, fmt.Errorf("insert fetch: %w", err)
+		}
+
+		// Insert piece items with raw size and source_url for task to pick up
+		for _, piece := range pieces {
+			_, err := tx.Exec(`
+				INSERT INTO pdp_piece_pull_items (fetch_id, piece_cid, piece_raw_size, source_url)
+				VALUES ($1, $2, $3, $4)
+			`, pullID, piece.CidV1.String(), piece.RawSize, piece.SourceURL)
+			if err != nil {
+				return false, fmt.Errorf("insert pull item: %w", err)
+			}
+		}
+
+		return true, nil
+	}, harmonydb.OptionRetry())
+
+	return pullID, err
+}
+
+func (s *dbPullStore) GetPieceStatuses(ctx context.Context, pieceCids []cid.Cid) (map[string]*PieceStatus, error) {
+	if len(pieceCids) == 0 {
+		return make(map[string]*PieceStatus), nil
+	}
+
+	// Build array of CID strings for batch query
+	cidStrs := make([]string, len(pieceCids))
+	for i, c := range pieceCids {
+		cidStrs[i] = c.String()
+	}
+
+	var pieces []struct {
+		PieceCid   string `db:"piece_cid"`
+		Complete   bool   `db:"complete"`
+		TaskID     *int64 `db:"task_id"`
+		TaskExists bool   `db:"task_exists"`
+		Retries    int    `db:"retries"`
+	}
+
+	// Batch query with ANY() for all CIDs at once
+	err := s.db.Select(ctx, &pieces, `
+		SELECT pp.piece_cid, pp.complete, pp.task_id,
+		       (ht.id IS NOT NULL) as task_exists,
+		       COALESCE(ht.retries, 0) as retries
+		FROM parked_pieces pp
+		LEFT JOIN harmony_task ht ON pp.task_id = ht.id
+		WHERE pp.piece_cid = ANY($1) AND pp.long_term = TRUE AND pp.cleanup_task_id IS NULL
+	`, cidStrs)
+	if err != nil {
+		return nil, fmt.Errorf("query piece statuses: %w", err)
+	}
+
+	result := make(map[string]*PieceStatus)
+	for _, p := range pieces {
+		result[p.PieceCid] = &PieceStatus{
+			PieceCid:   p.PieceCid,
+			Complete:   p.Complete,
+			TaskID:     p.TaskID,
+			TaskExists: p.TaskExists,
+			Retries:    p.Retries,
+		}
+	}
+
+	return result, nil
+}
+
+func (s *dbPullStore) GetPullItemStatuses(ctx context.Context, pullID int64, pieceCids []cid.Cid) (map[string]*PullItemStatus, error) {
+	if len(pieceCids) == 0 {
+		return make(map[string]*PullItemStatus), nil
+	}
+
+	// Build array of CID strings for batch query
+	cidStrs := make([]string, len(pieceCids))
+	for i, c := range pieceCids {
+		cidStrs[i] = c.String()
+	}
+
+	var items []struct {
+		PieceCid   string `db:"piece_cid"`
+		TaskID     *int64 `db:"task_id"`
+		TaskExists bool   `db:"task_exists"`
+		Retries    int    `db:"retries"`
+		Failed     bool   `db:"failed"`
+	}
+
+	// Batch query with ANY() for all CIDs at once
+	err := s.db.Select(ctx, &items, `
+		SELECT fi.piece_cid, fi.task_id, fi.failed,
+		       (ht.id IS NOT NULL) as task_exists,
+		       COALESCE(ht.retries, 0) as retries
+		FROM pdp_piece_pull_items fi
+		LEFT JOIN harmony_task ht ON fi.task_id = ht.id
+		WHERE fi.fetch_id = $1 AND fi.piece_cid = ANY($2)
+	`, pullID, cidStrs)
+	if err != nil {
+		return nil, fmt.Errorf("query pull item statuses: %w", err)
+	}
+
+	result := make(map[string]*PullItemStatus)
+	for _, item := range items {
+		result[item.PieceCid] = &PullItemStatus{
+			TaskID:     item.TaskID,
+			TaskExists: item.TaskExists,
+			Retries:    item.Retries,
+			Failed:     item.Failed,
+		}
+	}
+
+	return result, nil
+}
+
+func (s *dbPullStore) GetPullPieces(ctx context.Context, pullID int64) ([]PullPiece, error) {
+	var items []struct {
+		PieceCid     string  `db:"piece_cid"`
+		PieceRawSize uint64  `db:"piece_raw_size"`
+		SourceURL    string  `db:"source_url"`
+		Failed       bool    `db:"failed"`
+		FailReason   *string `db:"fail_reason"`
+	}
+
+	err := s.db.Select(ctx, &items, `
+		SELECT piece_cid, piece_raw_size, source_url, failed, fail_reason
+		FROM pdp_piece_pull_items WHERE fetch_id = $1
+	`, pullID)
+	if err != nil {
+		return nil, fmt.Errorf("query pull items: %w", err)
+	}
+
+	result := make([]PullPiece, len(items))
+	for i, item := range items {
+		c, err := cid.Parse(item.PieceCid)
+		if err != nil {
+			return nil, fmt.Errorf("parse CID %q: %w", item.PieceCid, err)
+		}
+		failReason := ""
+		if item.FailReason != nil {
+			failReason = *item.FailReason
+		}
+		result[i] = PullPiece{
+			CidV1:      c,
+			RawSize:    item.PieceRawSize,
+			SourceURL:  item.SourceURL,
+			Failed:     item.Failed,
+			FailReason: failReason,
+		}
+	}
+
+	return result, nil
+}
+
+func (s *dbPullStore) MarkPieceFailed(ctx context.Context, pullID int64, pieceCid string, reason string) error {
+	_, err := s.db.Exec(ctx, `
+		UPDATE pdp_piece_pull_items
+		SET failed = TRUE, fail_reason = $3
+		WHERE fetch_id = $1 AND piece_cid = $2
+	`, pullID, pieceCid, reason)
+	if err != nil {
+		return fmt.Errorf("mark piece failed: %w", err)
+	}
+	return nil
+}
+
+func (s *dbPullStore) CheckTaskExhaustedRetries(ctx context.Context, taskID int64) (bool, string, error) {
+	// Look up the last history entry for this task to check if it failed
+	var history []struct {
+		Result bool    `db:"result"` // true = success, false = failure
+		Err    *string `db:"err"`    // error message when result is false
+	}
+
+	err := s.db.Select(ctx, &history, `
+		SELECT result, err FROM harmony_task_history
+		WHERE task_id = $1
+		ORDER BY id DESC
+		LIMIT 1
+	`, taskID)
+	if err != nil {
+		return false, "", fmt.Errorf("query task history: %w", err)
+	}
+
+	if len(history) == 0 {
+		// Task may have been cleaned up or never ran
+		return false, "", nil
+	}
+
+	// result=false means the task failed
+	if !history[0].Result {
+		reason := "unknown error"
+		if history[0].Err != nil {
+			reason = *history[0].Err
+		}
+		return true, reason, nil
+	}
+
+	return false, "", nil
+}

--- a/pdp/handlers_pull_test.go
+++ b/pdp/handlers_pull_test.go
@@ -1,0 +1,761 @@
+package pdp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/snadrus/must"
+	"github.com/stretchr/testify/require"
+)
+
+// mockPullStore implements PullStore for testing
+type mockPullStore struct {
+	// Configuration for mock behavior
+	existingPull     *PullRecord
+	pieceStatuses    map[string]*PieceStatus    // keyed by v1 CID string (from parked_pieces)
+	pullItemStatuses map[string]*PullItemStatus // keyed by v1 CID string (from pdp_piece_pull_items)
+	pullPieces       []PullPiece                // v1 CID + raw size + source_url
+	createError      error
+
+	// Failure tracking configuration
+	exhaustedTasks map[int64]string // taskID -> error reason (for CheckTaskExhaustedRetries)
+
+	// Tracking calls
+	createFetchCalled         bool
+	createdFetch              *PullRecord
+	createdPieces             []PullPiece // v1 CID + raw size + source_url
+	getStatusesCalled         bool
+	getPullItemStatusesCalled bool
+	getFetchPiecesCalled      bool
+	lastCreatedID             int64
+	markedFailed              map[string]string // v1 CID -> reason
+}
+
+func (m *mockPullStore) GetPullByKey(ctx context.Context, service string, hash []byte, dataSetId uint64, recordKeeper string) (*PullRecord, error) {
+	return m.existingPull, nil
+}
+
+func (m *mockPullStore) CreatePullWithPieces(ctx context.Context, fetch *PullRecord, pieces []PullPiece) (int64, error) {
+	m.createFetchCalled = true
+	m.createdFetch = fetch
+	m.createdPieces = pieces
+	if m.createError != nil {
+		return 0, m.createError
+	}
+	m.lastCreatedID++
+	return m.lastCreatedID, nil
+}
+
+func (m *mockPullStore) GetPieceStatuses(ctx context.Context, pieceCids []cid.Cid) (map[string]*PieceStatus, error) {
+	m.getStatusesCalled = true
+	if m.pieceStatuses == nil {
+		return make(map[string]*PieceStatus), nil
+	}
+	return m.pieceStatuses, nil
+}
+
+func (m *mockPullStore) GetPullItemStatuses(ctx context.Context, fetchID int64, pieceCids []cid.Cid) (map[string]*PullItemStatus, error) {
+	m.getPullItemStatusesCalled = true
+	if m.pullItemStatuses == nil {
+		return make(map[string]*PullItemStatus), nil
+	}
+	return m.pullItemStatuses, nil
+}
+
+func (m *mockPullStore) GetPullPieces(ctx context.Context, fetchID int64) ([]PullPiece, error) {
+	m.getFetchPiecesCalled = true
+	if m.pullPieces != nil {
+		return m.pullPieces, nil
+	}
+	// Return the pieces that were created
+	return m.createdPieces, nil
+}
+
+func (m *mockPullStore) MarkPieceFailed(ctx context.Context, fetchID int64, pieceCid string, reason string) error {
+	if m.markedFailed == nil {
+		m.markedFailed = make(map[string]string)
+	}
+	m.markedFailed[pieceCid] = reason
+	return nil
+}
+
+func (m *mockPullStore) CheckTaskExhaustedRetries(ctx context.Context, taskID int64) (bool, string, error) {
+	if m.exhaustedTasks != nil {
+		if reason, ok := m.exhaustedTasks[taskID]; ok {
+			return true, reason, nil
+		}
+	}
+	return false, "", nil
+}
+
+// mockValidator implements AddPiecesValidator for testing
+type mockValidator struct {
+	shouldPass bool
+	err        error
+}
+
+func (m *mockValidator) ValidateAddPieces(ctx context.Context, params *AddPiecesValidatorParams) error {
+	if m.shouldPass {
+		return nil
+	}
+	if m.err != nil {
+		return m.err
+	}
+	return errors.New("validation failed")
+}
+
+// Valid test PieceCIDv2s
+const (
+	testCid1 = "bafkzcibf6x7poaqtr2pqm6qki6sgetps74xutpclzrwbux5ow6rw4nsfu6tbf2zfnmnq"
+	testCid2 = "bafkzcibf6x7poaqtihg2pifeyzwfy3ndaumj3ds6c5ddiqewo2dzfzr7pqlery5dwyba"
+	testCid3 = "bafkzcibf6x7poaqtzqrdhkbnlu53ftoiiom6rcu7fmwbaa423d5kihygqqhi7m5ypyfq"
+)
+
+// Test dataSetId for "add to existing dataset" case (avoids recordKeeper requirement)
+var testDataSetId = uint64(1)
+
+// testParsePieceCidV2 is a test helper that parses a v2 CID and returns PullPiece (v1 + raw size)
+func testParsePieceCidV2(t *testing.T, cidV2Str string) PullPiece {
+	t.Helper()
+	info, err := ParsePieceCidV2(cidV2Str)
+	require.NoError(t, err)
+	return PullPiece{CidV1: info.CidV1, RawSize: info.RawSize}
+}
+
+func TestHandlePull_MethodNotAllowed(t *testing.T) {
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+
+	req := httptest.NewRequest(http.MethodGet, "/pdp/piece/pull", nil)
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestHandlePull_InvalidJSON(t *testing.T) {
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewBufferString("not json"))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "Invalid request body")
+}
+
+func TestHandlePull_MissingExtraData(t *testing.T) {
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+
+	body := PullRequest{
+		ExtraData: "",
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "extraData is required")
+}
+
+func TestHandlePull_NoPieces(t *testing.T) {
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+
+	body := PullRequest{
+		ExtraData: "0x1234",
+		DataSetId: &testDataSetId,
+		Pieces:    []PullPieceRequest{},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "at least one piece")
+}
+
+func TestHandlePull_InvalidSourceURL(t *testing.T) {
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+
+	body := PullRequest{
+		ExtraData: "0x1234",
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "http://example.com/piece/" + testCid1}, // HTTP not HTTPS
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "HTTPS")
+}
+
+func TestHandlePull_ValidatorFails(t *testing.T) {
+	store := &mockPullStore{}
+	validator := &mockValidator{shouldPass: false, err: errors.New("contract validation failed")}
+	handler := NewPullHandler(&NullAuth{}, store, validator)
+
+	body := PullRequest{
+		ExtraData: "0x1234",
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "extraData validation failed")
+	// Store should not be called when validation fails
+	require.False(t, store.createFetchCalled)
+}
+
+func TestHandlePull_NewRequest_Success(t *testing.T) {
+	store := &mockPullStore{}
+	validator := &mockValidator{shouldPass: true}
+	handler := NewPullHandler(&NullAuth{}, store, validator)
+
+	body := PullRequest{
+		ExtraData: "0x1234",
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+			{PieceCid: testCid2, SourceURL: "https://example.com/piece/" + testCid2},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify store was called
+	require.True(t, store.createFetchCalled)
+	require.NotNil(t, store.createdFetch)
+	require.Equal(t, "public", store.createdFetch.Service) // NullAuth returns "public"
+	require.Len(t, store.createdPieces, 2)
+
+	// Verify pieces include source URLs
+	require.NotEmpty(t, store.createdPieces[0].SourceURL)
+	require.NotEmpty(t, store.createdPieces[1].SourceURL)
+
+	// Verify response returns v2 CIDs
+	var resp PullResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, PullStatusPending, resp.Status) // New pieces should be pending
+	require.Len(t, resp.Pieces, 2)
+	// Response should contain original v2 CIDs
+	cidSet := map[string]bool{}
+	for _, p := range resp.Pieces {
+		cidSet[p.PieceCid] = true
+	}
+	require.True(t, cidSet[testCid1])
+	require.True(t, cidSet[testCid2])
+}
+
+func TestHandlePull_CreateNew_MissingRecordKeeper(t *testing.T) {
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+
+	// dataSetId omitted (nil) requires recordKeeper
+	body := PullRequest{
+		ExtraData: "0x1234",
+		// DataSetId: nil (omitted = create new)
+		// RecordKeeper: nil (missing - should fail)
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "recordKeeper is required")
+}
+
+// Test recordKeeper address (any valid address works for non-public services)
+var testRecordKeeper = "0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f"
+
+// privateServiceAuth returns a non-public service name to bypass AllowedRecordKeepers check
+type privateServiceAuth struct{}
+
+func (a *privateServiceAuth) AuthService(r *http.Request) (string, error) {
+	return "test-service", nil
+}
+
+func TestHandlePull_CreateNew_Success(t *testing.T) {
+	store := &mockPullStore{}
+	validator := &mockValidator{shouldPass: true}
+	// Use non-public service auth to test create-new flow without AllowedRecordKeepers restriction
+	handler := NewPullHandler(&privateServiceAuth{}, store, validator)
+
+	// dataSetId omitted (nil) with recordKeeper = create new dataset
+	body := PullRequest{
+		ExtraData:    "0x1234",
+		RecordKeeper: &testRecordKeeper,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify store was called with correct values
+	require.True(t, store.createFetchCalled)
+	require.NotNil(t, store.createdFetch)
+	require.Equal(t, uint64(0), store.createdFetch.DataSetId) // create-new uses 0
+	require.Equal(t, testRecordKeeper, store.createdFetch.RecordKeeper)
+}
+
+func TestHandlePull_Idempotent(t *testing.T) {
+	// Get v1 CID info for test setup
+	piece1 := testParsePieceCidV2(t, testCid1)
+	v1Str1 := piece1.CidV1.String()
+
+	store := &mockPullStore{
+		existingPull: &PullRecord{
+			ID:            123,
+			Service:       "public",
+			ExtraDataHash: []byte("hash"),
+		},
+		pullPieces: []PullPiece{piece1},
+		pieceStatuses: map[string]*PieceStatus{
+			v1Str1: {PieceCid: v1Str1, Complete: true},
+		},
+	}
+	validator := &mockValidator{shouldPass: true}
+	handler := NewPullHandler(&NullAuth{}, store, validator)
+
+	body := PullRequest{
+		ExtraData: "0x1234",
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Should NOT create new fetch (idempotent - already exists)
+	require.False(t, store.createFetchCalled)
+
+	// Should return status of existing fetch with v2 CID in response
+	var resp PullResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, PullStatusComplete, resp.Status)
+	require.Len(t, resp.Pieces, 1)
+	require.Equal(t, PullStatusComplete, resp.Pieces[0].Status)
+	require.Equal(t, testCid1, resp.Pieces[0].PieceCid) // Response should have v2 CID
+}
+
+func TestHandlePull_MixedStatuses(t *testing.T) {
+	// Get v1 CID info for test setup
+	piece1 := testParsePieceCidV2(t, testCid1)
+	piece2 := testParsePieceCidV2(t, testCid2)
+	piece3 := testParsePieceCidV2(t, testCid3)
+	v1Str1 := piece1.CidV1.String()
+	v1Str2 := piece2.CidV1.String()
+
+	taskID := int64(123)
+	store := &mockPullStore{
+		pullPieces: []PullPiece{piece1, piece2, piece3},
+		pieceStatuses: map[string]*PieceStatus{
+			v1Str1: {PieceCid: v1Str1, Complete: true},
+			v1Str2: {PieceCid: v1Str2, Complete: false, TaskID: &taskID, TaskExists: true}, // inProgress
+			// piece3 not in map - should be pending
+		},
+	}
+	validator := &mockValidator{shouldPass: true}
+	handler := NewPullHandler(&NullAuth{}, store, validator)
+
+	body := PullRequest{
+		ExtraData: "0x1234",
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+			{PieceCid: testCid2, SourceURL: "https://example.com/piece/" + testCid2},
+			{PieceCid: testCid3, SourceURL: "https://example.com/piece/" + testCid3},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp PullResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, PullStatusInProgress, resp.Status) // Has inProgress piece
+	require.Len(t, resp.Pieces, 3)
+
+	// Find each piece status - response should have v2 CIDs
+	statusMap := make(map[string]PullStatus)
+	for _, p := range resp.Pieces {
+		statusMap[p.PieceCid] = p.Status
+	}
+	require.Equal(t, PullStatusComplete, statusMap[testCid1])
+	require.Equal(t, PullStatusInProgress, statusMap[testCid2])
+	require.Equal(t, PullStatusPending, statusMap[testCid3])
+}
+
+func TestHandlePull_CreateError(t *testing.T) {
+	store := &mockPullStore{
+		createError: errors.New("database error"),
+	}
+	validator := &mockValidator{shouldPass: true}
+	handler := NewPullHandler(&NullAuth{}, store, validator)
+
+	body := PullRequest{
+		ExtraData: "0x1234",
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestPadPieceSize(t *testing.T) {
+	// Test vectors from go-fil-commp-hashhash/testdata/zero.txt
+	// These are authoritative values: PayloadSize -> PieceSize
+	// FR32 padding: ceil(raw * 127/128) rounded to next power of 2
+	tests := []struct {
+		name     string
+		rawSize  int64
+		expected int64
+	}{
+		// Edge cases
+		{name: "zero", rawSize: 0, expected: 0},
+
+		// From commp testdata/zero.txt - boundary tests
+		{name: "127 -> 128 (exactly 1 FR32 block)", rawSize: 127, expected: 128},
+		{name: "254 -> 256 (exactly 2 FR32 blocks)", rawSize: 254, expected: 256},
+		{name: "255 -> 512 (just over 2 blocks)", rawSize: 255, expected: 512},
+		{name: "508 -> 512 (exactly 4 FR32 blocks)", rawSize: 508, expected: 512},
+		{name: "509 -> 1024 (just over 4 blocks)", rawSize: 509, expected: 1024},
+		{name: "1016 -> 1024 (exactly 8 FR32 blocks)", rawSize: 1016, expected: 1024},
+		{name: "1017 -> 2048 (just over 8 blocks)", rawSize: 1017, expected: 2048},
+		{name: "1024 -> 2048", rawSize: 1024, expected: 2048},
+
+		// Additional cases from testdata
+		{name: "96 -> 128", rawSize: 96, expected: 128},
+		{name: "192 -> 256", rawSize: 192, expected: 256},
+		{name: "384 -> 512", rawSize: 384, expected: 512},
+		{name: "768 -> 1024", rawSize: 768, expected: 1024},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PadPieceSize(tt.rawSize)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHandlePull_RetryingStatus(t *testing.T) {
+	// Piece with task that has retries > 0 should show "retrying" status
+	piece1 := testParsePieceCidV2(t, testCid1)
+	v1Str1 := piece1.CidV1.String()
+	taskID := int64(999)
+
+	store := &mockPullStore{
+		existingPull: &PullRecord{
+			ID:            123,
+			Service:       "public",
+			ExtraDataHash: []byte("hash"),
+		},
+		pullPieces: []PullPiece{piece1},
+		pieceStatuses: map[string]*PieceStatus{
+			v1Str1: {
+				PieceCid:   v1Str1,
+				Complete:   false,
+				TaskID:     &taskID,
+				TaskExists: true,
+				Retries:    2, // Has been retried twice
+			},
+		},
+	}
+	validator := &mockValidator{shouldPass: true}
+	handler := NewPullHandler(&NullAuth{}, store, validator)
+
+	body := PullRequest{
+		ExtraData: "0x1234",
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp PullResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, PullStatusRetrying, resp.Status)
+	require.Len(t, resp.Pieces, 1)
+	require.Equal(t, PullStatusRetrying, resp.Pieces[0].Status)
+}
+
+func TestHandlePull_FailedFromFetchItems(t *testing.T) {
+	// Piece already marked as failed in fetch_items should show "failed" status
+	piece1 := testParsePieceCidV2(t, testCid1)
+
+	store := &mockPullStore{
+		existingPull: &PullRecord{
+			ID:            123,
+			Service:       "public",
+			ExtraDataHash: []byte("hash"),
+		},
+		pullPieces: []PullPiece{
+			{
+				CidV1:      piece1.CidV1,
+				RawSize:    piece1.RawSize,
+				Failed:     true,
+				FailReason: "CommP mismatch: expected X, got Y",
+			},
+		},
+		// No piece status needed - Failed flag in PullPiece takes priority
+		pieceStatuses: map[string]*PieceStatus{},
+	}
+	validator := &mockValidator{shouldPass: true}
+	handler := NewPullHandler(&NullAuth{}, store, validator)
+
+	body := PullRequest{
+		ExtraData: "0x1234",
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp PullResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, PullStatusFailed, resp.Status)
+	require.Len(t, resp.Pieces, 1)
+	require.Equal(t, PullStatusFailed, resp.Pieces[0].Status)
+}
+
+func TestHandlePull_OrphanedTaskExhausted(t *testing.T) {
+	// Piece with orphaned task (task deleted, exhausted retries) should show "failed"
+	// and trigger MarkPieceFailed call
+	piece1 := testParsePieceCidV2(t, testCid1)
+	v1Str1 := piece1.CidV1.String()
+	taskID := int64(888)
+
+	store := &mockPullStore{
+		existingPull: &PullRecord{
+			ID:            123,
+			Service:       "public",
+			ExtraDataHash: []byte("hash"),
+		},
+		pullPieces: []PullPiece{piece1},
+		pieceStatuses: map[string]*PieceStatus{
+			v1Str1: {
+				PieceCid:   v1Str1,
+				Complete:   false,
+				TaskID:     &taskID,
+				TaskExists: false, // Task was deleted
+				Retries:    0,
+			},
+		},
+		exhaustedTasks: map[int64]string{
+			taskID: "size mismatch: expected 1000, got 500", // Task failed permanently
+		},
+	}
+	validator := &mockValidator{shouldPass: true}
+	handler := NewPullHandler(&NullAuth{}, store, validator)
+
+	body := PullRequest{
+		ExtraData: "0x1234",
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp PullResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, PullStatusFailed, resp.Status)
+	require.Len(t, resp.Pieces, 1)
+	require.Equal(t, PullStatusFailed, resp.Pieces[0].Status)
+
+	// Verify MarkPieceFailed was called with the error reason (prefixed with StorePiece:)
+	require.NotNil(t, store.markedFailed)
+	require.Equal(t, "StorePiece: size mismatch: expected 1000, got 500", store.markedFailed[v1Str1])
+}
+
+func TestHandlePull_OrphanedTaskNotExhausted(t *testing.T) {
+	// Piece with orphaned task but no exhaustion record - should show "failed"
+	// because the piece is stuck (poller won't pick it up with task_id still set)
+	piece1 := testParsePieceCidV2(t, testCid1)
+	v1Str1 := piece1.CidV1.String()
+	taskID := int64(777)
+
+	store := &mockPullStore{
+		existingPull: &PullRecord{
+			ID:            123,
+			Service:       "public",
+			ExtraDataHash: []byte("hash"),
+		},
+		pullPieces: []PullPiece{piece1},
+		pieceStatuses: map[string]*PieceStatus{
+			v1Str1: {
+				PieceCid:   v1Str1,
+				Complete:   false,
+				TaskID:     &taskID,
+				TaskExists: false, // Task was deleted
+				Retries:    0,
+			},
+		},
+		// exhaustedTasks is nil - no history found (purged or never ran)
+	}
+	validator := &mockValidator{shouldPass: true}
+	handler := NewPullHandler(&NullAuth{}, store, validator)
+
+	body := PullRequest{
+		ExtraData: "0x1234",
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp PullResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.Equal(t, PullStatusFailed, resp.Status)
+	require.Len(t, resp.Pieces, 1)
+	require.Equal(t, PullStatusFailed, resp.Pieces[0].Status)
+
+	// Verify MarkPieceFailed was called with orphan message (for StorePiece task)
+	require.NotNil(t, store.markedFailed)
+	require.Equal(t, "StorePiece task orphaned without failure record", store.markedFailed[v1Str1])
+}
+
+func TestComputeOverallStatus_Priority(t *testing.T) {
+	// Test that status priority is: failed > retrying > inProgress > pending > complete
+	tests := []struct {
+		name           string
+		pieceStatuses  []PullStatus
+		expectedStatus PullStatus
+	}{
+		{
+			name:           "all complete",
+			pieceStatuses:  []PullStatus{PullStatusComplete, PullStatusComplete},
+			expectedStatus: PullStatusComplete,
+		},
+		{
+			name:           "one pending makes overall pending",
+			pieceStatuses:  []PullStatus{PullStatusComplete, PullStatusPending},
+			expectedStatus: PullStatusPending,
+		},
+		{
+			name:           "inProgress overrides pending",
+			pieceStatuses:  []PullStatus{PullStatusPending, PullStatusInProgress, PullStatusComplete},
+			expectedStatus: PullStatusInProgress,
+		},
+		{
+			name:           "retrying overrides inProgress",
+			pieceStatuses:  []PullStatus{PullStatusInProgress, PullStatusRetrying, PullStatusComplete},
+			expectedStatus: PullStatusRetrying,
+		},
+		{
+			name:           "failed overrides all",
+			pieceStatuses:  []PullStatus{PullStatusComplete, PullStatusInProgress, PullStatusRetrying, PullStatusFailed},
+			expectedStatus: PullStatusFailed,
+		},
+		{
+			name:           "empty pieces is pending",
+			pieceStatuses:  []PullStatus{},
+			expectedStatus: PullStatusPending,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &PullResponse{
+				Pieces: make([]PullPieceStatus, len(tt.pieceStatuses)),
+			}
+			for i, s := range tt.pieceStatuses {
+				resp.Pieces[i] = PullPieceStatus{PieceCid: "test", Status: s}
+			}
+			resp.ComputeOverallStatus()
+			require.Equal(t, tt.expectedStatus, resp.Status)
+		})
+	}
+}

--- a/pdp/piece_cid.go
+++ b/pdp/piece_cid.go
@@ -1,0 +1,137 @@
+package pdp
+
+import (
+	"fmt"
+	"math/bits"
+
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multicodec"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+)
+
+// PieceCidInfo holds all derived information from a piece CID.
+// Depending on how it was constructed, some fields may be zero values.
+type PieceCidInfo struct {
+	CidV1   cid.Cid // Always populated
+	CidV2   cid.Cid // Undef if parsed from v1 without size
+	RawSize uint64  // 0 if parsed from v1 without size
+}
+
+// HasV2 returns true if the CidV2 is available (not Undef).
+func (p *PieceCidInfo) HasV2() bool {
+	return p.CidV2.Defined()
+}
+
+// ParsePieceCid parses any valid piece CID string (v1 or v2).
+// If the input is v1, CidV2 will be cid.Undef and RawSize will be 0.
+// If the input is v2, all fields will be populated.
+func ParsePieceCid(cidStr string) (*PieceCidInfo, error) {
+	pieceCid, err := cid.Decode(cidStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode piece CID: %w", err)
+	}
+
+	switch pieceCid.Prefix().MhType {
+	case uint64(multicodec.Sha2_256Trunc254Padded):
+		// v1 CID - we don't have size info
+		return &PieceCidInfo{
+			CidV1:   pieceCid,
+			CidV2:   cid.Undef,
+			RawSize: 0,
+		}, nil
+
+	case uint64(multicodec.Fr32Sha256Trunc254Padbintree):
+		// v2 CID - extract v1 and size
+		v1, rawSize, err := commcid.PieceCidV1FromV2(pieceCid)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract v1 from v2: %w", err)
+		}
+		return &PieceCidInfo{
+			CidV1:   v1,
+			CidV2:   pieceCid,
+			RawSize: rawSize,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported piece CID type: %d", pieceCid.Prefix().MhType)
+	}
+}
+
+// ParsePieceCidV2 parses a piece CID string that must be in v2 format.
+// Returns an error if the input is a v1 CID.
+// All fields in the returned PieceCidInfo will be populated.
+func ParsePieceCidV2(cidStr string) (*PieceCidInfo, error) {
+	pieceCid, err := cid.Decode(cidStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CID: %w", err)
+	}
+
+	if pieceCid.Prefix().MhType != uint64(multicodec.Fr32Sha256Trunc254Padbintree) {
+		return nil, fmt.Errorf("piece CID must be PieceCIDv2 format (got multihash type %d)", pieceCid.Prefix().MhType)
+	}
+
+	v1, rawSize, err := commcid.PieceCidV1FromV2(pieceCid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract v1 from v2: %w", err)
+	}
+
+	return &PieceCidInfo{
+		CidV1:   v1,
+		CidV2:   pieceCid,
+		RawSize: rawSize,
+	}, nil
+}
+
+// PieceCidV2FromV1 constructs a complete PieceCidInfo from a v1 CID and raw size.
+// This is typically used when reading from the database (which stores v1 + size)
+// and needing to return v2 in API responses.
+func PieceCidV2FromV1(v1 cid.Cid, rawSize uint64) (*PieceCidInfo, error) {
+	if rawSize == 0 {
+		return nil, fmt.Errorf("rawSize must be provided to construct v2 from v1")
+	}
+
+	v2, err := commcid.PieceCidV2FromV1(v1, rawSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct v2 from v1: %w", err)
+	}
+
+	return &PieceCidInfo{
+		CidV1:   v1,
+		CidV2:   v2,
+		RawSize: rawSize,
+	}, nil
+}
+
+// PieceCidV2FromV1Str is a convenience function that parses a v1 CID string
+// and constructs a complete PieceCidInfo. This handles the common case of
+// reading a v1 CID string from the database along with its size.
+func PieceCidV2FromV1Str(v1Str string, rawSize uint64) (*PieceCidInfo, error) {
+	v1, err := cid.Decode(v1Str)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode v1 CID: %w", err)
+	}
+
+	// Verify it's actually a v1 CID
+	if v1.Prefix().MhType != uint64(multicodec.Sha2_256Trunc254Padded) {
+		return nil, fmt.Errorf("expected v1 CID but got multihash type %d", v1.Prefix().MhType)
+	}
+
+	return PieceCidV2FromV1(v1, rawSize)
+}
+
+// PadPieceSize calculates the padded piece size from raw size using FR32 padding.
+// FR32 encoding: 127 bytes of data become 128 bytes, then rounded up to next power of 2.
+func PadPieceSize(rawSize int64) int64 {
+	if rawSize == 0 {
+		return 0
+	}
+	// Apply FR32 ratio: ceil(rawSize * 128 / 127)
+	fr32Padded := (uint64(rawSize)*128 + 126) / 127
+	// Round up to next power of 2
+	if fr32Padded == 0 {
+		return 1
+	}
+	fr32Padded--
+	return int64(1 << bits.Len64(fr32Padded))
+}

--- a/pdp/piece_cid_test.go
+++ b/pdp/piece_cid_test.go
@@ -1,0 +1,259 @@
+package pdp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+// Test CIDs - these are real valid CIDs from the codebase
+const (
+	// PieceCIDv2 format (Fr32Sha256Trunc254Padbintree multihash)
+	testV2Cid1 = "bafkzcibf6x7poaqtr2pqm6qki6sgetps74xutpclzrwbux5ow6rw4nsfu6tbf2zfnmnq"
+	testV2Cid2 = "bafkzcibf6x7poaqtihg2pifeyzwfy3ndaumj3ds6c5ddiqewo2dzfzr7pqlery5dwyba"
+
+	// PieceCIDv1 format (Sha2_256Trunc254Padded multihash)
+	testV1Cid1 = "baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy"
+)
+
+func TestParsePieceCid(t *testing.T) {
+	t.Run("parses v2 CID correctly", func(t *testing.T) {
+		info, err := ParsePieceCid(testV2Cid1)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		// V1 should be populated
+		require.True(t, info.CidV1.Defined())
+		require.NotEqual(t, testV2Cid1, info.CidV1.String(), "v1 should differ from v2")
+
+		// V2 should be the original
+		require.True(t, info.HasV2())
+		require.Equal(t, testV2Cid1, info.CidV2.String())
+
+		// RawSize should be populated
+		require.NotZero(t, info.RawSize)
+	})
+
+	t.Run("parses v1 CID correctly", func(t *testing.T) {
+		info, err := ParsePieceCid(testV1Cid1)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		// V1 should be the original
+		require.True(t, info.CidV1.Defined())
+		require.Equal(t, testV1Cid1, info.CidV1.String())
+
+		// V2 should be Undef (no size info available)
+		require.False(t, info.HasV2())
+		require.Equal(t, cid.Undef, info.CidV2)
+
+		// RawSize should be 0 (no size info available)
+		require.Zero(t, info.RawSize)
+	})
+
+	t.Run("rejects invalid CID", func(t *testing.T) {
+		_, err := ParsePieceCid("not-a-cid")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to decode")
+	})
+
+	t.Run("rejects empty string", func(t *testing.T) {
+		_, err := ParsePieceCid("")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects non-piece CID", func(t *testing.T) {
+		// A regular content CID (not a piece CID)
+		_, err := ParsePieceCid("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported piece CID type")
+	})
+}
+
+func TestParsePieceCidV2(t *testing.T) {
+	t.Run("parses v2 CID correctly", func(t *testing.T) {
+		info, err := ParsePieceCidV2(testV2Cid1)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		// All fields should be populated
+		require.True(t, info.CidV1.Defined())
+		require.True(t, info.HasV2())
+		require.Equal(t, testV2Cid1, info.CidV2.String())
+		require.NotZero(t, info.RawSize)
+	})
+
+	t.Run("rejects v1 CID", func(t *testing.T) {
+		_, err := ParsePieceCidV2(testV1Cid1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be PieceCIDv2")
+	})
+
+	t.Run("rejects invalid CID", func(t *testing.T) {
+		_, err := ParsePieceCidV2("not-a-cid")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid CID")
+	})
+
+	t.Run("multiple v2 CIDs produce different v1s", func(t *testing.T) {
+		info1, err := ParsePieceCidV2(testV2Cid1)
+		require.NoError(t, err)
+
+		info2, err := ParsePieceCidV2(testV2Cid2)
+		require.NoError(t, err)
+
+		require.NotEqual(t, info1.CidV1.String(), info2.CidV1.String())
+		require.NotEqual(t, info1.CidV2.String(), info2.CidV2.String())
+	})
+}
+
+func TestPieceCidV2FromV1(t *testing.T) {
+	// First get a valid v1 CID and its raw size from a v2
+	v2Info, err := ParsePieceCidV2(testV2Cid1)
+	require.NoError(t, err)
+
+	t.Run("reconstructs v2 from v1 and size", func(t *testing.T) {
+		info, err := PieceCidV2FromV1(v2Info.CidV1, v2Info.RawSize)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		// Should reconstruct to the same values
+		require.Equal(t, v2Info.CidV1.String(), info.CidV1.String())
+		require.Equal(t, v2Info.CidV2.String(), info.CidV2.String())
+		require.Equal(t, v2Info.RawSize, info.RawSize)
+	})
+
+	t.Run("rejects zero size", func(t *testing.T) {
+		_, err := PieceCidV2FromV1(v2Info.CidV1, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "rawSize must be provided")
+	})
+}
+
+func TestPieceCidV2FromV1Str(t *testing.T) {
+	// First get a valid v1 CID string and its raw size from a v2
+	v2Info, err := ParsePieceCidV2(testV2Cid1)
+	require.NoError(t, err)
+	v1Str := v2Info.CidV1.String()
+
+	t.Run("reconstructs v2 from v1 string and size", func(t *testing.T) {
+		info, err := PieceCidV2FromV1Str(v1Str, v2Info.RawSize)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		// Should reconstruct to the same values
+		require.Equal(t, v1Str, info.CidV1.String())
+		require.Equal(t, testV2Cid1, info.CidV2.String())
+		require.Equal(t, v2Info.RawSize, info.RawSize)
+	})
+
+	t.Run("rejects v2 CID string", func(t *testing.T) {
+		_, err := PieceCidV2FromV1Str(testV2Cid1, 1024)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected v1 CID")
+	})
+
+	t.Run("rejects invalid CID string", func(t *testing.T) {
+		_, err := PieceCidV2FromV1Str("not-a-cid", 1024)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to decode")
+	})
+
+	t.Run("rejects zero size", func(t *testing.T) {
+		_, err := PieceCidV2FromV1Str(v1Str, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "rawSize must be provided")
+	})
+}
+
+func TestRoundTrip(t *testing.T) {
+	t.Run("v2 -> v1 -> v2 round trip", func(t *testing.T) {
+		// Start with v2
+		original, err := ParsePieceCidV2(testV2Cid1)
+		require.NoError(t, err)
+
+		// Simulate storing v1 + size in DB, then reconstructing v2
+		reconstructed, err := PieceCidV2FromV1(original.CidV1, original.RawSize)
+		require.NoError(t, err)
+
+		// Should match original
+		require.Equal(t, original.CidV1.String(), reconstructed.CidV1.String())
+		require.Equal(t, original.CidV2.String(), reconstructed.CidV2.String())
+		require.Equal(t, original.RawSize, reconstructed.RawSize)
+	})
+
+	t.Run("v2 string -> v1 string -> v2 string round trip", func(t *testing.T) {
+		// Start with v2 string
+		info1, err := ParsePieceCidV2(testV2Cid1)
+		require.NoError(t, err)
+
+		// Get v1 string (as would be stored in DB)
+		v1Str := info1.CidV1.String()
+		rawSize := info1.RawSize
+
+		// Reconstruct v2 (as would be done for API response)
+		info2, err := PieceCidV2FromV1Str(v1Str, rawSize)
+		require.NoError(t, err)
+
+		// Should get back original v2 string
+		require.Equal(t, testV2Cid1, info2.CidV2.String())
+	})
+}
+
+func TestHasV2(t *testing.T) {
+	t.Run("returns true for v2 input", func(t *testing.T) {
+		info, err := ParsePieceCid(testV2Cid1)
+		require.NoError(t, err)
+		require.True(t, info.HasV2())
+	})
+
+	t.Run("returns false for v1 input", func(t *testing.T) {
+		info, err := ParsePieceCid(testV1Cid1)
+		require.NoError(t, err)
+		require.False(t, info.HasV2())
+	})
+
+	t.Run("returns true for reconstructed v2", func(t *testing.T) {
+		v2Info, err := ParsePieceCidV2(testV2Cid1)
+		require.NoError(t, err)
+
+		info, err := PieceCidV2FromV1(v2Info.CidV1, v2Info.RawSize)
+		require.NoError(t, err)
+		require.True(t, info.HasV2())
+	})
+}
+
+func TestParsePieceCidV2_ErrorMessages(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		errContains string
+	}{
+		{
+			name:        "invalid CID string",
+			input:       "not-a-cid",
+			errContains: "invalid CID",
+		},
+		{
+			name:        "v1 CID rejected",
+			input:       testV1Cid1,
+			errContains: "must be PieceCIDv2",
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			errContains: "invalid CID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePieceCidV2(tt.input)
+			require.Error(t, err)
+			require.True(t, strings.Contains(err.Error(), tt.errContains),
+				"error %q should contain %q", err.Error(), tt.errContains)
+		})
+	}
+}

--- a/pdp/pull_types.go
+++ b/pdp/pull_types.go
@@ -1,0 +1,230 @@
+package pdp
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// pullAllowInsecure relaxes security validations for development/testing environments.
+// Set CURIO_PULL_ALLOW_INSECURE=1 to:
+//   - Allow HTTP (not just HTTPS) for pull source URLs
+//   - Allow localhost and private IP addresses
+//
+// WARNING: Never enable this in production!
+var pullAllowInsecure = os.Getenv("CURIO_PULL_ALLOW_INSECURE") == "1"
+
+// PullStatus represents the status of a fetch operation or piece
+type PullStatus string
+
+const (
+	PullStatusPending    PullStatus = "pending"
+	PullStatusInProgress PullStatus = "inProgress"
+	PullStatusRetrying   PullStatus = "retrying"
+	PullStatusComplete   PullStatus = "complete"
+	PullStatusFailed     PullStatus = "failed"
+)
+
+// piecePathPattern matches URLs ending with /piece/{cid}
+var piecePathPattern = regexp.MustCompile(`/piece/([^/]+)$`)
+
+// ValidatePullSourceURL validates that a source URL is safe and properly formatted
+// for fetching a piece from another SP.
+//
+// Validation rules:
+//   - Must be HTTPS
+//   - Path must end with /piece/{pieceCid}
+//   - The pieceCid in the URL must match the expected pieceCid
+//   - Host must not be localhost, private IP, or link-local address
+func ValidatePullSourceURL(sourceURL string, expectedPieceCid string) error {
+	parsed, err := url.Parse(sourceURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	// Must be HTTPS (or HTTP if explicitly allowed for development)
+	if parsed.Scheme != "https" && (!pullAllowInsecure || parsed.Scheme != "http") {
+		return fmt.Errorf("URL must use HTTPS scheme, got %q", parsed.Scheme)
+	}
+
+	// Validate path matches /piece/{cid} pattern
+	matches := piecePathPattern.FindStringSubmatch(parsed.Path)
+	if matches == nil {
+		return fmt.Errorf("URL path must end with /piece/{pieceCid}, got %q", parsed.Path)
+	}
+
+	// Extract pieceCid from URL and compare with expected
+	urlPieceCid := matches[1]
+	if urlPieceCid != expectedPieceCid {
+		return fmt.Errorf("pieceCid in URL %q does not match expected %q", urlPieceCid, expectedPieceCid)
+	}
+
+	// Validate host is not a private/local address (skip in devnet mode)
+	if !pullAllowInsecure {
+		if err := validatePublicHost(parsed.Host); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validatePublicHost ensures the host is not localhost, a private IP, or link-local address
+func validatePublicHost(host string) error {
+	// Strip port if present
+	hostname := host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		hostname = h
+	}
+
+	// Strip brackets from IPv6 addresses (e.g., [::1] -> ::1)
+	hostname = strings.TrimPrefix(hostname, "[")
+	hostname = strings.TrimSuffix(hostname, "]")
+
+	// Block localhost and common aliases
+	lower := strings.ToLower(hostname)
+	if strings.HasPrefix(lower, "localhost") ||
+		lower == "ip6-localhost" ||
+		lower == "ip6-loopback" {
+		return fmt.Errorf("localhost addresses are not allowed")
+	}
+
+	// Try to parse as IP address and validate
+	ip := net.ParseIP(hostname)
+	if ip != nil {
+		if err := validatePublicIP(ip); err != nil {
+			return err
+		}
+	}
+
+	// For hostnames, we can't fully validate without DNS lookup
+	// The actual connection will fail if it resolves to a private IP
+	// Additional protection could be added at the HTTP client level
+
+	return nil
+}
+
+// validatePublicIP checks that an IP address is not private, loopback, or link-local
+func validatePublicIP(ip net.IP) error {
+	if ip.IsLoopback() {
+		return fmt.Errorf("loopback addresses are not allowed")
+	}
+	if ip.IsPrivate() {
+		return fmt.Errorf("private IP addresses are not allowed")
+	}
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return fmt.Errorf("link-local addresses are not allowed")
+	}
+	if ip.IsUnspecified() {
+		return fmt.Errorf("unspecified addresses (0.0.0.0, ::) are not allowed")
+	}
+
+	return nil
+}
+
+// PullPieceRequest represents a single piece in a fetch request
+type PullPieceRequest struct {
+	PieceCid  string `json:"pieceCid"`
+	SourceURL string `json:"sourceUrl"`
+}
+
+// PullRequest represents the incoming fetch request body
+type PullRequest struct {
+	ExtraData    string             `json:"extraData"`
+	DataSetId    *uint64            `json:"dataSetId,omitempty"`    // nil or 0 = create new dataset
+	RecordKeeper *string            `json:"recordKeeper,omitempty"` // required when dataSetId is nil/0
+	Pieces       []PullPieceRequest `json:"pieces"`
+}
+
+// IsCreateNew returns true if this fetch will create a new dataset (dataSetId is nil or 0)
+func (r *PullRequest) IsCreateNew() bool {
+	return r.DataSetId == nil || *r.DataSetId == 0
+}
+
+// Validate performs validation on the entire fetch request
+func (r *PullRequest) Validate() error {
+	if r.ExtraData == "" {
+		return fmt.Errorf("extraData is required")
+	}
+
+	// Validate dataSetId/recordKeeper combination
+	if r.IsCreateNew() {
+		if r.RecordKeeper == nil || *r.RecordKeeper == "" {
+			return fmt.Errorf("recordKeeper is required when dataSetId is not provided or is 0")
+		}
+	}
+
+	if len(r.Pieces) == 0 {
+		return fmt.Errorf("at least one piece is required")
+	}
+
+	// Validate each piece (CID format validation is done later by ParsePieceCidV2)
+	for i, piece := range r.Pieces {
+		if piece.PieceCid == "" {
+			return fmt.Errorf("piece[%d]: pieceCid is required", i)
+		}
+		if piece.SourceURL == "" {
+			return fmt.Errorf("piece[%d]: sourceUrl is required", i)
+		}
+		if err := ValidatePullSourceURL(piece.SourceURL, piece.PieceCid); err != nil {
+			return fmt.Errorf("piece[%d]: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// PullPieceStatus represents the status of a single piece
+type PullPieceStatus struct {
+	PieceCid string     `json:"pieceCid"`
+	Status   PullStatus `json:"status"`
+}
+
+// PullResponse represents the response from a fetch request
+type PullResponse struct {
+	Status PullStatus        `json:"status"`
+	Pieces []PullPieceStatus `json:"pieces"`
+}
+
+// ComputeOverallStatus derives the overall status from individual piece statuses.
+// Priority: failed > retrying > inProgress > pending > complete
+func (r *PullResponse) ComputeOverallStatus() {
+	if len(r.Pieces) == 0 {
+		r.Status = PullStatusPending
+		return
+	}
+
+	allComplete := true
+	anyFailed := false
+	anyRetrying := false
+	anyInProgress := false
+
+	for _, p := range r.Pieces {
+		if p.Status != PullStatusComplete {
+			allComplete = false
+		}
+		switch p.Status {
+		case PullStatusFailed:
+			anyFailed = true
+		case PullStatusRetrying:
+			anyRetrying = true
+		case PullStatusInProgress:
+			anyInProgress = true
+		}
+	}
+
+	if allComplete {
+		r.Status = PullStatusComplete
+	} else if anyFailed {
+		r.Status = PullStatusFailed
+	} else if anyRetrying {
+		r.Status = PullStatusRetrying
+	} else if anyInProgress {
+		r.Status = PullStatusInProgress
+	} else {
+		r.Status = PullStatusPending
+	}
+}

--- a/pdp/pull_types_test.go
+++ b/pdp/pull_types_test.go
@@ -1,0 +1,368 @@
+package pdp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePullSourceURL(t *testing.T) {
+	// Valid PieceCIDv2
+	const validCid = "bafkzcibf6x7poaqtr2pqm6qki6sgetps74xutpclzrwbux5ow6rw4nsfu6tbf2zfnmnq"
+
+	tests := []struct {
+		name        string
+		url         string
+		pieceCid    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "valid HTTPS URL",
+			url:      "https://sp.example.com/piece/" + validCid,
+			pieceCid: validCid,
+			wantErr:  false,
+		},
+		{
+			name:     "valid HTTPS URL with port",
+			url:      "https://sp.example.com:8080/piece/" + validCid,
+			pieceCid: validCid,
+			wantErr:  false,
+		},
+		{
+			name:     "valid HTTPS URL with path prefix",
+			url:      "https://sp.example.com/api/v1/piece/" + validCid,
+			pieceCid: validCid,
+			wantErr:  false,
+		},
+		{
+			name:        "HTTP not allowed",
+			url:         "http://sp.example.com/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "HTTPS",
+		},
+		{
+			name:        "wrong path pattern - missing /piece/",
+			url:         "https://sp.example.com/data/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "must end with /piece/",
+		},
+		{
+			name:        "wrong path pattern - /pieces/ instead of /piece/",
+			url:         "https://sp.example.com/pieces/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "must end with /piece/",
+		},
+		{
+			name:        "pieceCid mismatch",
+			url:         "https://sp.example.com/piece/bafkzcibf6x7poaqtihg2pifeyzwfy3ndaumj3ds6c5ddiqewo2dzfzr7pqlery5dwyba",
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "does not match expected",
+		},
+		{
+			name:        "localhost not allowed",
+			url:         "https://localhost/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "localhost",
+		},
+		{
+			name:        "localhost with port not allowed",
+			url:         "https://localhost:8080/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "localhost",
+		},
+		{
+			name:        "localhost.localdomain not allowed",
+			url:         "https://localhost.localdomain/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "localhost",
+		},
+		{
+			name:        "localhost4 not allowed",
+			url:         "https://localhost4/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "localhost",
+		},
+		{
+			name:        "localhost6 not allowed",
+			url:         "https://localhost6/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "localhost",
+		},
+		{
+			name:        "ip6-localhost not allowed",
+			url:         "https://ip6-localhost/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "localhost",
+		},
+		{
+			name:        "ip6-loopback not allowed",
+			url:         "https://ip6-loopback/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "localhost",
+		},
+		{
+			name:        "127.0.0.1 not allowed",
+			url:         "https://127.0.0.1/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "loopback", // net.IP.IsLoopback() returns true for 127.x.x.x
+		},
+		{
+			name:        "private IP 10.x not allowed",
+			url:         "https://10.0.0.1/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "private",
+		},
+		{
+			name:        "private IP 192.168.x not allowed",
+			url:         "https://192.168.1.1/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "private",
+		},
+		{
+			name:        "private IP 172.16.x not allowed",
+			url:         "https://172.16.0.1/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "private",
+		},
+		{
+			name:        "link-local not allowed",
+			url:         "https://169.254.1.1/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "link-local",
+		},
+		{
+			name:        "IPv6 loopback not allowed",
+			url:         "https://[::1]/piece/" + validCid,
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "loopback",
+		},
+		{
+			name:        "invalid URL",
+			url:         "not-a-url",
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "HTTPS",
+		},
+		{
+			name:        "empty URL",
+			url:         "",
+			pieceCid:    validCid,
+			wantErr:     true,
+			errContains: "HTTPS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePullSourceURL(tt.url, tt.pieceCid)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.True(t, strings.Contains(err.Error(), tt.errContains),
+						"error %q should contain %q", err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPullRequest_Validate(t *testing.T) {
+	// Valid PieceCIDv2 CIDs
+	const validCid = "bafkzcibf6x7poaqtr2pqm6qki6sgetps74xutpclzrwbux5ow6rw4nsfu6tbf2zfnmnq"
+	const validCid2 = "bafkzcibf6x7poaqtihg2pifeyzwfy3ndaumj3ds6c5ddiqewo2dzfzr7pqlery5dwyba"
+	validURL := "https://sp.example.com/piece/" + validCid
+	dataSetId := uint64(1) // Use existing dataset to avoid recordKeeper requirement
+
+	tests := []struct {
+		name        string
+		req         PullRequest
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid request with one piece",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, SourceURL: validURL},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid request with multiple pieces",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, SourceURL: validURL},
+					{PieceCid: validCid2, SourceURL: "https://sp.example.com/piece/" + validCid2},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing extraData",
+			req: PullRequest{
+				ExtraData: "",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, SourceURL: validURL},
+				},
+			},
+			wantErr:     true,
+			errContains: "extraData is required",
+		},
+		{
+			name: "no pieces",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces:    []PullPieceRequest{},
+			},
+			wantErr:     true,
+			errContains: "at least one piece",
+		},
+		{
+			name: "piece missing pieceCid",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: "", SourceURL: validURL},
+				},
+			},
+			wantErr:     true,
+			errContains: "pieceCid is required",
+		},
+		{
+			name: "piece missing sourceUrl",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, SourceURL: ""},
+				},
+			},
+			wantErr:     true,
+			errContains: "sourceUrl is required",
+		},
+		{
+			name: "invalid sourceUrl",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, SourceURL: "http://localhost/piece/" + validCid},
+				},
+			},
+			wantErr:     true,
+			errContains: "HTTPS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					require.True(t, strings.Contains(err.Error(), tt.errContains),
+						"error %q should contain %q", err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPullResponse_ComputeOverallStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		pieces         []PullPieceStatus
+		expectedStatus PullStatus
+	}{
+		{
+			name:           "empty pieces",
+			pieces:         []PullPieceStatus{},
+			expectedStatus: PullStatusPending,
+		},
+		{
+			name: "all complete",
+			pieces: []PullPieceStatus{
+				{PieceCid: "cid1", Status: PullStatusComplete},
+				{PieceCid: "cid2", Status: PullStatusComplete},
+			},
+			expectedStatus: PullStatusComplete,
+		},
+		{
+			name: "all pending",
+			pieces: []PullPieceStatus{
+				{PieceCid: "cid1", Status: PullStatusPending},
+				{PieceCid: "cid2", Status: PullStatusPending},
+			},
+			expectedStatus: PullStatusPending,
+		},
+		{
+			name: "mixed with inProgress",
+			pieces: []PullPieceStatus{
+				{PieceCid: "cid1", Status: PullStatusComplete},
+				{PieceCid: "cid2", Status: PullStatusInProgress},
+			},
+			expectedStatus: PullStatusInProgress,
+		},
+		{
+			name: "some complete some pending",
+			pieces: []PullPieceStatus{
+				{PieceCid: "cid1", Status: PullStatusComplete},
+				{PieceCid: "cid2", Status: PullStatusPending},
+			},
+			expectedStatus: PullStatusPending,
+		},
+		{
+			name: "single complete",
+			pieces: []PullPieceStatus{
+				{PieceCid: "cid1", Status: PullStatusComplete},
+			},
+			expectedStatus: PullStatusComplete,
+		},
+		{
+			name: "single inProgress",
+			pieces: []PullPieceStatus{
+				{PieceCid: "cid1", Status: PullStatusInProgress},
+			},
+			expectedStatus: PullStatusInProgress,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &PullResponse{Pieces: tt.pieces}
+			resp.ComputeOverallStatus()
+			require.Equal(t, tt.expectedStatus, resp.Status)
+		})
+	}
+}

--- a/tasks/pdp/task_pull_piece.go
+++ b/tasks/pdp/task_pull_piece.go
@@ -1,0 +1,372 @@
+package pdp
+
+import (
+	"context"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/ipfs/go-cid"
+	"golang.org/x/xerrors"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+	commp "github.com/filecoin-project/go-fil-commp-hashhash"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+	"github.com/filecoin-project/curio/harmony/resources"
+	"github.com/filecoin-project/curio/harmony/taskhelp"
+	"github.com/filecoin-project/curio/lib/dealdata"
+	"github.com/filecoin-project/curio/lib/paths"
+	"github.com/filecoin-project/curio/lib/promise"
+	"github.com/filecoin-project/curio/pdp"
+)
+
+// PullPiecePollInterval is how often to poll for new pull items
+var PullPiecePollInterval = 10 * time.Second
+
+// PDPPullPieceTask downloads pieces from external SPs, verifies CommP,
+// and stores them in custore:// for StorePiece to pick up.
+//
+// Flow:
+//  1. Handler creates pdp_piece_pull_items with source_url
+//  2. This task polls for items with task_id IS NULL AND failed = FALSE
+//  3. Task downloads piece, computes CommP, verifies it matches expected
+//  4. On success: stores in StashStore, creates parked_pieces entry with custore:// URL
+//  5. StorePiece task picks up the parked_piece and moves to long-term storage
+//
+// Future enhancement: implement verified piece retrieval per FRC-XXXX
+// for streaming verification with intermediate tree proofs.
+type PDPPullPieceTask struct {
+	db      *harmonydb.DB
+	storage paths.StashStore
+
+	TF promise.Promise[harmonytask.AddTaskFunc]
+
+	max int
+}
+
+// NewPDPPullPieceTask creates a new PDPPullPieceTask
+func NewPDPPullPieceTask(ctx context.Context, db *harmonydb.DB, storage paths.StashStore, max int) *PDPPullPieceTask {
+	t := &PDPPullPieceTask{
+		db:      db,
+		storage: storage,
+		max:     max,
+	}
+
+	go t.pollPullItems(ctx)
+	return t
+}
+
+// pollPullItems polls for pull items that need processing
+func (t *PDPPullPieceTask) pollPullItems(ctx context.Context) {
+	ticker := time.NewTicker(PullPiecePollInterval)
+	defer ticker.Stop()
+
+	for {
+		var items []struct {
+			FetchID      int64  `db:"fetch_id"`
+			PieceCid     string `db:"piece_cid"`
+			PieceRawSize int64  `db:"piece_raw_size"`
+			SourceURL    string `db:"source_url"`
+		}
+
+		// Select items that:
+		// 1. Have no task assigned (task_id IS NULL)
+		// 2. Have not permanently failed
+		// 3. Do NOT already have a parked_pieces entry (pull already completed)
+		err := t.db.Select(ctx, &items, `
+			SELECT fi.fetch_id, fi.piece_cid, fi.piece_raw_size, fi.source_url
+			FROM pdp_piece_pull_items fi
+			WHERE fi.task_id IS NULL AND fi.failed = FALSE
+			AND NOT EXISTS (
+				SELECT 1 FROM parked_pieces pp
+				WHERE pp.piece_cid = fi.piece_cid
+				AND pp.long_term = TRUE
+				AND pp.cleanup_task_id IS NULL
+			)
+		`)
+		if err != nil {
+			log.Errorf("failed to query pull items: %s", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				continue
+			}
+		}
+
+		if len(items) == 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				continue
+			}
+		}
+
+		for _, item := range items {
+			fetchID := item.FetchID
+			pieceCid := item.PieceCid
+
+			t.TF.Val(ctx)(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, err error) {
+				// Atomically assign task_id, with same checks as the SELECT query
+				// to prevent race with concurrent parked_pieces creation
+				n, err := tx.Exec(`
+					UPDATE pdp_piece_pull_items fi
+					SET task_id = $1
+					WHERE fi.fetch_id = $2 AND fi.piece_cid = $3
+					AND fi.task_id IS NULL AND fi.failed = FALSE
+					AND NOT EXISTS (
+						SELECT 1 FROM parked_pieces pp
+						WHERE pp.piece_cid = fi.piece_cid
+						AND pp.long_term = TRUE
+						AND pp.cleanup_task_id IS NULL
+					)
+				`, id, fetchID, pieceCid)
+				if err != nil {
+					return false, xerrors.Errorf("updating pull item task_id: %w", err)
+				}
+
+				return n > 0, nil
+			})
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// continue to next iteration
+		}
+	}
+}
+
+// pullItemData holds the data for a pull item task
+type pullItemData struct {
+	FetchID      int64  `db:"fetch_id"`
+	PieceCid     string `db:"piece_cid"`
+	PieceRawSize int64  `db:"piece_raw_size"`
+	SourceURL    string `db:"source_url"`
+}
+
+func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+	ctx := context.Background()
+
+	// Fetch task data
+	var items []pullItemData
+	err = t.db.Select(ctx, &items, `
+		SELECT fetch_id, piece_cid, piece_raw_size, source_url
+		FROM pdp_piece_pull_items
+		WHERE task_id = $1
+	`, taskID)
+	if err != nil {
+		return false, xerrors.Errorf("fetching task data: %w", err)
+	}
+
+	if len(items) == 0 {
+		return false, xerrors.Errorf("no pull item found for task_id: %d", taskID)
+	}
+
+	item := items[0]
+
+	// Parse expected CID
+	expectedCid, err := cid.Parse(item.PieceCid)
+	if err != nil {
+		return false, xerrors.Errorf("parsing expected piece CID: %w", err)
+	}
+
+	// Download and verify the piece
+	stashID, err := t.downloadAndVerify(ctx, item.SourceURL, item.PieceRawSize, expectedCid)
+	if err != nil {
+		// Mark as failed and return error (task will retry or exhaust retries)
+		log.Errorw("pull piece failed", "error", err, "pieceCid", item.PieceCid, "sourceUrl", item.SourceURL)
+		return false, xerrors.Errorf("download and verify piece: %w", err)
+	}
+
+	// Get stash URL for creating parked_pieces entry
+	stashURL, err := t.storage.StashURL(stashID)
+	if err != nil {
+		// Clean up stash on failure
+		_ = t.storage.StashRemove(ctx, stashID)
+		return false, xerrors.Errorf("getting stash URL: %w", err)
+	}
+
+	// Change scheme to custore://
+	stashURL.Scheme = dealdata.CustoreScheme
+	custoreURL := stashURL.String()
+
+	// Calculate padded size
+	paddedSize := pdp.PadPieceSize(item.PieceRawSize)
+
+	// Create parked_pieces entry in a transaction
+	_, err = t.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		// Create parked_pieces entry
+		var parkedPieceID int64
+		err := tx.QueryRow(`
+			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+			VALUES ($1, $2, $3, TRUE)
+			RETURNING id
+		`, item.PieceCid, paddedSize, item.PieceRawSize).Scan(&parkedPieceID)
+		if err != nil {
+			return false, xerrors.Errorf("insert parked_pieces: %w", err)
+		}
+
+		// Create parked_piece_refs entry with custore:// URL
+		_, err = tx.Exec(`
+			INSERT INTO parked_piece_refs (piece_id, data_url, long_term)
+			VALUES ($1, $2, TRUE)
+		`, parkedPieceID, custoreURL)
+		if err != nil {
+			return false, xerrors.Errorf("insert parked_piece_refs: %w", err)
+		}
+
+		// Clear task_id from pull item (task is done)
+		_, err = tx.Exec(`
+			UPDATE pdp_piece_pull_items
+			SET task_id = NULL
+			WHERE fetch_id = $1 AND piece_cid = $2
+		`, item.FetchID, item.PieceCid)
+		if err != nil {
+			return false, xerrors.Errorf("clearing pull item task_id: %w", err)
+		}
+
+		return true, nil
+	}, harmonydb.OptionRetry())
+	if err != nil {
+		// Clean up stash on failure
+		_ = t.storage.StashRemove(ctx, stashID)
+		return false, xerrors.Errorf("creating parked piece: %w", err)
+	}
+
+	log.Infow("pull piece complete", "pieceCid", item.PieceCid, "custoreUrl", custoreURL)
+	return true, nil
+}
+
+// downloadAndVerify downloads a piece from sourceURL, computes CommP, and verifies it matches expected.
+// On success, returns the stash ID where the piece is stored.
+func (t *PDPPullPieceTask) downloadAndVerify(ctx context.Context, sourceURL string, expectedSize int64, expectedCid cid.Cid) (uuid.UUID, error) {
+	// Validate URL - HTTPS required for security (HTTP allowed only with env var for testing)
+	parsedURL, err := url.Parse(sourceURL)
+	if err != nil {
+		return uuid.UUID{}, xerrors.Errorf("invalid source URL: %w", err)
+	}
+	allowHTTP := os.Getenv("CURIO_PULL_ALLOW_INSECURE") == "1"
+	if parsedURL.Scheme != "https" && (!allowHTTP || parsedURL.Scheme != "http") {
+		return uuid.UUID{}, xerrors.Errorf("source URL must use HTTPS scheme, got: %s", parsedURL.Scheme)
+	}
+
+	// 1 hour timeout for entire pull operation
+	ctx, cancel := context.WithTimeout(ctx, time.Hour)
+	defer cancel()
+
+	// Create HTTP client with header timeout
+	client := &http.Client{
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: 2 * time.Minute,
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
+	if err != nil {
+		return uuid.UUID{}, xerrors.Errorf("creating request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return uuid.UUID{}, xerrors.Errorf("HTTP request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return uuid.UUID{}, xerrors.Errorf("HTTP status %d from source", resp.StatusCode)
+	}
+
+	// Limit reader to expected size + 1 to detect oversized data
+	dataReader := io.LimitReader(resp.Body, expectedSize+1)
+
+	// Create commp calculator
+	cp := &commp.Calc{}
+	var readSize int64
+
+	// Write to stash while computing CommP
+	writeFunc := func(f *os.File) error {
+		multiWriter := io.MultiWriter(cp, f)
+
+		n, err := io.Copy(multiWriter, dataReader)
+		if err != nil {
+			return xerrors.Errorf("copying piece data: %w", err)
+		}
+
+		readSize = n
+		return nil
+	}
+
+	// Store in StashStore
+	stashID, err := t.storage.StashCreate(ctx, expectedSize, writeFunc)
+	if err != nil {
+		return uuid.UUID{}, xerrors.Errorf("creating stash: %w", err)
+	}
+
+	// Check size
+	if readSize != expectedSize {
+		_ = t.storage.StashRemove(ctx, stashID)
+		return uuid.UUID{}, xerrors.Errorf("size mismatch: expected %d, got %d", expectedSize, readSize)
+	}
+
+	// Finalize CommP calculation
+	digest, _, err := cp.Digest()
+	if err != nil {
+		_ = t.storage.StashRemove(ctx, stashID)
+		return uuid.UUID{}, xerrors.Errorf("computing CommP digest: %w", err)
+	}
+
+	// Convert to CID
+	computedCid, err := commcid.DataCommitmentV1ToCID(digest)
+	if err != nil {
+		_ = t.storage.StashRemove(ctx, stashID)
+		return uuid.UUID{}, xerrors.Errorf("converting digest to CID: %w", err)
+	}
+
+	// Verify CommP matches
+	if !expectedCid.Equals(computedCid) {
+		_ = t.storage.StashRemove(ctx, stashID)
+		return uuid.UUID{}, xerrors.Errorf("CommP mismatch: expected %s, got %s", expectedCid, computedCid)
+	}
+
+	return stashID, nil
+}
+
+func (t *PDPPullPieceTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) (*harmonytask.TaskID, error) {
+	id := ids[0]
+	return &id, nil
+}
+
+func (t *PDPPullPieceTask) TypeDetails() harmonytask.TaskTypeDetails {
+	return harmonytask.TaskTypeDetails{
+		Name: "PDPv0_PullPiece",
+		Max:  taskhelp.Max(t.max),
+		Cost: resources.Resources{
+			Cpu: 1,
+			Gpu: 0,
+			Ram: 128 << 20, // 128 MiB for streaming + CommP computation
+		},
+		MaxFailures: 5,
+		RetryWait: func(retries int) time.Duration {
+			const baseWait, maxWait, factor = 10 * time.Second, 5 * time.Minute, 2.0
+			return min(time.Duration(float64(baseWait)*math.Pow(factor, float64(retries))), maxWait)
+		},
+	}
+}
+
+func (t *PDPPullPieceTask) Adder(taskFunc harmonytask.AddTaskFunc) {
+	t.TF.Set(taskFunc)
+}
+
+var (
+	_ harmonytask.TaskInterface = &PDPPullPieceTask{}
+	_                           = harmonytask.Reg(&PDPPullPieceTask{})
+)


### PR DESCRIPTION
Implement POST /pdp/piece/fetch for fetching pieces from other SPs. Includes idempotent request handling, failure tracking with retry status, and CommP verification for external sources.

New files:
- handlers_fetch.go: fetch endpoint and database store implementation **See HandleFetch() Godoc for comprehensive details about new functionality.**
- fetch_types.go: request/response types with source URL validation
- piece_cid.go: PieceCIDv2 parsing utilities (consolidated existing PieceCID code)
- 20251212-pdp-fetch.sql: tracking tables for fetch requests

Changes:
- task_park_piece.go: verify CommP for external sources, reduce MaxFailures to 5
- handlers.go: refactor to use shared PieceCID utilities

Pulls in lib/ffi/piece_funcs.go from main branch as is.