### PR TITLE
fix: resolve goroutine leak in CommP calculation

### DIFF
--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -297,6 +297,7 @@ func loadPrivateKey() (*ecdsa.PrivateKey, error) {
 func preparePiece(r io.ReadSeeker) (cid.Cid, uint64, []byte, []byte, error) {
 	// Create commp calculator
 	cp := &commp.Calc{}
+	defer cp.Reset()
 
 	// Copy data into commp calculator
 	rawSize, err := io.Copy(cp, r)
@@ -1634,6 +1635,7 @@ var streamingPieceUploadCmd = &cli.Command{
 		}
 
 		cp := commp.Calc{}
+		defer cp.Reset()
 
 		pipeReader, pipeWriter := io.Pipe()
 

--- a/lib/proof/datacid.go
+++ b/lib/proof/datacid.go
@@ -80,6 +80,7 @@ func (w *DataCidWriter) Write(p []byte) (int, error) {
 				}()
 
 				cc := new(commp.Calc)
+				defer cc.Reset()
 				_, _ = cc.Write(w.tbufs[bufIdx][:])
 				p, _, _ := cc.Digest()
 				l, _ := commcid.PieceCommitmentV1ToCID(p)
@@ -117,6 +118,7 @@ func (w *DataCidWriter) Sum() (DataCIDSize, error) {
 		}
 
 		cc := new(commp.Calc)
+		defer cc.Reset()
 		_, _ = cc.Write(w.buf[:lastLen])
 		pb, pps, _ := cc.Digest()
 		p, _ := commcid.PieceCommitmentV1ToCID(pb)

--- a/pdp/handlers_upload.go
+++ b/pdp/handlers_upload.go
@@ -217,6 +217,7 @@ func (p *PDPService) handlePieceUpload(w http.ResponseWriter, r *http.Request) {
 
 	// Create a commp.Calc instance for calculating commP
 	cp := &commp.Calc{}
+	defer cp.Reset()
 	readSize := int64(0)
 
 	// Function to write data into StashStore and calculate commP
@@ -472,6 +473,7 @@ func (p *PDPService) handleStreamingUpload(w http.ResponseWriter, r *http.Reques
 
 	reader := NewTimeoutLimitReader(r.Body, 5*time.Second)
 	cp := &commp.Calc{}
+	defer cp.Reset()
 	readSize := int64(0)
 
 	// Function to write data into StashStore and calculate commP


### PR DESCRIPTION
https://github.com/filecoin-project/curio/issues/880#issuecomment-3777759004

The underlying library `github.com/filecoin-project/go-fil-commp-hashhash` spawns background goroutines (addLayer) to handle parallel tree construction. These goroutines are designed to exit only when:

1. The calculation finishes successfully (Digest completes and closes the channel).
2. Reset() is explicitly called.

However, if Digest() encounters an error (e.g., input data is smaller than MinPiecePayload (65 bytes), or io.Copy fails), it returns immediately without closing the internal channels. This leaves the background addLayer goroutines blocked indefinitely on channel reads, causing a silent accumulation of goroutines (observed ~500+ leaked goroutines in production during idle state).

lib/proof/datacid.go There also be this problem, fix it by the way