### PR TITLE
fix: use build version in /info endpoint

### DIFF
--- a/build/version_test.go
+++ b/build/version_test.go
@@ -1,0 +1,15 @@
+package build
+
+import (
+	"testing"
+)
+
+// verify version is set from BuildVersionArray, not hardcoded placeholder
+func TestBuildVersionNotZero(t *testing.T) {
+	if BuildVersion == "0.0.0" {
+		t.Fatal("BuildVersion should not be 0.0.0")
+	}
+	if BuildVersion == "" {
+		t.Fatal("BuildVersion should not be empty")
+	}
+}

--- a/market/retrieval/retrieval.go
+++ b/market/retrieval/retrieval.go
@@ -2,6 +2,7 @@ package retrieval
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"path"
 	"strconv"
@@ -20,6 +21,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 
+	"github.com/filecoin-project/curio/build"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/lib/cachedreader"
 	"github.com/filecoin-project/curio/market/indexstore"
@@ -256,7 +258,7 @@ func Router(mux *chi.Mux, rp *Provider) {
 }
 
 func handleInfo(rw http.ResponseWriter, r *http.Request) {
-	const infoOut = `{"Version":"0.4.0", "Server": "Curio/0.0.0"}`
+	infoOut := fmt.Sprintf(`{"Version":"0.4.0", "Server": "Curio/%s"}`, build.BuildVersion)
 
 	_, _ = rw.Write([]byte(infoOut))
 }

--- a/market/retrieval/retrieval_test.go
+++ b/market/retrieval/retrieval_test.go
@@ -157,6 +157,16 @@ func TestRouterSetup(t *testing.T) {
 	require.Contains(t, w.Body.String(), "Version")
 }
 
+// TestInfoEndpointVersion verifies that /info returns actual build version, not hardcoded "0.0.0"
+func TestInfoEndpointVersion(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/info", nil)
+	w := httptest.NewRecorder()
+	handleInfo(w, req)
+
+	body := w.Body.String()
+	require.NotContains(t, body, "0.0.0", "version should not be hardcoded 0.0.0")
+}
+
 // TestTrustlessGatewaySentinel tests the special sentinel CID (bafkqaaa - identity empty CID)
 // which is used as a probe for trustless gateway conformance
 func TestTrustlessGatewaySentinel(t *testing.T) {


### PR DESCRIPTION
## Summary

The `/info` endpoint returns hardcoded `"Curio/0.0.0"` instead of the actual build version.

**Before:** `{"Version":"0.4.0", "Server": "Curio/0.0.0"}`
**After:** `{"Version":"0.4.0", "Server": "Curio/1.27.2"}`

## Changes

- `market/retrieval/retrieval.go`: Use `build.BuildVersion` instead of hardcoded `"0.0.0"`
- `market/retrieval/retrieval_test.go`: Add test verifying version is not hardcoded
- `build/version_test.go`: Add test verifying BuildVersion is properly set

## Root cause

`handleInfo()` used a const string with hardcoded version instead of the build-time version variable.