### PR TITLE
fix(pay): detect rail finalization from getRail revert

### DIFF
--- a/tasks/pay/error_detection.go
+++ b/tasks/pay/error_detection.go
@@ -1,0 +1,35 @@
+package pay
+
+import (
+	"encoding/hex"
+	"strings"
+
+	"github.com/filecoin-project/curio/lib/filecoinpayment"
+)
+
+// ErrSelectorRailInactiveOrSettled is the hex-encoded 4-byte selector for
+// FilecoinPayV1's RailInactiveOrSettled(uint256). Reverts carrying it prove
+// the rail has been finalised and zeroed.
+var ErrSelectorRailInactiveOrSettled string
+
+func init() {
+	parsed, err := filecoinpayment.PaymentsMetaData.GetAbi()
+	if err != nil {
+		panic("failed to parse FilecoinPay Payments ABI: " + err.Error())
+	}
+	e, ok := parsed.Errors["RailInactiveOrSettled"]
+	if !ok {
+		panic("FilecoinPay Payments ABI missing RailInactiveOrSettled error")
+	}
+	ErrSelectorRailInactiveOrSettled = hex.EncodeToString(e.ID[:4])
+}
+
+// IsRailInactiveOrSettledError reports whether err carries the
+// RailInactiveOrSettled revert, proving the rail has been zeroed during
+// finalisation. Distinguishes finalisation from transient RPC errors.
+func IsRailInactiveOrSettledError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "0x"+ErrSelectorRailInactiveOrSettled)
+}

--- a/tasks/pay/watcher.go
+++ b/tasks/pay/watcher.go
@@ -146,13 +146,17 @@ func verifySettle(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthC
 			continue
 		}
 
