### PR TITLE
fix(rpc): remove superfluous WriteHeader in prometheus service discovery handler

### DIFF
--- a/cmd/curio/rpc/rpc.go
+++ b/cmd/curio/rpc/rpc.go
@@ -595,7 +595,6 @@ func prometheusServiceDiscovery(ctx context.Context, deps *deps.Deps) http.Handl
 				log.Errorf("failed to encode response: %s", err)
 			}
 		}
-		resp.WriteHeader(http.StatusOK)
 	}
 	return hnd
 }


### PR DESCRIPTION
The prometheus service discovery handler at /debug/service-discovery calls resp.WriteHeader(http.StatusOK) after the response body has already been written via json.Encode or w.Write. In Go net/http, writing to the body implicitly sends a 200 header, so the explicit call is a no-op that logs a 'superfluous response.WriteHeader' warning on every request.

The Content-Type header is already correctly set at the top of the handler. Remove the redundant WriteHeader call.