### PR TITLE
Shutdown poller design improvements

### DIFF
--- a/tasks/window/compute_task.go
+++ b/tasks/window/compute_task.go
@@ -427,11 +427,11 @@ func (t *WdPostTask) TypeDetails() harmonytask.TaskTypeDetails {
 	}
 
 	return harmonytask.TaskTypeDetails{
-		Name:                  "WdPost",
-		Max:                   taskhelp.Max(t.max),
-		MaxFailures:           5,
-		ShutdownPollFrequency: 3 * time.Second,
-		Follows:               nil,
+		Name:          "WdPost",
+		Max:           taskhelp.Max(t.max),
+		MaxFailures:   5,
+		TimeSensitive: true,
+		Follows:       nil,
 		Cost: resources.Resources{
 			Cpu: 1,
 

--- a/tasks/window/recover_task.go
+++ b/tasks/window/recover_task.go
@@ -2,7 +2,6 @@ package window
 
 import (
 	"context"
-	"time"
 
 	"golang.org/x/xerrors"
 
@@ -227,9 +226,8 @@ func (w *WdPostRecoverDeclareTask) TypeDetails() harmonytask.TaskTypeDetails {
 			Gpu: 0,
 			Ram: 128 << 20,
 		},
-		MaxFailures:           10,
-		Follows:               nil,
-		ShutdownPollFrequency: time.Second,
+		MaxFailures:   10,
+		TimeSensitive: true,
 	}
 }
 

--- a/tasks/window/submit_task.go
+++ b/tasks/window/submit_task.go
@@ -3,7 +3,6 @@ package window
 import (
 	"bytes"
 	"context"
-	"time"
 
 	"golang.org/x/xerrors"
 
@@ -197,9 +196,8 @@ func (w *WdPostSubmitTask) TypeDetails() harmonytask.TaskTypeDetails {
 			Gpu: 0,
 			Ram: 10 << 20,
 		},
-		MaxFailures:           10,
-		Follows:               nil, // ??
-		ShutdownPollFrequency: 3 * time.Second,
+		MaxFailures:   10,
+		TimeSensitive: true,
 	}
 }
 

--- a/tasks/winning/winning_task.go
+++ b/tasks/winning/winning_task.go
@@ -560,9 +560,9 @@ func (t *WinPostTask) TypeDetails() harmonytask.TaskTypeDetails {
 	}
 
 	return harmonytask.TaskTypeDetails{
-		Name:                  "WinPost",
-		Max:                   taskhelp.Max(t.max),
-		ShutdownPollFrequency: time.Second,
+		Name:          "WinPost",
+		Max:           taskhelp.Max(t.max),
+		TimeSensitive: true,
 
 		// We're not allowing retry to be conservative. Retry in winningPoSt done badly can lead to slashing, and
 		// that is generally worse than not mining a block. In general the task code is heavily defensive, and


### PR DESCRIPTION
Lets get task names out of the termination phase of harmonytask.
Should be ported to pdpv0 too, as it's extended there. 

Naming encourages other uses.