### PR TITLE
fix(ffi): downgrade reflink fallback log from ERROR to WARN

### DIFF
--- a/lib/ffi/sdr_funcs.go
+++ b/lib/ffi/sdr_funcs.go
@@ -275,7 +275,7 @@ func (sb *SealCalls) TreeRC(ctx context.Context, task *harmonytask.TaskID, secto
 				return cid.Undef, cid.Undef, xerrors.Errorf("truncating reflinked sealed file: %w", err)
 			}
 		} else {
-			log.Errorw("reflink treed -> sealed failed, falling back to slow copy, use single scratch btrfs or xfs filesystem", "error", err, "sector", sector, "cache", fspaths.Cache, "sealed", fspaths.Sealed)
+			log.Warnw("reflink treed -> sealed failed, falling back to slow copy, use single scratch btrfs or xfs filesystem", "error", err, "sector", sector, "cache", fspaths.Cache, "sealed", fspaths.Sealed)
 
 			// fallback to slow copy, copy ssize bytes from treed to sealed
 			dst, err := os.OpenFile(fspaths.Sealed, os.O_WRONLY|os.O_CREATE, 0644)


### PR DESCRIPTION
When the sealing filesystem doesn't support reflink (e.g. ext4), the treed→sealed copy falls back to a regular `io.CopyN`. This works fine — sealing completes normally, just without the CoW optimization.

Logging this at ERROR is misleading and triggers unnecessary alertmanager noise on every TreeD task for operators on non-reflink filesystems. WARN is more appropriate since it's a non-fatal performance hint, not an error condition.