-		// FilecoinPay zeroes the rail struct atomically with the final settle, so
-		// post-confirm GetRail reverts and the readable EndEpoch==SettledUpTo path
-		// below cannot fire. Treat the revert as finalization when FWSS still maps
-		// the rail and the lockup has elapsed.
+		// FilecoinPay zeroes the rail atomically with the final settle, so
+		// post-confirm GetRail reverts with RailInactiveOrSettled and the readable
+		// EndEpoch==SettledUpTo path below cannot fire. Treat that specific revert
+		// as finalization when FWSS still maps the rail and the lockup has elapsed.
 		if getRailErr != nil {
-			if dataSet.Int64() == 0 {
+			if !IsRailInactiveOrSettledError(getRailErr) {
 				log.Errorw("failed to get rail, skipping termination checks", "railId", railId, "error", getRailErr)
+				continue
+			}
+			if dataSet.Int64() == 0 {
+				log.Errorw("rail finalized but no FWSS dataset mapping, skipping", "railId", railId)
 				continue
 			}
 			finalized, finErr := pipelineFinalizationElapsed(ctx, db, dataSet.Int64(), current)
@@ -161,7 +165,7 @@ func verifySettle(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthC
 				continue
 			}
 			if !finalized {
-				log.Errorw("failed to get rail, skipping termination checks", "railId", railId, "error", getRailErr)
+				log.Warnw("rail finalized on chain but pipeline state not caught up, skipping", "railId", railId, "dataSetId", dataSet.Int64())
 				continue
 			}
 			log.Infow("rail finalized, inferred from getRail revert", "railId", railId, "dataSetId", dataSet.Int64())

--- a/tasks/pay/watcher.go
+++ b/tasks/pay/watcher.go
@@ -138,15 +138,36 @@ func verifySettle(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthC
 	}
 
 	for _, railId := range settle.Rails {
-		view, err := payment.GetRail(contract.EthCallOpts(ctx), big.NewInt(railId))
-		if err != nil {
-			log.Errorw("failed to get rail, skipping termination checks", "railId", railId, "error", err)
+		view, getRailErr := payment.GetRail(contract.EthCallOpts(ctx), big.NewInt(railId))
+
+		dataSet, dsErr := fwssv.RailToDataSet(contract.EthCallOpts(ctx), big.NewInt(railId))
+		if dsErr != nil {
+			log.Errorw("failed to get rail to data set, skipping termination checks", "railId", railId, "error", dsErr)
 			continue
 		}
 
-		dataSet, err := fwssv.RailToDataSet(contract.EthCallOpts(ctx), big.NewInt(railId))
-		if err != nil {
-			log.Errorw("failed to get rail to data set, skipping termination checks", "railId", railId, "error", err)
+		// FilecoinPay zeroes the rail struct atomically with the final settle, so
+		// post-confirm GetRail reverts and the readable EndEpoch==SettledUpTo path
+		// below cannot fire. Treat the revert as finalization when FWSS still maps
+		// the rail and the lockup has elapsed.
+		if getRailErr != nil {
+			if dataSet.Int64() == 0 {
+				log.Errorw("failed to get rail, skipping termination checks", "railId", railId, "error", getRailErr)
+				continue
+			}
+			finalized, finErr := pipelineFinalizationElapsed(ctx, db, dataSet.Int64(), current)
+			if finErr != nil {
+				log.Warnw("failed to check deletion pipeline state, skipping", "railId", railId, "dataSetId", dataSet.Int64(), "error", finErr)
+				continue
+			}
+			if !finalized {
+				log.Errorw("failed to get rail, skipping termination checks", "railId", railId, "error", getRailErr)
+				continue
+			}
+			log.Infow("rail finalized, inferred from getRail revert", "railId", railId, "dataSetId", dataSet.Int64())
+			if err := ensureDataSetDeletion(ctx, db, dataSet.Int64()); err != nil {
+				return err
+			}
 			continue
 		}
 
@@ -207,4 +228,27 @@ func ensureDataSetDeletion(ctx context.Context, db *harmonydb.DB, dataSetID int6
 		return xerrors.Errorf("expected to update 1 row, updated %d", n)
 	}
 	return nil
+}
+
+// pipelineFinalizationElapsed reports whether after_terminate_service is set
+// and service_termination_epoch (pdpEndEpoch) has elapsed. With both met, a
+// GetRail revert on the rail uniquely indicates finalization.
+func pipelineFinalizationElapsed(ctx context.Context, db *harmonydb.DB, dataSetID int64, current uint64) (bool, error) {
+	type row struct {
+		Epoch *int64 `db:"service_termination_epoch"`
+		After bool   `db:"after_terminate_service"`
+	}
+	var rows []row
+	err := db.Select(ctx, &rows, `
+		SELECT service_termination_epoch, after_terminate_service
+		FROM pdp_delete_data_set
+		WHERE id = $1
+	`, dataSetID)
+	if err != nil {
+		return false, xerrors.Errorf("query pdp_delete_data_set: %w", err)
+	}
+	if len(rows) == 0 || !rows[0].After || rows[0].Epoch == nil {
+		return false, nil
+	}
+	return uint64(*rows[0].Epoch) <= current, nil
 }


### PR DESCRIPTION
FilecoinPay zeroes the rail struct atomically with the settle that brings settledUpTo to endEpoch, so post-confirm getRail reverts and the existing EndEpoch == SettledUpTo observation never fires. deletion_allowed is never set and DeleteDataSetTask never runs.

Treat a getRail revert as finalization when pdp_delete_data_set shows after_terminate_service = TRUE and service_termination_epoch <= current. With both met, finalization is the only explanation for the revert.

---

This comes from observation; we have **zero** properly deleted data sets in PDPVerifier on mainnet out of out of 482 and 1 out of 6716 on calibnet and it's not FWSS mediated ([ref](https://filecoinproject.slack.com/archives/C08TVNKJV7C/p1777564051017669)).

* `settleRailInternal` has a special case for terminated rails that are not zeroed (I can't find a path into this branch, maybe it's just an invariant guard) https://github.com/FilOzone/filecoin-pay/blob/2f4c9a3486f8c61d04fff127e6479f7b0483e2e0/src/FilecoinPayV1.sol#L1220-L1221
* `settleRailInternal` in the normal last-settlement pass should hit `checkAndFinalizeTerminatedRail` https://github.com/FilOzone/filecoin-pay/blob/2f4c9a3486f8c61d04fff127e6479f7b0483e2e0/src/FilecoinPayV1.sol#L1270
* `checkAndFinalizeTerminatedRail` will finalize if this was the final settlement: https://github.com/FilOzone/filecoin-pay/blob/2f4c9a3486f8c61d04fff127e6479f7b0483e2e0/src/FilecoinPayV1.sol#L1287-L1288
* `finalizeTerminatedRail` will `_zeroOutRail` https://github.com/FilOzone/filecoin-pay/blob/2f4c9a3486f8c61d04fff127e6479f7b0483e2e0/src/FilecoinPayV1.sol#L1295
* `_zeroOutRail` is pretty brutal and sets everything to their uninitialised values: https://github.com/FilOzone/filecoin-pay/blob/2f4c9a3486f8c61d04fff127e6479f7b0483e2e0/src/FilecoinPayV1.sol#L1618-L1628

The reason this is a problem for us here is that the `payment.GetRail` call we're making in tasks/pay/watcher.go is gated by an address != 0 check: https://github.com/FilOzone/filecoin-pay/blob/2f4c9a3486f8c61d04fff127e6479f7b0483e2e0/src/FilecoinPayV1.sol#L1576 so it reverts and we get an `err` and don't continue.