### PR TITLE
Use correct `shouldCommit` value to considerWork immediately when bored

### DIFF
--- a/harmony/harmonytask/harmonytask.go
+++ b/harmony/harmonytask/harmonytask.go
@@ -476,7 +476,7 @@ func (e *TaskEngine) pollerTryAllWork(schedulable bool) bool {
 			err := v.IAmBored(func(extraInfo func(TaskID, *harmonydb.Tx) (shouldCommit bool, seriousError error)) {
 				v.AddTask(func(tID TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
 					b, err := extraInfo(tID, tx)
-					if err == nil && shouldCommit {
+					if err == nil && b {
 						added = append(added, tID)
 					}
 					return b, err


### PR DESCRIPTION
I don't have too much context here but I believe we are always considering `shouldCommit` false by incorrectly referring to the zero value of the named return rather than the value we want which is `b`.  I think this means we never considerWork right away when bored as added is always empty.  And so tasks must wait 3 seconds to be picked up by the poller.