### PR TITLE
harmonytask: reduce the waay too high storage sched backoff

### DIFF
--- a/harmony/harmonytask/task_type_handler.go
+++ b/harmony/harmonytask/task_type_handler.go
@@ -35,7 +35,7 @@ type taskTypeHandler struct {
 }
 
 // Anti-hammering of storage claims.
-const STORAGE_FAILURE_TIMEOUT = time.Hour
+const STORAGE_FAILURE_TIMEOUT = 3 * time.Minute
 
 func (h *taskTypeHandler) AddTask(extra func(TaskID, *harmonydb.Tx) (bool, error)) {
 	var tID TaskID


### PR DESCRIPTION
On a lot of sealing nodes storage backoff is the main means of backpressure, backing off for 1 hour is way way too long in that case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task scheduling behavior by retrying storage-claim failures after 3 minutes instead of 1 hour, which may increase load on storage subsystems if failures persist. The change is small but can materially affect runtime backpressure.
> 
> **Overview**
> Reduces the *anti-hammering* timeout for tasks that fail `Cost.Claim(...)` storage claims by changing `STORAGE_FAILURE_TIMEOUT` from **1 hour** to **3 minutes**, so those tasks re-enter consideration much sooner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce8b91401cb0ac0a17c135f784368040d1a76ea3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->