### PR TITLE
GUI shows per-machine build Git commit hash

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -82,3 +82,12 @@ func CommitIDPrefix() string {
 	}
 	return rest
 }
+
+// ClusterMachineVersionLabel returns the dotted release (BuildVersion) plus an optional short git hash for cluster UI, e.g. "1.27.4 abcdef1".
+func ClusterMachineVersionLabel() string {
+	v := BuildVersion
+	if g := CommitIDPrefix(); g != "" {
+		return v + " " + g
+	}
+	return v
+}

--- a/build/version.go
+++ b/build/version.go
@@ -65,3 +65,20 @@ func UserVersion() string {
 	}
 	return BuildVersion + BuildTypeString() + CurrentCommit
 }
+
+// CommitIDPrefix returns the first 7 characters of the git commit id embedded in
+// CurrentCommit (+git_<hash>_<committer ISO time>). Empty when no commit segment is present.
+func CommitIDPrefix() string {
+	const pfx = "+git_"
+	if !strings.HasPrefix(CurrentCommit, pfx) {
+		return ""
+	}
+	rest := strings.TrimPrefix(CurrentCommit, pfx)
+	if i := strings.Index(rest, "_"); i >= 0 {
+		rest = rest[:i]
+	}
+	if len(rest) > 7 {
+		return rest[:7]
+	}
+	return rest
+}

--- a/build/version_test.go
+++ b/build/version_test.go
@@ -13,3 +13,21 @@ func TestBuildVersionNotZero(t *testing.T) {
 		t.Fatal("BuildVersion should not be empty")
 	}
 }
+
+func TestCommitIDPrefix(t *testing.T) {
+	saved := CurrentCommit
+	t.Cleanup(func() { CurrentCommit = saved })
+
+	CurrentCommit = "+git_abcdef12345678_2024-01-01T00:00:00Z"
+	if got := CommitIDPrefix(); got != "abcdef1" {
+		t.Fatalf("got %q want abcdef1", got)
+	}
+	CurrentCommit = "+git_abcd_2024-01-01T00:00:00Z"
+	if got := CommitIDPrefix(); got != "abcd" {
+		t.Fatalf("got %q want abcd", got)
+	}
+	CurrentCommit = ""
+	if got := CommitIDPrefix(); got != "" {
+		t.Fatalf("got %q want empty", got)
+	}
+}

--- a/build/version_test.go
+++ b/build/version_test.go
@@ -31,3 +31,17 @@ func TestCommitIDPrefix(t *testing.T) {
 		t.Fatalf("got %q want empty", got)
 	}
 }
