### PR TITLE
pdpv0: reject addPieces for terminated data sets before gas estimation

### DIFF
--- a/pdp/handlers_add.go
+++ b/pdp/handlers_add.go
@@ -299,9 +299,6 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Reject addPieces for terminated data sets - avoids wasting gas estimation
-	// on data sets where the FWSS contract will revert with DataSetPaymentAlreadyTerminated.
-	// See #1059 for the error selector fix that detects this on-chain.
 	if unrecoverable != nil {
 		http.Error(w, "Data set has been terminated due to unrecoverable proving failure", http.StatusConflict)
 		return


### PR DESCRIPTION
## Summary

When external clients call `addPieces` for a data set that has been terminated due to proving failures, the handler proceeds all the way to gas estimation before the FWSS contract reverts with `DataSetPaymentAlreadyTerminated`. This wastes RPC calls and generates log spam.

On two mainnet SPs (ezpdpz-main and infrafolio), this produced ~2,700 and ~5,000 failed gas estimations per hour respectively across 14 terminated data sets.

## Fix

Check `unrecoverable_proving_failure_epoch` in the existing ownership query. If set, return HTTP 409 before any on-chain interaction.

## Why this is needed

#1059 fixed the error selector so Curio correctly detects `DataSetPaymentAlreadyTerminated` reverts going forward. But the HTTP handler has no guard -- external callers can still hit terminated data sets repeatedly. This closes that gap.