### PR TITLE
feat: robusthttp ssrf config

### DIFF
--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -433,6 +433,29 @@ Updates will affect running instances.`,
 Unlike lotus-miner, there is no fallback to PoRep when no snap sectors are available.
 When enabled, all deals will be processed as snap deals. (Default: false)`,
 		},
+		{
+			Name: "DisableSSRFProtection",
+			Type: "bool",
+
+			Comment: `DisableSSRFProtection disables all SSRF (Server-Side Request Forgery) protection
+on deal data URL fetching. When true, URLs pointing to private IPs, loopback
+addresses, and local hostnames are allowed. URL structure validation (scheme,
+control characters) is still enforced.
+WARNING: Only enable in development or testing environments. (Default: false)
+Updates will affect running instances.`,
+		},
+		{
+			Name: "SSRFAllowedHosts",
+			Type: "[]string",
+
+			Comment: `SSRFAllowedHosts is a list of hosts or host:port pairs that are allowed through
+SSRF protection. Matched hosts bypass IP and hostname restrictions while other
+safety checks (URL scheme, headers) remain active.
+Entries without a port match any port for that host.
+Example: ["192.168.1.100:8080", "my-dev-server.local"]
+(Default: [])
+Updates will affect running instances.`,
+		},
 	},
 	"CurioProvingConfig": {
 		{

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -71,6 +71,9 @@ func DefaultCurioConfig() *CurioConfig {
 			MaxQueueSnapProve:  NewDynamic(0),
 
 			MaxDealWaitTime: NewDynamic(time.Hour),
+
+			DisableSSRFProtection: NewDynamic(false),
+			SSRFAllowedHosts:      NewDynamic([]string{}),
 		},
 		Alerting: CurioAlertingConfig{
 			MinimumWalletBalance: types.MustParseFIL("5"),
@@ -612,6 +615,23 @@ type CurioIngestConfig struct {
 	// Unlike lotus-miner, there is no fallback to PoRep when no snap sectors are available.
 	// When enabled, all deals will be processed as snap deals. (Default: false)
 	DoSnap bool
+
+	// DisableSSRFProtection disables all SSRF (Server-Side Request Forgery) protection
+	// on deal data URL fetching. When true, URLs pointing to private IPs, loopback
+	// addresses, and local hostnames are allowed. URL structure validation (scheme,
+	// control characters) is still enforced.
+	// WARNING: Only enable in development or testing environments. (Default: false)
+	// Updates will affect running instances.
+	DisableSSRFProtection *Dynamic[bool]
+
+	// SSRFAllowedHosts is a list of hosts or host:port pairs that are allowed through
+	// SSRF protection. Matched hosts bypass IP and hostname restrictions while other
+	// safety checks (URL scheme, headers) remain active.
+	// Entries without a port match any port for that host.
+	// Example: ["192.168.1.100:8080", "my-dev-server.local"]
+	// (Default: [])
+	// Updates will affect running instances.
+	SSRFAllowedHosts *Dynamic[[]string]
 }
 
 type CurioAlertingConfig struct {

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -43,6 +43,7 @@ import (
 	"github.com/filecoin-project/curio/lib/paths"
 	"github.com/filecoin-project/curio/lib/pieceprovider"
 	"github.com/filecoin-project/curio/lib/repo"
+	"github.com/filecoin-project/curio/lib/robusthttp"
 	"github.com/filecoin-project/curio/lib/storiface"
 	"github.com/filecoin-project/curio/market/indexstore"
 	"github.com/filecoin-project/curio/market/ipni/chunker"
@@ -224,6 +225,32 @@ func (deps *Deps) PopulateRemainingDeps(ctx context.Context, cctx *cli.Context, 
 	}
 
 	log.Debugw("config", "config", deps.Cfg)
+
+	// Wire SSRF policy override from config so that all nil-policy callers
+	// (deal data fetchers, proposal validators) pick up the operator settings.
+	applySSRFOverride := func() {
+		disabled := deps.Cfg.Ingest.DisableSSRFProtection.Get()
+		hosts := deps.Cfg.Ingest.SSRFAllowedHosts.Get()
+		if !disabled && len(hosts) == 0 {
+			robusthttp.SetGlobalSSRFOverride(nil)
+			return
+		}
+		robusthttp.SetGlobalSSRFOverride(&robusthttp.SSRFPolicy{
+			Disabled:            disabled,
+			AllowLoopbackIPs:    disabled,
+			AllowLocalHostnames: disabled,
+			AllowPrivateIPs:     disabled,
+			AllowedHosts:        hosts,
+		})
+		if disabled {
+			log.Warnw("SSRF protection is disabled — do not use in production")
+		} else {
+			log.Infow("SSRF allowed hosts configured", "hosts", hosts)
+		}
+	}
+	applySSRFOverride()
+	deps.Cfg.Ingest.DisableSSRFProtection.OnChange(applySSRFOverride)
+	deps.Cfg.Ingest.SSRFAllowedHosts.OnChange(applySSRFOverride)
 
 	if deps.Verif == nil {
 		deps.Verif = ffiwrapper.ProofVerifier

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -939,6 +939,27 @@ description: The default curio configuration
   # type: bool
   #DoSnap = false
 
+  # DisableSSRFProtection disables all SSRF (Server-Side Request Forgery) protection
+  # on deal data URL fetching. When true, URLs pointing to private IPs, loopback
+  # addresses, and local hostnames are allowed. URL structure validation (scheme,
+  # control characters) is still enforced.
+  # WARNING: Only enable in development or testing environments. (Default: false)
+  # Updates will affect running instances.
+  #
+  # type: bool
+  #DisableSSRFProtection = false
+
+  # SSRFAllowedHosts is a list of hosts or host:port pairs that are allowed through
+  # SSRF protection. Matched hosts bypass IP and hostname restrictions while other
+  # safety checks (URL scheme, headers) remain active.
+  # Entries without a port match any port for that host.
+  # Example: ["192.168.1.100:8080", "my-dev-server.local"]
+  # (Default: [])
+  # Updates will affect running instances.
+  #
+  # type: []string
+  #SSRFAllowedHosts = []
+
 
 # Seal defines the configuration related to the sealing process in Curio.
 #

--- a/lib/robusthttp/ssrf.go
+++ b/lib/robusthttp/ssrf.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -26,6 +27,15 @@ type SSRFPolicy struct {
 
 	AllowLoopbackIPs    bool
 	AllowLocalHostnames bool
+	AllowPrivateIPs     bool
+
+	// AllowedHosts is a list of host or host:port entries that bypass IP and
+	// hostname validation. Entries without a port match any port for that host.
+	AllowedHosts []string
+
+	// Disabled skips all SSRF host/IP/header validation. URL structure checks
+	// (scheme, control characters) are still enforced.
+	Disabled bool
 }
 
 func DefaultSSRFPolicy() SSRFPolicy {
@@ -40,10 +50,19 @@ func DefaultSSRFPolicy() SSRFPolicy {
 	}
 }
 
+var globalSSRFOverride atomic.Pointer[SSRFPolicy]
+
+// SetGlobalSSRFOverride installs a fallback SSRFPolicy that is used whenever
+// a caller passes a nil policy. Call with nil to clear the override.
+func SetGlobalSSRFOverride(p *SSRFPolicy) {
+	globalSSRFOverride.Store(p)
+}
+
 // ValidateClientFetchURL is for early deal/proposal validation.
 func ValidateClientFetchURL(raw string, headers http.Header, policy *SSRFPolicy) (*url.URL, error) {
 	policy = withSSRFDefaults(policy)
 
+	// Always validate basic URL structure.
 	if raw == "" {
 		return nil, errors.New("url is empty")
 	}
@@ -68,19 +87,29 @@ func ValidateClientFetchURL(raw string, headers http.Header, policy *SSRFPolicy)
 	}
 	u.Scheme = scheme
 
-	host := u.Hostname()
-	if err := validateFetchHostSyntax(host, policy); err != nil {
-		return nil, err
+	if policy.Disabled {
+		return u, nil
 	}
 
-	if _, err := normalizedFetchPort(u); err != nil {
+	host := u.Hostname()
+	port, err := normalizedFetchPort(u)
+	if err != nil {
 		return nil, err
+	}
+	allowed := isHostAllowed(host, port, policy.AllowedHosts)
+
+	if !allowed {
+		if err := validateFetchHostSyntax(host, policy); err != nil {
+			return nil, err
+		}
 	}
 
 	// Catch unsafe IP literals early. DNS names are checked at dial time.
-	if ip, err := netip.ParseAddr(host); err == nil {
-		if err := validateFetchIP(ip, policy); err != nil {
-			return nil, err
+	if !allowed {
+		if ip, err := netip.ParseAddr(host); err == nil {
+			if err := validateFetchIP(ip, policy); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -184,11 +213,23 @@ func ssrfSafeDial(ctx context.Context, network, addr string, policy *SSRFPolicy)
 	if err != nil {
 		return nil, xerrors.Errorf("split dial address: %w", err)
 	}
+
+	dialer := net.Dialer{Timeout: policy.DialTimeout, KeepAlive: 30 * time.Second}
+
+	if policy.Disabled {
+		return dialer.DialContext(ctx, network, addr)
+	}
+
 	if err := validateFetchPort(port); err != nil {
 		return nil, err
 	}
-	if err := validateFetchHostSyntax(host, policy); err != nil {
-		return nil, err
+
+	allowed := isHostAllowed(host, port, policy.AllowedHosts)
+
+	if !allowed {
+		if err := validateFetchHostSyntax(host, policy); err != nil {
+			return nil, err
+		}
 	}
 
 	ips, err := resolveFetchHost(ctx, host)
@@ -199,13 +240,13 @@ func ssrfSafeDial(ctx context.Context, network, addr string, policy *SSRFPolicy)
 		return nil, xerrors.Errorf("host %q resolved to no addresses", host)
 	}
 
-	for _, ip := range ips {
-		if err := validateFetchIP(ip, policy); err != nil {
-			return nil, xerrors.Errorf("unsafe resolved address %s for %q: %w", ip, host, err)
+	if !allowed {
+		for _, ip := range ips {
+			if err := validateFetchIP(ip, policy); err != nil {
+				return nil, xerrors.Errorf("unsafe resolved address %s for %q: %w", ip, host, err)
+			}
 		}
 	}
-
-	dialer := net.Dialer{Timeout: policy.DialTimeout, KeepAlive: 30 * time.Second}
 
 	var lastErr error
 	for _, ip := range ips {
@@ -274,15 +315,26 @@ func validateFetchIP(ip netip.Addr, policy *SSRFPolicy) error {
 		return xerrors.Errorf("non-public ip %s is not allowed", ip)
 	}
 	if ip.IsPrivate() {
+		if policy.AllowPrivateIPs {
+			return nil
+		}
 		return xerrors.Errorf("non-public ip %s is not allowed", ip)
 	}
-	if ip.IsUnspecified() || ip.IsLinkLocalUnicast() || ip.IsMulticast() {
+	if ip.IsLinkLocalUnicast() {
+		if policy.AllowPrivateIPs {
+			return nil
+		}
+		return xerrors.Errorf("non-public ip %s is not allowed", ip)
+	}
+	if ip.IsUnspecified() || ip.IsMulticast() {
 		return xerrors.Errorf("non-public ip %s is not allowed", ip)
 	}
 
-	for _, p := range forbiddenFetchPrefixes {
-		if p.Contains(ip) {
-			return xerrors.Errorf("forbidden ip range %s", p)
+	if !policy.AllowPrivateIPs {
+		for _, p := range forbiddenFetchPrefixes {
+			if p.Contains(ip) {
+				return xerrors.Errorf("forbidden ip range %s", p)
+			}
 		}
 	}
 
@@ -313,6 +365,25 @@ var forbiddenFetchPrefixes = []netip.Prefix{
 	netip.MustParsePrefix("fc00::/7"),
 	netip.MustParsePrefix("fe80::/10"),
 	netip.MustParsePrefix("ff00::/8"),
+}
+
+// isHostAllowed reports whether host:port is covered by any entry in the
+// allow-list. Entries may be "host" (matches any port) or "host:port".
+func isHostAllowed(host, port string, allowed []string) bool {
+	for _, entry := range allowed {
+		eHost, ePort, err := net.SplitHostPort(entry)
+		if err != nil {
+			// No port in entry — match any port for this host.
+			if strings.EqualFold(host, entry) {
+				return true
+			}
+			continue
+		}
+		if strings.EqualFold(host, eHost) && port == ePort {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizedFetchPort(u *url.URL) (string, error) {
@@ -352,7 +423,11 @@ func withSSRFDefaults(p *SSRFPolicy) *SSRFPolicy {
 	d := DefaultSSRFPolicy()
 
 	if p == nil {
-		return &d
+		if override := globalSSRFOverride.Load(); override != nil {
+			p = override
+		} else {
+			return &d
+		}
 	}
 
 	cfg := *p


### PR DESCRIPTION
I have a dev cluster on calib where data is fetched from a service on the same machine, the protections make that setup really annoying