### PR TITLE
harmonydb: fix err return in backoff

### DIFF
--- a/harmony/harmonydb/userfuncs.go
+++ b/harmony/harmonydb/userfuncs.go
@@ -25,7 +25,7 @@ func backoffForSerializationError[T any](f func() (T, error)) (whatever T, err e
 	for _, backoff := range backoffs {
 		res, err := f()
 		if !IsErrSerialization(err) {
-			return res, nil
+			return res, err
 		}
 		time.Sleep(backoff)
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Fix error propagation in retry helper**
> 
> - Updates `backoffForSerializationError` in `harmonydb/userfuncs.go` to return `res, err` when the error is not a serialization failure, instead of swallowing the error.
> - Affects callers that rely on this helper (e.g., `Exec`, `Query`, `Select`, and transaction retry path), which will now receive the original non-serialization errors correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95d79efa0cec689e1109dec2c691ddb7f5d2ed3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->