### PR TITLE
Unerring device provisioner

### DIFF
--- a/lib/ffiselect/deviceOrdinalMgr_test.go
+++ b/lib/ffiselect/deviceOrdinalMgr_test.go
@@ -1,6 +1,8 @@
 package ffiselect
 
 import (
+	"context"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -13,39 +15,22 @@ func TestNoGPUs(t *testing.T) {
 		return []string{}, nil
 	})
 
-	// Test get and release
-	ord := d.Get()
-	d.Release(ord)
-
-	acquireChan := make(chan int)
-	d.acquireChan <- acquireChan
-	select {
-	case ord = <-acquireChan:
-		if ord != 0 {
-			t.Fatal("should have gotten GPU 0")
+	// Every acquire should immediately return -1 when there are no GPUs.
+	for i := 0; i < 3; i++ {
+		acquireChan := make(chan int)
+		d.acquireChan <- acquireChan
+		select {
+		case ord := <-acquireChan:
+			if ord != -1 {
+				t.Fatalf("iteration %d: expected -1 for no GPUs, got %d", i, ord)
+			}
+		case <-time.After(time.Millisecond * 100):
+			t.Fatalf("iteration %d: timeout waiting for acquire", i)
 		}
-	case <-time.After(time.Millisecond * 100):
-		t.Fatal("timeout")
 	}
 
-	d.acquireChan <- acquireChan
-	select {
-	case _ = <-acquireChan:
-		t.Fatal("should not have gotten a GPU")
-	case <-time.After(time.Millisecond * 100):
-		// preferred outcome: no additional GPU
-	}
-	d.Release(ord)
-
-	select {
-	case ord = <-acquireChan:
-		if ord != 0 {
-			t.Fatal("should have gotten GPU 0")
-		}
-	case <-time.After(time.Millisecond * 100):
-		t.Fatal("timeout")
-	}
-	d.Release(ord)
+	// Release of -1 should not panic or block.
+	d.Release(-1)
 }
 
 func TestOverprovisionFactor(t *testing.T) {
@@ -132,4 +117,92 @@ func TestWaitList(t *testing.T) {
 func TestGlobal(t *testing.T) {
 	ord := deviceOrdinalMgr.Get()
 	deviceOrdinalMgr.Release(ord)
+}
+
+// Regression: no-GPU manager must never hand out ordinal 0.
+// Before the fix, gpuSlots was []byte{1} when no GPUs existed, so Get()
+// returned 0 and call() would set CUDA_VISIBLE_DEVICES=0 for a device
+// that doesn't exist.
+func TestNoGPUs_NeverReturnsZero(t *testing.T) {
+	d := newDeviceOrdinalManager(func() ([]string, error) {
+		return []string{}, nil
+	})
+
+	for i := 0; i < 10; i++ {
+		ord := d.Get()
+		if ord != -1 {
+			t.Fatalf("no-GPU manager returned ordinal %d, want -1", ord)
+		}
+		// Release should not block or panic even with -1.
+		d.Release(ord)
+	}
+}
+
+// Regression: extracting log context from a bare context must not panic.
+// Before the fix, ctx.Value(logCtxKey).([]any) was a hard type assertion
+// that panicked when the context had no logCtxKey value.
+func TestLogCtxNilSafe(t *testing.T) {
+	ctx := context.Background() // no WithLogCtx
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("extracting logCtxKey from bare context panicked: %v", r)
+		}
+	}()
+
+	// This is the exact pattern used in call(). Before the fix it was:
+	//   ctx.Value(logCtxKey).([]any)   — panics on nil
+	// After the fix:
+	//   logKvs, _ := ctx.Value(logCtxKey).([]any)
+	logKvs, _ := ctx.Value(logCtxKey).([]any)
+	if logKvs != nil {
+		t.Fatalf("expected nil logKvs from bare context, got %v", logKvs)
+	}
+
+	// NewLogWriter must handle nil ctx gracefully.
+	lw := NewLogWriter(logKvs, io.Discard)
+	if lw == nil {
+		t.Fatal("NewLogWriter returned nil")
+	}
+}
+
+// Regression: double-release must not overflow the byte slot counter.
+// Before the fix, gpuSlots[ordinal]++ had no bounds check and could
+// exceed GpuOverprovisionFactor or wrap around byte(255)->0.
+func TestDoubleReleaseIgnored(t *testing.T) {
+	d := newDeviceOrdinalManager(func() ([]string, error) {
+		return []string{"gpu0"}, nil
+	})
+
+	ord := d.Get()
+	d.Release(ord)
+
+	// Second release of the same ordinal — should be silently ignored,
+	// not inflate capacity.
+	d.Release(ord)
+
+	// We should still only be able to acquire GpuOverprovisionFactor times
+	// (which is 1 by default). If double-release inflated the counter,
+	// we'd be able to acquire more than once.
+	acquireChan := make(chan int)
+
+	// First acquire should succeed.
+	d.acquireChan <- acquireChan
+	select {
+	case got := <-acquireChan:
+		if got != 0 {
+			t.Fatalf("expected ordinal 0, got %d", got)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Fatal("timeout on first acquire")
+	}
+
+	// Second acquire should block (only 1 slot with default overprovision=1).
+	d.acquireChan <- acquireChan
+	select {
+	case got := <-acquireChan:
+		t.Fatalf("should have blocked, but got ordinal %d", got)
+	case <-time.After(time.Millisecond * 100):
+		// expected: blocked because capacity is 1
+	}
 }

--- a/lib/ffiselect/ffiselect.go
+++ b/lib/ffiselect/ffiselect.go
@@ -55,18 +55,36 @@ func newDeviceOrdinalManager(getGPUDevices func() ([]string, error)) *deviceOrdi
 		if err != nil {
 			panic(err)
 		}
-		gpuSlots := []byte{1}
-		if len(devices) > 0 {
-			gpuSlots = make([]byte, len(devices))
-			for i := range gpuSlots {
-				gpuSlots[i] = byte(resources.GpuOverprovisionFactor)
+
+		// No GPUs: immediately respond with -1 to every acquire, ignore releases.
+		if len(devices) == 0 {
+			for {
+				select {
+				case <-d.releaseChan:
+					// nothing to track
+				case acquireChan := <-d.acquireChan:
+					acquireChan <- -1
+				}
 			}
+		}
+
+		gpuSlots := make([]byte, len(devices))
+		for i := range gpuSlots {
+			gpuSlots[i] = byte(resources.GpuOverprovisionFactor)
 		}
 
 		waitList := []chan int{}
 		for { // distribute loop
 			select {
 			case ordinal := <-d.releaseChan:
+				if ordinal < 0 || ordinal >= len(gpuSlots) {
+					logger.Errorf("release of invalid GPU ordinal %d (have %d GPUs), ignoring", ordinal, len(gpuSlots))
+					continue
+				}
+				if gpuSlots[ordinal] >= byte(resources.GpuOverprovisionFactor) {
+					logger.Errorf("double-release of GPU ordinal %d (slot already at capacity %d), ignoring", ordinal, resources.GpuOverprovisionFactor)
+					continue
+				}
 				if len(waitList) > 0 { // unblock the delayed requests
 					waitList[0] <- ordinal
 					waitList = waitList[1:]
@@ -168,7 +186,8 @@ func call(ctx context.Context, body []byte) (io.ReadCloser, error) {
 
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	lw := NewLogWriter(ctx.Value(logCtxKey).([]any), os.Stderr)
+	logKvs, _ := ctx.Value(logCtxKey).([]any)
+	lw := NewLogWriter(logKvs, os.Stderr)
 
 	cmd.Stderr = lw
 	cmd.Stdout = lw
@@ -181,11 +200,15 @@ func call(ctx context.Context, body []byte) (io.ReadCloser, error) {
 	cmd.Stdin = bytes.NewReader(body)
 	err = cmd.Run()
 	if err != nil {
+		_ = outFile.Close()
+		_ = os.Remove(outFile.Name())
 		return nil, err
 	}
 
 	// seek to start
 	if _, err := outFile.Seek(0, io.SeekStart); err != nil {
+		_ = outFile.Close()
+		_ = os.Remove(outFile.Name())
 		return nil, xerrors.Errorf("failed to seek to beginning of output file: %w", err)
 	}
 


### PR DESCRIPTION
GPU needs a device provisioner that waits instead of errs in rare over-request scenarios. 
This cannot be a simple "heavy channel" as this may overschedule 1 GPU. 

The fix keeps the pool but protects it on both sides with chans (instead of mutexes)