### PR TITLE
fix: FixRawSize SQL column name, join, and filetype bugs

### DIFF
--- a/tasks/storage-market/task_fix_rawSize.go
+++ b/tasks/storage-market/task_fix_rawSize.go
@@ -40,10 +40,10 @@ func (f *FixRawSize) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done
 
 	var id, pieceCidStr string
 	var spID, sectorNumer, pieceOffset, pieceSize, proof int64
-	err = f.db.QueryRow(ctx, `SELECT f.id, mpd.sp_id, mpd.sector_number, mpd.piece_cid, mpd.piece_offset, mpd.piece_length, m.reg_seal_proof 
+	err = f.db.QueryRow(ctx, `SELECT f.id, mpd.sp_id, mpd.sector_num, mpd.piece_cid, mpd.piece_offset, mpd.piece_length, m.reg_seal_proof 
 									FROM market_fix_raw_size f 
 									INNER JOIN market_piece_deal mpd ON f.id = mpd.id
-									INNER JOIN sectors_meta m ON mpd.sp_id = m.sp_id AND mpd.sector_number = m.sector_num
+									INNER JOIN sectors_meta m ON mpd.sp_id = m.sp_id AND mpd.sector_num = m.sector_num
 									WHERE  f.task_id = $1 AND mpd.raw_size = 0 
 									    AND piece_offset IS NOT NULL 
 									LIMIT 1`, taskID).Scan(&id, &spID, &sectorNumer, &pieceCidStr, &pieceOffset, &pieceSize, &proof)
@@ -129,7 +129,7 @@ func (f *FixRawSize) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.Tas
 	err := f.db.QueryRow(ctx, `SELECT COALESCE(array_agg(task_id), '{}')::bigint[] AS task_ids FROM (
 						SELECT f.task_id FROM market_fix_raw_size f
 						INNER JOIN market_piece_deal mpd ON f.id = mpd.id
-						INNER JOIN sector_location l ON mpd.sp_id = mpd.miner_id AND mpd.sector_number = l.sector_num AND l.sector_filetype = 4
+						INNER JOIN sector_location l ON mpd.sp_id = l.miner_id AND mpd.sector_num = l.sector_num AND l.sector_filetype = 1
 						INNER JOIN storage_path sp ON sp.storage_id = l.storage_id 
 						WHERE f.task_id = ANY($1::bigint[])  AND sp.urls IS NOT NULL AND sp.urls LIKE '%' || $2 || '%' LIMIT 100) s`, indIDs, engine.Host()).Scan(&acceptedIDs)
 	if err != nil {


### PR DESCRIPTION
## Summary

Complete fix for all SQL bugs in `FixRawSize` (`task_fix_rawSize.go`). Follow-up to #1035 (array cast fix). All bugs introduced in #855.

## Bugs Fixed (4)

### 1. CanAccept: wrong table alias in join
```diff
- INNER JOIN sector_location l ON mpd.sp_id = mpd.miner_id
+ INNER JOIN sector_location l ON mpd.sp_id = l.miner_id
```
`market_piece_deal` has no `miner_id` column → `column mpd.miner_id does not exist (SQLSTATE 42703)`

### 2. Do() + CanAccept: wrong column name `sector_number`
```diff
- mpd.sector_number
+ mpd.sector_num
```
`market_piece_deal` column is `sector_num`, not `sector_number`. Bug in Do() was masked because CanAccept() always fails first — task is never accepted, Do() is never reached.

### 3. Do(): same column name bug in sectors_meta join
```diff
- INNER JOIN sectors_meta m ON mpd.sp_id = m.sp_id AND mpd.sector_number = m.sector_num
+ INNER JOIN sectors_meta m ON mpd.sp_id = m.sp_id AND mpd.sector_num = m.sector_num
```

### 4. CanAccept: wrong sector_filetype constant
```diff
- l.sector_filetype = 4
+ l.sector_filetype = 1
```
Restored to `FTUnsealed` (1), which was the original value before #855. The task reads piece data via `ReadPiece()` which requires **unsealed** sector data, not cache. The existing panic guard (`storiface.FTUnsealed != 1`) on line 116 confirms the original intent. Changed to 4 (`FTCache`) during the #855 rewrite by copying the pattern from `task_treed.go` (which correctly uses FTCache for its own purposes).

## Verification

Every other query against `market_piece_deal` in the codebase correctly uses `sector_num`:
- `tasks/indexing/task_check_indexes.go`
- `lib/cachedreader/cachedreader.go`
- `web/api/webrpc/market.go`

Full column-by-column audit against schema definitions:
- `20260211-fix-raw-size-table.sql` (market_fix_raw_size)
- `20240731-market-migration.sql` (market_piece_deal)
- `20240425-sector_meta.sql` (sectors_meta)
- `20230712-sector_index.sql` (sector_location, storage_path)

All 7 SQL queries in the file verified.