### PR TITLE
feat: allow location-bound pipeline tasks to drain on cordoned nodes

### DIFF
--- a/tasks/seal/task_finalize.go
+++ b/tasks/seal/task_finalize.go
@@ -228,6 +228,8 @@ func (f *FinalizeTask) TypeDetails() harmonytask.TaskTypeDetails {
 		// This allows finalize to unblock move-storage and PoRep for multiple hours while the node is technically not schedulable,
 		// but is still finishing another batch. In most cases this behavior enables nearly zero-waste restarts of supraseal nodes.
 		SchedulingOverrides: batchTaskNameGrid(),
+
+		AllowOnCordoned: true, // always location-bound — safe to drain on cordon
 	}
 }
 

--- a/tasks/seal/task_synth_proofs.go
+++ b/tasks/seal/task_synth_proofs.go
@@ -212,8 +212,9 @@ func (s *SyntheticProofTask) TypeDetails() harmonytask.TaskTypeDetails {
 			Ram:     ram,
 			Storage: s.sc.Storage(s.taskToSector, storiface.FTNone, storiface.FTCache|storiface.FTSealed, ssize, storiface.PathSealing, paths.MinFreeStoragePercentage),
 		},
-		MaxFailures: 5,
-		Follows:     nil,
+		MaxFailures:     5,
+		Follows:         nil,
+		AllowOnCordoned: true, // always location-bound — safe to drain on cordon
 	}
 
 	return res

--- a/tasks/seal/task_treed.go
+++ b/tasks/seal/task_treed.go
@@ -83,8 +83,9 @@ func (t *TreeDTask) TypeDetails() harmonytask.TaskTypeDetails {
 			Gpu:     0,
 			Storage: t.sc.Storage(t.taskToSector, storiface.FTNone, storiface.FTCache, ssize, storiface.PathSealing, 1.0),
 		},
-		MaxFailures: 3,
-		Follows:     nil,
+		MaxFailures:     3,
+		Follows:         nil,
+		AllowOnCordoned: t.bound, // when bound to node, CanAccept filters to local data — safe to drain on cordon
 	}
 }
 

--- a/tasks/seal/task_treerc.go
+++ b/tasks/seal/task_treerc.go
@@ -168,8 +168,9 @@ func (t *TreeRCTask) TypeDetails() harmonytask.TaskTypeDetails {
 			Ram:     ram,
 			Storage: t.sc.Storage(t.taskToSector, storiface.FTSealed, storiface.FTCache, ssize, storiface.PathSealing, paths.MinFreeStoragePercentage),
 		},
-		MaxFailures: 3,
-		Follows:     nil,
+		MaxFailures:     3,
+		Follows:         nil,
+		AllowOnCordoned: true, // always location-bound — safe to drain on cordon
 	}
 }
 


### PR DESCRIPTION
## Problem

When a node is cordoned (`curio cordon` / `unschedulable = true`), the Harmony scheduler blocks **all** new task scheduling except for tasks with `SchedulingOverrides` (currently only Finalize for supraseal batch drain). This causes sectors mid-pipeline to get **permanently stuck** when their data is location-bound to the cordoned node.

**Example:** SDR completes on Node A → TreeRC task is created → Node A is cordoned → TreeRC is skipped by the scheduler → Node B cannot run it (sector cache is on Node A) → sector is stuck until uncordon.

Affected stages: TreeD (when bound), TreeRC, SyntheticProofs, Finalize.

Reported in #1025.

## Solution

Add an `AllowOnCordoned` flag to `TaskTypeDetails`. When set, the scheduler allows the task to be scheduled on cordoned nodes. This is **safe** for location-bound tasks because their `CanAccept()` already filters to tasks whose sector data resides on the local machine — so this only drains in-progress pipelines, it does not start new work.

### Tasks with AllowOnCordoned:
| Task | Why |
|------|-----|
| TreeD | Only when `BindSDRTreeToNode` is enabled (CanAccept filters to local cache) |
| TreeRC | Always location-bound (joins sector_location → storage_path by host) |
| SyntheticProofs | Always location-bound (same pattern) |
| Finalize | Always location-bound (same pattern, also retains existing SchedulingOverrides for batch) |

### Intentionally excluded:
- **SDR** — first pipeline stage; not location-bound; would start new work
- **PreCommitBatch / CommitBatch** — chain messages; any node can send them
- **PoRep** — can run remotely (data fetched over network)
- **MoveStorage** — not location-bound (checks CanStore, not data locality)

### Unchanged behavior:
- **IAmBored** (new work creation) remains blocked when cordoned
- **followWorkInDB** (Follows) remains blocked when cordoned (no pipeline tasks use Follows)
- **yieldBackground** still causes CanYield/background tasks to yield
- **SchedulingOverrides** still works as before (Finalize + Batch drain)

## Testing

The change is minimal and additive:
- 1 new boolean field on `TaskTypeDetails`
- 1 branch in `pollerTryAllWork()` to check it before the existing override logic
- 4 task TypeDetails updated with the flag

Existing SchedulingOverrides behavior is preserved (Finalize retains both mechanisms).

Closes #1025