### PR TITLE
pdpv0: remove CODEOWNERS entry for pdpv0 branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @filecoin-project/curio
+


### PR DESCRIPTION
Goal here is to make clear that there isn't a default reviewer.  If Curio-team involvement is needed, they should be requested like anyone else.