### PR TITLE
chore: Lower ParkMinFreeStoragePercent

### DIFF
--- a/tasks/piece/task_park_piece.go
+++ b/tasks/piece/task_park_piece.go
@@ -25,7 +25,7 @@ import (
 var log = logging.Logger("cu-piece")
 var PieceParkPollInterval = time.Second
 
-const ParkMinFreeStoragePercent = 20
+const ParkMinFreeStoragePercent = 0
 
 // ParkPieceTask gets a piece from some origin, and parks it in storage
 // Pieces are always f00, piece ID is mapped to pieceCID in the DB


### PR DESCRIPTION
I don't know why the percentage of 20 was originally set, but I think it's certainly unreasonable.
Whether it is temporary storage or long-term storage, setting it to 0 does not seem to have any problems. And the highest ratio elsewhere is only 1.
This problem has been seen on the feiyan PDP node. It still has a lot of space, but it cannot continue to provide services.