### PR TITLE
fix(build): use prebuilt FFI on macOS, remove forced clean on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,11 @@ setup-cgo-env:
 	fi
 
 build/.filecoin-install: $(FFI_PATH)
+ifeq ($(shell uname),Darwin)
+	$(MAKE) -C $(FFI_PATH) $(FFI_DEPS:$(FFI_PATH)%=%)
+else
 	$(MAKE) curio-libfilecoin
+endif
 	@touch $@
 
 MODULES+=$(FFI_PATH)
@@ -53,7 +57,7 @@ curio-libfilecoin:
 	FFI_USE_CUDA=$(if $(FFI_USE_OPENCL),0,1) \
 	FFI_USE_MULTICORE_SDR=1 \
 	RUSTFLAGS='-C codegen-units=1 -C opt-level=3 -C strip=symbols' \
-	$(MAKE) -C $(FFI_PATH) clean .install-filcrypto
+	$(MAKE) -C $(FFI_PATH) .install-filcrypto
 
 ffi-version-check:
 	@[[ "$$(awk '/const Version/{print $$5}' extern/filecoin-ffi/version.go)" -eq 3 ]] || (echo "FFI version mismatch, update submodules"; exit 1)


### PR DESCRIPTION
## Problem

After #1004 removed the `CURIO_OPTIMAL_LIBFILCRYPTO` gate, **every** build — including macOS — compiles FFI from source via Rust. This is unnecessary on macOS where CUDA/supraseal don't apply, and makes dev builds painfully slow.

Additionally, the `curio-libfilecoin` target runs `make clean` before building FFI, which forces a **full rebuild from scratch** on every `make` invocation, even when nothing has changed.

## Changes

1. **macOS (Darwin)**: skip from-source build, use prebuilt FFI binaries (same as the old non-optimal path)
2. **Linux**: keep the from-source optimized build exactly as #1004 intended
3. **Remove `clean`** from the `curio-libfilecoin` target — the build system handles incremental builds correctly; forcing clean on every invocation wastes significant build time

## Impact

- macOS dev builds go from minutes (full Rust FFI compile) back to seconds (prebuilt download)
- Linux builds no longer redundantly rebuild FFI when nothing changed
- No change to Linux build output or behavior