### PR TITLE
chore(deps): replace x/crypto with filecoin-project/go-keccak for optimised keccak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/filecoin-project/go-fil-commcid v0.3.1
 	github.com/filecoin-project/go-fil-commp-hashhash v0.3.0
 	github.com/filecoin-project/go-jsonrpc v0.10.1
+	github.com/filecoin-project/go-keccak v0.1.0
 	github.com/filecoin-project/go-padreader v0.0.1
 	github.com/filecoin-project/go-state-types v0.18.0-dev
 	github.com/filecoin-project/go-statestore v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,8 @@ github.com/filecoin-project/go-hamt-ipld/v3 v3.4.1 h1:wl+ZHruCcE9LvwU7blpwWn35XO
 github.com/filecoin-project/go-hamt-ipld/v3 v3.4.1/go.mod h1:AqjryNfkxffpnqsa5mwnJHlazhVqF6W2nilu+VYKIq8=
 github.com/filecoin-project/go-jsonrpc v0.10.1 h1:iEhgrjO0+rawwOZWRNgexLrWGLA+IEUyWiRRL134Ob8=
 github.com/filecoin-project/go-jsonrpc v0.10.1/go.mod h1:OG7kVBVh/AbDFHIwx7Kw0l9ARmKOS6gGOr0LbdBpbLc=
+github.com/filecoin-project/go-keccak v0.1.0 h1:SWoaAVbqKgB9iXBceIjmgMskr8DlJTAJ8vWK/bQUXRg=
+github.com/filecoin-project/go-keccak v0.1.0/go.mod h1:X3vAWrEOJSO5GnJfzRFZzv8QC/2IacwECuIj11cnE4Y=
 github.com/filecoin-project/go-padreader v0.0.1 h1:8h2tVy5HpoNbr2gBRr+WD6zV6VD6XHig+ynSGJg8ZOs=
 github.com/filecoin-project/go-padreader v0.0.1/go.mod h1:VYVPJqwpsfmtoHnAmPx6MUwmrK6HIcDqZJiuZhtmfLQ=
 github.com/filecoin-project/go-paramfetch v0.0.4 h1:H+Me8EL8T5+79z/KHYQQcT8NVOzYVqXIi7nhb48tdm8=

--- a/tasks/pdp/task_prove.go
+++ b/tasks/pdp/task_prove.go
@@ -20,10 +20,10 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/samber/lo"
 	"github.com/yugabyte/pgx/v5"
-	"golang.org/x/crypto/sha3"
 	"golang.org/x/xerrors"
 
 	commcid "github.com/filecoin-project/go-fil-commcid"
+	"github.com/filecoin-project/go-keccak"
 	"github.com/filecoin-project/go-padreader"
 	"github.com/filecoin-project/go-state-types/abi"
 
@@ -362,7 +362,7 @@ func generateChallengeIndex(seed abi.Randomness, dataSetID int64, proofIndex int
 	data = append(data, proofIndexBytes...)
 
 	// Compute the Keccak-256 hash
-	hash := sha3.NewLegacyKeccak256()
+	hash := keccak.NewLegacyKeccak256()
 	hash.Write(data)
 	hashBytes := hash.Sum(nil)
 


### PR DESCRIPTION
x/crypto dropped their ASM for keccak in 0.44; we maintain a fork now with the ASM left intact. This PR uses it just for the currently single use on main, not touching other uses of x/crypto.

Trivial change, but we have more on pdpv0 and there will be more to come so we may as well be consistent.