### PR TITLE
speed up DB itests

### DIFF
--- a/itests/alertnow_test.go
+++ b/itests/alertnow_test.go
@@ -21,7 +21,7 @@ func TestAlertNow(t *testing.T) {
 	}
 	// Create dependencies
 	sharedITestID := harmonydb.ITestNewID()
-	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID)
+	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID, true)
 	require.NoError(t, err)
 
 	an := alertmanager.NewAlertNow(db, "alertNowMachine")

--- a/itests/curio_test.go
+++ b/itests/curio_test.go
@@ -76,7 +76,7 @@ func TestCurioHappyPath(t *testing.T) {
 	sharedITestID := harmonydb.ITestNewID()
 	t.Logf("sharedITestID: %s", sharedITestID)
 
-	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID)
+	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID, true)
 	require.NoError(t, err)
 
 	defer db.ITestDeleteAll()

--- a/itests/dyncfg_test.go
+++ b/itests/dyncfg_test.go
@@ -17,7 +17,7 @@ func TestDynamicConfig(t *testing.T) {
 	defer cancel()
 
 	sharedITestID := harmonydb.ITestNewID()
-	cdb, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID)
+	cdb, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID, true)
 	require.NoError(t, err)
 
 	databaseContents := &config.CurioConfig{

--- a/itests/harmonydb_test.go
+++ b/itests/harmonydb_test.go
@@ -20,7 +20,7 @@ func TestCrud(t *testing.T) {
 	defer cancel()
 
 	sharedITestID := harmonydb.ITestNewID()
-	cdb, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID)
+	cdb, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID, false)
 	require.NoError(t, err)
 
 	//cdb := miner.BaseAPI.(*impl.StorageMinerAPI).HarmonyDB
@@ -52,7 +52,7 @@ func TestTransaction(t *testing.T) {
 	defer cancel()
 
 	testID := harmonydb.ITestNewID()
-	cdb, err := harmonydb.NewFromConfigWithITestID(t, testID)
+	cdb, err := harmonydb.NewFromConfigWithITestID(t, testID, false)
 	require.NoError(t, err)
 	_, err = cdb.Exec(ctx, "INSERT INTO itest_scratch (some_int) VALUES (4), (5), (6)")
 	require.NoError(t, err)
@@ -116,7 +116,7 @@ func TestPartialWalk(t *testing.T) {
 	defer cancel()
 
 	testID := harmonydb.ITestNewID()
-	cdb, err := harmonydb.NewFromConfigWithITestID(t, testID)
+	cdb, err := harmonydb.NewFromConfigWithITestID(t, testID, false)
 	require.NoError(t, err)
 	_, err = cdb.Exec(ctx, `
 			INSERT INTO 
@@ -161,7 +161,7 @@ func TestDowngradeTo(t *testing.T) {
 	defer cancel()
 
 	testID := harmonydb.ITestNewID()
-	cdb, err := harmonydb.NewFromConfigWithITestID(t, testID)
+	cdb, err := harmonydb.NewFromConfigWithITestID(t, testID, true)
 	require.NoError(t, err)
 
 	// The setup: lets make revert files going forward in time, but ignore the past.

--- a/itests/market_deal_dynamic_test.go
+++ b/itests/market_deal_dynamic_test.go
@@ -79,7 +79,7 @@ func TestMarketDealDynamicMinerUpdate(t *testing.T) {
 	sharedITestID := harmonydb.ITestNewID()
 	t.Logf("sharedITestID: %s", sharedITestID)
 
-	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID)
+	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID, true)
 	require.NoError(t, err)
 
 	defer db.ITestDeleteAll()
@@ -443,7 +443,7 @@ func TestMarketDealSystemBasic(t *testing.T) {
 	sharedITestID := harmonydb.ITestNewID()
 	t.Logf("sharedITestID: %s", sharedITestID)
 
-	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID)
+	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID, true)
 	require.NoError(t, err)
 	defer db.ITestDeleteAll()
 

--- a/itests/sql_idempotent_test.go
+++ b/itests/sql_idempotent_test.go
@@ -21,7 +21,7 @@ func TestSQLIdempotent(t *testing.T) {
 	}
 
 	testID := harmonydb.ITestNewID()
-	cdb, err := harmonydb.NewFromConfigWithITestID(t, testID)
+	cdb, err := harmonydb.NewFromConfigWithITestID(t, testID, true)
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/lib/paths/local_test.go
+++ b/lib/paths/local_test.go
@@ -84,7 +84,7 @@ func TestLocalStorage(t *testing.T) {
 
 	sharedITestID := harmonydb.ITestNewID()
 
-	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID)
+	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID, true)
 	require.NoError(t, err)
 
 	index := NewDBIndex(nil, db)

--- a/lib/paths/remote_test.go
+++ b/lib/paths/remote_test.go
@@ -61,7 +61,7 @@ func TestMoveShared(t *testing.T) {
 
 	sharedITestID := harmonydb.ITestNewID()
 
-	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID)
+	db, err := harmonydb.NewFromConfigWithITestID(t, sharedITestID, true)
 	require.NoError(t, err)
 
 	index := paths.NewDBIndex(nil, db)


### PR DESCRIPTION
Old numbers

--- PASS: TestCrud (83.16s)
=== RUN   TestTransaction
--- PASS: TestTransaction (90.80s)
=== RUN   TestPartialWalk
--- PASS: TestPartialWalk (82.95s)
=== RUN   TestDowngradeTo
--- PASS: TestDowngradeTo (96.46s)


New numbers

--- PASS: TestCrud (1.68s)
=== RUN   TestTransaction
--- PASS: TestTransaction (1.20s)
=== RUN   TestPartialWalk
--- PASS: TestPartialWalk (1.09s)
=== RUN   TestDowngradeTo
--- PASS: TestDowngradeTo (89.40s)