### PR TITLE
Properly schedule prove task and migration cleanup work

### DIFF
--- a/tasks/pdpv0/task_save_cache.go
+++ b/tasks/pdpv0/task_save_cache.go
@@ -184,26 +184,21 @@ func (t *TaskPDPSaveCache) TypeDetails() harmonytask.TaskTypeDetails {
 		},
 		MaxFailures: 3,
 		IAmBored: passcall.Every(3*time.Second, func(taskFunc harmonytask.AddTaskFunc) error {
-			return t.schedule(context.Background(), taskFunc)
+			return t.scheduleMigrationCleanup(context.Background(), taskFunc)
 		}),
 	}
 }
 
-func (t *TaskPDPSaveCache) schedule(_ context.Context, taskFunc harmonytask.AddTaskFunc) error {
-	// To facilitate the migration from no-cache to cache this
-	// query bulk updates all pieces that are "need save_cache" but
-	// trivially will not populate the cache because they are too small
-	_, err := t.db.Exec(context.Background(), `
-            UPDATE pdp_piecerefs pr SET needs_save_cache = FALSE, caching_task_completed = NOW()
-            FROM parked_piece_refs pprf
-            JOIN parked_pieces pp ON pp.id = pprf.piece_id
-            WHERE pprf.ref_id = pr.piece_ref
-            AND pr.needs_save_cache = TRUE
-            AND pr.save_cache_task_id IS NULL
-            AND pp.piece_raw_size <= $1`, MinSizeForCache)
-	if err != nil {
-		return xerrors.Errorf("bulk clearing small pieces: %w", err)
+func (t *TaskPDPSaveCache) Adder(taskFunc harmonytask.AddTaskFunc) {
+	for {
+		if err := t.schedule(context.Background(), taskFunc); err != nil {
+			log.Errorf("PDPv0_SaveCache schedule: %s", err)
+		}
+		time.Sleep(3 * time.Second)
 	}
+}
+
+func (t *TaskPDPSaveCache) schedule(ctx context.Context, taskFunc harmonytask.AddTaskFunc) error {
 	var stop bool
 	for !stop {
 		taskFunc(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
@@ -243,7 +238,23 @@ func (t *TaskPDPSaveCache) schedule(_ context.Context, taskFunc harmonytask.AddT
 	return nil
 }
 
-func (t *TaskPDPSaveCache) Adder(taskFunc harmonytask.AddTaskFunc) {}
+func (t *TaskPDPSaveCache) scheduleMigrationCleanup(_ context.Context, taskFunc harmonytask.AddTaskFunc) error {
+	// To facilitate the migration from no-cache to cache this
+	// query bulk updates all pieces that are "need save_cache" but
+	// trivially will not populate the cache because they are too small
+	_, err := t.db.Exec(context.Background(), `
+            UPDATE pdp_piecerefs pr SET needs_save_cache = FALSE, caching_task_completed = NOW()
+            FROM parked_piece_refs pprf
+            JOIN parked_pieces pp ON pp.id = pprf.piece_id
+            WHERE pprf.ref_id = pr.piece_ref
+            AND pr.needs_save_cache = TRUE
+            AND pr.save_cache_task_id IS NULL
+            AND pp.piece_raw_size <= $1`, MinSizeForCache)
+	if err != nil {
+		return xerrors.Errorf("bulk clearing small pieces: %w", err)
+	}
+	return nil
+}
 
 var _ harmonytask.TaskInterface = &TaskPDPSaveCache{}
 var _ = harmonytask.Reg(&TaskPDPSaveCache{})


### PR DESCRIPTION
Copy pasted some code suggested by our resident curio coder @TippyFlitsUK into scheduleMigrationCleanup which we are leaving in IAMBored.  Additionally Ive moved the critical cache save task scheduling to a poller.  I think I am finally getting the hang of harmony scheduling but @rvagg and @snadrus tagged to confirm that this makes sense.