### PR TITLE
fix(alertmanager): correct inverted condition in permanentStorageCheck

### DIFF
--- a/alertmanager/alerts.go
+++ b/alertmanager/alerts.go
@@ -289,9 +289,10 @@ func permanentStorageCheck(al *alerts) {
 		sectorMap[key] = false
 
 		for _, strg := range storages {
-			if space > strg.Available {
+			if space <= strg.Available {
 				strg.Available -= space
 				sectorMap[key] = true
+				break
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

The storage space check in `permanentStorageCheck` has an inverted condition that causes the `PermanentStorageSpace` alert to misreport storage availability.

## The Bug

The condition on [alertmanager/alerts.go L292](https://github.com/filecoin-project/curio/blob/main/alertmanager/alerts.go#L292) reads:

```go
if space > strg.Available {
    strg.Available -= space
    sectorMap[key] = true
}
```

This marks a sector as **accounted for** when the required space is **greater** than what's available — the exact opposite of the intended logic. The result:

- Sectors that **can't fit** on any storage get marked as placed (false negative — no alert when one is needed)
- Sectors that **can fit** remain unaccounted (false positive — spurious "insufficient storage" alerts)
- Available space is decremented even when a sector doesn't actually fit, compounding the error for subsequent sectors

## The Fix

1. **Invert the condition** from `space > strg.Available` to `space <= strg.Available` — only mark a sector as accounted when the storage path actually has enough room.
2. **Add `break`** after successfully placing a sector — once a sector fits on one storage path, stop iterating so it isn't double-counted against multiple paths.

## Diff

```diff
-  if space > strg.Available {
+  if space <= strg.Available {
       strg.Available -= space
       sectorMap[key] = true
+      break
   }
```

Two-line fix. No behavioral change to any other code path.