### PR TITLE
Enforce sybil fee payment from client by default

### DIFF
--- a/pdp/handlers_create.go
+++ b/pdp/handlers_create.go
@@ -115,7 +115,7 @@ func (p *PDPService) handleCreateDataSetAndAddPieces(w http.ResponseWriter, r *h
 	tx := types.NewTransaction(
 		0,
 		contract.ContractAddresses().PDPVerifier,
-		contract.SybilFee(),
+		big.NewInt(0),
 		0,
 		nil,
 		data,
@@ -282,7 +282,7 @@ func (p *PDPService) handleCreateDataSet(w http.ResponseWriter, r *http.Request)
 	tx := types.NewTransaction(
 		0,
 		contract.ContractAddresses().PDPVerifier,
-		contract.SybilFee(),
+		big.NewInt(0),
 		0,
 		nil,
 		data,

--- a/pdp/handlers_pull.go
+++ b/pdp/handlers_pull.go
@@ -151,8 +151,8 @@ func (v *EthCallValidator) ValidateAddPieces(ctx context.Context, params *AddPie
 	}
 
 	// Build addPieces calldata
-	// When dataSetId is 0 (create new), use recordKeeper address and sybil fee
-	// When dataSetId > 0 (add to existing), use zero address and no fee
+	// When dataSetId is 0 (create new), use recordKeeper address
+	// When dataSetId > 0 (add to existing), use zero address for listener
 	isCreateNew := params.DataSetId.Cmp(big.NewInt(0)) == 0
 	listenerAddr := common.Address{}
 	if isCreateNew {
@@ -164,12 +164,8 @@ func (v *EthCallValidator) ValidateAddPieces(ctx context.Context, params *AddPie
 		return fmt.Errorf("failed to pack addPieces call: %w", err)
 	}
 
-	// eth_call to validate
+	// eth_call to validate — match tx value used for dataset creation (no sybil fee)
 	value := big.NewInt(0)
-	if isCreateNew {
-		// Sybil fee only required for create-new case
-		value = contract.SybilFee()
-	}
 	msg := ethereum.CallMsg{
 		From:  v.senderAddr,
 		To:    new(contract.ContractAddresses().PDPVerifier),

--- a/tasks/pdp/task_add_data_set.go
+++ b/tasks/pdp/task_add_data_set.go
@@ -3,6 +3,7 @@ package pdp
 import (
 	"context"
 	"errors"
+	"math/big"
 	"strings"
 	"time"
 
@@ -89,7 +90,7 @@ func (p *PDPTaskAddDataSet) Do(taskID harmonytask.TaskID, stillOwned func() bool
 	tx := types.NewTransaction(
 		0,
 		contract.ContractAddresses().PDPVerifier,
-		contract.SybilFee(),
+		big.NewInt(0),
 		0,
 		nil,
 		data,


### PR DESCRIPTION
Closes #1077 

As a refresher for the reviewer we recently changed the FWSS contract to default to charging the client for sybil fees and updated the PDP Verifier to look for this behavior and count it towards sybil fee payment.  This is today the default behavior and solvent clients will pay the sybil fee and the SP will get a refund.  However if client is not solvent and the SP provides the funds for a sybil fee the system will collect this fee from the SP.  If the SP does not include value with the transaction then the dataset creation step will simply error.  

This change stops providing funds and therefore enforces that client always pays sybil fee, protecting SP from abuse.