### PR TITLE
docs: update snark market build instructions and batch sealing deal guidance

### DIFF
--- a/documentation/en/experimental-features/Snark-Market.md
+++ b/documentation/en/experimental-features/Snark-Market.md
@@ -44,7 +44,7 @@ Before enabling the Snark Market on your node:
 * 70GB base system RAM + ~220 GB Per GPU
   * Lower amount is acceptable, but you won't be able to use the much faster CUDA C2 feature (batch sealing toolchain)\
     Meaning ~10mins/proof instead of 2.
-* Curio from `main` branch (Snark Market support is not yet part of a release)
+* Curio **v1.27.0 or later** (Snark Market is included in official releases)
 * FIL balance on Mainnet
 
 ***
@@ -70,10 +70,10 @@ sudo apt update
 sudo apt install -y build-essential pkg-config libssl-dev curl git clang cmake golang
 ```
 
-Then, build Curio from the Main branch:
+Then, build Curio (for CUDA C2 support, build from source):
 
 ```bash
-git pull
+git checkout v1.27.2  # or latest release tag
 git submodule update
 make clean
 RUSTFLAGS="-C target-cpu=native -g" FFI_BUILD_FROM_SOURCE=1 FFI_USE_CUDA_SUPRASEAL=1 make clean build all

--- a/documentation/en/supraseal.md
+++ b/documentation/en/supraseal.md
@@ -7,7 +7,7 @@ description: This page explains how to set up Curio batch sealing (extern/supras
 {% hint style="danger" %}
 **Disclaimer:** Batch sealing is currently in **BETA**. Use with caution and expect potential issues or changes in future versions. Some additional manual system configuration is required.
 
-Batch sealing only supports **CC sectors** at the moment.
+Batch sealing only supports **CC sectors** at the moment. The recommended workflow for onboarding deal data is to batch-seal CC sectors and then upgrade them with SnapDeals.
 
 If you enable batch sealing on a node but do **not** enable SnapDeals in the cluster, deals may be routed into the CC/batch pipeline which will seal empty sectors (discarding deal data). Make sure SnapDeals are enabled if you intend to onboard real data deals.
 {% endhint %}
@@ -17,7 +17,7 @@ If you enable batch sealing on a node but do **not** enable SnapDeals in the clu
 Curio includes a **CC Scheduler** UI and DB table (`sectors_cc_scheduler`) used to decide how many CC sectors to queue for batch sealing per SP.
 
 - The **CC Scheduler is only used for batch sealing**.
-- Do not enable or rely on it for deals/SnapDeals.
+- Do not enable or rely on it for deals.
 
 Curio’s web UI exposes this as the **CC Scheduler** page/tab.
 


### PR DESCRIPTION
- **Snark Market**: update system requirements and build instructions to point to v1.27.2 release instead of building from `main` (Snark Market has been included in official releases since v1.27.0)
- **Batch Sealing**: remove SnapDeals from the "do not rely on it for deals/SnapDeals" warning, since the recommended workflow is to batch-seal CC sectors and then upgrade them with SnapDeals
- Add a note clarifying the recommended CC → SnapDeals workflow for deal onboarding