### PR TITLE
fix(alertmanager): use configured MinimumWalletBalance in alert message

### DIFF
--- a/alertmanager/alerts.go
+++ b/alertmanager/alerts.go
@@ -142,7 +142,7 @@ func balanceCheck(al *alerts) {
 		}
 
 		if abi.TokenAmount(al.cfg.MinimumWalletBalance).GreaterThanEqual(balance) {
-			ret += fmt.Sprintf("Balance for wallet %s (%s) is below 5 Fil. ", addr, keyAddr)
+			ret += fmt.Sprintf("Balance for wallet %s (%s) is below %s. ", addr, keyAddr, al.cfg.MinimumWalletBalance.Short())
 		}
 	}
 	if ret != "" {


### PR DESCRIPTION
## Problem

The balance alert in `balanceCheck` compares wallet balances against the configurable `MinimumWalletBalance` threshold (default 5 FIL), but the alert message always displays a hardcoded **"below 5 Fil"** regardless of the actual configured value.

An operator who sets `MinimumWalletBalance = "10 FIL"` would see:

```
Balance for wallet f3abc... (f1xyz...) is below 5 Fil.
```

…when the alert actually fired because the balance was below 10 FIL. This is confusing and could lead operators to misdiagnose the issue.

The hardcoded string has been present since the original alertManager implementation (`0137faf6`, May 2024). The format string was touched in `5370e48f` (Sep 2024) but the hardcoded value was not corrected.

## Fix

One-line change: replace the hardcoded `"5 Fil"` with `al.cfg.MinimumWalletBalance.Short()` which formats the actual configured threshold (e.g. `"5 FIL"`, `"10 FIL"`).