### PR TITLE
test(pdpv0): Extend PDP caching itests for various sizes

### DIFF
--- a/itests/pdp_prove_test.go
+++ b/itests/pdp_prove_test.go
@@ -2,6 +2,7 @@ package itests
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math/rand"
 	"os"
@@ -27,7 +28,21 @@ import (
 
 // TestPDPProving verifies the functionality of generating and validating PDP proofs
 // using a random file and a cached snapshot layer stored in Cassandra.
+// It runs as a table-driven test across multiple piece sizes.
 func TestPDPProving(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawSize int64
+		seed    int64
+	}{
+		{"small_4MB", 4 * 1024 * 1024, 1001},
+		{"medium_28MB", 28 * 1024 * 1024, 2002},
+		{"above_threshold_40MB", 40 * 1024 * 1024, 3003},
+		{"large_256MB", 256 * 1024 * 1024, 4004},
+		{"xlarge_512MB", 512 * 1024 * 1024, 5005},
+		{"xxlarge_1GB", 1024 * 1024 * 1024, 6006},
+	}
+
 	ctx := context.Background()
 	cfg := config.DefaultCurioConfig()
 	idxStore, err := indexstore.NewIndexStore([]string{testutils.EnvElse("CURIO_HARMONYDB_HOSTS", "127.0.0.1")}, 9042, cfg)
@@ -37,14 +52,24 @@ func TestPDPProving(t *testing.T) {
 	err = idxStore.Start(ctx, true)
 	require.NoError(t, err)
 
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testPDPProvingWithSize(t, ctx, idxStore, tc.rawSize, tc.seed)
+		})
+	}
+}
+
+func testPDPProvingWithSize(t *testing.T, ctx context.Context, idxStore *indexstore.IndexStore, rawSize, seed int64) {
+	// Deterministic PRNG seeded per test case for challenge selection.
+	prng := rand.New(rand.NewSource(seed))
+
 	dir := t.TempDir()
 
-	rawSize := int64(5 * 1024 * 1024)
 	pieceSize := padreader.PaddedSize(uint64(rawSize)).Padded()
 
-	// Create a temporary random file of the desired raw size. This file
-	// will be used to compute a commP and a snapshot layer for the test.
-	fileStr, err := testutils.CreateRandomFile(dir, 0, rawSize)
+	// Create a temporary deterministic random file of the desired raw size.
+	// The seed ensures identical file content across runs.
+	fileStr, err := testutils.CreateRandomFile(dir, seed, rawSize)
 	require.NoError(t, err)
 
 	defer func() {
@@ -69,8 +94,7 @@ func TestPDPProving(t *testing.T) {
 
 	// Compute the piece commitment (commP) and capture a snapshot layer.
 	// The snapshot layer records node digests at a middle merkle-tree level
-	// which we will store in the indexstore and later use to accelerate
-	// proof generation.
+	// which we later use to accelerate proof generation.
 	cp := savecache.NewCommPWithSizeForTest(uint64(rawSize))
 	_, err = io.Copy(cp, f)
 	require.NoError(t, err)
@@ -107,12 +131,12 @@ func TestPDPProving(t *testing.T) {
 	err = idxStore.AddPDPLayer(ctx, pcid2, leafs)
 	require.NoError(t, err)
 
-	// Choose a random challenge leaf index inside the piece (in terms of
-	// 32-byte leaves). This is the same selection logic used by the on-chain
-	// PDP verifier to pick challenge positions.
-	challenge := int64(rand.Intn(int(numberOfLeafs)))
+	// Choose a deterministic challenge leaf index inside the piece (in terms
+	// of 32-byte leaves). This is the same selection logic used by the
+	// on-chain PDP verifier to pick challenge positions.
+	challenge := int64(prng.Intn(int(numberOfLeafs)))
 
-	t.Logf("Challenge: %d", challenge)
+	t.Logf("Challenge: %d (seed=%d, rawSize=%s)", challenge, seed, formatSize(rawSize))
 
 	has, outLayerIndex, err := idxStore.GetPDPLayerIndex(ctx, pcid2)
 	require.NoError(t, err)
@@ -234,4 +258,9 @@ func TestPDPProving(t *testing.T) {
 	// Clean up the cached layer from the index store - keep tests isolated.
 	err = idxStore.DeletePDPLayer(ctx, pcid2)
 	require.NoError(t, err)
+}
+
+func formatSize(bytes int64) string {
+	const mb = 1024 * 1024
+	return fmt.Sprintf("%dMB", bytes/mb)
 }


### PR DESCRIPTION
```
=== RUN   TestPDPProving
Using test keyspace: test32576
=== RUN   TestPDPProving/small_4MB
    pdp_prove_test.go:90: File Size: 4194304
copied number of nodes 2065
count 2031
    pdp_prove_test.go:107: Digest: 7c2603ece7f0ba7752b53dd9fd2fe9af4d6a9dc85ec5e0f8c08527901d068124
    pdp_prove_test.go:108: PieceSize: 8388608
    pdp_prove_test.go:109: LayerIdx: 6
    pdp_prove_test.go:110: Expected Node Count: 4096
    pdp_prove_test.go:111: Number of Nodes in snapshot layer: 4096
    pdp_prove_test.go:112: Total Number of Leafs: 260096
    pdp_prove_test.go:139: Challenge: 125795 (seed=1001, rawSize=4MB)
    pdp_prove_test.go:150: Leaves per Node: 64
    pdp_prove_test.go:151: Start Leaf: 125760
    pdp_prove_test.go:152: Snapshot Node Index: 1965
    pdp_prove_test.go:168: Offset: 3992880
    pdp_prove_test.go:169: Length: 2032
    pdp_prove_test.go:174: Subroot Size: 2048
    pdp_prove_test.go:183: File Remaining: 201424
    pdp_prove_test.go:184: Is Padding: false
    pdp_prove_test.go:225: Layer Bytes: 131072
=== RUN   TestPDPProving/medium_28MB
    pdp_prove_test.go:90: File Size: 29360128
copied number of nodes 14449
count 1935
    pdp_prove_test.go:107: Digest: 996ad4bebe3dfb02ee43b0150487b2d64632dbb3a5e3433f94fffcbd347bc110
    pdp_prove_test.go:108: PieceSize: 33554432
    pdp_prove_test.go:109: LayerIdx: 6
    pdp_prove_test.go:110: Expected Node Count: 16384
    pdp_prove_test.go:111: Number of Nodes in snapshot layer: 16384
    pdp_prove_test.go:112: Total Number of Leafs: 1040384
    pdp_prove_test.go:139: Challenge: 138037 (seed=2002, rawSize=28MB)
    pdp_prove_test.go:150: Leaves per Node: 64
    pdp_prove_test.go:151: Start Leaf: 137984
    pdp_prove_test.go:152: Snapshot Node Index: 2156
    pdp_prove_test.go:168: Offset: 4380992
    pdp_prove_test.go:169: Length: 2032
    pdp_prove_test.go:174: Subroot Size: 2048
    pdp_prove_test.go:183: File Remaining: 24979136
    pdp_prove_test.go:184: Is Padding: false
    pdp_prove_test.go:225: Layer Bytes: 524288
=== RUN   TestPDPProving/above_threshold_40MB
    pdp_prove_test.go:90: File Size: 41943040
copied number of nodes 20642
count 12126
    pdp_prove_test.go:107: Digest: c4251a546dbbeca191460a6a74992d7cf6b02e79f2b79b42aacdaa5f07f35e0c
    pdp_prove_test.go:108: PieceSize: 67108864
    pdp_prove_test.go:109: LayerIdx: 6
    pdp_prove_test.go:110: Expected Node Count: 32768
    pdp_prove_test.go:111: Number of Nodes in snapshot layer: 32768
    pdp_prove_test.go:112: Total Number of Leafs: 2080768
    pdp_prove_test.go:139: Challenge: 136710 (seed=3003, rawSize=40MB)
    pdp_prove_test.go:150: Leaves per Node: 64
    pdp_prove_test.go:151: Start Leaf: 136704
    pdp_prove_test.go:152: Snapshot Node Index: 2136
    pdp_prove_test.go:168: Offset: 4340352
    pdp_prove_test.go:169: Length: 2032
    pdp_prove_test.go:174: Subroot Size: 2048
    pdp_prove_test.go:183: File Remaining: 37602688
    pdp_prove_test.go:184: Is Padding: false
    pdp_prove_test.go:225: Layer Bytes: 1048576
=== RUN   TestPDPProving/large_256MB
    pdp_prove_test.go:90: File Size: 268435456
copied number of nodes 132105
count 130039
    pdp_prove_test.go:107: Digest: 8f05ff255cdb3d257be886caeed2aa5119689ee0243a5515a65f96099b2dfa1c
    pdp_prove_test.go:108: PieceSize: 536870912
    pdp_prove_test.go:109: LayerIdx: 6
    pdp_prove_test.go:110: Expected Node Count: 262144
    pdp_prove_test.go:111: Number of Nodes in snapshot layer: 262144
    pdp_prove_test.go:112: Total Number of Leafs: 16646144
    pdp_prove_test.go:139: Challenge: 6426072 (seed=4004, rawSize=256MB)
    pdp_prove_test.go:150: Leaves per Node: 64
    pdp_prove_test.go:151: Start Leaf: 6426048
    pdp_prove_test.go:152: Snapshot Node Index: 100407
    pdp_prove_test.go:168: Offset: 204027024
    pdp_prove_test.go:169: Length: 2032
    pdp_prove_test.go:174: Subroot Size: 2048
    pdp_prove_test.go:183: File Remaining: 64408432
    pdp_prove_test.go:184: Is Padding: false
    pdp_prove_test.go:225: Layer Bytes: 8388608
=== RUN   TestPDPProving/large_512MB
    pdp_prove_test.go:90: File Size: 536870912
copied number of nodes 264209
count 260079
    pdp_prove_test.go:107: Digest: ffc9caad52b9925807671398da4afc8e6e79c56f9f24c0c18f6c67ad1111671d
    pdp_prove_test.go:108: PieceSize: 1073741824
    pdp_prove_test.go:109: LayerIdx: 6
    pdp_prove_test.go:110: Expected Node Count: 524288
    pdp_prove_test.go:111: Number of Nodes in snapshot layer: 524288
    pdp_prove_test.go:112: Total Number of Leafs: 33292288
    pdp_prove_test.go:139: Challenge: 8441882 (seed=5005, rawSize=512MB)
    pdp_prove_test.go:150: Leaves per Node: 64
    pdp_prove_test.go:151: Start Leaf: 8441856
    pdp_prove_test.go:152: Snapshot Node Index: 131904
    pdp_prove_test.go:168: Offset: 268028928
    pdp_prove_test.go:169: Length: 2032
    pdp_prove_test.go:174: Subroot Size: 2048
    pdp_prove_test.go:183: File Remaining: 268841984
    pdp_prove_test.go:184: Is Padding: false
    pdp_prove_test.go:225: Layer Bytes: 16777216
=== RUN   TestPDPProving/large_1GB
    pdp_prove_test.go:90: File Size: 1073741824
copied number of nodes 528417
count 520159
    pdp_prove_test.go:107: Digest: 0637782dee675e41a551fd6a87b22dabab97c98ab9864011dcf98d30a592b132
    pdp_prove_test.go:108: PieceSize: 2147483648
    pdp_prove_test.go:109: LayerIdx: 6
    pdp_prove_test.go:110: Expected Node Count: 1048576
    pdp_prove_test.go:111: Number of Nodes in snapshot layer: 1048576
    pdp_prove_test.go:112: Total Number of Leafs: 66584576
    pdp_prove_test.go:139: Challenge: 13276655 (seed=6006, rawSize=1024MB)
    pdp_prove_test.go:150: Leaves per Node: 64
    pdp_prove_test.go:151: Start Leaf: 13276608
    pdp_prove_test.go:152: Snapshot Node Index: 207447
    pdp_prove_test.go:168: Offset: 421532304
    pdp_prove_test.go:169: Length: 2032
    pdp_prove_test.go:174: Subroot Size: 2048
    pdp_prove_test.go:183: File Remaining: 652209520
    pdp_prove_test.go:184: Is Padding: false
    pdp_prove_test.go:225: Layer Bytes: 33554432
--- PASS: TestPDPProving (63.65s)
    --- PASS: TestPDPProving/small_4MB (0.20s)
    --- PASS: TestPDPProving/medium_28MB (0.77s)
    --- PASS: TestPDPProving/above_threshold_40MB (1.38s)
    --- PASS: TestPDPProving/large_256MB (7.84s)
    --- PASS: TestPDPProving/large_512MB (16.89s)
    --- PASS: TestPDPProving/large_1GB (35.48s)
PASS
ok      github.com/filecoin-project/curio/itests        63.722s
```