### PR TITLE
fix: make parked_piece entries truly unique

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -246,7 +246,8 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 			}
 			cleanupPieceTask := piece2.NewCleanupPieceTask(db, must.One(slrLazy.Val()), 0)
 			aggregateChunksTask := piece2.NewAggregateChunksTask(db, stor, must.One(slrLazy.Val()))
-			activeTasks = append(activeTasks, parkPieceTask, cleanupPieceTask, aggregateChunksTask)
+			pfix := piece2.NewFixParkPieceTask(db, must.One(slrLazy.Val()))
+			activeTasks = append(activeTasks, parkPieceTask, cleanupPieceTask, aggregateChunksTask, pfix)
 		}
 	}
 

--- a/harmony/harmonydb/sql/20260410-ipni-head-cas.sql
+++ b/harmony/harmonydb/sql/20260410-ipni-head-cas.sql
@@ -185,9 +185,27 @@ BEGIN
 END;
 $$;
 
-CREATE UNIQUE INDEX IF NOT EXISTS parked_pieces_active_piece_key
-    ON parked_pieces (piece_cid, piece_padded_size, long_term)
-    WHERE cleanup_task_id IS NULL;
+-- Create a unique index for the parked_pieces table if duplicates do not exist.
+-- This is to avoid duplicate entries in the parked_pieces table.
+-- This is a no-op if the index already exists.
+-- If duplicates exist, then a Go task will remove them correctly and create the index
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM (
+      SELECT piece_cid, piece_padded_size, long_term
+      FROM parked_pieces
+      WHERE cleanup_task_id IS NULL
+      GROUP BY 1,2,3
+      HAVING count(*) > 1
+    ) dupes
+  ) THEN
+    CREATE UNIQUE INDEX IF NOT EXISTS parked_pieces_active_piece_key
+      ON parked_pieces (piece_cid, piece_padded_size, long_term)
+      WHERE cleanup_task_id IS NULL;
+  END IF;
+END $$;
 
 -- This function triggers a download for an offline piece.
 -- It is different from MK1.2 PoRep pipeline as it downloads the offline pieces

