### PR TITLE
pdpv0: Document PDP task inventory and dependency tree 

### DIFF
--- a/documentation/en/experimental-features/PDPCURIOSPEC.md
+++ b/documentation/en/experimental-features/PDPCURIOSPEC.md
@@ -147,9 +147,6 @@ There are two paths for getting pieces into the system:
 6. Once `service_termination_epoch <= current_block` and `deletion_allowed = TRUE`, **PDPv0_DelDataSet** calls `PDPVerifier.deleteDataSet()`.
 7. When the delete transaction lands, **DataSetDeleteWatcher** verifies the dataset is no longer live on-chain and deletes the `pdp_data_sets` row (CASCADE removes pieces and prove tasks).
 
-**If a rail is fully settled/finalized:**
-3. SettleWatcher calls `ensureDataSetDeletion()`, which sets `deletion_allowed = TRUE` in `pdp_delete_data_set`. This is then picked up by **PDPv0_DelDataSet** at step 6 above.
-
 ## Piece Removal
 
 1. Client calls `removePieces()` via HTTP, which sends a `PDPVerifier.removePieces()` transaction.


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
- Adds a complete inventory of all 8 PDP harmony tasks and 5 chain-handler watchers to PDPCURIOSPEC.md
- Adds ASCII dependency tree diagrams covering piece ingestion, the proving cycle, payment settlement/termination, piece removal, and error recovery

Closes remaining parts of #904