### PR TITLE
pdpv0: Gracefully terminate pdp proving

### DIFF
--- a/harmony/harmonytask/harmonytask.go
+++ b/harmony/harmonytask/harmonytask.go
@@ -280,7 +280,7 @@ func (e *TaskEngine) GracefullyTerminate() {
 
 			if h.Name == "PDPv0_ProvPeriod" && h.Max.Active() > 0 {
 				timeout = time.Second
-				log.Infof("node shutdown deferred for %f seconds due to running PDPNextProvingPeriod task", timeout.Seconds())
+				log.Infof("node shutdown deferred for %f seconds due to running PDPv0_ProvPeriod task", timeout.Seconds())
 				continue
 			}
 


### PR DESCRIPTION
This is a follow on from #934.

#934 handles the much more reachable case of a proving task getting woken up too late and needing to gracefully exit the system.  

This PR is hoping to further reduce the less likely but more nefarious state of nextProvingPeriod task getting shut down midway and leaving blockchain and db in bad state which leads to unschedulable prove task for that period.  To do this we add `PDPv0_ProvPeriod` to the graceful shutdown list.  

I'm also adding `PDPv0_Prove` to the list because it will help SPs avoid missing proofs.  But this is a slighly lower concern than gracefully shutting down `PDPv0_ProvPeriod`.