--- a/itests/harmonydb_test.go
+++ b/itests/harmonydb_test.go
@@ -155,6 +155,10 @@ func TestDowngradeTo(t *testing.T) {
 	cdb, err := harmonydb.NewFromConfigWithITestID(t)
 	require.NoError(t, err)
 
+	// Let's ensure all applied are time.now() and not template time
+	_, err = cdb.Exec(ctx, `UPDATE base SET applied = NOW()`)
+	require.NoError(t, err)
+
 	// The setup: lets make revert files going forward in time, but ignore the past.
 	rowCt, err := cdb.Exec(ctx, "UPDATE base SET applied = applied - INTERVAL '10 DAY' WHERE TO_DATE(entry, 'YYYYMMDD') < DATE '2025-08-15'")
 	require.NoError(t, err)

--- a/itests/helpers/market.go
+++ b/itests/helpers/market.go
@@ -113,8 +113,8 @@ func InsertCompletedParkedPiece(tx *harmonydb.Tx, pieceCID string, pieceSize abi
 	var pieceID int64
 	err := tx.QueryRow(
 		`INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, complete, long_term)
-		 VALUES ($1, $2, $3, TRUE, $4)
-		 RETURNING id`,
+		 VALUES ($1, $2, $3, TRUE, $4) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
+			RETURNING id`,
 		pieceCID, pieceSize, rawSize, longTerm,
 	).Scan(&pieceID)
 	if err != nil {

--- a/itests/helpers/market.go
+++ b/itests/helpers/market.go
@@ -113,8 +113,8 @@ func InsertCompletedParkedPiece(tx *harmonydb.Tx, pieceCID string, pieceSize abi
 	var pieceID int64
 	err := tx.QueryRow(
 		`INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, complete, long_term)
-		 VALUES ($1, $2, $3, TRUE, $4) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-			RETURNING id`,
+			 VALUES ($1, $2, $3, TRUE, $4) ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL DO NOTHING
+			 RETURNING id`,
 		pieceCID, pieceSize, rawSize, longTerm,
 	).Scan(&pieceID)
 	if err != nil {

--- a/itests/park_piece_test.go
+++ b/itests/park_piece_test.go
@@ -1,6 +1,7 @@
 package itests
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -31,36 +32,7 @@ func TestParkPieceCanAccept_SliceBounds(t *testing.T) {
 	piece.PieceParkPollInterval = time.Hour
 	t.Cleanup(func() { piece.PieceParkPollInterval = oldInterval })
 
-	ctx := context.Background()
-	db, err := harmonydb.NewFromConfigWithITestID(t)
-	require.NoError(t, err)
-
-	// Set up a local storage path.
-	root := t.TempDir()
-	storageDir := filepath.Join(root, "storage")
-	require.NoError(t, os.MkdirAll(storageDir, 0755))
-
-	storageID := storiface.ID(uuid.New().String())
-	meta := &storiface.LocalStorageMeta{
-		ID:       storageID,
-		Weight:   10,
-		CanSeal:  true,
-		CanStore: true,
-	}
-	mb, err := json.MarshalIndent(meta, "", "  ")
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(storageDir, "sectorstore.json"), mb, 0644))
-
-	bls := &paths.BasicLocalStorage{PathToJSON: filepath.Join(root, "storage.json")}
-	index := paths.NewDBIndex(nil, db)
-	ls, err := paths.NewLocal(ctx, bls, index, "")
-	require.NoError(t, err)
-	require.NoError(t, ls.OpenPath(ctx, storageDir))
-
-	remote, err := paths.NewRemote(ls, index, nil, 20, &paths.DefaultPartialFileHandler{})
-	require.NoError(t, err)
-
-	sc := ffi.NewSealCalls(remote, ls, index)
+	ctx, db, sc, remote, storageID := setupPieceParkTestEnv(t)
 
 	// Create ParkPieceTask with maxInPark=15, matching the production crash.
 	const maxInPark = 15
@@ -107,4 +79,361 @@ func TestParkPieceCanAccept_SliceBounds(t *testing.T) {
 	accepted, err = ppt.CanAccept(ids, engine)
 	require.NoError(t, err)
 	require.Nil(t, accepted, "should reject all when at capacity")
+}
+
+func TestFixParkPieceTask_RepairsDuplicateRefs(t *testing.T) {
+	// Slow down the background piece poller so it doesn't interfere.
+	oldInterval := piece.PieceParkPollInterval
+	piece.PieceParkPollInterval = time.Hour
+	t.Cleanup(func() { piece.PieceParkPollInterval = oldInterval })
+
+	type refExpectation struct {
+		refID           int64
+		expectedPieceID int64
+	}
+
+	testCases := []struct {
+		name                    string
+		setup                   func(t *testing.T, ctx context.Context, db *harmonydb.DB, sc *ffi.SealCalls) []refExpectation
+		expectIndexAfterCleanup bool
+	}{
+		{
+			name: "moves refs from incomplete row without task",
+			setup: func(t *testing.T, ctx context.Context, db *harmonydb.DB, sc *ffi.SealCalls) []refExpectation {
+				const (
+					pieceCID   = "fix-piece-no-task"
+					paddedSize = int64(32)
+					rawSize    = int64(16)
+				)
+
+				winnerID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, true, true, nil)
+				makePieceReadable(t, ctx, sc, winnerID, rawSize, true)
+				winnerRef := insertParkedPieceRef(t, ctx, db, winnerID, true)
+
+				loserID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, false, true, nil)
+				loserRef := insertParkedPieceRef(t, ctx, db, loserID, true)
+
+				return []refExpectation{
+					{refID: winnerRef, expectedPieceID: winnerID},
+					{refID: loserRef, expectedPieceID: winnerID},
+				}
+			},
+			expectIndexAfterCleanup: true,
+		},
+		{
+			name: "moves refs from incomplete row with stale task",
+			setup: func(t *testing.T, ctx context.Context, db *harmonydb.DB, sc *ffi.SealCalls) []refExpectation {
+				const (
+					pieceCID   = "fix-piece-stale-task"
+					paddedSize = int64(32)
+					rawSize    = int64(16)
+				)
+
+				winnerID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, true, true, nil)
+				makePieceReadable(t, ctx, sc, winnerID, rawSize, true)
+				winnerRef := insertParkedPieceRef(t, ctx, db, winnerID, true)
+
+				staleTaskID := int64(999_001)
+				loserID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, false, true, &staleTaskID)
+				loserRef := insertParkedPieceRef(t, ctx, db, loserID, true)
+
+				return []refExpectation{
+					{refID: winnerRef, expectedPieceID: winnerID},
+					{refID: loserRef, expectedPieceID: winnerID},
+				}
+			},
+			expectIndexAfterCleanup: true,
+		},
+		{
+			name: "skips active incomplete row but moves stale sibling",
+			setup: func(t *testing.T, ctx context.Context, db *harmonydb.DB, sc *ffi.SealCalls) []refExpectation {
+				const (
+					pieceCID   = "fix-piece-active-task"
+					paddedSize = int64(32)
+					rawSize    = int64(16)
+				)
+
+				winnerID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, true, true, nil)
+				makePieceReadable(t, ctx, sc, winnerID, rawSize, true)
+				winnerRef := insertParkedPieceRef(t, ctx, db, winnerID, true)
+
+				activeTaskID := insertHarmonyTask(t, ctx, db, "ParkPiece")
+				activeLoserID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, false, true, &activeTaskID)
+				activeRef := insertParkedPieceRef(t, ctx, db, activeLoserID, true)
+
+				staleTaskID := int64(999_002)
+				staleLoserID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, false, true, &staleTaskID)
+				staleRef := insertParkedPieceRef(t, ctx, db, staleLoserID, true)
+
+				return []refExpectation{
+					{refID: winnerRef, expectedPieceID: winnerID},
+					{refID: activeRef, expectedPieceID: activeLoserID},
+					{refID: staleRef, expectedPieceID: winnerID},
+				}
+			},
+			expectIndexAfterCleanup: false,
+		},
+		{
+			name: "chooses readable winner among multiple complete rows",
+			setup: func(t *testing.T, ctx context.Context, db *harmonydb.DB, sc *ffi.SealCalls) []refExpectation {
+				const (
+					pieceCID   = "fix-piece-multiple-complete"
+					paddedSize = int64(32)
+					rawSize    = int64(16)
+				)
+
+				unreadableCompleteID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, true, true, nil)
+				unreadableRef := insertParkedPieceRef(t, ctx, db, unreadableCompleteID, true)
+
+				readableWinnerID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, true, true, nil)
+				makePieceReadable(t, ctx, sc, readableWinnerID, rawSize, true)
+				winnerRef := insertParkedPieceRef(t, ctx, db, readableWinnerID, true)
+
+				staleTaskID := int64(999_003)
+				staleLoserID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, false, true, &staleTaskID)
+				staleRef := insertParkedPieceRef(t, ctx, db, staleLoserID, true)
+
+				return []refExpectation{
+					{refID: unreadableRef, expectedPieceID: readableWinnerID},
+					{refID: winnerRef, expectedPieceID: readableWinnerID},
+					{refID: staleRef, expectedPieceID: readableWinnerID},
+				}
+			},
+			expectIndexAfterCleanup: true,
+		},
+		{
+			name: "does not move refs when no readable complete winner exists",
+			setup: func(t *testing.T, ctx context.Context, db *harmonydb.DB, sc *ffi.SealCalls) []refExpectation {
+				const (
+					pieceCID   = "fix-piece-no-readable-winner"
+					paddedSize = int64(32)
+					rawSize    = int64(16)
+				)
+
+				unreadableCompleteID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, true, true, nil)
+				unreadableRef := insertParkedPieceRef(t, ctx, db, unreadableCompleteID, true)
+
+				staleTaskID := int64(999_004)
+				staleLoserID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, false, true, &staleTaskID)
+				staleRef := insertParkedPieceRef(t, ctx, db, staleLoserID, true)
+
+				return []refExpectation{
+					{refID: unreadableRef, expectedPieceID: unreadableCompleteID},
+					{refID: staleRef, expectedPieceID: staleLoserID},
+				}
+			},
+			expectIndexAfterCleanup: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, db, sc, _, _ := setupPieceParkTestEnv(t)
+			dropParkedPieceIndex(t, ctx, db)
+
+			expectedRefs := tc.setup(t, ctx, db, sc)
+
+			fixTask := piece.NewFixParkPieceTask(db, sc)
+			done, err := fixTask.Do(0, func() bool { return true })
+			require.False(t, done)
+			require.ErrorContains(t, err, "creating index")
+
+			for _, expected := range expectedRefs {
+				require.Equal(t, expected.expectedPieceID, parkedPieceIDForRef(t, ctx, db, expected.refID))
+			}
+
+			cleanupTaskIDs := markOrphanPiecesForCleanup(t, ctx, db)
+			if len(cleanupTaskIDs) > 0 {
+				cleanupTask := piece.NewCleanupPieceTask(db, sc, 0)
+				for _, cleanupTaskID := range cleanupTaskIDs {
+					done, err = cleanupTask.Do(cleanupTaskID, func() bool { return true })
+					require.True(t, done)
+					require.NoError(t, err)
+				}
+			}
+
+			done, err = fixTask.Do(0, func() bool { return true })
+			if tc.expectIndexAfterCleanup {
+				require.True(t, done)
+				require.NoError(t, err)
+				require.True(t, parkedPieceIndexExists(t, ctx, db))
+			} else {
+				require.False(t, done)
+				require.ErrorContains(t, err, "creating index")
+				require.False(t, parkedPieceIndexExists(t, ctx, db))
+			}
+
+			for _, expected := range expectedRefs {
+				require.Equal(t, expected.expectedPieceID, parkedPieceIDForRef(t, ctx, db, expected.refID))
+			}
+		})
+	}
+}
+
+func setupPieceParkTestEnv(t *testing.T) (context.Context, *harmonydb.DB, *ffi.SealCalls, *paths.Remote, storiface.ID) {
+	t.Helper()
+
+	ctx := context.Background()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	root := t.TempDir()
+	storageDir := filepath.Join(root, "storage")
+	require.NoError(t, os.MkdirAll(storageDir, 0755))
+
+	storageID := storiface.ID(uuid.New().String())
+	meta := &storiface.LocalStorageMeta{
+		ID:       storageID,
+		Weight:   10,
+		CanSeal:  true,
+		CanStore: true,
+	}
+	mb, err := json.MarshalIndent(meta, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(storageDir, "sectorstore.json"), mb, 0644))
+
+	bls := &paths.BasicLocalStorage{PathToJSON: filepath.Join(root, "storage.json")}
+	index := paths.NewDBIndex(nil, db)
+	ls, err := paths.NewLocal(ctx, bls, index, "")
+	require.NoError(t, err)
+	require.NoError(t, ls.OpenPath(ctx, storageDir))
+
+	remote, err := paths.NewRemote(ls, index, nil, 20, &paths.DefaultPartialFileHandler{})
+	require.NoError(t, err)
+
+	sc := ffi.NewSealCalls(remote, ls, index)
+	return ctx, db, sc, remote, storageID
+}
+
+func dropParkedPieceIndex(t *testing.T, ctx context.Context, db *harmonydb.DB) {
+	t.Helper()
+
+	_, err := db.Exec(ctx, `DROP INDEX IF EXISTS parked_pieces_active_piece_key`)
+	require.NoError(t, err)
+}
+
+func insertParkedPiece(t *testing.T, ctx context.Context, db *harmonydb.DB, pieceCID string, paddedSize, rawSize int64, complete, longTerm bool, taskID *int64) int64 {
+	t.Helper()
+
+	var pieceID int64
+	err := db.QueryRow(ctx, `
+		INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, complete, long_term, task_id)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id
+	`, pieceCID, paddedSize, rawSize, complete, longTerm, taskID).Scan(&pieceID)
+	require.NoError(t, err)
+	return pieceID
+}
+
+func insertParkedPieceRef(t *testing.T, ctx context.Context, db *harmonydb.DB, pieceID int64, longTerm bool) int64 {
+	t.Helper()
+
+	var refID int64
+	err := db.QueryRow(ctx, `
+		INSERT INTO parked_piece_refs (piece_id, long_term)
+		VALUES ($1, $2)
+		RETURNING ref_id
+	`, pieceID, longTerm).Scan(&refID)
+	require.NoError(t, err)
+	return refID
+}
+
+func insertHarmonyTask(t *testing.T, ctx context.Context, db *harmonydb.DB, name string) int64 {
+	t.Helper()
+
+	var taskID int64
+	err := db.QueryRow(ctx, `
+		INSERT INTO harmony_task (name, added_by, posted_time)
+		VALUES ($1, $2, CURRENT_TIMESTAMP)
+		RETURNING id
+	`, name, 1).Scan(&taskID)
+	require.NoError(t, err)
+	return taskID
+}
+
+func makePieceReadable(t *testing.T, ctx context.Context, sc *ffi.SealCalls, pieceID, rawSize int64, longTerm bool) {
+	t.Helper()
+
+	payload := bytes.Repeat([]byte{byte(pieceID % 251)}, int(rawSize))
+	storageType := storiface.PathSealing
+	if longTerm {
+		storageType = storiface.PathStorage
+	}
+
+	err := sc.WritePiece(ctx, nil, storiface.PieceNumber(pieceID), rawSize, bytes.NewReader(payload), storageType)
+	require.NoError(t, err)
+}
+
+func parkedPieceIDForRef(t *testing.T, ctx context.Context, db *harmonydb.DB, refID int64) int64 {
+	t.Helper()
+
+	var pieceID int64
+	err := db.QueryRow(ctx, `SELECT piece_id FROM parked_piece_refs WHERE ref_id = $1`, refID).Scan(&pieceID)
+	require.NoError(t, err)
+	return pieceID
+}
+
+func markOrphanPiecesForCleanup(t *testing.T, ctx context.Context, db *harmonydb.DB) []harmonytask.TaskID {
+	t.Helper()
+
+	var orphanPieceIDs []int64
+	err := db.Select(ctx, &orphanPieceIDs, `
+		SELECT pp.id
+		FROM parked_pieces pp
+		WHERE pp.cleanup_task_id IS NULL
+		  AND NOT EXISTS (
+			  SELECT 1
+			  FROM parked_piece_refs ppr
+			  WHERE ppr.piece_id = pp.id
+		  )
+		ORDER BY pp.id
+	`)
+	require.NoError(t, err)
+
+	taskIDs := make([]harmonytask.TaskID, 0, len(orphanPieceIDs))
+	for i, pieceID := range orphanPieceIDs {
+		taskID := harmonytask.TaskID(10_000 + i + int(pieceID))
+		_, err := db.Exec(ctx, `UPDATE parked_pieces SET cleanup_task_id = $1 WHERE id = $2`, taskID, pieceID)
+		require.NoError(t, err)
+		taskIDs = append(taskIDs, taskID)
+	}
+
+	return taskIDs
+}
+
+func parkedPieceIndexExists(t *testing.T, ctx context.Context, db *harmonydb.DB) bool {
+	t.Helper()
+
+	var exists bool
+	err := db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_catalog.pg_index ix
+			JOIN pg_catalog.pg_class idx ON idx.oid = ix.indexrelid
+			JOIN pg_catalog.pg_class tbl ON tbl.oid = ix.indrelid
+			JOIN pg_catalog.pg_namespace ns ON ns.oid = tbl.relnamespace
+			JOIN pg_catalog.pg_am am ON am.oid = idx.relam
+			WHERE ns.nspname = current_schema()
+			  AND idx.relnamespace = ns.oid
+			  AND tbl.relname = 'parked_pieces'
+			  AND idx.relname = 'parked_pieces_active_piece_key'
+			  AND idx.relkind = 'i'
+			  AND am.amname = 'btree'
+			  AND ix.indisunique
+			  AND ix.indisvalid
+			  AND ix.indisready
+			  AND ix.indislive
+			  AND ix.indnkeyatts = 3
+			  AND ix.indnatts = 3
+			  AND ix.indexprs IS NULL
+			  AND ARRAY(
+				  SELECT pg_catalog.pg_get_indexdef(ix.indexrelid, n, true)
+				  FROM generate_series(1, ix.indnkeyatts) AS n
+				  ORDER BY n
+			  ) = ARRAY['piece_cid', 'piece_padded_size', 'long_term']
+			  AND pg_catalog.pg_get_expr(ix.indpred, ix.indrelid, false) = '(cleanup_task_id IS NULL)'
+		)
+	`).Scan(&exists)
+	require.NoError(t, err)
+	return exists
 }

--- a/market/mk12/mk12.go
+++ b/market/mk12/mk12.go
@@ -566,10 +566,24 @@ func (m *MK12) processDeal(ctx context.Context, deal *ProviderDealState) (*Provi
 				if errors.Is(err, pgx.ErrNoRows) {
 					// Piece does not exist, attempt to insert
 					err = tx.QueryRow(`
