### PR TITLE
release v1.27.3-rc3

### DIFF
--- a/build/openrpc/curio.json
+++ b/build/openrpc/curio.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.6",
     "info": {
         "title": "Curio RPC API",
-        "version": "1.27.3-rc2"
+        "version": "1.27.3-rc3"
     },
     "methods": [
         {

--- a/build/version.go
+++ b/build/version.go
@@ -44,7 +44,7 @@ func BuildTypeString() string {
 var BuildVersionArray = [3]int{1, 27, 3}
 
 // RC
-var BuildVersionRC = 2
+var BuildVersionRC = 3
 
 // Ex: "1.2.3" or "1.2.3-rcX"
 var BuildVersion string

--- a/documentation/en/curio-cli/curio.md
+++ b/documentation/en/curio-cli/curio.md
@@ -7,7 +7,7 @@ USAGE:
    curio [global options] command [command options]
 
 VERSION:
-   1.27.3-rc2
+   1.27.3-rc3
 
 COMMANDS:
    cli           Execute cli commands

--- a/documentation/en/curio-cli/sptool.md
+++ b/documentation/en/curio-cli/sptool.md
@@ -7,7 +7,7 @@ USAGE:
    sptool [global options] command [command options]
 
 VERSION:
-   1.27.3-rc2
+   1.27.3-rc3
 
 COMMANDS:
    actor    Manage Filecoin Miner Actor Metadata

--- a/documentation/en/versions.md
+++ b/documentation/en/versions.md
@@ -21,6 +21,7 @@ This is the compatibility matrix for the latest free Curio releases.
 | v1.27.2                                                      | v1.34.1       | Mainnet | NA         | v2025.1 / Automatic | 0.30 / Automatic |
 | v1.27.3-rc1                                                  | v1.34.1       | Mainnet | NA         | v2025.1 / Automatic | 0.30 / Automatic |
 | v1.27.3-rc2                                                  | v1.34.1       | Mainnet | NA         | v2025.1 / Automatic | 0.30 / Automatic |
+| v1.27.3-rc3                                                  | v1.34.1       | Mainnet | NA         | v2025.1 / Automatic | 0.30 / Automatic |
 
 {% hint style="danger" %}
 Releases in <mark style="color:red;">red color</mark> are **not recommended**. Please proceed with the next stable release.


### PR DESCRIPTION
Version bump for v1.27.3-rc3.

## Changes since rc2

- fix raw size only if unseal exists (#1047)
- fix: batch timeout timezone bug and move evaluation to testable Go (#1044)
- chore(deps): replace x/crypto with filecoin-project/go-keccak for optimised keccak (#1060)
- update pdp contract bindings (#1013)
- better uniq (#1072)
- allow piece cid v1 and v2 interoperability (#1048)
- refactor(proof): extract cached proof pipeline behind testable interfaces (#1068)

## Files changed
- `build/version.go` — RC 2 → 3
- `build/openrpc/curio.json` — version string
- `documentation/en/curio-cli/curio.md` — CLI version
- `documentation/en/curio-cli/sptool.md` — CLI version
- `documentation/en/versions.md` — compatibility matrix row