### PR TITLE
fix: v1 v2 cid interop regressions

### DIFF
--- a/lib/cachedreader/cachedreader.go
+++ b/lib/cachedreader/cachedreader.go
@@ -462,7 +462,7 @@ func (cpr *CachedPieceReader) GetSharedPieceReader(ctx context.Context, pieceCid
 
 			reader, size, err = cpr.getPieceReaderFromMarketPieceDeal(readerCtx, pieceCidV2, retrieval)
 			if err != nil {
-				log.Errorw("failed to get piece reader", "piececid", pieceCidV2, err)
+				log.Errorw("failed to get piece reader", "piececid", pieceCidV2, "err", err)
 				finalErr := fmt.Errorf("failed to get piece reader from aggregate, sector or piece park: %w, %w", aerr, err)
 
 				// Record error metric

--- a/web/api/webrpc/market.go
+++ b/web/api/webrpc/market.go
@@ -754,6 +754,8 @@ func (a *WebRPC) PieceParkStates(ctx context.Context, pieceCID string) (*ParkedP
 			return nil, xerrors.Errorf("failed to get piece CID v1 from piece CID v2: %w", err)
 		}
 		pcid1 = pcid
+	} else {
+		pcid1 = pcid2
 	}
 
 	var pps ParkedPieceState
@@ -950,6 +952,8 @@ func (a *WebRPC) PieceDealDetail(ctx context.Context, pieceCid string) (*PieceDe
 			return nil, xerrors.Errorf("failed to get piece CID v1 from piece CID v2: %w", err)
 		}
 		pcid1 = pcid
+	} else {
+		pcid1 = pcid2
 	}
 
 	var mk12Deals []*MK12Deal


### PR DESCRIPTION
Commit https://github.com/filecoin-project/curio/commit/9ef4d6918fca0f0041ec9b2e3bb6b67c5c11deb6 removed the $2 placeholder from the piece deals SQL
query (WHERE piece_cid = $1) but left the second Go argument (ret.Size),
causing pgx to return 'expected 1 arguments, got 2' and breaking the
/pages/piece/ web UI for any piece with deals.

Separately, PieceParkStates and PieceDealDetail declared pcid1 but only assigned it
inside the v2 branch, leaving it as a zero-value CID when a v1 CID was
passed. This caused queries to match nothing. Add else branches to use
the input CID directly when it is already v1.

Also fix a missing key in log.Errorw in cachedreader that produced
garbled structured log output.