-							INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size)
-							VALUES ($1, $2, $3)
-							ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-							RETURNING id`, prop.PieceCID.String(), int64(prop.PieceSize), int64(deal.Transfer.Size)).Scan(&pieceID)
+							WITH existing_piece AS (
+							  SELECT id
+							  FROM parked_pieces
+							  WHERE piece_cid = $1
+								AND piece_padded_size = $2
+								AND long_term = FALSE
+								AND cleanup_task_id IS NULL
+							),
+							inserted_piece AS (
+							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+							  SELECT $1, $2, $3, FALSE
+							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  RETURNING id
+							)
+							SELECT id FROM existing_piece
+							UNION ALL
+							SELECT id FROM inserted_piece
+							LIMIT 1;`, prop.PieceCID.String(), int64(prop.PieceSize), int64(deal.Transfer.Size)).Scan(&pieceID)
 					if err != nil {
 						return false, xerrors.Errorf("inserting new parked piece and getting id: %w", err)
 					}

--- a/market/mk20/mk20.go
+++ b/market/mk20/mk20.go
@@ -638,10 +638,24 @@ func insertPDPPipeline(ctx context.Context, tx *harmonydb.Tx, deal *Deal) error 
 			if errors.Is(err, pgx.ErrNoRows) {
 				// Piece does not exist, attempt to insert
 				err = tx.QueryRow(`
-							INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-							VALUES ($1, $2, $3, TRUE)
-							ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-							RETURNING id`, pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&pieceID)
+							WITH existing_piece AS (
+							  SELECT id
+							  FROM parked_pieces
+							  WHERE piece_cid = $1
+								AND piece_padded_size = $2
+								AND long_term = TRUE
+								AND cleanup_task_id IS NULL
+							),
+							inserted_piece AS (
+							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+							  SELECT $1, $2, $3, TRUE
+							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  RETURNING id
+							)
+							SELECT id FROM existing_piece
+							UNION ALL
+							SELECT id FROM inserted_piece
+							LIMIT 1;`, pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&pieceID)
 				if err != nil {
 					return xerrors.Errorf("inserting new parked piece and getting id: %w", err)
 				}
@@ -737,32 +751,47 @@ func insertPDPPipeline(ctx context.Context, tx *harmonydb.Tx, deal *Deal) error 
 				if headers == nil {
 					headers = []byte("{}")
 				}
-				batch.Queue(`WITH inserted_piece AS (
-									  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-									  VALUES ($1, $2, $3, FALSE)
-									  ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-									  RETURNING id
-									),
-									selected_piece AS (
-									  SELECT COALESCE(
-										(SELECT id FROM inserted_piece),
-										(SELECT id FROM parked_pieces
-										 WHERE piece_cid = $1 AND piece_padded_size = $2 AND long_term = FALSE AND cleanup_task_id IS NULL)
-									  ) AS id
-									),
-									inserted_ref AS (
-									  INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
-									  SELECT id, $4, $5, FALSE FROM selected_piece
-									  RETURNING ref_id
-									)
-									INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
-									VALUES ($6, $8, $7, ARRAY[(SELECT ref_id FROM inserted_ref)])
-									ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
-									SET ref_ids = array_append(
-									  market_mk20_download_pipeline.ref_ids,
-									  (SELECT ref_id FROM inserted_ref)
-									)
-									WHERE NOT market_mk20_download_pipeline.ref_ids @> ARRAY[(SELECT ref_id FROM inserted_ref)];`,
+				batch.Queue(`
+							WITH existing_piece AS (
+							  SELECT id
+							  FROM parked_pieces
+							  WHERE piece_cid = $1
+								AND piece_padded_size = $2
+								AND long_term = FALSE
+								AND cleanup_task_id IS NULL
+							),
+							insert_piece AS (
+							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+							  SELECT $1, $2, $3, FALSE
+							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  RETURNING id
+							),
+							inserted_piece AS (
+								SELECT id FROM existing_piece
+								UNION ALL
+								SELECT id FROM insert_piece
+								LIMIT 1
+							),
+							selected_piece AS (
+							  SELECT COALESCE(
+								(SELECT id FROM inserted_piece),
+								(SELECT id FROM parked_pieces
+								 WHERE piece_cid = $1 AND piece_padded_size = $2 AND long_term = FALSE AND cleanup_task_id IS NULL)
+							  ) AS id
+							),
+							inserted_ref AS (
+							  INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
+							  SELECT id, $4, $5, FALSE FROM selected_piece
+							  RETURNING ref_id
+							)
+							INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
+							VALUES ($6, $8, $7, ARRAY[(SELECT ref_id FROM inserted_ref)])
+							ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
+							SET ref_ids = array_append(
+							  market_mk20_download_pipeline.ref_ids,
+							  (SELECT ref_id FROM inserted_ref)
+							)
+							WHERE NOT market_mk20_download_pipeline.ref_ids @> ARRAY[(SELECT ref_id FROM inserted_ref)];`,
 					k.PieceCID.String(), k.Size, k.RawSize, src.URL, headers, k.ID, ProductNamePDPV1, k.PieceCIDV2.String())
 			}
 

--- a/market/mk20/mk20_upload.go
+++ b/market/mk20/mk20_upload.go
@@ -346,10 +346,24 @@ func (m *MK20) HandleUploadChunk(id ulid.ULID, chunk int, data io.ReadCloser, w 
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				err = tx.QueryRow(`
-							INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-							VALUES ($1, $2, $3, FALSE, TRUE)
-							ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-							RETURNING id`, tpcid.String(), tsize, n).Scan(&pnum)
+							WITH existing_piece AS (
+							  SELECT id
+							  FROM parked_pieces
+							  WHERE piece_cid = $1
+								AND piece_padded_size = $2
+								AND long_term = FALSE
+								AND cleanup_task_id IS NULL
+							),
+							inserted_piece AS (
+							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
+							  SELECT $1, $2, $3, FALSE, TRUE
+							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  RETURNING id
+							)
+							SELECT id FROM existing_piece
+							UNION ALL
+							SELECT id FROM inserted_piece
+							LIMIT 1;`, tpcid.String(), tsize, n).Scan(&pnum)
 				if err != nil {
 					return false, xerrors.Errorf("inserting new parked piece and getting id: %w", err)
 				}
