### PR TITLE
fix(pdp): separate eth_call timeouts within proving task

### DIFF
--- a/tasks/pdpv0/task_prove.go
+++ b/tasks/pdpv0/task_prove.go
@@ -261,10 +261,8 @@ func (p *ProveTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 		return false, xerrors.Errorf("failed to instantiate PDPVerifier contract at %s: %w", pdpVerifierAddress.Hex(), err)
 	}
 
-	callOpts := contract.EthCallOpts(ctx)
-
 	// Proof parameters
-	challengeEpoch, err := pdpVerifier.GetNextChallengeEpoch(callOpts, big.NewInt(dataSetId))
+	challengeEpoch, err := pdpVerifier.GetNextChallengeEpoch(contract.EthCallOpts(ctx), big.NewInt(dataSetId))
 	if err != nil {
 		return false, xerrors.Errorf("failed to get next challenge epoch: %w", err)
 	}
@@ -278,7 +276,7 @@ func (p *ProveTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 		return true, nil
 	}
 
-	totalLeafCount, err := pdpVerifier.GetChallengeRange(callOpts, big.NewInt(dataSetId))
+	totalLeafCount, err := pdpVerifier.GetChallengeRange(contract.EthCallOpts(ctx), big.NewInt(dataSetId))
 	if err != nil {
 		return false, xerrors.Errorf("failed to get data set leaf count: %w", err)
 	}
@@ -339,7 +337,7 @@ func (p *ProveTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 	pdpVerifierRaw := contract.PDPVerifierRaw{Contract: pdpVerifier}
 
 	calcProofFeeResult := make([]any, 0)
-	err = pdpVerifierRaw.Call(callOpts, &calcProofFeeResult, "calculateProofFee", big.NewInt(dataSetId))
+	err = pdpVerifierRaw.Call(contract.EthCallOpts(ctx), &calcProofFeeResult, "calculateProofFee", big.NewInt(dataSetId))
 	if err != nil {
 		return false, xerrors.Errorf("failed to calculate proof fee: %w", err)
 	}
@@ -359,7 +357,7 @@ func (p *ProveTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 	proofFee = new(big.Int).Mul(proofFee, big.NewInt(3))
 
 	// Get the sender address for this data set
-	owner, _, err := pdpVerifier.GetDataSetStorageProvider(callOpts, big.NewInt(dataSetId))
+	owner, _, err := pdpVerifier.GetDataSetStorageProvider(contract.EthCallOpts(ctx), big.NewInt(dataSetId))
 	if err != nil {
 		return false, xerrors.Errorf("failed to get owner: %w", err)
 	}


### PR DESCRIPTION
Currently they share a timeout, but they also span the actual proving which can take a good chunk of time, so this isn't a good strategy. Instead we'll treat these calls as isolated, like the rest of the eth_calls we make.

h/t to @TippyFlitsUK for reporting that this strategy was bad