### PR TITLE
fix(supraseal): add Turing (sm_75) back to CUDA architectures

### DIFF
--- a/extern/supraseal/build.sh
+++ b/extern/supraseal/build.sh
@@ -179,9 +179,11 @@ export PATH=$CUDA/bin:$PATH
 
 echo "Found CUDA $CUDA_VERSION at: $CUDA"
 SPDK="deps/spdk-v24.05"
-# CUDA 13 architectures - removed compute_70 (Volta) as it's no longer supported in CUDA 13+
+# CUDA architectures — include all supported generations.
+# CUDA 13 dropped Volta (sm_70) but still supports Turing (sm_75).
+# sm_75: Turing (GTX 1650/1660, RTX 2060-2080, T4)
 # sm_80: Ampere (A100), sm_86: Ampere (RTX 30xx), sm_89: Ada Lovelace (RTX 40xx, L40), sm_90: Hopper (H100)
-CUDA_ARCH="-arch=sm_80 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90,code=sm_90 -t0"
+CUDA_ARCH="-arch=sm_75 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90,code=sm_90 -t0"
 CXXSTD=`$CXX -dM -E -x c++ /dev/null | \
         awk '{ if($2=="__cplusplus" && $3<"2017") print "-std=c++17"; }'`
 


### PR DESCRIPTION
## Problem

Building Curio on machines with Turing GPUs (RTX 2060-2080, GTX 1650/1660, Tesla T4) produces a binary that segfaults immediately — even on `./curio --version`.

## Root Cause

When CUDA 13 support was added to `extern/supraseal/build.sh`, Volta (`sm_70`) was correctly removed (CUDA 13 dropped it). However, **Turing (`sm_75`) was also removed** even though CUDA 13 still fully supports it:

```
Minimum supported GPU with CUDA 13:
  Turing (2018+): GTX 1650, 1660, RTX 2060-2080, Tesla T4
  And everything newer (Ampere, Ada Lovelace, Hopper, Blackwell)
```

The `CUDA_ARCH` flags only included sm_80+:
```bash
CUDA_ARCH="-arch=sm_80 -gencode arch=compute_80,code=sm_80 ..."
```

The CUDA kernels in `pc2.cu` are compiled into `libsupraseal.a` and linked into the curio binary. When the CUDA runtime initializes at binary load time and finds no compatible kernel for sm_75, supraseal's native code crashes → segfault before `main()` even runs.

**Binaries built on Ampere+ machines work fine** when copied to Turing machines because the CUDA kernels match the build machine's GPU, and supraseal tasks aren't invoked at startup.

## Fix

```diff
-CUDA_ARCH="-arch=sm_80 -gencode arch=compute_80,code=sm_80 ..."
+CUDA_ARCH="-arch=sm_75 -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 ..."
```

## Affected Hardware

Any Turing GPU building locally with CUDA 13:
- GeForce: GTX 1650, 1660 (Ti/Super), RTX 2060/2070/2080 (Ti/Super)
- Data center: Tesla T4

## Workaround (until this merges)

```bash
DISABLE_SUPRASEAL=1 make build
```
Or copy a binary built on an Ampere+ machine.