### PR TITLE
Porep undersized

### DIFF
--- a/tasks/seal/task_porep.go
+++ b/tasks/seal/task_porep.go
@@ -166,7 +166,7 @@ func (p *PoRepTask) CanAccept(ids []harmonytask.TaskID, _ *harmonytask.TaskEngin
 
 func (p *PoRepTask) TypeDetails() harmonytask.TaskTypeDetails {
 	gpu := 1.0
-	mem := uint64(160 << 30)
+	mem := uint64(128 << 30) // for GPU sealing. 160 for CPU sealing, which we pretend nobody uses.
 	if IsDevnet {
 		gpu = 0
 		mem = 1 << 30


### PR DESCRIPTION
Fix PoREP ram: 50 --> 96.
I've seen it OOM over 60GB. Inspecting it, it appears to easily hit 80GB. I have no way to test it at max size. 

Lotus says 128GB, but that seems high enough that I would have expected an OOM in 2 years to be reported. 