### PR TITLE
feat(pdp): add devnet support

### DIFF
--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -637,6 +637,7 @@ var pieceUploadCmd = &cli.Command{
 			return fmt.Errorf("failed to upload piece: %v", err)
 		}
 
+		fmt.Printf("Piece CID: %s\n", pieceCIDComputed.String())
 		fmt.Println("Piece uploaded successfully.")
 		return nil
 	},
@@ -1752,6 +1753,7 @@ var streamingPieceUploadCmd = &cli.Command{
 			return fmt.Errorf("failed to finalize, status code %d: %s", resp.StatusCode, string(ret))
 		}
 
+		fmt.Printf("Piece CID: %s\n", pcid2.String())
 		fmt.Println("Piece uploaded successfully.")
 		if localNotifWait {
 			fmt.Println("Waiting for server notification...")

--- a/lib/filecoinpayment/address.go
+++ b/lib/filecoinpayment/address.go
@@ -1,6 +1,8 @@
 package filecoinpayment
 
 import (
+	"os"
+
 	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/xerrors"
 
@@ -16,6 +18,11 @@ func PaymentContractAddress() (common.Address, error) {
 		return common.HexToAddress(PaymentContractCalibnet), nil
 	case build.BuildMainnet:
 		return common.HexToAddress(PaymentContractMainnet), nil
+	case build.Build2k:
+		if addr := os.Getenv("CURIO_DEVNET_PAYMENTS_ADDRESS"); addr != "" {
+			return common.HexToAddress(addr), nil
+		}
+		return common.Address{}, xerrors.Errorf("payment contract address not configured for devnet - set CURIO_DEVNET_PAYMENTS_ADDRESS env var")
 	default:
 		return common.Address{}, xerrors.Errorf("payment contract address not set for this network %s", build.BuildTypeString()[1:])
 	}

--- a/lib/multicall/address.go
+++ b/lib/multicall/address.go
@@ -1,6 +1,8 @@
 package multicall
 
 import (
+	"os"
+
 	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/xerrors"
 
@@ -16,6 +18,11 @@ func MultiCallAddress() (common.Address, error) {
 		return common.HexToAddress(MultiCallAddressCalibnet), nil
 	case build.BuildMainnet:
 		return common.HexToAddress(MultiCallAddressMainnet), nil
+	case build.Build2k:
+		if addr := os.Getenv("CURIO_DEVNET_MULTICALL_ADDRESS"); addr != "" {
+			return common.HexToAddress(addr), nil
+		}
+		return common.Address{}, xerrors.Errorf("multicall address not configured for devnet - set CURIO_DEVNET_MULTICALL_ADDRESS env var")
 	default:
 		return common.Address{}, xerrors.Errorf("multicall address not set for this network %s", build.BuildTypeString()[1:])
 	}


### PR DESCRIPTION
This is https://github.com/filecoin-project/curio/pull/872 but with some tweaks. I can't force-push back to that remote.

    feat(pdp): add devnet support via env vars
    
    Environment variables for Build2k devnet configuration:
    
    - CURIO_DEVNET_PDP_VERIFIER_ADDRESS: PDPVerifier contract (required for PDP)
    - CURIO_DEVNET_FWSS_ADDRESS: FWSS contract (required)
    - CURIO_DEVNET_RECORD_KEEPER_SIMPLE_ADDRESS: Simple record keeper (optional)
    - CURIO_DEVNET_SERVICE_REGISTRY_ADDRESS: ServiceProviderRegistry contract
    - CURIO_DEVNET_USDFC_ADDRESS: USDFC token contract
    - CURIO_DEVNET_PAYMENTS_ADDRESS: Payment contract
    - CURIO_DEVNET_MULTICALL_ADDRESS: Multicall contract