### PR TITLE
pdpv0: re-enable DELETE in processPendingCleanup to stop RPC flood

### DIFF
--- a/tasks/pdpv0/watch_piece_delete.go
+++ b/tasks/pdpv0/watch_piece_delete.go
@@ -177,12 +177,11 @@ func processPendingCleanup(ctx context.Context, db *harmonydb.DB, ethClient *eth
 		}
 
 		if !live {
-			// XXX(Kubuxu): commented out as this has lead to proving failures
-			//_, err := db.Exec(ctx, `DELETE FROM pdp_data_set_pieces WHERE data_set = $1 AND piece_id = $2`, piece.DataSetID, piece.PieceID)
-			err = nil
+			_, err = db.Exec(ctx, `DELETE FROM pdp_data_set_pieces WHERE data_set = $1 AND piece_id = $2 AND removed = TRUE`, piece.DataSetID, piece.PieceID)
 			if err != nil {
 				return xerrors.Errorf("failed to delete piece %d: %w", piece.PieceID, err)
 			}
+			log.Infow("deleted confirmed-removed piece from DB", "dataSetId", piece.DataSetID, "pieceId", piece.PieceID)
 		}
 	}
 


### PR DESCRIPTION
## Problem

Commit #947  fixed a `lo.Contains` pointer comparison bug in `processPendingPieceDeletes`,
which caused pieces to be correctly marked `removed=TRUE` for the first time. On calibration
nodes with ~2,900 such pieces, this had an unintended side effect:

`processPendingCleanup` runs on every Filecoin block (~30s) and calls `verifier.PieceLive()`
for every piece where `removed=TRUE`. The DELETE that would remove confirmed-dead pieces from
the table was commented out (`// XXX(Kubuxu): commented out as this has lead to proving failures`),
so the list never shrinks.

**Result:** ~2,900 `eth_call` RPC requests to Lotus per block, continuous and permanent.

**Impact:**
- Lotus overwhelmed with FVM instantiations ("using FVM V1" at 20+ per second)
- `eth_estimateGas` calls time out with `i/o timeout`
- Proving tasks fail, triggering exponential backoff
- After 5 consecutive failures, datasets marked `unrecoverable_proving_failure_epoch`
- 50+ datasets per hour becoming unrecoverable on calibration nodes

Mainnet unaffected (only 67 `removed=TRUE` pieces vs ~2,900 on calibration).

## Fix

Re-enable the DELETE with an `AND removed=TRUE` guard. `processPendingCleanup` already
calls `PieceLive()` immediately before the DELETE to confirm the piece is gone on-chain,
making this safe. Once the backlog is cleared (one-time cost on first run), the function
has zero rows to process and makes zero RPC calls per block.