@@ -752,10 +766,24 @@ func (m *MK20) HandleSerialUpload(id ulid.ULID, body io.Reader, w http.ResponseW
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				err = tx.QueryRow(`
-							INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-							VALUES ($1, $2, $3, TRUE, TRUE)
-							ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-							RETURNING id`, tpcid.String(), tsize, trSize).Scan(&pnum)
+							WITH existing_piece AS (
+							  SELECT id
+							  FROM parked_pieces
+							  WHERE piece_cid = $1
+								AND piece_padded_size = $2
+								AND long_term = TRUE
+								AND cleanup_task_id IS NULL
+							),
+							inserted_piece AS (
+							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
+							  SELECT $1, $2, $3, TRUE, TRUE
+							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  RETURNING id
+							)
+							SELECT id FROM existing_piece
+							UNION ALL
+							SELECT id FROM inserted_piece
+							LIMIT 1;`, tpcid.String(), tsize, trSize).Scan(&pnum)
 				if err != nil {
 					return false, xerrors.Errorf("inserting new parked piece and getting id: %w", err)
 				}

--- a/pdp/handlers_upload.go
+++ b/pdp/handlers_upload.go
@@ -301,7 +301,8 @@ func (p *PDPService) handlePieceUpload(w http.ResponseWriter, r *http.Request) {
 		var parkedPieceID int64
 		err := tx.QueryRow(`
             INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-            VALUES ($1, $2, $3, TRUE) RETURNING id
+            VALUES ($1, $2, $3, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
+			RETURNING id
         `, pieceCIDComputed.String(), paddedPieceSize, readSize).Scan(&parkedPieceID)
 		if err != nil {
 			return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)
@@ -525,7 +526,8 @@ func (p *PDPService) handleStreamingUpload(w http.ResponseWriter, r *http.Reques
 		var parkedPieceID int64
 		err := tx.QueryRow(`
             INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-            VALUES ($1, $2, $3, TRUE) RETURNING id
+            VALUES ($1, $2, $3, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
+			RETURNING id
         `, pcid.String(), paddedPieceSize, readSize).Scan(&parkedPieceID)
 		if err != nil {
 			return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)

--- a/pdp/handlers_upload.go
+++ b/pdp/handlers_upload.go
@@ -300,10 +300,24 @@ func (p *PDPService) handlePieceUpload(w http.ResponseWriter, r *http.Request) {
 		// 1. Create a long-term parked piece entry
 		var parkedPieceID int64
 		err := tx.QueryRow(`
-            INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-            VALUES ($1, $2, $3, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-			RETURNING id
-        `, pieceCIDComputed.String(), paddedPieceSize, readSize).Scan(&parkedPieceID)
+							WITH existing_piece AS (
+							  SELECT id
+							  FROM parked_pieces
+							  WHERE piece_cid = $1
+								AND piece_padded_size = $2
+								AND long_term = TRUE
+								AND cleanup_task_id IS NULL
+							),
+							inserted_piece AS (
+							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+							  SELECT $1, $2, $3, TRUE
+							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  RETURNING id
+							)
+							SELECT id FROM existing_piece
+							UNION ALL
+							SELECT id FROM inserted_piece
+							LIMIT 1;`, pieceCIDComputed.String(), paddedPieceSize, readSize).Scan(&parkedPieceID)
 		if err != nil {
 			return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)
 		}
@@ -525,9 +539,24 @@ func (p *PDPService) handleStreamingUpload(w http.ResponseWriter, r *http.Reques
 		// 1. Create a long-term parked piece entry
 		var parkedPieceID int64
 		err := tx.QueryRow(`
-            INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-            VALUES ($1, $2, $3, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-			RETURNING id
+							WITH existing_piece AS (
+							  SELECT id
+							  FROM parked_pieces
+							  WHERE piece_cid = $1
+								AND piece_padded_size = $2
+								AND long_term = TRUE
+								AND cleanup_task_id IS NULL
+							),
+							inserted_piece AS (
+							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+							  SELECT $1, $2, $3, TRUE
+							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  RETURNING id
+							)
+							SELECT id FROM existing_piece
+							UNION ALL
+							SELECT id FROM inserted_piece
+							LIMIT 1;
         `, pcid.String(), paddedPieceSize, readSize).Scan(&parkedPieceID)
 		if err != nil {
 			return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)

--- a/tasks/pdp/task_aggregation.go
+++ b/tasks/pdp/task_aggregation.go
@@ -214,7 +214,8 @@ func (a *AggregatePDPDealTask) Do(taskID harmonytask.TaskID, stillOwned func() b
 			// If piece does not exist then let's create one
 			err = tx.QueryRow(`
             INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-            VALUES ($1, $2, $3, TRUE, TRUE) RETURNING id`,
+            VALUES ($1, $2, $3, TRUE, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
+			RETURNING id`,
 				pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&parkedPieceID)
 			if err != nil {
 				return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)

--- a/tasks/pdp/task_aggregation.go
+++ b/tasks/pdp/task_aggregation.go
@@ -213,9 +213,24 @@ func (a *AggregatePDPDealTask) Do(taskID harmonytask.TaskID, stillOwned func() b
 			}
 			// If piece does not exist then let's create one
 			err = tx.QueryRow(`
-            INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-            VALUES ($1, $2, $3, TRUE, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-			RETURNING id`,
+							WITH existing_piece AS (
+							  SELECT id
+							  FROM parked_pieces
+							  WHERE piece_cid = $1
+								AND piece_padded_size = $2
+								AND long_term = TRUE
+								AND cleanup_task_id IS NULL
+							),
+							inserted_piece AS (
+							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
+							  SELECT $1, $2, $3, TRUE, TRUE
+							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  RETURNING id
+							)
+							SELECT id FROM existing_piece
+							UNION ALL
+							SELECT id FROM inserted_piece
+							LIMIT 1;`,
 				pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&parkedPieceID)
 			if err != nil {
 				return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)

--- a/tasks/pdpv0/task_pull_piece.go
+++ b/tasks/pdpv0/task_pull_piece.go
@@ -263,7 +263,7 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		var parkedPieceID int64
 		err = tx.QueryRow(`
 			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-			VALUES ($1, $2, $3, TRUE)
+			VALUES ($1, $2, $3, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
 			RETURNING id
 		`, item.PieceCid, paddedSize, item.PieceRawSize).Scan(&parkedPieceID)
 		if err != nil {

--- a/tasks/pdpv0/task_pull_piece.go
+++ b/tasks/pdpv0/task_pull_piece.go
@@ -262,9 +262,24 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		// Create parked_pieces entry
 		var parkedPieceID int64
 		err = tx.QueryRow(`
-			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-			VALUES ($1, $2, $3, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-			RETURNING id
+							WITH existing_piece AS (
+							  SELECT id
+							  FROM parked_pieces
+							  WHERE piece_cid = $1
+								AND piece_padded_size = $2
+								AND long_term = TRUE
+								AND cleanup_task_id IS NULL
+							),
+							inserted_piece AS (
+							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+							  SELECT $1, $2, $3, TRUE
+							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  RETURNING id
+							)
+							SELECT id FROM existing_piece
+							UNION ALL
+							SELECT id FROM inserted_piece
+							LIMIT 1;
 		`, item.PieceCid, paddedSize, item.PieceRawSize).Scan(&parkedPieceID)
 		if err != nil {
 			return false, xerrors.Errorf("insert parked_pieces: %w", err)

--- a/tasks/piece/task_aggregate_chunks.go
+++ b/tasks/piece/task_aggregate_chunks.go
@@ -155,8 +155,8 @@ func (a *AggregateChunksTask) Do(taskID harmonytask.TaskID, stillOwned func() bo
 			// If piece does not exist then let's create one
 			err = tx.QueryRow(`
             INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-            VALUES ($1, $2, $3, TRUE, TRUE) RETURNING id`,
-				pcid.String(), psize, rawSize).Scan(&parkedPieceID)
+            VALUES ($1, $2, $3, TRUE, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
+			RETURNING id`, pcid.String(), psize, rawSize).Scan(&parkedPieceID)
 			if err != nil {
 				return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)
 			}

--- a/tasks/piece/task_aggregate_chunks.go
+++ b/tasks/piece/task_aggregate_chunks.go
@@ -154,9 +154,24 @@ func (a *AggregateChunksTask) Do(taskID harmonytask.TaskID, stillOwned func() bo
 			}
 			// If piece does not exist then let's create one
 			err = tx.QueryRow(`
-            INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-            VALUES ($1, $2, $3, TRUE, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-			RETURNING id`, pcid.String(), psize, rawSize).Scan(&parkedPieceID)
+					WITH existing_piece AS (
+					  SELECT id
+					  FROM parked_pieces
+					  WHERE piece_cid = $1
+						AND piece_padded_size = $2
+						AND long_term = TRUE
+						AND cleanup_task_id IS NULL
+					),
+					inserted_piece AS (
+					  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
+					  SELECT $1, $2, $3, TRUE, TRUE
+					  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+					  RETURNING id
+					)
+					SELECT id FROM existing_piece
+					UNION ALL
+					SELECT id FROM inserted_piece
+					LIMIT 1;`, pcid.String(), psize, rawSize).Scan(&parkedPieceID)
 			if err != nil {
 				return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)
 			}

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -1,0 +1,200 @@
+package piece
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/curiostorage/harmonyquery"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+	"github.com/filecoin-project/curio/harmony/resources"
+	"github.com/filecoin-project/curio/lib/ffi"
+	"github.com/filecoin-project/curio/lib/promise"
+	"github.com/filecoin-project/curio/lib/storiface"
+)
+
+type FixParkPieceTask struct {
+	db *harmonydb.DB
+	sc *ffi.SealCalls
+
+	TF promise.Promise[harmonytask.AddTaskFunc]
+}
+
+func NewFixParkPieceTask(db *harmonydb.DB, sc *ffi.SealCalls) *FixParkPieceTask {
+	return &FixParkPieceTask{
+		db: db,
+		sc: sc,
+	}
+}
+
+func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+	ctx := context.Background()
+
+	// Check index first
+	exists, err := f.checkIfIndexExists(ctx)
+	if err != nil {
+		return false, xerrors.Errorf("checking if index exists: %w", err)
+	}
+	if exists {
+		return true, nil
+	}
+
+	type duplicate struct {
+		PieceCid  string  `db:"piece_cid"`
+		PieceSize int64   `db:"piece_padded_size"`
+		LongTerm  bool    `db:"long_term"`
+		RowCount  int64   `db:"row_count"`
+		IDs       []int64 `db:"ids"`
+	}
+
+	var duplicates []duplicate
+
+	err = f.db.Select(ctx, &duplicates, `SELECT piece_cid, piece_padded_size, long_term,
+										   count(*) AS row_count,
+										   array_agg(id ORDER BY id) AS ids
+									FROM parked_pieces
+									WHERE cleanup_task_id IS NULL
+									  AND complete = true
+									GROUP BY 1,2,3
+									HAVING count(*) > 1;`)
+
+	if err != nil {
+		return false, xerrors.Errorf("querying parked piece: %w", err)
+	}
+
+	if len(duplicates) == 0 {
+		_, err = f.db.Exec(ctx, `CREATE UNIQUE INDEX parked_pieces_active_piece_key ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL;`)
+		if err != nil {
+			if strings.Contains(err.Error(), "SQLSTATE 23505") {
+				// Let's fail this so we can retry few seconds later, which is likely to succeed
+				return false, xerrors.Errorf("duplicate rows exist while creating index: %w", err)
+			}
+			return false, xerrors.Errorf("creating index: %w", err)
+		}
+		return true, nil
+	}
+
+	for _, dup := range duplicates {
+		if stillOwned() {
+			comm, err := f.db.BeginTransaction(ctx, func(tx *harmonyquery.Tx) (commit bool, err error) {
+				for _, id := range dup.IDs {
+					// Verify that the piece is still parked
+					// If piece exists then check if we can access the data
+					pr, err := f.sc.PieceReader(ctx, storiface.PieceNumber(id))
+					if err != nil {
+						// If piece does not exist then we will park it otherwise fail here
+						if !errors.Is(err, storiface.ErrSectorNotFound) {
+							continue
+						}
+					}
+					defer func() {
+						_ = pr.Close()
+					}()
+
+					_, err = tx.Exec(`UPDATE parked_piece_refs 
+										SET piece_id = $1 
+										WHERE piece_id = ANY($2::bigint[]);`, id)
+					if err != nil {
+						return false, xerrors.Errorf("updating parked piece refs: %w", err)
+					}
+
+					return true, nil
+				}
+
+				return false, xerrors.Errorf("no suitable piece found for ids: %d", dup.IDs)
+			}, harmonydb.OptionRetry())
+			if err != nil {
+				return false, xerrors.Errorf("updating DB: %w", err)
+			}
+			if !comm {
+				return false, xerrors.Errorf("failed to commit the transaction")
+			}
+		}
+	}
+
+	_, err = f.db.BeginTransaction(ctx, func(tx *harmonyquery.Tx) (commit bool, err error) {
+		var reduplicates []duplicate
+
+		err = tx.Select(&reduplicates, `SELECT piece_cid, piece_padded_size, long_term,
+													   count(*) AS row_count,
+													   array_agg(id ORDER BY id) AS ids
+												FROM parked_pieces
+												WHERE cleanup_task_id IS NULL
+												  AND complete = true
+												GROUP BY 1,2,3
+												HAVING count(*) > 1;`)
+
+		if err != nil {
+			return false, xerrors.Errorf("querying parked piece: %w", err)
+		}
+
+		if len(reduplicates) > 0 {
+			return false, nil
+		}
+
+		_, err = tx.Exec(`CREATE UNIQUE INDEX parked_pieces_active_piece_key ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL;`)
+		if err != nil {
+			if strings.Contains(err.Error(), "SQLSTATE 23505") {
+				return false, nil
+			}
+			return false, xerrors.Errorf("creating index: %w", err)
+		}
+		return true, nil
+	}, harmonydb.OptionRetry())
+	if err != nil {
+		return false, xerrors.Errorf("updating DB: %w", err)
+	}
+	return true, nil
+}
+
+func (f *FixParkPieceTask) checkIfIndexExists(ctx context.Context) (bool, error) {
+	var exists bool
+	err := f.db.QueryRow(ctx, `
+					SELECT EXISTS (
+					  SELECT 1
+					  FROM pg_indexes
+					  WHERE schemaname = current_schema()
+						AND tablename = 'parked_pieces'
+						AND indexname = 'parked_pieces_active_piece_key'
+						AND indexdef LIKE '%UNIQUE INDEX parked_pieces_active_piece_key%'
+						AND indexdef LIKE '%(piece_cid, piece_padded_size, long_term)%'
+						AND indexdef LIKE '%WHERE cleanup_task_id IS NULL%'
+					);`).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("checking if index exists: %w", err)
+	}
+	return exists, nil
+}
+
+func (f *FixParkPieceTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) ([]harmonytask.TaskID, error) {
+	return ids, nil
+}
+
+func (f *FixParkPieceTask) TypeDetails() harmonytask.TaskTypeDetails {
+	return harmonytask.TaskTypeDetails{
+		Name: "FixParkPiece",
+		Cost: resources.Resources{
+			Cpu: 1,
+			Gpu: 0,
+			Ram: 64 << 20,
+		},
+		MaxFailures: 10,
+		RetryWait: func(retries int) time.Duration {
+			const baseWait, maxWait, factor = 5 * time.Second, time.Minute, 1.5
+			// Use math.Pow for exponential backoff
+			return min(time.Duration(float64(baseWait)*math.Pow(factor, float64(retries))), maxWait)
+		},
+		IAmBored: harmonytask.SingletonTaskAdder(time.Hour, f),
+	}
+}
+
+func (f *FixParkPieceTask) Adder(taskFunc harmonytask.AddTaskFunc) {}
+
+var _ harmonytask.TaskInterface = &FixParkPieceTask{}
+var _ = harmonytask.Reg(&FixParkPieceTask{})

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -16,6 +16,8 @@ import (
 	"github.com/filecoin-project/curio/lib/storiface"
 )
 
+// TODO: This task should be removed at NV30 upgrade along with CTEs for parked_piece insert
+
 type FixParkPieceTask struct {
 	db *harmonydb.DB
 	sc *ffi.SealCalls

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -2,7 +2,6 @@ package piece
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -38,14 +37,31 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 	var exists bool
 	err = f.db.QueryRow(ctx, `
 					SELECT EXISTS (
-					  SELECT 1
-					  FROM pg_indexes
-					  WHERE schemaname = current_schema()
-						AND tablename = 'parked_pieces'
-						AND indexname = 'parked_pieces_active_piece_key'
-						AND indexdef LIKE '%UNIQUE INDEX parked_pieces_active_piece_key%'
-						AND indexdef LIKE '%(piece_cid, piece_padded_size, long_term)%'
-						AND indexdef LIKE '%WHERE cleanup_task_id IS NULL%'
+						SELECT 1
+						FROM pg_catalog.pg_index ix
+						JOIN pg_catalog.pg_class idx ON idx.oid = ix.indexrelid
+						JOIN pg_catalog.pg_class tbl ON tbl.oid = ix.indrelid
+						JOIN pg_catalog.pg_namespace ns ON ns.oid = tbl.relnamespace
+						JOIN pg_catalog.pg_am am ON am.oid = idx.relam
+						WHERE ns.nspname = current_schema()
+						  AND idx.relnamespace = ns.oid
+						  AND tbl.relname = 'parked_pieces'
+						  AND idx.relname = 'parked_pieces_active_piece_key'
+						  AND idx.relkind = 'i'
+						  AND am.amname = 'btree'
+						  AND ix.indisunique
+						  AND ix.indisvalid
+						  AND ix.indisready
+						  AND ix.indislive
+						  AND ix.indnkeyatts = 3
+						  AND ix.indnatts = 3
+						  AND ix.indexprs IS NULL
+						  AND ARRAY(
+							  SELECT pg_catalog.pg_get_indexdef(ix.indexrelid, n, true)
+							  FROM generate_series(1, ix.indnkeyatts) AS n
+							  ORDER BY n
+						  ) = ARRAY['piece_cid', 'piece_padded_size', 'long_term']
+						  AND pg_catalog.pg_get_expr(ix.indpred, ix.indrelid, false) = '(cleanup_task_id IS NULL)'
 					);`).Scan(&exists)
 	if err != nil {
 		return false, fmt.Errorf("checking if index exists: %w", err)
@@ -83,22 +99,19 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 				// If piece exists then check if we can access the data
 				pr, err := f.sc.PieceReader(ctx, storiface.PieceNumber(id))
 				if err != nil {
-					// If piece does not exist then we will park it otherwise fail here
-					if !errors.Is(err, storiface.ErrSectorNotFound) {
-						continue
-					}
+					// If piece does not exist then we check the next one
+					continue
 				}
-				defer func() {
-					_ = pr.Close()
-				}()
-
-				_, err = f.db.Exec(ctx, `UPDATE parked_piece_refs SET piece_id = $1 WHERE piece_id = ANY($2::bigint[]);`, id)
+				_ = pr.Close()
+				_, err = f.db.Exec(ctx, `UPDATE parked_piece_refs SET piece_id = $1 WHERE piece_id = ANY($2::bigint[]);`, id, dup.IDs)
 				if err != nil {
 					return false, xerrors.Errorf("updating parked piece refs: %w", err)
 				}
 				// Break out of the loop if we fixed the issue
 				break
 			}
+		} else {
+			return false, nil
 		}
 	}
 

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -192,7 +192,7 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		}
 	}
 
-	_, err = f.db.Exec(ctx, `CREATE UNIQUE INDEX parked_pieces_active_piece_key ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL;`)
+	_, err = f.db.Exec(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS parked_pieces_active_piece_key ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL;`)
 	if err != nil {
 		return false, xerrors.Errorf("creating index: %w", err)
 	}

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/curiostorage/harmonyquery"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
@@ -79,38 +78,26 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 
 	for _, dup := range duplicates {
 		if stillOwned() {
-			comm, err := f.db.BeginTransaction(ctx, func(tx *harmonyquery.Tx) (commit bool, err error) {
-				for _, id := range dup.IDs {
-					// Verify that the piece is still parked
-					// If piece exists then check if we can access the data
-					pr, err := f.sc.PieceReader(ctx, storiface.PieceNumber(id))
-					if err != nil {
-						// If piece does not exist then we will park it otherwise fail here
-						if !errors.Is(err, storiface.ErrSectorNotFound) {
-							continue
-						}
+			for _, id := range dup.IDs {
+				// Verify that the piece is still parked
+				// If piece exists then check if we can access the data
+				pr, err := f.sc.PieceReader(ctx, storiface.PieceNumber(id))
+				if err != nil {
+					// If piece does not exist then we will park it otherwise fail here
+					if !errors.Is(err, storiface.ErrSectorNotFound) {
+						continue
 					}
-					defer func() {
-						_ = pr.Close()
-					}()
-
-					_, err = tx.Exec(`UPDATE parked_piece_refs 
-										SET piece_id = $1 
-										WHERE piece_id = ANY($2::bigint[]);`, id)
-					if err != nil {
-						return false, xerrors.Errorf("updating parked piece refs: %w", err)
-					}
-
-					return true, nil
 				}
+				defer func() {
+					_ = pr.Close()
+				}()
 
-				return false, xerrors.Errorf("no suitable piece found for ids: %d", dup.IDs)
-			}, harmonydb.OptionRetry())
-			if err != nil {
-				return false, xerrors.Errorf("updating DB: %w", err)
-			}
-			if !comm {
-				return false, xerrors.Errorf("failed to commit the transaction")
+				_, err = f.db.Exec(ctx, `UPDATE parked_piece_refs SET piece_id = $1 WHERE piece_id = ANY($2::bigint[]);`, id)
+				if err != nil {
+					return false, xerrors.Errorf("updating parked piece refs: %w", err)
+				}
+				// Break out of the loop if we fixed the issue
+				break
 			}
 		}
 	}

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/curiostorage/harmonyquery"
@@ -37,23 +36,33 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 	ctx := context.Background()
 
 	// Check index first
-	exists, err := f.checkIfIndexExists(ctx)
+	var exists bool
+	err = f.db.QueryRow(ctx, `
+					SELECT EXISTS (
+					  SELECT 1
+					  FROM pg_indexes
+					  WHERE schemaname = current_schema()
+						AND tablename = 'parked_pieces'
+						AND indexname = 'parked_pieces_active_piece_key'
+						AND indexdef LIKE '%UNIQUE INDEX parked_pieces_active_piece_key%'
+						AND indexdef LIKE '%(piece_cid, piece_padded_size, long_term)%'
+						AND indexdef LIKE '%WHERE cleanup_task_id IS NULL%'
+					);`).Scan(&exists)
 	if err != nil {
-		return false, xerrors.Errorf("checking if index exists: %w", err)
+		return false, fmt.Errorf("checking if index exists: %w", err)
 	}
+
 	if exists {
 		return true, nil
 	}
 
-	type duplicate struct {
+	var duplicates []struct {
 		PieceCid  string  `db:"piece_cid"`
 		PieceSize int64   `db:"piece_padded_size"`
 		LongTerm  bool    `db:"long_term"`
 		RowCount  int64   `db:"row_count"`
 		IDs       []int64 `db:"ids"`
 	}
-
-	var duplicates []duplicate
 
 	err = f.db.Select(ctx, &duplicates, `SELECT piece_cid, piece_padded_size, long_term,
 										   count(*) AS row_count,
@@ -66,18 +75,6 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 
 	if err != nil {
 		return false, xerrors.Errorf("querying parked piece: %w", err)
-	}
-
-	if len(duplicates) == 0 {
-		_, err = f.db.Exec(ctx, `CREATE UNIQUE INDEX parked_pieces_active_piece_key ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL;`)
-		if err != nil {
-			if strings.Contains(err.Error(), "SQLSTATE 23505") {
-				// Let's fail this so we can retry few seconds later, which is likely to succeed
-				return false, xerrors.Errorf("duplicate rows exist while creating index: %w", err)
-			}
-			return false, xerrors.Errorf("creating index: %w", err)
-		}
-		return true, nil
 	}
 
 	for _, dup := range duplicates {
@@ -118,58 +115,12 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		}
 	}
 
-	_, err = f.db.BeginTransaction(ctx, func(tx *harmonyquery.Tx) (commit bool, err error) {
-		var reduplicates []duplicate
-
-		err = tx.Select(&reduplicates, `SELECT piece_cid, piece_padded_size, long_term,
-													   count(*) AS row_count,
-													   array_agg(id ORDER BY id) AS ids
-												FROM parked_pieces
-												WHERE cleanup_task_id IS NULL
-												  AND complete = true
-												GROUP BY 1,2,3
-												HAVING count(*) > 1;`)
-
-		if err != nil {
-			return false, xerrors.Errorf("querying parked piece: %w", err)
-		}
-
-		if len(reduplicates) > 0 {
-			return false, nil
-		}
-
-		_, err = tx.Exec(`CREATE UNIQUE INDEX parked_pieces_active_piece_key ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL;`)
-		if err != nil {
-			if strings.Contains(err.Error(), "SQLSTATE 23505") {
-				return false, nil
-			}
-			return false, xerrors.Errorf("creating index: %w", err)
-		}
-		return true, nil
-	}, harmonydb.OptionRetry())
+	_, err = f.db.Exec(ctx, `CREATE UNIQUE INDEX parked_pieces_active_piece_key ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL;`)
 	if err != nil {
-		return false, xerrors.Errorf("updating DB: %w", err)
+		return false, xerrors.Errorf("creating index: %w", err)
 	}
+
 	return true, nil
-}
-
-func (f *FixParkPieceTask) checkIfIndexExists(ctx context.Context) (bool, error) {
-	var exists bool
-	err := f.db.QueryRow(ctx, `
-					SELECT EXISTS (
-					  SELECT 1
-					  FROM pg_indexes
-					  WHERE schemaname = current_schema()
-						AND tablename = 'parked_pieces'
-						AND indexname = 'parked_pieces_active_piece_key'
-						AND indexdef LIKE '%UNIQUE INDEX parked_pieces_active_piece_key%'
-						AND indexdef LIKE '%(piece_cid, piece_padded_size, long_term)%'
-						AND indexdef LIKE '%WHERE cleanup_task_id IS NULL%'
-					);`).Scan(&exists)
-	if err != nil {
-		return false, fmt.Errorf("checking if index exists: %w", err)
-	}
-	return exists, nil
 }
 
 func (f *FixParkPieceTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) ([]harmonytask.TaskID, error) {

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -73,44 +73,119 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		return true, nil
 	}
 
-	var duplicates []struct {
-		PieceCid  string  `db:"piece_cid"`
-		PieceSize int64   `db:"piece_padded_size"`
-		LongTerm  bool    `db:"long_term"`
-		RowCount  int64   `db:"row_count"`
-		IDs       []int64 `db:"ids"`
+	/*
+		Look at duplicate groups across all active parked_pieces rows, not just completed rows,
+		but only processes groups that have at least one complete row.
+		It picks a readable complete row as the winner, moves refs from stale/no-task losers to that winner,
+		and skips losers whose task_id still exists in harmony_task.
+
+		Covered Cases:
+		1. complete + incomplete with task_id IS NULL
+		2. complete + incomplete with stale task_id
+		3. multiple complete rows
+		4. active incomplete rows are left alone
+
+		Ignored:
+		1. unique incomplete rows
+		2. duplicate groups with no complete row
+	*/
+	type duplicateKey struct {
+		PieceCid  string
+		PieceSize int64
+		LongTerm  bool
 	}
 
-	err = f.db.Select(ctx, &duplicates, `SELECT piece_cid, piece_padded_size, long_term,
-										   count(*) AS row_count,
-										   array_agg(id ORDER BY id) AS ids
+	type duplicateRow struct {
+		PieceCid   string `db:"piece_cid"`
+		PieceSize  int64  `db:"piece_padded_size"`
+		LongTerm   bool   `db:"long_term"`
+		ID         int64  `db:"id"`
+		Complete   bool   `db:"complete"`
+		TaskID     *int64 `db:"task_id"`
+		TaskActive bool   `db:"task_active"`
+	}
+
+	var duplicateRows []duplicateRow
+	err = f.db.Select(ctx, &duplicateRows, `
+								SELECT pp.piece_cid, pp.piece_padded_size, pp.long_term,
+									   pp.id, pp.complete, pp.task_id,
+									   ht.id IS NOT NULL AS task_active
+								FROM parked_pieces pp
+								LEFT JOIN harmony_task ht ON ht.id = pp.task_id
+								JOIN (
+									SELECT piece_cid, piece_padded_size, long_term
 									FROM parked_pieces
 									WHERE cleanup_task_id IS NULL
-									  AND complete = true
 									GROUP BY 1,2,3
-									HAVING count(*) > 1;`)
+									HAVING count(*) > 1
+									   AND bool_or(complete)
+								) dup ON dup.piece_cid = pp.piece_cid
+									 AND dup.piece_padded_size = pp.piece_padded_size
+									 AND dup.long_term = pp.long_term
+								WHERE pp.cleanup_task_id IS NULL
+								ORDER BY pp.piece_cid, pp.piece_padded_size, pp.long_term, pp.complete DESC, pp.id;`)
 
 	if err != nil {
 		return false, xerrors.Errorf("querying parked piece: %w", err)
 	}
 
-	for _, dup := range duplicates {
+	duplicates := map[duplicateKey][]duplicateRow{}
+	var keys []duplicateKey
+	for _, row := range duplicateRows {
+		key := duplicateKey{
+			PieceCid:  row.PieceCid,
+			PieceSize: row.PieceSize,
+			LongTerm:  row.LongTerm,
+		}
+		if _, ok := duplicates[key]; !ok {
+			keys = append(keys, key)
+		}
+		duplicates[key] = append(duplicates[key], row)
+	}
+
+	for _, key := range keys {
+		dup := duplicates[key]
 		if stillOwned() {
-			for _, id := range dup.IDs {
+			var winner *int64
+			for _, row := range dup {
+				if !row.Complete {
+					continue
+				}
+
 				// Verify that the piece is still parked
 				// If piece exists then check if we can access the data
-				pr, err := f.sc.PieceReader(ctx, storiface.PieceNumber(id))
+				pr, err := f.sc.PieceReader(ctx, storiface.PieceNumber(row.ID))
 				if err != nil {
 					// If piece does not exist then we check the next one
 					continue
 				}
 				_ = pr.Close()
-				_, err = f.db.Exec(ctx, `UPDATE parked_piece_refs SET piece_id = $1 WHERE piece_id = ANY($2::bigint[]);`, id, dup.IDs)
-				if err != nil {
-					return false, xerrors.Errorf("updating parked piece refs: %w", err)
-				}
-				// Break out of the loop if we fixed the issue
+				winner = new(row.ID)
 				break
+			}
+
+			if winner == nil {
+				continue
+			}
+
+			var loserIDs []int64
+			for _, row := range dup {
+				if row.ID == *winner {
+					continue
+				}
+				if row.TaskActive {
+					continue
+				}
+				loserIDs = append(loserIDs, row.ID)
+			}
+
+			if len(loserIDs) == 0 {
+				continue
+			}
+
+			_, err = f.db.Exec(ctx, `UPDATE parked_piece_refs SET piece_id = $1 WHERE piece_id = ANY($2::bigint[]);`, *winner, loserIDs)
+			if err != nil {
+				return false, xerrors.Errorf("updating parked piece refs: %w", err)
 			}
 		} else {
 			return false, nil

--- a/tasks/storage-market/mk20.go
+++ b/tasks/storage-market/mk20.go
@@ -739,7 +739,7 @@ func (d *CurioStorageDealMarket) findOfflineURLMk20Deal(ctx context.Context, pie
 										existing_piece AS (
 										  SELECT id AS piece_id
 										  FROM parked_pieces
-										  WHERE piece_cid = $2 AND piece_padded_size = $3
+										  WHERE piece_cid = $2 AND piece_padded_size = $3 AND long_term = NOT (p.deal_aggregation > 0)
 										),
 										inserted_piece AS (
 										  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)

--- a/tasks/storage-market/mk20.go
+++ b/tasks/storage-market/mk20.go
@@ -356,10 +356,24 @@ func insertPiecesInTransaction(ctx context.Context, tx *harmonydb.Tx, deal *mk20
 			if errors.Is(err, pgx.ErrNoRows) {
 				// Piece does not exist, attempt to insert
 				err = tx.QueryRow(`
-							INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-							VALUES ($1, $2, $3, TRUE)
-							ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-							RETURNING id`, pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&pieceID)
+							WITH existing_piece AS (
+							  SELECT id
+							  FROM parked_pieces
+							  WHERE piece_cid = $1
+								AND piece_padded_size = $2
+								AND long_term = TRUE
+								AND cleanup_task_id IS NULL
+							),
+							inserted_piece AS (
+							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+							  SELECT $1, $2, $3, TRUE
+							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  RETURNING id
+							)
+							SELECT id FROM existing_piece
+							UNION ALL
+							SELECT id FROM inserted_piece
+							LIMIT 1;`, pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&pieceID)
 				if err != nil {
 					return xerrors.Errorf("inserting new parked piece and getting id: %w", err)
 				}
@@ -477,11 +491,25 @@ func insertPiecesInTransaction(ctx context.Context, tx *harmonydb.Tx, deal *mk20
 				if headers == nil {
 					headers = []byte("{}")
 				}
-				batch.Queue(`WITH inserted_piece AS (
+				batch.Queue(`WITH existing_piece AS (
+									  SELECT id
+									  FROM parked_pieces
+									  WHERE piece_cid = $1
+										AND piece_padded_size = $2
+										AND long_term = FALSE
+										AND cleanup_task_id IS NULL
+									),
+									insert_piece AS (
 									  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-									  VALUES ($1, $2, $3, FALSE)
-									  ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
+									  SELECT $1, $2, $3, FALSE
+									  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
 									  RETURNING id
+									),
+									inserted_piece AS (
+									SELECT id FROM existing_piece
+									UNION ALL
+									SELECT id FROM insert_piece
+									LIMIT 1
 									),
 									selected_piece AS (
 									  SELECT COALESCE(

--- a/tasks/storage-market/task_aggregation.go
+++ b/tasks/storage-market/task_aggregation.go
@@ -234,7 +234,8 @@ func (a *AggregateDealTask) Do(taskID harmonytask.TaskID, stillOwned func() bool
 			// If piece does not exist then let's create one
 			err = tx.QueryRow(`
             INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-            VALUES ($1, $2, $3, TRUE, TRUE) RETURNING id`,
+            VALUES ($1, $2, $3, TRUE, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
+			RETURNING id`,
 				pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&parkedPieceID)
 			if err != nil {
 				return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)

--- a/tasks/storage-market/task_aggregation.go
+++ b/tasks/storage-market/task_aggregation.go
@@ -233,9 +233,24 @@ func (a *AggregateDealTask) Do(taskID harmonytask.TaskID, stillOwned func() bool
 			}
 			// If piece does not exist then let's create one
 			err = tx.QueryRow(`
-            INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-            VALUES ($1, $2, $3, TRUE, TRUE) ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING
-			RETURNING id`,
+							WITH existing_piece AS (
+							  SELECT id
+							  FROM parked_pieces
+							  WHERE piece_cid = $1
+								AND piece_padded_size = $2
+								AND long_term = TRUE
+								AND cleanup_task_id IS NULL
+							),
+							inserted_piece AS (
+							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
+							  SELECT $1, $2, $3, TRUE, TRUE
+							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  RETURNING id
+							)
+							SELECT id FROM existing_piece
+							UNION ALL
+							SELECT id FROM inserted_piece
+							LIMIT 1;`,
 				pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&parkedPieceID)
 			if err != nil {
 				return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)


### PR DESCRIPTION
# Summary

Fix duplicate active rows in parked_pieces and safely enforce the intended uniqueness rule.

## Problem

A previous uniqueness constraint allowed multiple active rows for the same piece key due to NULL behavior on cleanup_task_id.

```
yugabyte=# SELECT
  NULL = NULL           AS eq_null,
  NULL <> NULL          AS neq_null,
  NULL IS NULL          AS is_null,
  NULL IS NOT DISTINCT FROM NULL AS same_null;
 eq_null | neq_null | is_null | same_null 
---------+----------+---------+-----------
         |          | t       | t
(1 row)
```


This caused duplicate active records and blocked creation of the correct active-row unique index.

## Solution

1. Update migration logic to create the index only when duplicates are absent.
2. Add a Go repair job to clean duplicate active groups on live systems.
3. Select a keeper row that still has the backing file on disk.
4. Reattach refs to the keeper row.
5. Retire duplicate rows through normal cleanup flow.
6. Create the unique partial index after cleanup completes.

## Result

Only one active row can exist per logical piece key, while preserving file safety and live-system compatibility.