### PR TITLE
fix(alertmanager): correct inverted condition in permanentStorageCheck

### DIFF
--- a/alertmanager/alerts.go
+++ b/alertmanager/alerts.go
@@ -289,9 +289,10 @@ func permanentStorageCheck(al *alerts) {
 		sectorMap[key] = false
 
 		for _, strg := range storages {
-			if space > strg.Available {
+			if space <= strg.Available {
 				strg.Available -= space
 				sectorMap[key] = true
+				break
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

The storage space check in `permanentStorageCheck` had an inverted condition: it marked sectors as accounted for when space was *greater* than available storage, which is the opposite of the intended behavior. This caused the alert to misreport storage availability — sectors that couldn't fit would be marked as placed, and sectors that could fit would be left unaccounted.

Additionally, the loop lacked a `break` after placing a sector, so a single sector could be "placed" across multiple storage paths simultaneously, double-counting the space deduction.

The bug has been present since the original alertManager implementation (`0137faf6`, May 2024).

## Changes

- Flip condition from `space > strg.Available` to `space <= strg.Available` so sectors are only marked as accounted when storage actually has sufficient space.
- Add `break` after placing a sector so it isn't double-counted across multiple storage paths.