### PR TITLE
CI speed test

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,6 @@ self-hosted-runner:
     - docker
     - 2xlarge
     - 2xlarge+curio
+    - 4xlarge+curio
+    - 2xlarge+amd+curio
+    - 4xlarge+amd+curio

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,12 +1,21 @@
 name: 'Install Dependencies'
 description: 'Install common dependencies'
 
+inputs:
+  skip:
+    default: "false"
+    description: "skips the apt update"
+
 runs:
   using: 'composite'
   steps:
+    - name: Update apt cache
+      run: sudo apt-get update
+      shell: bash
+      if: ${{ inputs.skip == 'false' }}
+
     - name: Install dependencies
       run: |
-        sudo apt-get update
         sudo apt-get install -y \
           build-essential \
           gcc-13 g++-13 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         shell: bash
 
   test:
-    runs-on: ["self-hosted", "linux", "x64", "4xlarge+curio"]
+    runs-on: ["self-hosted", "linux", "x64", "2xlarge+amd+curio"]
     needs: [ci-lint]
     strategy:
       fail-fast: false  # Continue running even if one test fails

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,8 @@ jobs:
 
       - name: Install Dependencies
         uses: ./.github/actions/install-deps
+        with:
+          skip: 'true'
 
       - name: Install FFI
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         shell: bash
 
   test:
-    runs-on: ["self-hosted", "linux", "x64", "2xlarge+amd+curio"]
+    runs-on: ["self-hosted", "linux", "x64", "4xlarge+amd+curio"]
     needs: [ci-lint]
     strategy:
       fail-fast: false  # Continue running even if one test fails

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         shell: bash
 
   test:
-    runs-on: ["self-hosted", "linux", "x64", "4xlarge+amd+curio"]
+    runs-on: ["self-hosted", "linux", "x64", "2xlarge+amd+curio"]
     needs: [ci-lint]
     strategy:
       fail-fast: false  # Continue running even if one test fails

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         shell: bash
 
   test:
-    runs-on: ["self-hosted", "linux", "x64", "2xlarge+curio"]
+    runs-on: ["self-hosted", "linux", "x64", "4xlarge+curio"]
     needs: [ci-lint]
     strategy:
       fail-fast: false  # Continue running even if one test fails

--- a/tasks/storage-market/task_fix_rawSize.go
+++ b/tasks/storage-market/task_fix_rawSize.go
@@ -149,7 +149,7 @@ func (f *FixRawSize) TypeDetails() harmonytask.TaskTypeDetails {
 			Ram: 64 << 20,
 		},
 		MaxFailures: 3,
-		IAmBored: passcall.Every(time.Minute, func(taskFunc harmonytask.AddTaskFunc) error {
+		IAmBored: passcall.Every(time.Minute*30, func(taskFunc harmonytask.AddTaskFunc) error {
 			return f.schedule(context.Background(), taskFunc)
 		}),
 	}


### PR DESCRIPTION
This PR is testing over all CI execution time on all available runner types. 

Based on the result and cost: 2xlarge AMD (c5a) is the most suitable runner for our use case. It is faster than intel and costs the least amount among the 4. 

This PR does following changes:
1. Set the runner type
2. Incraese `fix_raw_size` task schedule time to 30 minutes (fix flaky retrieval test)
3. Stop doing `apt-get update` on self hosted runners