### PR TITLE
fix: FixRawSize CanAccept SQL array cast typo

### DIFF
--- a/tasks/storage-market/task_fix_rawSize.go
+++ b/tasks/storage-market/task_fix_rawSize.go
@@ -131,7 +131,7 @@ func (f *FixRawSize) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.Tas
 						INNER JOIN market_piece_deal mpd ON f.id = mpd.id
 						INNER JOIN sector_location l ON mpd.sp_id = mpd.miner_id AND mpd.sector_number = l.sector_num AND l.sector_filetype = 4
 						INNER JOIN storage_path sp ON sp.storage_id = l.storage_id 
-						WHERE f.task_id = ANY($1::[]bigint)  AND sp.urls IS NOT NULL AND sp.urls LIKE '%' || $2 || '%' LIMIT 100) s`, indIDs, engine.Host()).Scan(&acceptedIDs)
+						WHERE f.task_id = ANY($1::bigint[])  AND sp.urls IS NOT NULL AND sp.urls LIKE '%' || $2 || '%' LIMIT 100) s`, indIDs, engine.Host()).Scan(&acceptedIDs)
 	if err != nil {
 		return nil, xerrors.Errorf("getting tasks from DB: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fix PostgreSQL syntax error in `FixRawSize.CanAccept()` that breaks all FixRawSize task acceptance on v1.27.3-rc1.

## Problem

`tasks/storage-market/task_fix_rawSize.go:134` has:
```sql
WHERE f.task_id = ANY($1::[]bigint)
```

`::[]bigint` is Go slice syntax, not valid PostgreSQL. The `[` after `::` triggers:
```
ERROR: syntax error at or near "[" (SQLSTATE 42601)
```

This fires on every 3s poll cycle, rejecting all FixRawSize tasks. The scheduler (`IAmBored`, 60s interval) keeps creating entries up to its cap of 100, none of which can ever be accepted.

## Fix

```diff
- WHERE f.task_id = ANY($1::[]bigint)
+ WHERE f.task_id = ANY($1::bigint[])
```

Every other `CanAccept` rewrite in the codebase already uses the correct `::bigint[]` form.

## Root Cause

Introduced in #855 (improve canAccept() performance) — all other files in that PR use the correct cast; this one was missed.