### PR TITLE
service needs library path & nvcc missing should err when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ CLEAN+=build/.filecoin-install
 ## By default, requires CUDA on Linux. Set FFI_USE_OPENCL=1 to build with OpenCL instead.
 .PHONY: curio-libfilecoin
 curio-libfilecoin:
-	@if [ "$$(uname)" = "Linux" ] && [ -z "$(FFI_USE_OPENCL)" ] && ! command -v nvcc >/dev/null 2>&1; then \
+	@if [ "$$(uname)" = "Linux" ] && [ "$(FFI_USE_OPENCL)" != "1" ] && ! command -v nvcc >/dev/null 2>&1; then \
 		echo ""; \
 		echo "ERROR: nvcc not found but CUDA build is required for Curio on Linux."; \
 		echo ""; \

--- a/apt/curio.service
+++ b/apt/curio.service
@@ -6,7 +6,7 @@ After=network.target
 ExecStart=/usr/local/bin/curio run
 Environment=GOLOG_FILE="/var/log/curio/curio.log"
 Environment=GOLOG_LOG_FMT="json"
-Environment=LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/lib64
+Environment=LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:/usr/lib64"
 LimitNOFILE=1000000
 Restart=always
 RestartSec=10

--- a/documentation/en/installation.md
+++ b/documentation/en/installation.md
@@ -201,7 +201,7 @@ Once all the dependencies are installed, you can build and install Curio.
 
     If you want to use OpenCL instead of CUDA (e.g., for AMD GPUs or systems without CUDA), build with:
     ```bash
-    make FFI_USE_OPENCL=1 build
+    FFI_USE_OPENCL=1 make clean build
     ```
     {% endhint %}
 


### PR DESCRIPTION
The example service file doesn't set LD_LIBRARY_PATH and then Rust uses CPU proving instead of GPU.
Added Ubuntu & Redhat paths for broader applicability.

Also, properly error-out when nvcc is needed not provided. The correct fix would be in filecoin-ffi, but since it's just a check, Makefile is ok.