### PR TITLE
fix(alertmanager): iterate mmap instead of tmap for machine failure alerts

### DIFF
--- a/alertmanager/alerts.go
+++ b/alertmanager/alerts.go
@@ -217,7 +217,7 @@ func taskFailureCheck(al *alerts) {
 	}
 
 	// Alert if a machine failed more than 5 tasks
-	for name, count := range tmap {
+	for name, count := range mmap {
 		if count > 5 {
 			al.alertMap[Name].alertString += fmt.Sprintf("Machine: %s, Failures: %d. ", name, count)
 		}


### PR DESCRIPTION
## Problem

The "Alert if a machine failed more than 5 tasks" loop in `taskFailureCheck` iterates over `tmap` (task name → aggregate failure count) instead of `mmap` (machine host:port → aggregate failure count).

This causes the alert to print **task names as if they were machine names**, e.g.:

```
Machine: SDR, Failures: 8. Machine: TreeD, Failures: 6.
```

…when the intended output is:

```
Machine: curio-1:12300, Failures: 8. Machine: curio-2:12300, Failures: 6.
```

The bug has been present since the original alertManager implementation (`0137faf6`, May 2024) and was never caught because the two maps happen to share the same `map[string]int` type, so it compiles and runs without error — just with wrong labels.

## Fix

One-line change: replace `tmap` → `mmap` in the machine failure loop (line 220).

The task-level alert loop above (lines 210-217) correctly uses `tmap` and is left unchanged.