### PR TITLE
fix: Fix gc task spam with no storage

### DIFF
--- a/tasks/gc/storage_endpoint_gc.go
+++ b/tasks/gc/storage_endpoint_gc.go
@@ -65,6 +65,11 @@ func (s *StorageEndpointGC) Do(taskID harmonytask.TaskID, stillOwned func() bool
 		return false, xerrors.Errorf("getting path metadata: %w", err)
 	}
 
+	if len(pathRefs) == 0 {
+		log.Debugw("no storage paths configured, nothing to GC")
+		return true, nil
+	}
+
 	type pingResult struct {
 		storageID storiface.ID
 		url       string


### PR DESCRIPTION
Clusters with no storage would run StorageEndpointGC in an infinite failing loop.