+
+func TestClusterMachineVersionLabel(t *testing.T) {
+	saved := CurrentCommit
+	t.Cleanup(func() { CurrentCommit = saved })
+
+	CurrentCommit = "+git_abcdef12345678_2024-01-01T00:00:00Z"
+	if got := ClusterMachineVersionLabel(); got != BuildVersion+" abcdef1" {
+		t.Fatalf("got %q want %q + abcdef1", got, BuildVersion)
+	}
+	CurrentCommit = ""
+	if got := ClusterMachineVersionLabel(); got != BuildVersion {
+		t.Fatalf("got %q want %q", got, BuildVersion)
+	}
+}

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -586,7 +586,7 @@ func machineDetails(deps *deps.Deps, activeTasks []harmonytask.TaskInterface, ma
 		(tasks, layers, startup_time, miners, machine_id, machine_name, version) VALUES ($1, $2, $3, $4, $5, $6, $7)
 		ON CONFLICT (machine_id) DO UPDATE SET tasks=$1, layers=$2, startup_time=$3, miners=$4, machine_id=$5, machine_name=$6, version=$7`,
 			strings.Join(taskNames, ","), strings.Join(deps.Layers, ","),
-			time.Now(), strings.Join(miners, ","), machineID, machineName, curiobuild.UserVersion())
+			time.Now(), strings.Join(miners, ","), machineID, machineName, curiobuild.CommitIDPrefix())
 
 		if err != nil {
 			log.Errorf("failed to update machine details: %s", err)

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/filecoin-project/curio/alertmanager"
 	"github.com/filecoin-project/curio/api"
+	curiobuild "github.com/filecoin-project/curio/build"
 	"github.com/filecoin-project/curio/cuhttp"
 	"github.com/filecoin-project/curio/deps"
 	"github.com/filecoin-project/curio/deps/config"
@@ -582,10 +583,10 @@ func machineDetails(deps *deps.Deps, activeTasks []harmonytask.TaskInterface, ma
 		sort.Strings(miners)
 
 		_, err := deps.DB.Exec(context.Background(), `INSERT INTO harmony_machine_details 
-		(tasks, layers, startup_time, miners, machine_id, machine_name) VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (machine_id) DO UPDATE SET tasks=$1, layers=$2, startup_time=$3, miners=$4, machine_id=$5, machine_name=$6`,
+		(tasks, layers, startup_time, miners, machine_id, machine_name, version) VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (machine_id) DO UPDATE SET tasks=$1, layers=$2, startup_time=$3, miners=$4, machine_id=$5, machine_name=$6, version=$7`,
 			strings.Join(taskNames, ","), strings.Join(deps.Layers, ","),
-			time.Now(), strings.Join(miners, ","), machineID, machineName)
+			time.Now(), strings.Join(miners, ","), machineID, machineName, curiobuild.UserVersion())
 
 		if err != nil {
 			log.Errorf("failed to update machine details: %s", err)

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -586,7 +586,7 @@ func machineDetails(deps *deps.Deps, activeTasks []harmonytask.TaskInterface, ma
 		(tasks, layers, startup_time, miners, machine_id, machine_name, version) VALUES ($1, $2, $3, $4, $5, $6, $7)
 		ON CONFLICT (machine_id) DO UPDATE SET tasks=$1, layers=$2, startup_time=$3, miners=$4, machine_id=$5, machine_name=$6, version=$7`,
 			strings.Join(taskNames, ","), strings.Join(deps.Layers, ","),
-			time.Now(), strings.Join(miners, ","), machineID, machineName, curiobuild.CommitIDPrefix())
+			time.Now(), strings.Join(miners, ","), machineID, machineName, curiobuild.ClusterMachineVersionLabel())
 
 		if err != nil {
 			log.Errorf("failed to update machine details: %s", err)

--- a/harmony/harmonydb/sql/20260501-machine-detail-version.sql
+++ b/harmony/harmonydb/sql/20260501-machine-detail-version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE harmony_machine_details ADD COLUMN IF NOT EXISTS version TEXT;

--- a/web/api/webrpc/cluster.go
+++ b/web/api/webrpc/cluster.go
@@ -2,6 +2,7 @@ package webrpc
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,6 +27,7 @@ type MachineSummary struct {
 	Gpu            int
 	Layers         string
 	Uptime         string
+	Version        string
 	Unschedulable  bool
 	RestartRequest string
 	Restarting     bool
@@ -47,7 +49,8 @@ func (a *WebRPC) ClusterMachines(ctx context.Context) ([]MachineSummary, error) 
 							hmd.machine_name,
 							hmd.tasks,
 							hmd.layers,
-							hmd.startup_time
+							hmd.startup_time,
+							hmd.version
 						FROM 
 							harmony_machines hm
 						LEFT JOIN 
@@ -66,9 +69,13 @@ func (a *WebRPC) ClusterMachines(ctx context.Context) ([]MachineSummary, error) 
 		var ram int64
 		var uptime time.Time
 		var restartRequest *time.Time
+		var version sql.NullString
 
-		if err := rows.Scan(&m.ID, &m.Address, &lastContact, &m.Cpu, &ram, &m.Gpu, &m.Unschedulable, &restartRequest, &m.Name, &m.Tasks, &m.Layers, &uptime); err != nil {
+		if err := rows.Scan(&m.ID, &m.Address, &lastContact, &m.Cpu, &ram, &m.Gpu, &m.Unschedulable, &restartRequest, &m.Name, &m.Tasks, &m.Layers, &uptime, &version); err != nil {
 			return nil, err // Handle error
+		}
+		if version.Valid {
+			m.Version = version.String
 		}
 		m.SinceContact = lastContact.Round(time.Second).String()
 		m.RamHumanized = humanize.Bytes(uint64(ram))

--- a/web/static/cluster-machines.mjs
+++ b/web/static/cluster-machines.mjs
@@ -84,6 +84,7 @@ customElements.define('cluster-machines', class ClusterMachines extends LitEleme
                                         : ''
                                     }
                                     <th>Last Contact</th>
+                                    <th>Version</th>
                                     <th>Uptime</th>
                                     <th>Scheduling</th>
                                     ${
@@ -118,6 +119,7 @@ customElements.define('cluster-machines', class ClusterMachines extends LitEleme
                                         : ''
                                     }
                                     <td>${item.SinceContact}</td>
+                                    <td>${item.Version ?? ''}</td>
                                     <td>${item.Uptime}</td>
 
                                     <td style="white-space: nowrap;">

--- a/web/static/cluster-machines.mjs
+++ b/web/static/cluster-machines.mjs
@@ -9,8 +9,7 @@ customElements.define('cluster-machines', class ClusterMachines extends LitEleme
 
     static styles = css`
         .col-build-git {
-            width: 10rem;
-            max-width: 10rem;
+            max-width: 20rem;
             min-width: 0;
             overflow-x: auto;
             overflow-y: hidden;

--- a/web/static/cluster-machines.mjs
+++ b/web/static/cluster-machines.mjs
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
+import { LitElement, css, html } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
 import RPCCall from '/lib/jsonrpc.mjs';
 
 customElements.define('cluster-machines', class ClusterMachines extends LitElement {
@@ -6,6 +6,18 @@ customElements.define('cluster-machines', class ClusterMachines extends LitEleme
         data: { type: Array },
         detailed: { type: Boolean }
     };
+
+    static styles = css`
+        .col-build-git {
+            width: 10rem;
+            max-width: 10rem;
+            min-width: 0;
+            overflow-x: auto;
+            overflow-y: hidden;
+            white-space: nowrap;
+            vertical-align: middle;
+        }
+    `;
 
     constructor() {
         super();
@@ -84,7 +96,7 @@ customElements.define('cluster-machines', class ClusterMachines extends LitEleme
                                         : ''
                                     }
                                     <th>Last Contact</th>
-                                    <th>Version</th>
+                                    <th class="col-build-git">Build's Git</th>
                                     <th>Uptime</th>
                                     <th>Scheduling</th>
                                     ${
@@ -119,7 +131,7 @@ customElements.define('cluster-machines', class ClusterMachines extends LitEleme
                                         : ''
                                     }
                                     <td>${item.SinceContact}</td>
-                                    <td>${item.Version ?? ''}</td>
+                                    <td class="col-build-git">${item.Version ?? ''}</td>
                                     <td>${item.Uptime}</td>
 
                                     <td style="white-space: nowrap;">


### PR DESCRIPTION
The Cluster Machines GUI would be more helpful if it included the per-machine Curio git hash. That way during "upgrade day" it would be clear what's done & what's not. 
Completes: https://github.com/filecoin-project/curio/issues/1193
