### PR TITLE
fix: correct snap edge case

### DIFF
--- a/cmd/curio/guidedsetup/shared.go
+++ b/cmd/curio/guidedsetup/shared.go
@@ -388,13 +388,14 @@ func MigrateSectors(ctx context.Context, maddr address.Address, mmeta datastore.
 			_, err := tx.Exec(`
         INSERT INTO sectors_meta (sp_id, sector_num, reg_seal_proof, ticket_epoch, ticket_value,
                                   orig_sealed_cid, orig_unsealed_cid, cur_sealed_cid, cur_unsealed_cid,
-                                  msg_cid_precommit, msg_cid_commit, msg_cid_update, seed_epoch, seed_value)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+                                  msg_cid_precommit, msg_cid_commit, msg_cid_update, seed_epoch, seed_value, has_sector_key)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
         ON CONFLICT (sp_id, sector_num) DO UPDATE
         SET reg_seal_proof = excluded.reg_seal_proof, ticket_epoch = excluded.ticket_epoch, ticket_value = excluded.ticket_value,
             orig_sealed_cid = excluded.orig_sealed_cid, orig_unsealed_cid = excluded.orig_unsealed_cid, cur_sealed_cid = excluded.cur_sealed_cid,
             cur_unsealed_cid = excluded.cur_unsealed_cid, msg_cid_precommit = excluded.msg_cid_precommit, msg_cid_commit = excluded.msg_cid_commit,
-            msg_cid_update = excluded.msg_cid_update, seed_epoch = excluded.seed_epoch, seed_value = excluded.seed_value`,
+            msg_cid_update = excluded.msg_cid_update, seed_epoch = excluded.seed_epoch, seed_value = excluded.seed_value,
+            has_sector_key = excluded.has_sector_key`,
 				mid,
 				sectr.SectorNumber,
 				sectr.SectorType,
@@ -409,6 +410,7 @@ func MigrateSectors(ctx context.Context, maddr address.Address, mmeta datastore.
 				cidPtrToStrptr(sectr.ReplicaUpdateMessage),
 				sectr.SeedEpoch,
 				sectr.SeedValue,
+				sectr.UpdateSealed != nil, // has_sector_key: true if sector was snap-upgraded in lotus
 			)
 			if err != nil {
 				b, _ := json.MarshalIndent(sectr, "", "  ")

--- a/harmony/harmonydb/downgrade/20260407-has-sector-key.sql
+++ b/harmony/harmonydb/downgrade/20260407-has-sector-key.sql
@@ -1,0 +1,57 @@
+-- Downgrade: Restore trigger functions to the 20260315 version that uses
+-- orig_sealed_cid = cur_sealed_cid instead of has_sector_key.
+-- The has_sector_key column is kept (harmless, avoids data loss).
+
+CREATE OR REPLACE FUNCTION update_is_cc()
+    RETURNS TRIGGER AS $$
+BEGIN
+    NEW.is_cc := (NEW.orig_sealed_cid = NEW.cur_sealed_cid) AND NOT EXISTS (
+        SELECT 1
+        FROM sectors_snap_pipeline
+        WHERE sectors_snap_pipeline.sp_id = NEW.sp_id
+          AND sectors_snap_pipeline.sector_number = NEW.sector_num
+    ) AND EXISTS (
+        SELECT 1
+        FROM sectors_cc_values
+        WHERE sectors_cc_values.reg_seal_proof = NEW.reg_seal_proof
+          AND sectors_cc_values.cur_unsealed_cid = NEW.cur_unsealed_cid
+    );
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION update_sectors_meta_is_cc()
+    RETURNS TRIGGER AS $$
+DECLARE
+    v_sp_id BIGINT;
+    v_sector_number BIGINT;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        v_sp_id := OLD.sp_id;
+        v_sector_number := OLD.sector_number;
+    ELSE
+        v_sp_id := NEW.sp_id;
+        v_sector_number := NEW.sector_number;
+    END IF;
+
+    UPDATE sectors_meta
+    SET is_cc = (sectors_meta.orig_sealed_cid = sectors_meta.cur_sealed_cid) AND NOT EXISTS (
+        SELECT 1
+        FROM sectors_snap_pipeline
+        WHERE sectors_snap_pipeline.sp_id = sectors_meta.sp_id
+          AND sectors_snap_pipeline.sector_number = sectors_meta.sector_num
+    ) AND EXISTS (
+        SELECT 1
+        FROM sectors_cc_values
+        WHERE sectors_cc_values.reg_seal_proof = sectors_meta.reg_seal_proof
+          AND sectors_cc_values.cur_unsealed_cid = sectors_meta.cur_unsealed_cid
+    )
+    WHERE sp_id = v_sp_id AND sector_num = v_sector_number;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/harmony/harmonydb/sql/20260407-has-sector-key.sql
+++ b/harmony/harmonydb/sql/20260407-has-sector-key.sql
@@ -1,0 +1,74 @@
+-- Add has_sector_key column to sectors_meta.
+-- This mirrors chain state: true when the on-chain sector has SectorKeyCID set
+-- (i.e. the sector has been snap-upgraded). It replaces the unreliable
+-- orig_sealed_cid != cur_sealed_cid heuristic which breaks when a snap-deal
+-- encodes all-zero data, producing an identical CommR.
+--
+-- Backfill of this column happens in the SectorMetadata reconciliation task
+-- which reads chain state for every sector. No SQL-level backfill is performed
+-- because the DB cannot call the chain API.
+
+ALTER TABLE sectors_meta ADD COLUMN IF NOT EXISTS has_sector_key BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Seed the column from the best heuristic available in SQL: if the CIDs differ
+-- the sector was definitely snapped. This covers the common case immediately;
+-- zero-data-snap sectors (where CIDs match) will be fixed by the metadata task.
+UPDATE sectors_meta SET has_sector_key = TRUE
+WHERE orig_sealed_cid != cur_sealed_cid;
+
+-- Replace the BEFORE INSERT/UPDATE trigger on sectors_meta to use has_sector_key
+-- instead of orig_sealed_cid = cur_sealed_cid.
+CREATE OR REPLACE FUNCTION update_is_cc()
+    RETURNS TRIGGER AS $$
+BEGIN
+    NEW.is_cc := (NOT NEW.has_sector_key) AND NOT EXISTS (
+        SELECT 1
+        FROM sectors_snap_pipeline
+        WHERE sectors_snap_pipeline.sp_id = NEW.sp_id
+          AND sectors_snap_pipeline.sector_number = NEW.sector_num
+    ) AND EXISTS (
+        SELECT 1
+        FROM sectors_cc_values
+        WHERE sectors_cc_values.reg_seal_proof = NEW.reg_seal_proof
+          AND sectors_cc_values.cur_unsealed_cid = NEW.cur_unsealed_cid
+    );
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Replace the AFTER INSERT/UPDATE/DELETE trigger on sectors_snap_pipeline
+CREATE OR REPLACE FUNCTION update_sectors_meta_is_cc()
+    RETURNS TRIGGER AS $$
+DECLARE
+    v_sp_id BIGINT;
+    v_sector_number BIGINT;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        v_sp_id := OLD.sp_id;
+        v_sector_number := OLD.sector_number;
+    ELSE
+        v_sp_id := NEW.sp_id;
+        v_sector_number := NEW.sector_number;
+    END IF;
+
+    UPDATE sectors_meta
+    SET is_cc = (NOT sectors_meta.has_sector_key) AND NOT EXISTS (
+        SELECT 1
+        FROM sectors_snap_pipeline
+        WHERE sectors_snap_pipeline.sp_id = sectors_meta.sp_id
+          AND sectors_snap_pipeline.sector_number = sectors_meta.sector_num
+    ) AND EXISTS (
+        SELECT 1
+        FROM sectors_cc_values
+        WHERE sectors_cc_values.reg_seal_proof = sectors_meta.reg_seal_proof
+          AND sectors_cc_values.cur_unsealed_cid = sectors_meta.cur_unsealed_cid
+    )
+    WHERE sp_id = v_sp_id AND sector_num = v_sector_number;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/lib/ffi/snap_funcs.go
+++ b/lib/ffi/snap_funcs.go
@@ -340,12 +340,9 @@ func (sb *SealCalls) EncodeUpdate(
 		return cid.Undef, cid.Undef, xerrors.Errorf("compute sealed cid: %w", err)
 	}
 
-	// Guard: reject zero-data snaps where the encode was a no-op.
-	// When deal data is all zeros, the encode formula out[i] = key[i] + 0*rho(i) = key[i]
-	// produces an identical replica, leaving CommR unchanged. This creates a sector
-	// where SealedCID == SectorKeyCID on chain, breaking snap detection assumptions.
 	if sealedCid == sectorKeyCid {
-		return cid.Undef, cid.Undef, xerrors.Errorf("snap encode produced identical CommR to sector key (%s); deal data is likely all zeros", sealedCid)
+		log.Warnw("snap encode produced identical CommR to sector key; deal data is likely all zeros",
+			"sectorID", sector.ID, "taskID", taskID, "commR", sealedCid)
 	}
 
 	// STEP 3: Generate update proofs

--- a/lib/ffi/snap_funcs.go
+++ b/lib/ffi/snap_funcs.go
@@ -340,6 +340,14 @@ func (sb *SealCalls) EncodeUpdate(
 		return cid.Undef, cid.Undef, xerrors.Errorf("compute sealed cid: %w", err)
 	}
 
+	// Guard: reject zero-data snaps where the encode was a no-op.
+	// When deal data is all zeros, the encode formula out[i] = key[i] + 0*rho(i) = key[i]
+	// produces an identical replica, leaving CommR unchanged. This creates a sector
+	// where SealedCID == SectorKeyCID on chain, breaking snap detection assumptions.
+	if sealedCid == sectorKeyCid {
+		return cid.Undef, cid.Undef, xerrors.Errorf("snap encode produced identical CommR to sector key (%s); deal data is likely all zeros", sealedCid)
+	}
+
 	// STEP 3: Generate update proofs
 
 	genVpsStart := time.Now()

--- a/tasks/gc/storage_gc_mark.go
+++ b/tasks/gc/storage_gc_mark.go
@@ -370,7 +370,7 @@ func (s *StorageGCMark) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 	}
 
 	var minerIDs []int64
-	if err = s.db.Select(ctx, &minerIDs, `SELECT DISTINCT sp_id FROM sectors_meta WHERE orig_sealed_cid != cur_sealed_cid`); err != nil {
+	if err = s.db.Select(ctx, &minerIDs, `SELECT DISTINCT sp_id FROM sectors_meta WHERE has_sector_key = TRUE`); err != nil {
 		return false, xerrors.Errorf("distinct miners from snap sectors: %w", err)
 	}
 
@@ -394,12 +394,11 @@ func (s *StorageGCMark) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 		finalityMinerStates[abi.ActorID(mID)] = mState
 	}
 
-	// SELECT sp_id, sector_num FROM sectors_meta WHERE orig_sealed_cid != cur_sealed_cid
 	var snapSectors []struct {
 		SpID      int64 `db:"sp_id"`
 		SectorNum int64 `db:"sector_num"`
 	}
-	err = s.db.Select(ctx, &snapSectors, `SELECT sp_id, sector_num FROM sectors_meta WHERE orig_sealed_cid != cur_sealed_cid ORDER BY sp_id, sector_num`)
+	err = s.db.Select(ctx, &snapSectors, `SELECT sp_id, sector_num FROM sectors_meta WHERE has_sector_key = TRUE ORDER BY sp_id, sector_num`)
 	if err != nil {
 		return false, xerrors.Errorf("select snap sectors: %w", err)
 	}

--- a/tasks/metadata/task_sector_expirations.go
+++ b/tasks/metadata/task_sector_expirations.go
@@ -79,6 +79,7 @@ func (s *SectorMetadata) Do(taskID harmonytask.TaskID, stillOwned func() bool) (
 		SectorNum uint64 `db:"sector_num"`
 
 		CurSealedCID string `db:"cur_sealed_cid"`
+		HasSectorKey bool   `db:"has_sector_key"`
 
 		Expiration *uint64 `db:"expiration_epoch"`
 
@@ -88,7 +89,7 @@ func (s *SectorMetadata) Do(taskID harmonytask.TaskID, stillOwned func() bool) (
 		InSnapPipeline bool `db:"in_snap_pipeline"`
 	}
 
-	if err := s.db.Select(ctx, &sectors, `SELECT sm.sp_id, sm.sector_num, sm.cur_sealed_cid, sm.expiration_epoch, sm.partition, sm.deadline,
+	if err := s.db.Select(ctx, &sectors, `SELECT sm.sp_id, sm.sector_num, sm.cur_sealed_cid, sm.has_sector_key, sm.expiration_epoch, sm.partition, sm.deadline,
 		EXISTS(SELECT 1 FROM sectors_snap_pipeline snp WHERE snp.sp_id = sm.sp_id AND snp.sector_number = sm.sector_num) AS in_snap_pipeline
 		FROM sectors_meta sm ORDER BY sm.sp_id, sm.sector_num`); err != nil {
 		return false, xerrors.Errorf("get sector list: %w", err)
@@ -104,9 +105,53 @@ func (s *SectorMetadata) Do(taskID harmonytask.TaskID, stillOwned func() bool) (
 		Deadline  uint64
 	}
 
-	const batchSize = 1000
+	type sectorKeyUpdate struct {
+		SpID         uint64
+		SectorNum    uint64
+		HasSectorKey bool
+	}
+
+	const batchSize = 100
 	updateBatch := make([]partitionUpdate, 0, batchSize)
 	total := 0
+
+	sectorKeyBatch := make([]sectorKeyUpdate, 0, batchSize)
+	sectorKeyTotal := 0
+
+	flushSectorKeyBatch := func() error {
+		if len(sectorKeyBatch) == 0 {
+			return nil
+		}
+
+		sectorKeyTotal += len(sectorKeyBatch)
+		log.Infow("updating has_sector_key", "total", sectorKeyTotal)
+
+		_, err := s.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (commit bool, err error) {
+			batch := &pgx.Batch{}
+			for _, update := range sectorKeyBatch {
+				batch.Queue("UPDATE sectors_meta SET has_sector_key = $1 WHERE sp_id = $2 AND sector_num = $3",
+					update.HasSectorKey, update.SpID, update.SectorNum)
+			}
+
+			br, err := tx.SendBatch(ctx, batch)
+			if err != nil {
+				return false, xerrors.Errorf("failed to send has_sector_key batch: %w", err)
+			}
+			defer func() {
+				_ = br.Close()
+			}()
+
+			for i := 0; i < batch.Len(); i++ {
+				_, err := br.Exec()
+				if err != nil {
+					return false, xerrors.Errorf("executing has_sector_key batch update %d: %w", i, err)
+				}
+			}
+
+			return true, nil
+		}, harmonydb.OptionRetry())
+		return err
+	}
 
 	flushBatch := func() error {
 		if len(updateBatch) == 0 {
@@ -219,6 +264,30 @@ func (s *SectorMetadata) Do(taskID harmonytask.TaskID, stillOwned func() bool) (
 			}
 		}
 
+		// Reconcile has_sector_key from chain state.
+		// SectorKeyCID is set on-chain when a sector has been snap-upgraded.
+		// This is the authoritative source of truth; the DB column is kept in
+		// sync here. Skip sectors currently in the snap pipeline.
+		chainHasSectorKey := si.SectorKeyCID != nil
+		if sector.HasSectorKey != chainHasSectorKey && !sector.InSnapPipeline {
+			log.Infow("reconciling has_sector_key from chain",
+				"sp", sector.SpID, "sector", sector.SectorNum,
+				"db", sector.HasSectorKey, "chain", chainHasSectorKey)
+
+			sectorKeyBatch = append(sectorKeyBatch, sectorKeyUpdate{
+				SpID:         sector.SpID,
+				SectorNum:    sector.SectorNum,
+				HasSectorKey: chainHasSectorKey,
+			})
+
+			if len(sectorKeyBatch) >= batchSize {
+				if err := flushSectorKeyBatch(); err != nil {
+					return false, xerrors.Errorf("flushing has_sector_key batch: %w", err)
+				}
+				sectorKeyBatch = sectorKeyBatch[:0]
+			}
+		}
+
 		needsPartitionUpdate := false
 
 		if sector.Partition == nil || sector.Deadline == nil {
@@ -301,6 +370,9 @@ func (s *SectorMetadata) Do(taskID harmonytask.TaskID, stillOwned func() bool) (
 	}
 
 	// Flush any remaining updates
+	if err := flushSectorKeyBatch(); err != nil {
+		return false, xerrors.Errorf("flushing final has_sector_key batch: %w", err)
+	}
 	if err := flushBatch(); err != nil {
 		return false, xerrors.Errorf("flushing final batch: %w", err)
 	}

--- a/tasks/snap/task_submit.go
+++ b/tasks/snap/task_submit.go
@@ -239,6 +239,24 @@ func (s *SubmitTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done
 			return false, xerrors.Errorf("Proof mismatch between on chain %d and local database %d for sector %d of miner %d", onChainInfo.SealProof, regProof, update.SectorNumber, update.SpID)
 		}
 
+		// Check that the sector is a CC sector (SectorKeyCID must be nil for CC sectors).
+		// If SectorKeyCID is set, the sector was already snapped and cannot be updated again.
+		if onChainInfo.SectorKeyCID != nil {
+			log.Errorw("sector is not CC on-chain (SectorKeyCID is set), skipping", "sp", update.SpID, "sector", update.SectorNumber, "sector_key_cid", onChainInfo.SectorKeyCID)
+
+			_, err := s.db.Exec(ctx, `UPDATE sectors_snap_pipeline SET
+                                 failed = TRUE, failed_at = NOW(), failed_reason = 'not-cc', failed_reason_msg = $1,
+                                 task_id_submit = NULL, after_submit = FALSE
+                             WHERE sp_id = $2 AND sector_number = $3`,
+				fmt.Sprintf("sector %d is not a CC sector on-chain: SectorKeyCID is set to %s", update.SectorNumber, onChainInfo.SectorKeyCID),
+				update.SpID, update.SectorNumber)
+			if err != nil {
+				return false, xerrors.Errorf("marking sector as failed (not CC): %w", err)
+			}
+
+			continue // Skip this sector
+		}
+
 		sl, err := s.api.StateSectorPartition(ctx, maddr, snum, types.EmptyTSK)
 		if err != nil {
 			return false, xerrors.Errorf("getting sector location: %w", err)
@@ -366,7 +384,8 @@ func (s *SubmitTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done
 	}
 
 	if len(params.SectorUpdates) == 0 {
-		return false, xerrors.Errorf("no sector updates")
+		log.Warnw("no sector updates to submit after filtering, all sectors were skipped")
+		return true, nil
 	}
 
 	enc := new(bytes.Buffer)

--- a/tasks/snap/task_submit.go
+++ b/tasks/snap/task_submit.go
@@ -463,7 +463,7 @@ func (s *SubmitTask) transferUpdatedSectorData(ctx context.Context, spID int64, 
 		for sectorNum, cids := range transferMap {
 			sectorNum, cids := sectorNum, cids
 			n, err := tx.Exec(`UPDATE sectors_meta SET cur_sealed_cid = $1,
-	                        		cur_unsealed_cid = $2, msg_cid_update = $3
+	                        		cur_unsealed_cid = $2, msg_cid_update = $3, has_sector_key = TRUE
 	                        		WHERE sp_id = $4 AND sector_num = $5`, cids.sealed.String(), cids.unsealed.String(), mcid.String(), spID, sectorNum)
 
 			if err != nil {

--- a/tasks/unseal/task_unseal_decode.go
+++ b/tasks/unseal/task_unseal_decode.go
@@ -71,9 +71,10 @@ func (t *TaskUnsealDecode) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		OrigSealedCID  string `db:"orig_sealed_cid"`
 		CurSealedCID   string `db:"cur_sealed_cid"`
 		CurUnsealedCID string `db:"cur_unsealed_cid"`
+		HasSectorKey   bool   `db:"has_sector_key"`
 	}
 	err = t.db.Select(ctx, &sectorMeta, `
-		SELECT ticket_value, orig_sealed_cid, cur_sealed_cid, cur_unsealed_cid
+		SELECT ticket_value, orig_sealed_cid, cur_sealed_cid, cur_unsealed_cid, has_sector_key
 		FROM sectors_meta
 		WHERE sp_id = $1 AND sector_num = $2`, sectorParams.SpID, sectorParams.SectorNumber)
 	if err != nil {
@@ -128,7 +129,7 @@ func (t *TaskUnsealDecode) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		ProofType: abi.RegisteredSealProof(sectorParams.RegSealProof),
 	}
 
-	isSnap := commK != commR
+	isSnap := smeta.HasSectorKey
 	log.Infow("unseal decode", "snap", isSnap, "task", taskID, "commK", commK, "commR", commR, "commD", commD)
 	if isSnap {
 		err := t.sc.DecodeSnap(ctx, taskID, commD, commK, sref)

--- a/web/api/webrpc/sector.go
+++ b/web/api/webrpc/sector.go
@@ -78,6 +78,20 @@ type SectorInfo struct {
 	// On-chain partition state (detailed)
 	PartitionState *SectorPartitionState
 
+	// On-chain data for DB comparison
+	OnChain           bool
+	ChainSealedCID    string // Current sealed CID from chain (SealedCID)
+	ChainSectorKeyCID string // Original pre-snap sealed CID from chain (SectorKeyCID), empty if not snapped
+	ChainExpiration   *int64
+	ChainIsSnap       bool   // true if SectorKeyCID is set on chain
+	DBExpirationEpoch *int64 // Original DB expiration before chain overwrite (for comparison display)
+
+	// Mismatch flags (DB vs chain)
+	MismatchSealedCID    bool // cur_sealed_cid != chain SealedCID
+	MismatchSectorKeyCID bool // orig_sealed_cid != chain SectorKeyCID (for snapped sectors on chain)
+	MismatchExpiration   bool // DB expiration != chain Expiration
+	MismatchIsSnap       bool // DB snap state disagrees with chain (e.g. chain says snapped but DB CIDs are equal)
+
 	Pieces      []SectorPieceMeta
 	Locations   []LocationTable
 	Tasks       []SectorInfoTaskSummary
@@ -794,6 +808,49 @@ func (a *WebRPC) SectorInfo(ctx context.Context, sp string, intid int64) (*Secto
 			si.ExpirationEpoch = &expr
 		}
 		si.DealWeight = dealWeight
+
+		// Populate on-chain comparison fields
+		si.OnChain = true
+		si.ChainSealedCID = onChainInfo.SealedCID.String()
+		if onChainInfo.SectorKeyCID != nil {
+			si.ChainSectorKeyCID = onChainInfo.SectorKeyCID.String()
+			si.ChainIsSnap = true
+		}
+		chainExpr := int64(onChainInfo.Expiration)
+		si.ChainExpiration = &chainExpr
+
+		// Compute mismatches against DB values
+		if len(sectorMetas) > 0 {
+			dbMeta := sectorMetas[0]
+
+			// Preserve original DB expiration for comparison display
+			if dbMeta.ExpirationEpoch.Valid {
+				dbExp := dbMeta.ExpirationEpoch.Int64
+				si.DBExpirationEpoch = &dbExp
+			}
+
+			// cur_sealed_cid should match chain SealedCID
+			if dbMeta.UpdatedSealedCid != si.ChainSealedCID {
+				si.MismatchSealedCID = true
+			}
+
+			// For snapped sectors on chain: orig_sealed_cid should match chain SectorKeyCID
+			if si.ChainIsSnap && dbMeta.OrigSealedCid != si.ChainSectorKeyCID {
+				si.MismatchSectorKeyCID = true
+			}
+
+			// Expiration comparison (use original DB value, not the chain-overwritten one)
+			if dbMeta.ExpirationEpoch.Valid && dbMeta.ExpirationEpoch.Int64 != chainExpr {
+				si.MismatchExpiration = true
+			}
+
+			// Snap state: chain says snapped if SectorKeyCID != nil
+			// DB says snapped if orig_sealed_cid != cur_sealed_cid
+			dbIsSnap := dbMeta.OrigSealedCid != dbMeta.UpdatedSealedCid
+			if dbIsSnap != si.ChainIsSnap {
+				si.MismatchIsSnap = true
+			}
+		}
 	}
 
 	si.PipelinePoRep = sle

--- a/web/api/webrpc/sector.go
+++ b/web/api/webrpc/sector.go
@@ -223,6 +223,7 @@ type SectorMeta struct {
 	// Bools (NullBool = 2 bytes each)
 	IsCC          NullBool `db:"is_cc"`               // 2 bytes
 	UnsealedState NullBool `db:"target_unseal_state"` // 2 bytes
+	HasSectorKey  bool     `db:"has_sector_key"`
 }
 
 func (a *WebRPC) SectorInfo(ctx context.Context, sp string, intid int64) (*SectorInfo, error) {
@@ -462,7 +463,7 @@ func (a *WebRPC) SectorInfo(ctx context.Context, sp string, intid int64) (*Secto
        orig_unsealed_cid, cur_sealed_cid, cur_unsealed_cid, 
        msg_cid_precommit, msg_cid_commit, msg_cid_update, 
        expiration_epoch, deadline, partition, target_unseal_state, 
-       is_cc FROM sectors_meta 
+       is_cc, has_sector_key FROM sectors_meta 
              WHERE sp_id = $1 AND sector_num = $2`, spid, intid)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to fetch sector metadata: %w", err)
@@ -479,11 +480,7 @@ func (a *WebRPC) SectorInfo(ctx context.Context, sp string, intid int64) (*Secto
 		if sectormeta.UpdateCid.Valid {
 			si.UpdateMsg = sectormeta.UpdateCid.String
 		}
-		if sectormeta.IsCC.Valid {
-			si.IsSnap = !sectormeta.IsCC.Bool
-		} else {
-			si.IsSnap = false
-		}
+		si.IsSnap = sectormeta.HasSectorKey
 
 		if sectormeta.ExpirationEpoch.Valid {
 			e := sectormeta.ExpirationEpoch.Int64
@@ -845,9 +842,8 @@ func (a *WebRPC) SectorInfo(ctx context.Context, sp string, intid int64) (*Secto
 			}
 
 			// Snap state: chain says snapped if SectorKeyCID != nil
-			// DB says snapped if orig_sealed_cid != cur_sealed_cid
-			dbIsSnap := dbMeta.OrigSealedCid != dbMeta.UpdatedSealedCid
-			if dbIsSnap != si.ChainIsSnap {
+			// DB says snapped if has_sector_key is true
+			if dbMeta.HasSectorKey != si.ChainIsSnap {
 				si.MismatchIsSnap = true
 			}
 		}

--- a/web/static/pages/sector/sector-info.mjs
+++ b/web/static/pages/sector/sector-info.mjs
@@ -312,6 +312,40 @@ customElements.define('sector-info',class SectorInfo extends LitElement {
             flex-wrap: wrap;
             align-items: center;
         }
+        .comparison-alert {
+            padding: 8px 14px;
+            border-radius: 4px;
+            margin-bottom: 12px;
+            font-size: 0.9em;
+            border: 1px solid;
+        }
+        .comparison-alert-ok {
+            background-color: rgba(75, 181, 67, 0.1);
+            border-color: #4BB543;
+            color: #4BB543;
+        }
+        .comparison-alert-mismatch {
+            background-color: rgba(220, 53, 69, 0.15);
+            border-color: #dc3545;
+            color: #ff6b6b;
+        }
+        .comparison-table th {
+            border-bottom: 2px solid #444;
+        }
+        .comparison-table .cid-cell {
+            font-family: monospace;
+            font-size: 0.9em;
+        }
+        .row-mismatch {
+            background-color: rgba(220, 53, 69, 0.15) !important;
+        }
+        .status-match {
+            color: #4BB543;
+        }
+        .status-mismatch {
+            color: #ff6b6b;
+            font-weight: 600;
+        }
     `];
 
     render() {
@@ -379,6 +413,73 @@ customElements.define('sector-info',class SectorInfo extends LitElement {
                         </tr>
                 </table>
             </div>
+            ${this.data.OnChain ? html`
+                <div>
+                    <h3>DB vs Chain Comparison</h3>
+                    ${(this.data.MismatchSealedCID || this.data.MismatchSectorKeyCID || this.data.MismatchExpiration || this.data.MismatchIsSnap) ? html`
+                        <div class="comparison-alert comparison-alert-mismatch">
+                            Mismatches detected between local DB and on-chain state. This may indicate a snap deal metadata update failure.
+                        </div>
+                    ` : html`
+                        <div class="comparison-alert comparison-alert-ok">
+                            All checked fields match between DB and chain.
+                        </div>
+                    `}
+                    <table class="table table-dark table-sm comparison-table">
+                        <thead>
+                            <tr>
+                                <th>Field</th>
+                                <th>DB Value</th>
+                                <th>Chain Value</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="${this.data.MismatchSealedCID ? 'row-mismatch' : ''}">
+                                <td>Current Sealed CID</td>
+                                <td class="cid-cell" title="${this.data.UpdatedSealedCid}">${this.formatCid(this.data.UpdatedSealedCid)}</td>
+                                <td class="cid-cell" title="${this.data.ChainSealedCID}">${this.formatCid(this.data.ChainSealedCID)}</td>
+                                <td>${this.data.MismatchSealedCID
+                                    ? html`<span class="status-mismatch">MISMATCH</span>`
+                                    : html`<span class="status-match">Match</span>`}</td>
+                            </tr>
+                            ${this.data.ChainIsSnap ? html`
+                                <tr class="${this.data.MismatchSectorKeyCID ? 'row-mismatch' : ''}">
+                                    <td>Sector Key CID (orig sealed)</td>
+                                    <td class="cid-cell" title="${this.data.SealedCid}">${this.formatCid(this.data.SealedCid)}</td>
+                                    <td class="cid-cell" title="${this.data.ChainSectorKeyCID}">${this.formatCid(this.data.ChainSectorKeyCID)}</td>
+                                    <td>${this.data.MismatchSectorKeyCID
+                                        ? html`<span class="status-mismatch">MISMATCH</span>`
+                                        : html`<span class="status-match">Match</span>`}</td>
+                                </tr>
+                            ` : ''}
+                            <tr class="${this.data.MismatchIsSnap ? 'row-mismatch' : ''}">
+                                <td>Snap Deal Status</td>
+                                <td>${this.data.IsSnap ? 'Snapped (orig != cur)' : 'CC (orig = cur)'}</td>
+                                <td>${this.data.ChainIsSnap ? 'Snapped (SectorKeyCID set)' : 'CC (no SectorKeyCID)'}</td>
+                                <td>${this.data.MismatchIsSnap
+                                    ? html`<span class="status-mismatch">MISMATCH</span>`
+                                    : html`<span class="status-match">Match</span>`}</td>
+                            </tr>
+                            <tr class="${this.data.MismatchExpiration ? 'row-mismatch' : ''}">
+                                <td>Expiration Epoch</td>
+                                <td>${this.data.DBExpirationEpoch != null ? this.data.DBExpirationEpoch : 'N/A'}</td>
+                                <td>${this.data.ChainExpiration != null ? this.data.ChainExpiration : 'N/A'}</td>
+                                <td>${this.data.MismatchExpiration
+                                    ? html`<span class="status-mismatch">MISMATCH</span>`
+                                    : html`<span class="status-match">Match</span>`}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            ` : html`
+                <div>
+                    <h3>DB vs Chain Comparison</h3>
+                    <div class="comparison-alert" style="border-color: #666; color: #888;">
+                        Sector not found on chain. Comparison not available.
+                    </div>
+                </div>
+            `}
             ${this.data.PartitionState ? html`
                 <div>
                     <h3>On-Chain Partition State</h3>

--- a/web/static/pages/sector/sector-info.mjs
+++ b/web/static/pages/sector/sector-info.mjs
@@ -455,7 +455,7 @@ customElements.define('sector-info',class SectorInfo extends LitElement {
                             ` : ''}
                             <tr class="${this.data.MismatchIsSnap ? 'row-mismatch' : ''}">
                                 <td>Snap Deal Status</td>
-                                <td>${this.data.IsSnap ? 'Snapped (orig != cur)' : 'CC (orig = cur)'}</td>
+                                <td>${this.data.IsSnap ? 'Snapped (has_sector_key)' : 'CC'}</td>
                                 <td>${this.data.ChainIsSnap ? 'Snapped (SectorKeyCID set)' : 'CC (no SectorKeyCID)'}</td>
                                 <td>${this.data.MismatchIsSnap
                                     ? html`<span class="status-mismatch">MISMATCH</span>`


### PR DESCRIPTION
Found when sealing for calibnet, apparently CommR == CommK when snapping all zero data, which breaks the heuristic we used to figure out whether a sector was snapped or not. This is expected and because snapped data is `out = cc_sector_key + data * rho(i)` - when data is zero then output == sector key.