### PR TITLE
pdpv0: call IndexStore.Start() after NewIndexStore

### DIFF
--- a/deps/deps.go
+++ b/deps/deps.go
@@ -382,6 +382,10 @@ Get it with: jq .PrivateKey ~/.lotus-miner/keystore/MF2XI2BNNJ3XILLQOJUXMYLUMU`,
 
 		deps.IndexStore, err = indexstore.NewIndexStore(strings.Split(dbHost, ","), cctx.Int("db-cassandra-port"), deps.Cfg)
 		if err != nil {
+			return xerrors.Errorf("failed to create index store: %w", err)
+		}
+		err = deps.IndexStore.Start(cctx.Context, false)
+		if err != nil {
 			return xerrors.Errorf("failed to start index store: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary

#996  (`feat(pdpv0): introduce main alike indexstore in pdpv0 #996`) ported the `IndexStore` from `main` to `pdpv0` but did not carry over the `Start()` call that follows `NewIndexStore` in `deps/deps.go`.

As a result `i.session` is always `nil` after startup. Every `PDPv0_Indexing` task panics immediately at `CheckHasPiece` (`tasks/indexing/task_pdp_indexing.go:73`):

```
runtime error: invalid memory address or nil pointer dereference
gocql.(*Session).Query(0x0, ...)
  indexstore/indexstore.go:419 +0x167
indexing.(*PDPIndexingTask).Do(...)
  tasks/indexing/task_pdp_indexing.go:73
```

This means **no indexing tasks can complete** on any pdpv0 node running the binary produced after `5a8be7a9`.

## Fix

Add the missing `Start()` call, exactly mirroring what `main` already does:

```go
deps.IndexStore, err = indexstore.NewIndexStore(...)
if err != nil {
    return xerrors.Errorf("failed to create index store: %w", err)
}
err = deps.IndexStore.Start(cctx.Context, false)
if err != nil {
    return xerrors.Errorf("failed to start index store: %w", err)
}
```

## Notes

- This is independent of PR #1017 (indexing task count fix)
- `Start()` is idempotent for an existing keyspace (`CREATE KEYSPACE IF NOT EXISTS`)
- Error message wording aligned with `main`