### PR TITLE
fix: marketAddress client toggle and improvs

### DIFF
--- a/market/backpressure/backpressure.go
+++ b/market/backpressure/backpressure.go
@@ -179,7 +179,7 @@ func (c *CachedBackPressure) checkMK20Backpressure(ctx context.Context, cfg *con
 									
 										COUNT(DISTINCT id) FILTER (
 											WHERE agg_task_id IS NOT NULL AND agg_owner IS NULL
-										) AS agg_pending,
+										) AS agg_pending
 									FROM joined;`).Scan(&runningPipelines, &downloadingPending, &commpPending, &aggPending)
 	if err != nil {
 		return false, xerrors.Errorf("failed to query market pipeline backpressure stats: %w", err)

--- a/market/mk20/mk20.go
+++ b/market/mk20/mk20.go
@@ -21,7 +21,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/builtin/v16/miner"
-	"github.com/filecoin-project/go-state-types/builtin/v16/verifreg"
 	verifreg9 "github.com/filecoin-project/go-state-types/builtin/v9/verifreg"
 
 	"github.com/filecoin-project/curio/build"
@@ -390,6 +389,32 @@ func (m *MK20) sanitizeDDODeal(ctx context.Context, deal *Deal) (*ProviderDealRe
 			}, xerrors.Errorf("getting allocation: %w", err)
 		}
 
+		if alloc == nil && deal.Products.DDOV1.MarketAddress != "" {
+			contractAddr, perr := lethtypes.ParseEthAddress(deal.Products.DDOV1.MarketAddress)
+			if perr != nil {
+				log.Errorw("error parsing market address", "market address", deal.Products.DDOV1.MarketAddress, "error", perr)
+				return &ProviderDealRejectionInfo{
+					HTTPCode: ErrBadProposal,
+					Reason:   "Market address is not valid",
+				}, nil
+			}
+			fc, cerr := contractAddr.ToFilecoinAddress()
+			if cerr != nil {
+				log.Errorw("error converting market address to filecoin address", "market address", deal.Products.DDOV1.MarketAddress, "error", cerr)
+				return &ProviderDealRejectionInfo{
+					HTTPCode: ErrBadProposal,
+					Reason:   "Market address is not valid filecoin address",
+				}, nil
+			}
+			alloc, err = m.api.StateGetAllocation(ctx, fc, verifreg9.AllocationId(*deal.Products.DDOV1.AllocationId), types.EmptyTSK)
+			if err != nil {
+				return &ProviderDealRejectionInfo{
+					HTTPCode: ErrServerInternalError,
+					Reason:   "Server Internal Error",
+				}, xerrors.Errorf("getting allocation via market contract: %w", err)
+			}
+		}
+
 		if alloc == nil {
 			return &ProviderDealRejectionInfo{
 				HTTPCode: ErrBadProposal,
@@ -397,64 +422,6 @@ func (m *MK20) sanitizeDDODeal(ctx context.Context, deal *Deal) (*ProviderDealRe
 			}, nil
 		}
 
-		clientIDAdr, err := m.api.StateLookupID(ctx, client, types.EmptyTSK)
-		if err != nil {
-			return &ProviderDealRejectionInfo{
-				HTTPCode: ErrServerInternalError,
-				Reason:   "Server Internal Error",
-			}, xerrors.Errorf("looking up client ID: %w", err)
-		}
-
-		clientID, err := address.IDFromAddress(clientIDAdr)
-		if err != nil {
-			return &ProviderDealRejectionInfo{
-				HTTPCode: ErrBadProposal,
-				Reason:   "Invalid client address",
-			}, nil
-		}
-
-		if alloc.Client != abi.ActorID(clientID) {
-			// Check if maybe allocation was created by the market contract itself
-			contractAddr, err := lethtypes.ParseEthAddress(deal.Products.DDOV1.MarketAddress)
-			if err != nil {
-				log.Errorw("error parsing market address", "market address", deal.Products.DDOV1.MarketAddress, "error", err)
-				return &ProviderDealRejectionInfo{
-					HTTPCode: ErrBadProposal,
-					Reason:   "Market address is not valid",
-				}, nil
-			}
-			fc, err := contractAddr.ToFilecoinAddress()
-			if err != nil {
-				log.Errorw("error converting market address to filecoin address", "market address", deal.Products.DDOV1.MarketAddress, "error", err)
-				return &ProviderDealRejectionInfo{
-					HTTPCode: ErrBadProposal,
-					Reason:   "Market address is not valid filecoin address",
-				}, nil
-			}
-
-			cAdr, err := m.api.StateLookupID(ctx, fc, types.EmptyTSK)
-			if err != nil {
-				return &ProviderDealRejectionInfo{
-					HTTPCode: ErrServerInternalError,
-					Reason:   "Server Internal Error",
-				}, xerrors.Errorf("looking up client ID: %w", err)
-			}
-
-			cID, err := address.IDFromAddress(cAdr)
-			if err != nil {
-				return &ProviderDealRejectionInfo{
-					HTTPCode: ErrBadProposal,
-					Reason:   "Invalid client address",
-				}, nil
-			}
-
-			if alloc.Client != abi.ActorID(cID) {
-				return &ProviderDealRejectionInfo{
-					HTTPCode: ErrBadProposal,
-					Reason:   "client or contract address does not match the allocation client address",
-				}, nil
-			}
-		}
 
 		prov, err := address.NewIDAddress(uint64(alloc.Provider))
 		if err != nil {

--- a/tasks/storage-market/mk20.go
+++ b/tasks/storage-market/mk20.go
@@ -34,6 +34,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/proofs"
 	"github.com/filecoin-project/lotus/chain/types"
+	lethtypes "github.com/filecoin-project/lotus/chain/types/ethtypes"
 	lpiece "github.com/filecoin-project/lotus/storage/pipeline/piece"
 )
 
@@ -1074,10 +1075,39 @@ func (d *CurioStorageDealMarket) processMK20DealIngestion(ctx context.Context) {
 		end := start + abi.ChainEpoch(deal.Duration)
 		var vak *miner.VerifiedAllocationKey
 		if mk20Deal.Products.DDOV1.AllocationId != nil {
+			allocClientID := clientId
 			alloc, err := d.api.StateGetAllocation(ctx, client, verifreg.AllocationId(*mk20Deal.Products.DDOV1.AllocationId), types.EmptyTSK)
 			if err != nil {
 				log.Errorw("failed to get allocation", "deal", deal.ID, "error", err)
 				continue
+			}
+			if alloc == nil && mk20Deal.Products.DDOV1.MarketAddress != "" {
+				contractAddr, perr := lethtypes.ParseEthAddress(mk20Deal.Products.DDOV1.MarketAddress)
+				if perr != nil {
+					log.Errorw("bad market address", "deal", deal.ID, "error", perr)
+					continue
+				}
+				fc, cerr := contractAddr.ToFilecoinAddress()
+				if cerr != nil {
+					log.Errorw("bad market address to filecoin address", "deal", deal.ID, "error", cerr)
+					continue
+				}
+				cAdr, lerr := d.api.StateLookupID(ctx, fc, types.EmptyTSK)
+				if lerr != nil {
+					log.Errorw("failed to lookup contract id", "deal", deal.ID, "error", lerr)
+					continue
+				}
+				cID, ierr := address.IDFromAddress(cAdr)
+				if ierr != nil {
+					log.Errorw("failed to parse contract id", "deal", deal.ID, "error", ierr)
+					continue
+				}
+				alloc, err = d.api.StateGetAllocation(ctx, fc, verifreg.AllocationId(*mk20Deal.Products.DDOV1.AllocationId), types.EmptyTSK)
+				if err != nil {
+					log.Errorw("failed to get allocation via market", "deal", deal.ID, "error", err)
+					continue
+				}
+				allocClientID = cID
 			}
 			if alloc == nil {
 				log.Errorw("allocation not found", "deal", deal.ID, "error", err)
@@ -1089,7 +1119,7 @@ func (d *CurioStorageDealMarket) processMK20DealIngestion(ctx context.Context) {
 			}
 			end = start + alloc.TermMin
 			vak = &miner.VerifiedAllocationKey{
-				Client: abi.ActorID(clientId),
+				Client: abi.ActorID(allocClientID),
 				ID:     verifreg13.AllocationId(*mk20Deal.Products.DDOV1.AllocationId),
 			}
 		}


### PR DESCRIPTION
This pull request improves the handling of verified deal allocations in the MK20 storage market flow, focusing on supporting deals where the allocation may have been created by a market contract rather than the client directly. The changes ensure that allocation lookups correctly handle both client and contract addresses, with improved error handling and code simplification.

**Verified allocation lookup improvements:**

* Updated `sanitizeDDODeal` in `market/mk20/mk20.go` to attempt allocation lookup using the market contract address if the initial client-based lookup fails, and to handle errors more clearly. This simplifies the logic and ensures deals with allocations created by contracts are properly validated.
* Enhanced `processMK20DealIngestion` in `tasks/storage-market/mk20.go` to mirror the contract-based allocation lookup logic, including address parsing, conversion, and error handling. The allocation client ID is now set correctly depending on which address was used to find the allocation. [[1]](diffhunk://#diff-60e8bbe9655d1c27795a05c23c754b9dc095213688d30ad679f398e06cf1895aR1078-R1111) [[2]](diffhunk://#diff-60e8bbe9655d1c27795a05c23c754b9dc095213688d30ad679f398e06cf1895aL1092-R1122)

**Dependency and import updates:**

* Removed an unused import of `verifreg` v16 and ensured only `verifreg9` is used in `market/mk20/mk20.go`.
* Added the `ethtypes` import in `tasks/storage-market/mk20.go` to support Ethereum address conversions.

**Minor code cleanup:**

* Fixed a minor SQL formatting issue in `market/backpressure/backpressure.go` for better readability.