### PR TITLE
Fix: downgrade-test

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -4,7 +4,7 @@ description: 'Install common dependencies'
 inputs:
   skip:
     default: "false"
-    description: "skips the apt update"
+    description: "when true, only apt-get update (refresh indexes) then git/submodules; skips apt install and GCC alternatives for pre-provisioned runners"
 
 runs:
   using: 'composite'
@@ -12,7 +12,6 @@ runs:
     - name: Update apt cache
       run: sudo apt-get update
       shell: bash
-      if: ${{ inputs.skip == 'false' }}
 
     - name: Install dependencies
       run: |
@@ -29,6 +28,7 @@ runs:
           libfuse3-dev uuid-dev libssl-dev libnuma-dev libaio-dev libarchive-dev libkeyutils-dev libncurses-dev \
           libgmp-dev libconfig++-dev
       shell: bash
+      if: ${{ inputs.skip == 'false' }}
 
     - name: Set up GCC 13 as default
       run: |
@@ -39,6 +39,7 @@ runs:
         echo "CC=gcc-13" >> $GITHUB_ENV
         echo "CXX=g++-13" >> $GITHUB_ENV
       shell: bash
+      if: ${{ inputs.skip == 'false' }}
 
     # NOTE: CI sometimes flakes on large/full fetches (HTTP/2 early EOF).
     # We only need tags (and only from origin) for versioning/metadata, so keep

--- a/itests/harmonydb_test.go
+++ b/itests/harmonydb_test.go
@@ -162,6 +162,12 @@ func TestDowngradeTo(t *testing.T) {
 	if rowCt == 0 {
 		t.Fatal("no rows in save set")
 	}
+	// DowngradeTo selects rows with applied >= TO_DATE(last_good). A reused itest
+	// template may have old applied timestamps for newer migrations; refresh them
+	// so forward-dated entries are actually eligible for downgrade (deterministic).
+	_, err = cdb.Exec(ctx, "UPDATE base SET applied = CURRENT_TIMESTAMP WHERE entry > '20250815'")
+	require.NoError(t, err)
+
 	n, _ := strconv.Atoi(time.Now().AddDate(0, 0, -1).Format("20060102"))
 	err = cdb.DowngradeTo(ctx, n)
 	require.NoError(t, err, "error reverting. All sql entries need a revert file.")


### PR DESCRIPTION
Downgrade test expects a certain db setup that the template code breaks. 
This makes the test friendly for template DBs. 