### PR TITLE
feat(pdpv0): cap exponential backoff to a max limit for retries

### DIFF
--- a/harmony/taskhelp/retry.go
+++ b/harmony/taskhelp/retry.go
@@ -20,3 +20,10 @@ func RetryWaitExp(initial time.Duration, factor float64) RetryWaitFunc {
 		return time.Duration(float64(initial) * math.Pow(factor, float64(retries)))
 	}
 }
+
+// RetryWaitExpWithMax returns a function that calculates an exponentially increasing duration based on retries, with a maximum cap.
+func RetryWaitExpWithMax(initial time.Duration, factor float64, max time.Duration) RetryWaitFunc {
+	return func(retries int) time.Duration {
+		return min(time.Duration(float64(initial)*math.Pow(factor, float64(retries))), max)
+	}
+}

--- a/tasks/pdpv0/notify_task.go
+++ b/tasks/pdpv0/notify_task.go
@@ -184,7 +184,7 @@ func (t *PDPNotifyTask) TypeDetails() harmonytask.TaskTypeDetails {
 			Ram: 128 << 20, // 128MB
 		},
 		MaxFailures: 14,
-		RetryWait:   taskhelp.RetryWaitExp(5*time.Second, 2),
+		RetryWait:   taskhelp.RetryWaitExpWithMax(5*time.Second, 2, 5*time.Minute),
 	}
 }
 

--- a/tasks/pdpv0/task_init_pp.go
+++ b/tasks/pdpv0/task_init_pp.go
@@ -273,7 +273,7 @@ func (ipp *InitProvingPeriodTask) TypeDetails() harmonytask.TaskTypeDetails {
 			Ram: 1 << 20,
 		},
 		MaxFailures: 3, // Set retry limit to 3 attempts
-		RetryWait:   taskhelp.RetryWaitExp(5*time.Second, 2),
+		RetryWait:   taskhelp.RetryWaitExpWithMax(5*time.Second, 2, 5*time.Minute),
 	}
 }
 

--- a/tasks/pdpv0/task_next_pp.go
+++ b/tasks/pdpv0/task_next_pp.go
@@ -408,7 +408,7 @@ func (n *NextProvingPeriodTask) TypeDetails() harmonytask.TaskTypeDetails {
 			Ram: 1 << 20,
 		},
 		MaxFailures: 3, // Set retry limit to 3 attempts
-		RetryWait:   taskhelp.RetryWaitExp(5*time.Second, 2),
+		RetryWait:   taskhelp.RetryWaitExpWithMax(5*time.Second, 2, 5*time.Minute),
 	}
 }
 

--- a/tasks/pdpv0/task_pull_piece.go
+++ b/tasks/pdpv0/task_pull_piece.go
@@ -3,7 +3,6 @@ package pdpv0
 import (
 	"context"
 	"io"
-	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -389,10 +388,7 @@ func (t *PDPPullPieceTask) TypeDetails() harmonytask.TaskTypeDetails {
 			Ram: 128 << 20, // 128 MiB for streaming + CommP computation
 		},
 		MaxFailures: 5,
-		RetryWait: func(retries int) time.Duration {
-			const baseWait, maxWait, factor = 10 * time.Second, 5 * time.Minute, 2.0
-			return min(time.Duration(float64(baseWait)*math.Pow(factor, float64(retries))), maxWait)
-		},
+		RetryWait:   taskhelp.RetryWaitExpWithMax(10*time.Second, 2, 5*time.Minute),
 	}
 }
 


### PR DESCRIPTION
Introduces a new helper function `RetryWaitExpWithMax` that caps exponential backoff to a max limit. This change makes sure no `pdpv0` task has unbounded exponential waits.