### PR TITLE
Fix UPDATE orphanage

### DIFF
--- a/tasks/indexing/task_pdp_indexing.go
+++ b/tasks/indexing/task_pdp_indexing.go
@@ -217,10 +217,13 @@ func (P *PDPIndexingTask) schedule(_ context.Context, taskFunc harmonytask.AddTa
 			}
 
 			pending := pendings[0]
-			_, err = tx.Exec(`UPDATE pdp_piecerefs SET indexing_task_id = $1 
+			n, err := tx.Exec(`UPDATE pdp_piecerefs SET indexing_task_id = $1
                              WHERE indexing_task_id IS NULL AND id = $2`, id, pending.ID)
 			if err != nil {
 				return false, xerrors.Errorf("updating PDP indexing task id: %w", err)
+			}
+			if n == 0 {
+				return false, nil // Another task already claimed this piece
 			}
 			log.Debugf("PDP indexing task scheduled for pending indexing task %d", pending.ID)
 

--- a/tasks/indexing/task_pdp_ipni.go
+++ b/tasks/indexing/task_pdp_ipni.go
@@ -355,10 +355,13 @@ func (P *PDPIPNITask) schedule(ctx context.Context, taskFunc harmonytask.AddTask
 			}
 
 			pending := pendings[0]
-			_, err = tx.Exec(`UPDATE pdp_piecerefs SET ipni_task_id = $1
+			n, err := tx.Exec(`UPDATE pdp_piecerefs SET ipni_task_id = $1
 						 WHERE ipni_task_id IS NULL AND id = $2`, id, pending.ID)
 			if err != nil {
 				return false, xerrors.Errorf("updating PDP ipni task id: %w", err)
+			}
+			if n == 0 {
+				return false, nil // Another task already claimed this piece
 			}
 
 			log.Debugf("PDP IPNI task scheduled for pending IPNI task %d", pending.ID)


### PR DESCRIPTION
We haven't been checking the output rows effected by tx.Exec UPDATE and apparently this doesn't actually fail during a race but succeeds and returns n==0.  This means that we have been allowing tasks with no matching pdp piece ref to get scheduled.  In the case of indexing this closely matches the error behavior we are seeing on ezpdpz.  Unclear if this is the actual cause but it is a possible match we should try.