### PR TITLE
fix(pdp): add missing returns after httpServerError in handlers

### DIFF
--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -174,6 +174,7 @@ func (p *PDPService) handlePing(w http.ResponseWriter, r *http.Request) {
 	_, err := p.AuthService(r)
 	if err != nil {
 		httpServerError(w, http.StatusUnauthorized, "Failed to authorize request", err)
+		return
 	}
 
 	// Return 200 OK
@@ -188,6 +189,7 @@ func (p *PDPService) handleGetPieceStatus(w http.ResponseWriter, r *http.Request
 	serviceLabel, err := p.AuthService(r)
 	if err != nil {
 		httpServerError(w, http.StatusUnauthorized, "Failed to authorize request", err)
+		return
 	}
 
 	// Extract pieceCid from URL and convert to v1 for DB query
@@ -1016,6 +1018,7 @@ func (p *PDPService) handleGetDataSetPiece(w http.ResponseWriter, r *http.Reques
 	serviceLabel, err := p.AuthService(r)
 	if err != nil {
 		httpServerError(w, http.StatusUnauthorized, "Failed to authorize request", err)
+		return
 	}
 
 	// Step 2: Extract and validate parameters

--- a/pdp/handlers_add.go
+++ b/pdp/handlers_add.go
@@ -346,6 +346,7 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		log.Warnf("Failed to process AddPieces request data: %+v", err)
 		httpServerError(w, http.StatusBadRequest, "Failed to process request: "+err.Error(), err)
+		return
 	}
 
 	// Step 5: Prepare the Ethereum transaction data outside the DB transaction
@@ -453,7 +454,6 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 		// Return true to commit the transaction
 		return true, nil
 	}, harmonydb.OptionRetry())
-
 	if err != nil {
 		log.Errorw("Failed to insert into database", "error", err, "txHash", txHashLower, "subPieces", subPieceInfoMap)
 		httpServerError(w, http.StatusInternalServerError, "Internal server error", err)

--- a/pdp/handlers_create.go
+++ b/pdp/handlers_create.go
@@ -160,7 +160,6 @@ func (p *PDPService) handleCreateDataSetAndAddPieces(w http.ResponseWriter, r *h
 
 		return true, err
 	}, harmonydb.OptionRetry())
-
 	if err != nil {
 		log.Errorf("Failed to insert into message_waits_eth, pdp_data_set_piece_adds and pdp_data_set_creates: %+v", err)
 		httpServerError(w, http.StatusInternalServerError, "Internal server error", err)
@@ -314,7 +313,6 @@ func (p *PDPService) handleCreateDataSet(w http.ResponseWriter, r *http.Request)
 
 		return true, nil
 	}, harmonydb.OptionRetry())
-
 	if err != nil {
 		log.Errorf("Failed to insert database tracking records: %+v", err)
 		httpServerError(w, http.StatusInternalServerError, "Internal server error", err)


### PR DESCRIPTION
The `handleAddPieceToDataSet` missing return came up in [Slack](https://filecoinproject.slack.com/archives/C0APZ22SJ2C/p1777560000054389?thread_ts=1777507641.696139&cid=C0APZ22SJ2C) where a user experienced a `Must add at least one piece` error that comes out of PDPVerifier which only triggers when you try to run a tx that has no pieces; which is silly obviously. But it's because there was an earlier error of "can't find your pieces" without an early return and then a filtering of their pieces down to zero of them and on to the transaction. So this adds the missing `return` and a few more (and my editor formatter is insisting on removing the newlines in pdp/handlers_create.go but I think they're a good idea because they localise the error handling).