### PR TITLE
chore(log): consolidate pdp loggers under "pdp" namespace

### DIFF
--- a/pdp/contract/utils.go
+++ b/pdp/contract/utils.go
@@ -32,7 +32,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 )
 
-var log = logging.Logger("pdp-contract")
+var log = logging.Logger("pdp")
 
 // Standard capability keys for PDP product type (must match ServiceProviderRegistry.sol REQUIRED_PDP_KEYS Bloom filter)
 const (

--- a/pdp/handlers_add.go
+++ b/pdp/handlers_add.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/go-chi/chi/v5"
 	"github.com/ipfs/go-cid"
-	logger "github.com/ipfs/go-log/v2"
 	"github.com/yugabyte/pgx/v5"
 
 	"github.com/filecoin-project/go-commp-utils/nonffi"
@@ -49,8 +48,6 @@ type SubPieceInfo struct {
 	PDPPieceRefID  int64
 	SubPieceOffset uint64
 }
-
-var logAdd = logger.Logger("pdp/add")
 
 func (p *PDPService) transformAddPiecesRequest(ctx context.Context, serviceLabel string, pieces []AddPieceRequest) ([]PieceData, map[string]*SubPieceInfo, error) {
 	// Collect all subPieceCids to fetch their info in a batch
@@ -341,7 +338,7 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 	// Step 4: Prepare piece information
 	pieceDataArray, subPieceInfoMap, err := p.transformAddPiecesRequest(ctx, serviceLabel, payload.Pieces)
 	if err != nil {
-		logAdd.Warnf("Failed to process AddPieces request data: %+v", err)
+		log.Warnf("Failed to process AddPieces request data: %+v", err)
 		http.Error(w, "Failed to process request: "+err.Error(), http.StatusBadRequest)
 	}
 
@@ -382,12 +379,12 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 	// Step 8: Check for indexing requirements
 	mustIndex, err := CheckIfIndexingNeeded(ctx, p.ethClient, dataSetIdUint64)
 	if err != nil {
-		logAdd.Errorw("Failed to check indexing requirements", "error", err, "dataSetId", dataSetId)
+		log.Errorw("Failed to check indexing requirements", "error", err, "dataSetId", dataSetId)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 	if mustIndex {
-		logAdd.Infow("Data set has withIPFSIndexing enabled, pieces will be indexed", "dataSetId", dataSetId)
+		log.Infow("Data set has withIPFSIndexing enabled, pieces will be indexed", "dataSetId", dataSetId)
 	}
 
 	// Step 9: Send the transaction
@@ -395,20 +392,20 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 	txHash, err := p.sender.Send(workCtx, fromAddress, txEth, reason)
 	if err != nil {
 		http.Error(w, "Failed to send transaction: "+err.Error(), http.StatusInternalServerError)
-		logAdd.Errorf("Failed to send transaction: %+v", err)
+		log.Errorf("Failed to send transaction: %+v", err)
 		return
 	}
 
 	// Step 10: Insert database tracking records
 	txHashLower := strings.ToLower(txHash.Hex())
-	logAdd.Infow("PDP AddPieces: Inserting transaction tracking",
+	log.Infow("PDP AddPieces: Inserting transaction tracking",
 		"txHash", txHashLower,
 		"dataSetId", dataSetIdUint64,
 		"pieceCount", len(payload.Pieces))
 
 	comm, err := p.db.BeginTransaction(workCtx, func(txdb *harmonydb.Tx) (bool, error) {
 		// Insert into message_waits_eth
-		logAdd.Debugw("Inserting AddPieces into message_waits_eth",
+		log.Debugw("Inserting AddPieces into message_waits_eth",
 			"txHash", txHashLower,
 			"status", "pending")
 		n, err := txdb.Exec(`
@@ -416,14 +413,14 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
             VALUES ($1, $2)
         `, txHashLower, "pending")
 		if err != nil {
-			logAdd.Errorw("Failed to insert AddPieces into message_waits_eth",
+			log.Errorw("Failed to insert AddPieces into message_waits_eth",
 				"txHash", txHashLower,
 				"error", err)
 			return false, err // Return false to rollback the transaction
 		}
 
 		if n != 1 {
-			logAdd.Errorw("Failed to insert AddPieces into message_waits_eth",
+			log.Errorw("Failed to insert AddPieces into message_waits_eth",
 				"txHash", txHashLower,
 				"expected_rows", 1,
 				"actual_rows", n)
@@ -437,7 +434,7 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 		}
 
 		if mustIndex {
-			logAdd.Debugw("Data set metadata exists, marking all subpieces as needing indexing", "dataSetId", dataSetId)
+			log.Debugw("Data set metadata exists, marking all subpieces as needing indexing", "dataSetId", dataSetId)
 			subPieceRefIDs := make([]int64, 0, len(subPieceInfoMap))
 			for _, info := range subPieceInfoMap {
 				subPieceRefIDs = append(subPieceRefIDs, info.PDPPieceRefID)
@@ -452,13 +449,13 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 	}, harmonydb.OptionRetry())
 
 	if err != nil {
-		logAdd.Errorw("Failed to insert into database", "error", err, "txHash", txHashLower, "subPieces", subPieceInfoMap)
+		log.Errorw("Failed to insert into database", "error", err, "txHash", txHashLower, "subPieces", subPieceInfoMap)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	if !comm {
-		logAdd.Errorw("Failed to commit database transaction", "txHash", txHashLower)
+		log.Errorw("Failed to commit database transaction", "txHash", txHashLower)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/pdp/handlers_create.go
+++ b/pdp/handlers_create.go
@@ -14,13 +14,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	logger "github.com/ipfs/go-log/v2"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/pdp/contract"
 )
-
-var logCreate = logger.Logger("pdp/create")
 
 // handleCreateDataSetAndAddPieces handles the creation of a new data set and adding pieces at the same time
 func (p *PDPService) handleCreateDataSetAndAddPieces(w http.ResponseWriter, r *http.Request) {
@@ -83,16 +80,16 @@ func (p *PDPService) handleCreateDataSetAndAddPieces(w http.ResponseWriter, r *h
 	// Check if indexing is needed by decoding the extraData
 	mustIndex, err := CheckIfIndexingNeededFromExtraData(extraDataBytes)
 	if err != nil {
-		logCreate.Warnw("Failed to check if indexing is needed from extraData, skipping indexing", "error", err)
+		log.Warnw("Failed to check if indexing is needed from extraData, skipping indexing", "error", err)
 		mustIndex = false
 	}
 	if mustIndex {
-		logCreate.Infow("ExtraData contains withIPFSIndexing metadata, pieces will be marked for indexing")
+		log.Infow("ExtraData contains withIPFSIndexing metadata, pieces will be marked for indexing")
 	}
 
 	pieceDataArray, subPieceInfoMap, err := p.transformAddPiecesRequest(ctx, serviceLabel, reqBody.Pieces)
 	if err != nil {
-		logCreate.Warnf("Failed to process AddPieces request data: %+v", err)
+		log.Warnf("Failed to process AddPieces request data: %+v", err)
 		http.Error(w, "Failed to process request: "+err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -128,12 +125,12 @@ func (p *PDPService) handleCreateDataSetAndAddPieces(w http.ResponseWriter, r *h
 	txHash, err := p.sender.Send(workCtx, fromAddress, tx, reason)
 	if err != nil {
 		http.Error(w, "Failed to send transaction: "+err.Error(), http.StatusInternalServerError)
-		logCreate.Errorf("Failed to send transaction: %+v", err)
+		log.Errorf("Failed to send transaction: %+v", err)
 		return
 	}
 
 	txHashLower := strings.ToLower(txHash.Hex())
-	logCreate.Infow("PDP CreateDataSet: Inserting transaction tracking",
+	log.Infow("PDP CreateDataSet: Inserting transaction tracking",
 		"txHash", txHashLower,
 		"service", serviceLabel,
 		"recordKeeper", recordKeeperAddr.Hex())
@@ -151,7 +148,7 @@ func (p *PDPService) handleCreateDataSetAndAddPieces(w http.ResponseWriter, r *h
 
 		// Enable indexing if the extraData indicates indexing is needed
 		if mustIndex {
-			logCreate.Debugw("ExtraData metadata indicates indexing needed, marking all subpieces as needing indexing")
+			log.Debugw("ExtraData metadata indicates indexing needed, marking all subpieces as needing indexing")
 			subPieceRefIDs := make([]int64, 0, len(subPieceInfoMap))
 			for _, info := range subPieceInfoMap {
 				subPieceRefIDs = append(subPieceRefIDs, info.PDPPieceRefID)
@@ -165,13 +162,13 @@ func (p *PDPService) handleCreateDataSetAndAddPieces(w http.ResponseWriter, r *h
 	}, harmonydb.OptionRetry())
 
 	if err != nil {
-		logCreate.Errorf("Failed to insert into message_waits_eth, pdp_data_set_piece_adds and pdp_data_set_creates: %+v", err)
+		log.Errorf("Failed to insert into message_waits_eth, pdp_data_set_piece_adds and pdp_data_set_creates: %+v", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	if !comm {
-		logCreate.Error("Failed to commit database transaction")
+		log.Error("Failed to commit database transaction")
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -189,7 +186,7 @@ func decodeExtraData(extraDataString *string) ([]byte, error) {
 	extraDataHexStr := *extraDataString
 	decodedBytes, err := hex.DecodeString(strings.TrimPrefix(extraDataHexStr, "0x"))
 	if err != nil {
-		logCreate.Errorf("Failed to decode hex extraData: %v", err)
+		log.Errorf("Failed to decode hex extraData: %v", err)
 		return nil, err
 	}
 	return decodedBytes, nil
@@ -296,13 +293,13 @@ func (p *PDPService) handleCreateDataSet(w http.ResponseWriter, r *http.Request)
 	txHash, err := p.sender.Send(workCtx, fromAddress, tx, reason)
 	if err != nil {
 		http.Error(w, "Failed to send transaction: "+err.Error(), http.StatusInternalServerError)
-		logCreate.Errorf("Failed to send transaction: %+v", err)
+		log.Errorf("Failed to send transaction: %+v", err)
 		return
 	}
 
 	// Step 6: Insert into message_waits_eth and pdp_data_set_creates
 	txHashLower := strings.ToLower(txHash.Hex())
-	logCreate.Infow("PDP CreateDataSet: Inserting transaction tracking",
+	log.Infow("PDP CreateDataSet: Inserting transaction tracking",
 		"txHash", txHashLower,
 		"service", serviceLabel,
 		"recordKeeper", recordKeeperAddr.Hex())
@@ -318,13 +315,13 @@ func (p *PDPService) handleCreateDataSet(w http.ResponseWriter, r *http.Request)
 	}, harmonydb.OptionRetry())
 
 	if err != nil {
-		logCreate.Errorf("Failed to insert database tracking records: %+v", err)
+		log.Errorf("Failed to insert database tracking records: %+v", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	if !comm {
-		logCreate.Error("Failed to commit database transaction")
+		log.Error("Failed to commit database transaction")
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -337,7 +334,7 @@ func (p *PDPService) handleCreateDataSet(w http.ResponseWriter, r *http.Request)
 // insertMessageWaitsAndDataSetCreate inserts records into message_waits_eth and pdp_data_set_creates
 func (p *PDPService) insertMessageWaitsAndDataSetCreate(tx *harmonydb.Tx, txHashHex string, serviceLabel string) error {
 	// Insert into message_waits_eth
-	logCreate.Debugw("Inserting into message_waits_eth",
+	log.Debugw("Inserting into message_waits_eth",
 		"txHash", txHashHex,
 		"status", "pending")
 	n, err := tx.Exec(`
@@ -345,7 +342,7 @@ func (p *PDPService) insertMessageWaitsAndDataSetCreate(tx *harmonydb.Tx, txHash
             VALUES ($1, $2)
         `, txHashHex, "pending")
 	if err != nil {
-		logCreate.Errorw("Failed to insert into message_waits_eth",
+		log.Errorw("Failed to insert into message_waits_eth",
 			"txHash", txHashHex,
 			"error", err)
 		return err
@@ -356,7 +353,7 @@ func (p *PDPService) insertMessageWaitsAndDataSetCreate(tx *harmonydb.Tx, txHash
 	}
 
 	// Insert into pdp_data_set_creates
-	logCreate.Debugw("Inserting into pdp_data_set_creates",
+	log.Debugw("Inserting into pdp_data_set_creates",
 		"txHash", txHashHex,
 		"service", serviceLabel)
 	n, err = tx.Exec(`
@@ -364,7 +361,7 @@ func (p *PDPService) insertMessageWaitsAndDataSetCreate(tx *harmonydb.Tx, txHash
             VALUES ($1, $2)
         `, txHashHex, serviceLabel)
 	if err != nil {
-		logCreate.Errorw("Failed to insert into pdp_data_set_creates",
+		log.Errorw("Failed to insert into pdp_data_set_creates",
 			"txHash", txHashHex,
 			"error", err)
 		return err
@@ -374,7 +371,7 @@ func (p *PDPService) insertMessageWaitsAndDataSetCreate(tx *harmonydb.Tx, txHash
 		return fmt.Errorf("expected 1 row to be inserted into pdp_data_set_creates, got %d", n)
 	}
 
-	logCreate.Infow("Successfully inserted transaction tracking records",
+	log.Infow("Successfully inserted transaction tracking records",
 		"txHash", txHashHex,
 		"service", serviceLabel)
 	return nil

--- a/pdp/handlers_upload.go
+++ b/pdp/handlers_upload.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
-	logger "github.com/ipfs/go-log/v2"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/multiformats/go-multicodec"
 	"github.com/multiformats/go-multihash"
 	"github.com/yugabyte/pgx/v5"
@@ -30,7 +30,7 @@ import (
 	"github.com/filecoin-project/curio/lib/proof"
 )
 
-var log = logger.Logger("pdp")
+var log = logging.Logger("pdpv0")
 
 // PieceSizeLimit in bytes
 var PieceSizeLimit = abi.PaddedPieceSize(proof.MaxMemtreeSize).Unpadded()

--- a/tasks/pdpv0/notify_task.go
+++ b/tasks/pdpv0/notify_task.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	logger "github.com/ipfs/go-log/v2"
+	logging "github.com/ipfs/go-log/v2"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
@@ -18,7 +18,7 @@ import (
 	"github.com/filecoin-project/curio/lib/promise"
 )
 
-var log = logger.Logger("pdp")
+var log = logging.Logger("pdpv0")
 
 // NotifyPollInterval is how often to poll for uploads ready to finalize.
 var NotifyPollInterval = 2 * time.Second


### PR DESCRIPTION
go-log doesn't have hierarchical selection so pdp/add etc don't help us and we also have pdp-contracts as an inconsistent namespace. So consolidate them all into "pdp" for easier selection.

Ref: https://github.com/FilOzone/foc-devnet/pull/80