### PR TITLE
feat(src): copy lotus' fiximports parallelism

### DIFF
--- a/scripts/fiximports/main.go
+++ b/scripts/fiximports/main.go
@@ -3,16 +3,18 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"io/fs"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/tools/imports"
+	"golang.org/x/xerrors"
 )
 
 var (
@@ -28,7 +30,16 @@ var (
 	consecutiveNewlinesRegex = regexp.MustCompile(`\n\s*\n`)
 )
 
+type fileContent struct {
+	path     string
+	original []byte
+	current  []byte
+	changed  bool
+}
+
 func main() {
+	numWorkers := runtime.NumCPU()
+
 	// Get files changed since merge-base with main
 	// Files already on main have had fiximports run, so we only need to process changes
 	changedFiles := getChangedFilesSinceMergeBase()
@@ -40,11 +51,28 @@ func main() {
 
 	fmt.Printf("Processing %d changed Go file(s)\n", len(changedFiles))
 
-	for _, path := range changedFiles {
-		if err := fixGoImports(path); err != nil {
-			fmt.Printf("Error fixing imports in %s: %v\n", path, err)
+	// Read all file contents in parallel
+	fileContents, err := readFilesParallel(changedFiles, numWorkers)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error reading files: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Because we have multiple ways of separating imports, we have to imports.Process for each one
+	// but imports.LocalPrefix is a global, so we have to set it for each group and process files
+	// in parallel.
+	for _, prefix := range groupByPrefixes {
+		imports.LocalPrefix = prefix
+		if err := processFilesParallel(fileContents, numWorkers); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error processing files with prefix %s: %v\n", prefix, err)
 			os.Exit(1)
 		}
+	}
+
+	// Write modified files in parallel
+	if err := writeFilesParallel(fileContents, numWorkers); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error writing files: %v\n", err)
+		os.Exit(1)
 	}
 }
 
@@ -128,42 +156,80 @@ func getAllGoFiles() []string {
 	return files
 }
 
-func fixGoImports(path string) error {
-	sourceFile, err := os.OpenFile(path, os.O_RDWR, 0666)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = sourceFile.Close() }()
+func readFilesParallel(files []string, numWorkers int) ([]*fileContent, error) {
+	fileContents := make([]*fileContent, len(files))
 
-	source, err := io.ReadAll(sourceFile)
-	if err != nil {
-		return err
+	var g errgroup.Group
+	g.SetLimit(numWorkers)
+
+	for i, path := range files {
+		g.Go(func() error {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return xerrors.Errorf("reading %s: %w", path, err)
+			}
+
+			// Collapse is a cheap operation to do here
+			collapsed := collapseImportNewlines(content)
+			fileContents[i] = &fileContent{
+				path:     path,
+				original: content,
+				current:  collapsed,
+				changed:  !bytes.Equal(content, collapsed),
+			}
+			return nil
+		})
 	}
-	formatted := collapseImportNewlines(source)
-	for _, prefix := range groupByPrefixes {
-		imports.LocalPrefix = prefix
-		formatted, err = imports.Process(path, formatted, nil)
-		if err != nil {
-			return err
-		}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
-	if !bytes.Equal(source, formatted) {
-		if err := replaceFileContent(sourceFile, formatted); err != nil {
-			return err
-		}
-	}
-	return nil
+
+	return fileContents, nil
 }
 
-func replaceFileContent(target *os.File, replacement []byte) error {
-	if _, err := target.Seek(0, io.SeekStart); err != nil {
-		return err
+func processFilesParallel(fileContents []*fileContent, numWorkers int) error {
+	var g errgroup.Group
+	g.SetLimit(numWorkers)
+
+	for _, file := range fileContents {
+		if file == nil {
+			continue
+		}
+		g.Go(func() error {
+			formatted, err := imports.Process(file.path, file.current, nil)
+			if err != nil {
+				return xerrors.Errorf("processing %s: %w", file.path, err)
+			}
+
+			if !bytes.Equal(file.current, formatted) {
+				file.current = formatted
+				file.changed = true
+			}
+			return nil
+		})
 	}
-	written, err := target.Write(replacement)
-	if err != nil {
-		return err
+
+	return g.Wait()
+}
+
+func writeFilesParallel(fileContents []*fileContent, numWorkers int) error {
+	var g errgroup.Group
+	g.SetLimit(numWorkers)
+
+	for _, file := range fileContents {
+		if file == nil || !file.changed {
+			continue
+		}
+		g.Go(func() error {
+			if err := os.WriteFile(file.path, file.current, 0666); err != nil {
+				return xerrors.Errorf("writing %s: %w", file.path, err)
+			}
+			return nil
+		})
 	}
-	return target.Truncate(int64(written))
+
+	return g.Wait()
 }
 
 func collapseImportNewlines(content []byte) []byte {


### PR DESCRIPTION
I'm noticing that you don't have the fiximports parallelism optimisations we did in lotus last year (or the year before?) but you do have a merge-base optimisation we don't have, so I'm combining them both in here and I'll do the same in Lotus.