### PR TITLE
fix(web): correct Susbystems typo in auto-generated config layer

### DIFF
--- a/cmd/curio/run.go
+++ b/cmd/curio/run.go
@@ -177,7 +177,7 @@ var webCmd = &cli.Command{
 		webtxt, err := getConfig(db, "web")
 		if err != nil || webtxt == "" {
 
-			s := `[Susbystems]
+			s := `[Subsystems]
 			EnableWebGui = true
 			`
 			if err = setConfig(db, "web", s); err != nil {


### PR DESCRIPTION
## Problem

The curio web command auto-creates a web config layer in the database on first run. The TOML content uses `[Susbystems]` (transposed s and b) instead of `[Subsystems]`.

BurntSushi/toml matches section names case-insensitively but not spelling-insensitively. Since `Susbystems` != `Subsystems`, the decoder silently ignores the section and `EnableWebGui` is never set from this layer.

First-time `curio web` users get a config layer that looks correct but does not actually enable the web GUI — it only works if `EnableWebGui` is set in another layer.

Present since the original webCmd implementation (`bf5f77f5`, Ajax, Mar 2024).

## Fix

One-character fix: `Susbystems` → `Subsystems`.