### PR TITLE
fix(pdp): race-safe parked_pieces upsert

### DIFF
--- a/itests/park_piece_test.go
+++ b/itests/park_piece_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/lib/ffi"
+	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/lib/paths"
 	"github.com/filecoin-project/curio/lib/storiface"
 	"github.com/filecoin-project/curio/tasks/piece"
@@ -79,6 +81,430 @@ func TestParkPieceCanAccept_SliceBounds(t *testing.T) {
 	accepted, err = ppt.CanAccept(ids, engine)
 	require.NoError(t, err)
 	require.Nil(t, accepted, "should reject all when at capacity")
+}
+
+// TestParkedPiecesActivePieceKey is a regression guard for the
+// parked_pieces_active_piece_key partial unique index and the parkpiece
+// upsert helpers. The index enforces at most one row per
+// (piece_cid, piece_padded_size, long_term) where cleanup_task_id IS NULL.
+// Loosening it reintroduces the check-then-insert race that produced
+// duplicate rows in production (see task_fix_park_piece_unique.go for the
+// legacy cleanup).
+//
+// Subtests are grouped: NEGATIVE (must fail / preserve invariant),
+// POSITIVE (outside the index predicate, must succeed), HELPER
+// (parkpiece.Upsert / UpsertSkip behaviour).
+func TestParkedPiecesActivePieceKey(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	require.True(t, parkedPieceIndexExists(t, ctx, db),
+		"parked_pieces_active_piece_key must be present and well-formed for these tests to mean anything")
+
+	rawInsert := func(cid string, paddedSize, rawSize int64, longTerm bool) error {
+		_, err := db.Exec(ctx, `
+			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+			VALUES ($1, $2, $3, $4)
+		`, cid, paddedSize, rawSize, longTerm)
+		return err
+	}
+	countByCID := func(cid string) int {
+		var n int
+		require.NoError(t, db.QueryRow(ctx, `SELECT COUNT(*) FROM parked_pieces WHERE piece_cid = $1`, cid).Scan(&n))
+		return n
+	}
+	activeCountByCID := func(cid string) int {
+		var n int
+		require.NoError(t, db.QueryRow(ctx,
+			`SELECT COUNT(*) FROM parked_pieces WHERE piece_cid = $1 AND cleanup_task_id IS NULL`,
+			cid).Scan(&n))
+		return n
+	}
+	// assertNoActiveDuplicates is the global invariant: across the entire
+	// parked_pieces table, no (piece_cid, piece_padded_size, long_term)
+	// triple may have more than one row with cleanup_task_id IS NULL.
+	assertNoActiveDuplicates := func(t *testing.T) {
+		t.Helper()
+		var dupes int
+		require.NoError(t, db.QueryRow(ctx, `
+			SELECT COUNT(*) FROM (
+				SELECT piece_cid, piece_padded_size, long_term
+				FROM parked_pieces
+				WHERE cleanup_task_id IS NULL
+				GROUP BY 1, 2, 3
+				HAVING COUNT(*) > 1
+			) AS d`).Scan(&dupes))
+		require.Equal(t, 0, dupes, "table-wide invariant violated: active duplicates exist")
+	}
+
+	// NEGATIVE: must fail or preserve the invariant.
+
+	t.Run("DirectDuplicateInsertFails", func(t *testing.T) {
+		const cid = "test-direct-duplicate"
+		require.NoError(t, rawInsert(cid, 32, 16, true))
+		err := rawInsert(cid, 32, 16, true)
+		require.Error(t, err)
+		require.True(t, harmonydb.IsErrUniqueContraint(err), "expected unique-violation, got %v", err)
+		require.Equal(t, 1, countByCID(cid))
+	})
+
+	t.Run("DifferentRawSizeStillFails", func(t *testing.T) {
+		// piece_raw_size is NOT in the index key; same (cid, padded, long_term) must still conflict.
+		const cid = "test-different-rawsize"
+		require.NoError(t, rawInsert(cid, 32, 10, true))
+		require.Error(t, rawInsert(cid, 32, 20, true))
+		require.Equal(t, 1, countByCID(cid))
+	})
+
+	t.Run("DifferentSkipStillFails", func(t *testing.T) {
+		const cid = "test-different-skip"
+		_, err := db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
+			VALUES ($1, 32, 16, TRUE, FALSE)`, cid)
+		require.NoError(t, err)
+		_, err = db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
+			VALUES ($1, 32, 16, TRUE, TRUE)`, cid)
+		require.Error(t, err)
+		require.Equal(t, 1, countByCID(cid))
+	})
+
+	t.Run("DifferentCompleteStillFails", func(t *testing.T) {
+		const cid = "test-different-complete"
+		_, err := db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, complete)
+			VALUES ($1, 32, 16, TRUE, FALSE)`, cid)
+		require.NoError(t, err)
+		_, err = db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, complete)
+			VALUES ($1, 32, 16, TRUE, TRUE)`, cid)
+		require.Error(t, err)
+		require.Equal(t, 1, countByCID(cid))
+	})
+
+	t.Run("MultiRowInsertWithInternalDuplicateFails", func(t *testing.T) {
+		// Two duplicates inside a single INSERT statement. Atomic - neither row should land.
+		const cid = "test-multirow-duplicate"
+		_, err := db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+			VALUES ($1, 32, 16, TRUE), ($1, 32, 16, TRUE)`, cid)
+		require.Error(t, err)
+		require.Equal(t, 0, countByCID(cid))
+	})
+
+	t.Run("InsertFromSelectFails", func(t *testing.T) {
+		// INSERT ... SELECT does not get to bypass the index.
+		const cid = "test-insert-from-select"
+		require.NoError(t, rawInsert(cid, 32, 16, true))
+		_, err := db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+			SELECT piece_cid, piece_padded_size, piece_raw_size, long_term FROM parked_pieces WHERE piece_cid = $1`, cid)
+		require.Error(t, err)
+		require.Equal(t, 1, countByCID(cid))
+	})
+
+	t.Run("UpdateToReintroduceConflictFails", func(t *testing.T) {
+		// A live row plus a cleanup-marked sibling can coexist. Clearing the
+		// cleanup_task_id on the sibling would create two live rows; the
+		// index must reject that UPDATE.
+		const cid = "test-update-reintroduce"
+		liveID := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, nil)
+		cleanupTaskID := int64(8888)
+		cleanupID := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, &cleanupTaskID)
+		require.NotEqual(t, liveID, cleanupID)
+		_, err := db.Exec(ctx, `UPDATE parked_pieces SET cleanup_task_id = NULL WHERE id = $1`, cleanupID)
+		require.Error(t, err, "UPDATE that produces a duplicate live row must fail")
+	})
+
+	t.Run("DifferentTaskIDStillFails", func(t *testing.T) {
+		// task_id (the work-task pointer) is NOT cleanup_task_id. Two rows
+		// with different task_id but cleanup_task_id NULL on both must still
+		// collide on the partial index.
+		const cid = "test-different-taskid"
+		_, err := db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, task_id)
+			VALUES ($1, 32, 16, TRUE, 100)`, cid)
+		require.NoError(t, err)
+		_, err = db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, task_id)
+			VALUES ($1, 32, 16, TRUE, 200)`, cid)
+		require.Error(t, err)
+		require.Equal(t, 1, activeCountByCID(cid))
+	})
+
+	t.Run("ExplicitNullCleanupTaskIDStillFails", func(t *testing.T) {
+		// Spelling cleanup_task_id = NULL explicitly must behave the same as the default.
+		const cid = "test-explicit-null-cleanup"
+		_, err := db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, cleanup_task_id)
+			VALUES ($1, 32, 16, TRUE, NULL)`, cid)
+		require.NoError(t, err)
+		_, err = db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, cleanup_task_id)
+			VALUES ($1, 32, 16, TRUE, NULL)`, cid)
+		require.Error(t, err)
+		require.Equal(t, 1, activeCountByCID(cid))
+	})
+
+	t.Run("OldFourColumnInferenceClauseErrors", func(t *testing.T) {
+		// The pre-2026-04-10 unique constraint was on
+		// (piece_cid, piece_padded_size, long_term, cleanup_task_id).
+		// That constraint no longer exists - any code attempting to
+		// resurrect it via this ON CONFLICT inference clause must fail
+		// with "no unique or exclusion constraint matching".
+		const cid = "test-old-four-col-inference"
+		_, err := db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+			VALUES ($1, 32, 16, TRUE)
+			ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING`, cid)
+		require.Error(t, err, "old 4-column inference must not match any existing constraint")
+	})
+
+	t.Run("UntargetedDoNothingPreservesSingleActiveRow", func(t *testing.T) {
+		// Untargeted ON CONFLICT DO NOTHING does not error, but it also
+		// must not produce a second active row. The partial unique index
+		// still catches the conflict; DO NOTHING just swallows it.
+		const cid = "test-untargeted-do-nothing"
+		_, err := db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+			VALUES ($1, 32, 16, TRUE)`, cid)
+		require.NoError(t, err)
+		_, err = db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+			VALUES ($1, 32, 16, TRUE) ON CONFLICT DO NOTHING`, cid)
+		require.NoError(t, err, "untargeted DO NOTHING must succeed silently")
+		require.Equal(t, 1, activeCountByCID(cid), "no second active row may exist")
+	})
+
+	t.Run("ConcurrentRawInsertsAllButOneFail", func(t *testing.T) {
+		// N goroutines race to INSERT the same key. Exactly one must win;
+		// the rest must fail with 23505. This is the property the
+		// pre-PR code violated by using a check-then-insert CTE.
+		const (
+			cid = "test-concurrent-raw"
+			n   = 20
+		)
+		var (
+			wg      sync.WaitGroup
+			barrier = make(chan struct{})
+			errs    = make([]error, n)
+		)
+		for i := range n {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				<-barrier
+				errs[idx] = rawInsert(cid, 32, 16, true)
+			}(i)
+		}
+		close(barrier)
+		wg.Wait()
+
+		successes := 0
+		for _, err := range errs {
+			if err == nil {
+				successes++
+				continue
+			}
+			require.True(t, harmonydb.IsErrUniqueContraint(err), "unexpected error: %v", err)
+		}
+		require.Equal(t, 1, successes, "exactly one direct insert must win")
+		require.Equal(t, 1, countByCID(cid))
+	})
+
+	// POSITIVE: outside the index predicate or differ on a key column.
+
+	t.Run("DifferentLongTermSucceeds", func(t *testing.T) {
+		// long_term IS part of the index key.
+		const cid = "test-different-longterm"
+		require.NoError(t, rawInsert(cid, 32, 16, true))
+		require.NoError(t, rawInsert(cid, 32, 16, false))
+		require.Equal(t, 2, countByCID(cid))
+	})
+
+	t.Run("DifferentPaddedSizeSucceeds", func(t *testing.T) {
+		const cid = "test-different-padded"
+		require.NoError(t, rawInsert(cid, 32, 16, true))
+		require.NoError(t, rawInsert(cid, 64, 32, true))
+		require.Equal(t, 2, countByCID(cid))
+	})
+
+	t.Run("CleanupSoftDeletedAndLiveCoexist", func(t *testing.T) {
+		// cleanup_task_id IS NOT NULL puts the row outside the partial index.
+		const cid = "test-cleanup-coexist"
+		cleanupTaskID := int64(7777)
+		cleanupID := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, &cleanupTaskID)
+		liveID := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, nil)
+		require.NotEqual(t, cleanupID, liveID)
+		require.Equal(t, 2, countByCID(cid))
+	})
+
+	t.Run("MultipleCleanupRowsCoexist", func(t *testing.T) {
+		// Multiple rows with non-null cleanup_task_id all sit outside the partial index.
+		const cid = "test-multi-cleanup"
+		t1, t2 := int64(11), int64(22)
+		id1 := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, &t1)
+		id2 := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, &t2)
+		require.NotEqual(t, id1, id2)
+		require.Equal(t, 2, countByCID(cid))
+	})
+
+	// HELPER: parkpiece.Upsert / UpsertSkip behaviour.
+
+	upsert := func(t *testing.T, cid string, paddedSize, rawSize int64, longTerm bool) int64 {
+		t.Helper()
+		var id int64
+		_, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+			pid, perr := parkpiece.Upsert(tx, cid, paddedSize, rawSize, longTerm)
+			if perr != nil {
+				return false, perr
+			}
+			id = pid
+			return true, nil
+		}, harmonydb.OptionRetry())
+		require.NoError(t, err)
+		return id
+	}
+	upsertSkip := func(t *testing.T, cid string, paddedSize, rawSize int64, longTerm, skip bool) int64 {
+		t.Helper()
+		var id int64
+		_, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+			pid, perr := parkpiece.UpsertSkip(tx, cid, paddedSize, rawSize, longTerm, skip)
+			if perr != nil {
+				return false, perr
+			}
+			id = pid
+			return true, nil
+		}, harmonydb.OptionRetry())
+		require.NoError(t, err)
+		return id
+	}
+
+	t.Run("UpsertIdempotent", func(t *testing.T) {
+		const cid = "test-upsert-idempotent"
+		id1 := upsert(t, cid, 32, 16, true)
+		id2 := upsert(t, cid, 32, 16, true)
+		require.Equal(t, id1, id2, "second Upsert must return the existing row id")
+		require.Equal(t, 1, countByCID(cid))
+	})
+
+	t.Run("UpsertAfterRawInsertReturnsExistingID", func(t *testing.T) {
+		// Mixed: a row created by direct INSERT must be discoverable by Upsert.
+		const cid = "test-upsert-after-raw"
+		rawID := insertParkedPiece(t, ctx, db, cid, 32, 16, false, true, nil)
+		upsertID := upsert(t, cid, 32, 16, true)
+		require.Equal(t, rawID, upsertID)
+		require.Equal(t, 1, countByCID(cid))
+	})
+
+	t.Run("UpsertWithDifferentRawSizeKeepsSingleRow", func(t *testing.T) {
+		// Calling Upsert twice with different raw_size must converge on
+		// one row. DO UPDATE writes EXCLUDED.piece_raw_size on the
+		// conflict path, so the row's raw_size reflects the latest call.
+		const cid = "test-upsert-different-rawsize"
+		id1 := upsert(t, cid, 32, 10, true)
+		id2 := upsert(t, cid, 32, 20, true)
+		require.Equal(t, id1, id2)
+		require.Equal(t, 1, activeCountByCID(cid))
+		var rawSize int64
+		require.NoError(t, db.QueryRow(ctx, `SELECT piece_raw_size FROM parked_pieces WHERE id = $1`, id1).Scan(&rawSize))
+		require.EqualValues(t, 20, rawSize, "DO UPDATE must apply the new raw_size on conflict")
+	})
+
+	t.Run("UpsertSkipPreservesExistingSkip", func(t *testing.T) {
+		// DO UPDATE only touches piece_raw_size, so the existing skip value
+		// is preserved across subsequent UpsertSkip calls.
+		const cid = "test-upsert-skip-preserve"
+		id1 := upsertSkip(t, cid, 32, 16, true, true)
+		id2 := upsertSkip(t, cid, 32, 16, true, false)
+		require.Equal(t, id1, id2)
+		var skip bool
+		require.NoError(t, db.QueryRow(ctx, `SELECT skip FROM parked_pieces WHERE id = $1`, id1).Scan(&skip))
+		require.True(t, skip, "DO UPDATE must not overwrite skip on the conflict path")
+	})
+
+	t.Run("UpsertConcurrentSamePieceConverges", func(t *testing.T) {
+		// The race the PR is meant to fix: N goroutines concurrently call
+		// Upsert with the same key. All must succeed, all must return the
+		// same id, and exactly one row must exist.
+		const (
+			cid = "test-upsert-concurrent"
+			n   = 32
+		)
+		var (
+			wg      sync.WaitGroup
+			barrier = make(chan struct{})
+			ids     = make([]int64, n)
+			errs    = make([]error, n)
+		)
+		for i := range n {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				<-barrier
+				_, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+					pid, perr := parkpiece.Upsert(tx, cid, 32, 16, true)
+					if perr != nil {
+						return false, perr
+					}
+					ids[idx] = pid
+					return true, nil
+				}, harmonydb.OptionRetry())
+				errs[idx] = err
+			}(i)
+		}
+		close(barrier)
+		wg.Wait()
+
+		for i, e := range errs {
+			require.NoErrorf(t, e, "goroutine %d failed", i)
+		}
+		for i := 1; i < n; i++ {
+			require.Equal(t, ids[0], ids[i], "all goroutines must return the same id")
+		}
+		require.Equal(t, 1, activeCountByCID(cid))
+	})
+
+	t.Run("UpsertMixedConcurrentConverges", func(t *testing.T) {
+		// Mix Upsert and UpsertSkip on the same key concurrently. Both
+		// helpers target the same partial unique index; all writers must
+		// converge on a single row regardless of which helper they used.
+		const (
+			cid = "test-upsert-mixed-concurrent"
+			n   = 32
+		)
+		var (
+			wg      sync.WaitGroup
+			barrier = make(chan struct{})
+			ids     = make([]int64, n)
+			errs    = make([]error, n)
+		)
+		for i := range n {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				<-barrier
+				_, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+					var (
+						pid  int64
+						perr error
+					)
+					if idx%2 == 0 {
+						pid, perr = parkpiece.Upsert(tx, cid, 32, 16, true)
+					} else {
+						pid, perr = parkpiece.UpsertSkip(tx, cid, 32, 16, true, true)
+					}
+					if perr != nil {
+						return false, perr
+					}
+					ids[idx] = pid
+					return true, nil
+				}, harmonydb.OptionRetry())
+				errs[idx] = err
+			}(i)
+		}
+		close(barrier)
+		wg.Wait()
+
+		for i, e := range errs {
+			require.NoErrorf(t, e, "goroutine %d (idx%%2=%d) failed", i, i%2)
+		}
+		for i := 1; i < n; i++ {
+			require.Equal(t, ids[0], ids[i], "all goroutines must return the same id regardless of helper")
+		}
+		require.Equal(t, 1, activeCountByCID(cid))
+	})
+
+	// Final invariant across all subtests above.
+	assertNoActiveDuplicates(t)
 }
 
 func TestFixParkPieceTask_RepairsDuplicateRefs(t *testing.T) {

--- a/itests/park_piece_test.go
+++ b/itests/park_piece_test.go
@@ -109,6 +109,16 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 		`, cid, paddedSize, rawSize, longTerm)
 		return err
 	}
+	// insertCleanupRow inserts a row whose cleanup_task_id IS NOT NULL, so it
+	// sits OUTSIDE the partial unique index. Used to set up coexistence cases.
+	insertCleanupRow := func(cid string, paddedSize, rawSize, cleanupTaskID int64, longTerm bool) int64 {
+		var id int64
+		require.NoError(t, db.QueryRow(ctx, `
+			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, cleanup_task_id)
+			VALUES ($1, $2, $3, $4, $5) RETURNING id
+		`, cid, paddedSize, rawSize, longTerm, cleanupTaskID).Scan(&id))
+		return id
+	}
 	countByCID := func(cid string) int {
 		var n int
 		require.NoError(t, db.QueryRow(ctx, `SELECT COUNT(*) FROM parked_pieces WHERE piece_cid = $1`, cid).Scan(&n))
@@ -203,10 +213,8 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 		// cleanup_task_id on the sibling would create two live rows; the
 		// index must reject that UPDATE.
 		const cid = "test-update-reintroduce"
-		liveID := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, nil)
-		cleanupTaskID := int64(8888)
-		cleanupID := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, &cleanupTaskID)
-		require.NotEqual(t, liveID, cleanupID)
+		require.NoError(t, rawInsert(cid, 32, 16, true))
+		cleanupID := insertCleanupRow(cid, 32, 16, 8888, true)
 		_, err := db.Exec(ctx, `UPDATE parked_pieces SET cleanup_task_id = NULL WHERE id = $1`, cleanupID)
 		require.Error(t, err, "UPDATE that produces a duplicate live row must fail")
 	})
@@ -235,19 +243,6 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 			VALUES ($1, 32, 16, TRUE, NULL)`, cid)
 		require.Error(t, err)
 		require.Equal(t, 1, activeCountByCID(cid))
-	})
-
-	t.Run("OldFourColumnInferenceClauseErrors", func(t *testing.T) {
-		// The pre-2026-04-10 unique constraint was on
-		// (piece_cid, piece_padded_size, long_term, cleanup_task_id).
-		// That constraint no longer exists - any code attempting to
-		// resurrect it via this ON CONFLICT inference clause must fail
-		// with "no unique or exclusion constraint matching".
-		const cid = "test-old-four-col-inference"
-		_, err := db.Exec(ctx, `INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-			VALUES ($1, 32, 16, TRUE)
-			ON CONFLICT (piece_cid, piece_padded_size, long_term, cleanup_task_id) DO NOTHING`, cid)
-		require.Error(t, err, "old 4-column inference must not match any existing constraint")
 	})
 
 	t.Run("UntargetedDoNothingPreservesSingleActiveRow", func(t *testing.T) {
@@ -319,9 +314,12 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 	t.Run("CleanupSoftDeletedAndLiveCoexist", func(t *testing.T) {
 		// cleanup_task_id IS NOT NULL puts the row outside the partial index.
 		const cid = "test-cleanup-coexist"
-		cleanupTaskID := int64(7777)
-		cleanupID := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, &cleanupTaskID)
-		liveID := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, nil)
+		cleanupID := insertCleanupRow(cid, 32, 16, 7777, true)
+		require.NoError(t, rawInsert(cid, 32, 16, true))
+		var liveID int64
+		require.NoError(t, db.QueryRow(ctx,
+			`SELECT id FROM parked_pieces WHERE piece_cid = $1 AND cleanup_task_id IS NULL`,
+			cid).Scan(&liveID))
 		require.NotEqual(t, cleanupID, liveID)
 		require.Equal(t, 2, countByCID(cid))
 	})
@@ -329,9 +327,8 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 	t.Run("MultipleCleanupRowsCoexist", func(t *testing.T) {
 		// Multiple rows with non-null cleanup_task_id all sit outside the partial index.
 		const cid = "test-multi-cleanup"
-		t1, t2 := int64(11), int64(22)
-		id1 := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, &t1)
-		id2 := insertParkedPiece(t, ctx, db, cid, 32, 16, true, true, &t2)
+		id1 := insertCleanupRow(cid, 32, 16, 11, true)
+		id2 := insertCleanupRow(cid, 32, 16, 22, true)
 		require.NotEqual(t, id1, id2)
 		require.Equal(t, 2, countByCID(cid))
 	})

--- a/itests/park_piece_test.go
+++ b/itests/park_piece_test.go
@@ -266,8 +266,7 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 
 	t.Run("ConcurrentRawInsertsAllButOneFail", func(t *testing.T) {
 		// N goroutines race to INSERT the same key. Exactly one must win;
-		// the rest must fail with 23505. This is the property the
-		// pre-PR code violated by using a check-then-insert CTE.
+		// the rest must fail with 23505.
 		const (
 			cid = "test-concurrent-raw"
 			n   = 20
@@ -412,9 +411,8 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 	})
 
 	t.Run("UpsertConcurrentSamePieceConverges", func(t *testing.T) {
-		// The race the PR is meant to fix: N goroutines concurrently call
-		// Upsert with the same key. All must succeed, all must return the
-		// same id, and exactly one row must exist.
+		// N goroutines concurrently call Upsert with the same key. All must
+		// succeed, all must return the same id, and exactly one row must exist.
 		const (
 			cid = "test-upsert-concurrent"
 			n   = 32

--- a/lib/parkpiece/upsert.go
+++ b/lib/parkpiece/upsert.go
@@ -1,0 +1,49 @@
+// Package parkpiece provides race-safe upsert helpers for the parked_pieces
+// table.
+package parkpiece
+
+import (
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+)
+
+// Upsert atomically inserts a parked_pieces row for the given
+// (piece_cid, piece_padded_size, long_term) or returns the id of the existing
+// live row. Safe under concurrent writers.
+//
+// Must be called inside a transaction.
+func Upsert(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm bool) (int64, error) {
+	var id int64
+	err := tx.QueryRow(`
+		INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
+		-- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
+		DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
+		RETURNING id`, pieceCID, paddedSize, rawSize, longTerm).Scan(&id)
+	if err != nil {
+		return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
+	}
+	return id, nil
+}
+
+// UpsertSkip is like Upsert but inserts the row with the given skip value when
+// new. The existing row's skip value is preserved on the conflict path -
+// callers that need to flip skip on an existing row must do so separately.
+//
+// Must be called inside a transaction.
+func UpsertSkip(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm, skip bool) (int64, error) {
+	var id int64
+	err := tx.QueryRow(`
+		INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
+		-- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
+		DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
+		RETURNING id`, pieceCID, paddedSize, rawSize, longTerm, skip).Scan(&id)
+	if err != nil {
+		return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
+	}
+	return id, nil
+}

--- a/market/mk12/mk12.go
+++ b/market/mk12/mk12.go
@@ -35,6 +35,7 @@ import (
 	"github.com/filecoin-project/curio/deps/config"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/lib/multictladdr"
+	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/lib/paths"
 	"github.com/filecoin-project/curio/market/backpressure"
 	"github.com/filecoin-project/curio/market/mk12/legacytypes"
@@ -581,26 +582,7 @@ func (m *MK12) processDeal(ctx context.Context, deal *ProviderDealState) (*Provi
 
 			if err != nil {
 				if errors.Is(err, pgx.ErrNoRows) {
-					// Piece does not exist, attempt to insert
-					err = tx.QueryRow(`
-							WITH existing_piece AS (
-							  SELECT id
-							  FROM parked_pieces
-							  WHERE piece_cid = $1
-								AND piece_padded_size = $2
-								AND long_term = FALSE
-								AND cleanup_task_id IS NULL
-							),
-							inserted_piece AS (
-							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-							  SELECT $1, $2, $3, FALSE
-							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
-							  RETURNING id
-							)
-							SELECT id FROM existing_piece
-							UNION ALL
-							SELECT id FROM inserted_piece
-							LIMIT 1;`, prop.PieceCID.String(), int64(prop.PieceSize), int64(deal.Transfer.Size)).Scan(&pieceID)
+					pieceID, err = parkpiece.Upsert(tx, prop.PieceCID.String(), int64(prop.PieceSize), int64(deal.Transfer.Size), false)
 					if err != nil {
 						return false, xerrors.Errorf("inserting new parked piece and getting id: %w", err)
 					}

--- a/market/mk20/mk20.go
+++ b/market/mk20/mk20.go
@@ -30,6 +30,7 @@ import (
 	"github.com/filecoin-project/curio/lib/ethchain"
 	"github.com/filecoin-project/curio/lib/ffi"
 	"github.com/filecoin-project/curio/lib/multictladdr"
+	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/lib/paths"
 	"github.com/filecoin-project/curio/market/backpressure"
 
@@ -759,26 +760,7 @@ func insertPDPPipeline(ctx context.Context, tx *harmonydb.Tx, deal *Deal) error 
 
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				// Piece does not exist, attempt to insert
-				err = tx.QueryRow(`
-							WITH existing_piece AS (
-							  SELECT id
-							  FROM parked_pieces
-							  WHERE piece_cid = $1
-								AND piece_padded_size = $2
-								AND long_term = TRUE
-								AND cleanup_task_id IS NULL
-							),
-							inserted_piece AS (
-							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-							  SELECT $1, $2, $3, TRUE
-							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
-							  RETURNING id
-							)
-							SELECT id FROM existing_piece
-							UNION ALL
-							SELECT id FROM inserted_piece
-							LIMIT 1;`, pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&pieceID)
+				pieceID, err = parkpiece.Upsert(tx, pi.PieceCIDV1.String(), int64(pi.Size), int64(pi.RawSize), true)
 				if err != nil {
 					return xerrors.Errorf("inserting new parked piece and getting id: %w", err)
 				}

--- a/market/mk20/mk20.go
+++ b/market/mk20/mk20.go
@@ -857,32 +857,13 @@ func insertPDPPipeline(ctx context.Context, tx *harmonydb.Tx, deal *Deal) error 
 					headers = []byte("{}")
 				}
 				batch.Queue(`
-							WITH existing_piece AS (
-							  SELECT id
-							  FROM parked_pieces
-							  WHERE piece_cid = $1
-								AND piece_padded_size = $2
-								AND long_term = FALSE
-								AND cleanup_task_id IS NULL
-							),
-							insert_piece AS (
+							WITH selected_piece AS (
 							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-							  SELECT $1, $2, $3, FALSE
-							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+							  VALUES ($1, $2, $3, FALSE)
+							  ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
+							  -- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
+							  DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
 							  RETURNING id
-							),
-							inserted_piece AS (
-								SELECT id FROM existing_piece
-								UNION ALL
-								SELECT id FROM insert_piece
-								LIMIT 1
-							),
-							selected_piece AS (
-							  SELECT COALESCE(
-								(SELECT id FROM inserted_piece),
-								(SELECT id FROM parked_pieces
-								 WHERE piece_cid = $1 AND piece_padded_size = $2 AND long_term = FALSE AND cleanup_task_id IS NULL)
-							  ) AS id
 							),
 							inserted_ref AS (
 							  INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)

--- a/market/mk20/mk20_upload.go
+++ b/market/mk20/mk20_upload.go
@@ -25,6 +25,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/lib/storiface"
 )
 
@@ -355,25 +356,7 @@ func (m *MK20) HandleUploadChunk(ctx context.Context, id ulid.ULID, chunk int, d
 
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				err = tx.QueryRow(`
-							WITH existing_piece AS (
-							  SELECT id
-							  FROM parked_pieces
-							  WHERE piece_cid = $1
-								AND piece_padded_size = $2
-								AND long_term = FALSE
-								AND cleanup_task_id IS NULL
-							),
-							inserted_piece AS (
-							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-							  SELECT $1, $2, $3, FALSE, TRUE
-							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
-							  RETURNING id
-							)
-							SELECT id FROM existing_piece
-							UNION ALL
-							SELECT id FROM inserted_piece
-							LIMIT 1;`, tpcid.String(), tsize, n).Scan(&pnum)
+				pnum, err = parkpiece.UpsertSkip(tx, tpcid.String(), int64(tsize), int64(n), false, true)
 				if err != nil {
 					return false, xerrors.Errorf("inserting new parked piece and getting id: %w", err)
 				}
@@ -775,25 +758,7 @@ func (m *MK20) HandleSerialUpload(ctx context.Context, id ulid.ULID, body io.Rea
 
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				err = tx.QueryRow(`
-							WITH existing_piece AS (
-							  SELECT id
-							  FROM parked_pieces
-							  WHERE piece_cid = $1
-								AND piece_padded_size = $2
-								AND long_term = TRUE
-								AND cleanup_task_id IS NULL
-							),
-							inserted_piece AS (
-							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-							  SELECT $1, $2, $3, TRUE, TRUE
-							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
-							  RETURNING id
-							)
-							SELECT id FROM existing_piece
-							UNION ALL
-							SELECT id FROM inserted_piece
-							LIMIT 1;`, tpcid.String(), tsize, trSize).Scan(&pnum)
+				pnum, err = parkpiece.UpsertSkip(tx, tpcid.String(), int64(tsize), int64(trSize), true, true)
 				if err != nil {
 					return false, xerrors.Errorf("inserting new parked piece and getting id: %w", err)
 				}

--- a/pdp/handlers_upload.go
+++ b/pdp/handlers_upload.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/lib/dealdata"
+	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/lib/proof"
 )
 
@@ -298,26 +299,7 @@ func (p *PDPService) handlePieceUpload(w http.ResponseWriter, r *http.Request) {
 
 	didCommit, err := p.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
 		// 1. Create a long-term parked piece entry
-		var parkedPieceID int64
-		err := tx.QueryRow(`
-							WITH existing_piece AS (
-							  SELECT id
-							  FROM parked_pieces
-							  WHERE piece_cid = $1
-								AND piece_padded_size = $2
-								AND long_term = TRUE
-								AND cleanup_task_id IS NULL
-							),
-							inserted_piece AS (
-							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-							  SELECT $1, $2, $3, TRUE
-							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
-							  RETURNING id
-							)
-							SELECT id FROM existing_piece
-							UNION ALL
-							SELECT id FROM inserted_piece
-							LIMIT 1;`, pieceCIDComputed.String(), paddedPieceSize, readSize).Scan(&parkedPieceID)
+		parkedPieceID, err := parkpiece.Upsert(tx, pieceCIDComputed.String(), int64(paddedPieceSize), readSize, true)
 		if err != nil {
 			return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)
 		}
@@ -537,27 +519,7 @@ func (p *PDPService) handleStreamingUpload(w http.ResponseWriter, r *http.Reques
 
 	didCommit, err := p.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
 		// 1. Create a long-term parked piece entry
-		var parkedPieceID int64
-		err := tx.QueryRow(`
-							WITH existing_piece AS (
-							  SELECT id
-							  FROM parked_pieces
-							  WHERE piece_cid = $1
-								AND piece_padded_size = $2
-								AND long_term = TRUE
-								AND cleanup_task_id IS NULL
-							),
-							inserted_piece AS (
-							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-							  SELECT $1, $2, $3, TRUE
-							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
-							  RETURNING id
-							)
-							SELECT id FROM existing_piece
-							UNION ALL
-							SELECT id FROM inserted_piece
-							LIMIT 1;
-        `, pcid.String(), paddedPieceSize, readSize).Scan(&parkedPieceID)
+		parkedPieceID, err := parkpiece.Upsert(tx, pcid.String(), int64(paddedPieceSize), readSize, true)
 		if err != nil {
 			return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)
 		}

--- a/tasks/pdp/task_aggregation.go
+++ b/tasks/pdp/task_aggregation.go
@@ -21,6 +21,7 @@ import (
 	"github.com/filecoin-project/curio/harmony/resources"
 	"github.com/filecoin-project/curio/harmony/taskhelp"
 	"github.com/filecoin-project/curio/lib/ffi"
+	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/lib/passcall"
 	"github.com/filecoin-project/curio/lib/storiface"
 	"github.com/filecoin-project/curio/market/mk20"
@@ -212,26 +213,7 @@ func (a *AggregatePDPDealTask) Do(taskID harmonytask.TaskID, stillOwned func() b
 				return false, fmt.Errorf("failed to check if piece already exists: %w", err)
 			}
 			// If piece does not exist then let's create one
-			err = tx.QueryRow(`
-							WITH existing_piece AS (
-							  SELECT id
-							  FROM parked_pieces
-							  WHERE piece_cid = $1
-								AND piece_padded_size = $2
-								AND long_term = TRUE
-								AND cleanup_task_id IS NULL
-							),
-							inserted_piece AS (
-							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-							  SELECT $1, $2, $3, TRUE, TRUE
-							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
-							  RETURNING id
-							)
-							SELECT id FROM existing_piece
-							UNION ALL
-							SELECT id FROM inserted_piece
-							LIMIT 1;`,
-				pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&parkedPieceID)
+			parkedPieceID, err = parkpiece.UpsertSkip(tx, pi.PieceCIDV1.String(), int64(pi.Size), int64(pi.RawSize), true, true)
 			if err != nil {
 				return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)
 			}

--- a/tasks/pdpv0/task_pull_piece.go
+++ b/tasks/pdpv0/task_pull_piece.go
@@ -22,6 +22,7 @@ import (
 	"github.com/filecoin-project/curio/harmony/resources"
 	"github.com/filecoin-project/curio/harmony/taskhelp"
 	"github.com/filecoin-project/curio/lib/dealdata"
+	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/lib/paths"
 	"github.com/filecoin-project/curio/lib/promise"
 	"github.com/filecoin-project/curio/pdp"
@@ -260,27 +261,7 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		}
 
 		// Create parked_pieces entry
-		var parkedPieceID int64
-		err = tx.QueryRow(`
-							WITH existing_piece AS (
-							  SELECT id
-							  FROM parked_pieces
-							  WHERE piece_cid = $1
-								AND piece_padded_size = $2
-								AND long_term = TRUE
-								AND cleanup_task_id IS NULL
-							),
-							inserted_piece AS (
-							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-							  SELECT $1, $2, $3, TRUE
-							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
-							  RETURNING id
-							)
-							SELECT id FROM existing_piece
-							UNION ALL
-							SELECT id FROM inserted_piece
-							LIMIT 1;
-		`, item.PieceCid, paddedSize, item.PieceRawSize).Scan(&parkedPieceID)
+		parkedPieceID, err := parkpiece.Upsert(tx, item.PieceCid, int64(paddedSize), item.PieceRawSize, true)
 		if err != nil {
 			return false, xerrors.Errorf("insert parked_pieces: %w", err)
 		}

--- a/tasks/piece/task_aggregate_chunks.go
+++ b/tasks/piece/task_aggregate_chunks.go
@@ -19,6 +19,7 @@ import (
 	"github.com/filecoin-project/curio/harmony/resources"
 	"github.com/filecoin-project/curio/harmony/taskhelp"
 	"github.com/filecoin-project/curio/lib/ffi"
+	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/lib/passcall"
 	"github.com/filecoin-project/curio/lib/paths"
 	"github.com/filecoin-project/curio/lib/storiface"
@@ -153,25 +154,7 @@ func (a *AggregateChunksTask) Do(taskID harmonytask.TaskID, stillOwned func() bo
 				return false, fmt.Errorf("failed to check if piece already exists: %w", err)
 			}
 			// If piece does not exist then let's create one
-			err = tx.QueryRow(`
-					WITH existing_piece AS (
-					  SELECT id
-					  FROM parked_pieces
-					  WHERE piece_cid = $1
-						AND piece_padded_size = $2
-						AND long_term = TRUE
-						AND cleanup_task_id IS NULL
-					),
-					inserted_piece AS (
-					  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-					  SELECT $1, $2, $3, TRUE, TRUE
-					  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
-					  RETURNING id
-					)
-					SELECT id FROM existing_piece
-					UNION ALL
-					SELECT id FROM inserted_piece
-					LIMIT 1;`, pcid.String(), psize, rawSize).Scan(&parkedPieceID)
+			parkedPieceID, err = parkpiece.UpsertSkip(tx, pcid.String(), int64(psize), int64(rawSize), true, true)
 			if err != nil {
 				return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)
 			}

--- a/tasks/storage-market/mk20.go
+++ b/tasks/storage-market/mk20.go
@@ -492,32 +492,13 @@ func insertPiecesInTransaction(ctx context.Context, tx *harmonydb.Tx, deal *mk20
 				if headers == nil {
 					headers = []byte("{}")
 				}
-				batch.Queue(`WITH existing_piece AS (
-									  SELECT id
-									  FROM parked_pieces
-									  WHERE piece_cid = $1
-										AND piece_padded_size = $2
-										AND long_term = FALSE
-										AND cleanup_task_id IS NULL
-									),
-									insert_piece AS (
+				batch.Queue(`WITH selected_piece AS (
 									  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-									  SELECT $1, $2, $3, FALSE
-									  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+									  VALUES ($1, $2, $3, FALSE)
+									  ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
+									  -- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
+									  DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
 									  RETURNING id
-									),
-									inserted_piece AS (
-									SELECT id FROM existing_piece
-									UNION ALL
-									SELECT id FROM insert_piece
-									LIMIT 1
-									),
-									selected_piece AS (
-									  SELECT COALESCE(
-										(SELECT id FROM inserted_piece),
-										(SELECT id FROM parked_pieces
-										 WHERE piece_cid = $1 AND piece_padded_size = $2 AND long_term = FALSE AND cleanup_task_id IS NULL)
-									  ) AS id
 									),
 									inserted_ref AS (
 									  INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
@@ -768,27 +749,14 @@ func (d *CurioStorageDealMarket) findOfflineURLMk20Deal(ctx context.Context, pie
 										  FROM market_mk20_pipeline
 										  WHERE id = $1 AND piece_cid = $2 AND piece_size = $3
 										),
-										existing_piece AS (
-										  SELECT pp.id AS piece_id
-										  FROM parked_pieces pp
-										  JOIN pipeline_piece p ON true
-										  WHERE pp.piece_cid = $2
-											AND pp.piece_padded_size = $3
-											AND pp.long_term = NOT (p.deal_aggregation > 0)
-											AND pp.cleanup_task_id IS NULL
-										),
-										insert_piece AS (
+										selected_piece AS (
 										  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
 										  SELECT $2, $3, $4, NOT (p.deal_aggregation > 0)
 										  FROM pipeline_piece p
-										  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+										  ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
+										  -- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
+										  DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
 										  RETURNING id AS piece_id
-										),
-										selected_piece AS (
-										  SELECT piece_id FROM existing_piece
-										  UNION ALL
-										  SELECT piece_id FROM insert_piece
-										  LIMIT 1
 										),
 										inserted_ref AS (
 										  INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)

--- a/tasks/storage-market/mk20.go
+++ b/tasks/storage-market/mk20.go
@@ -29,6 +29,7 @@ import (
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/lib/commcidv2"
+	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/market/mk20"
 
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
@@ -373,26 +374,7 @@ func insertPiecesInTransaction(ctx context.Context, tx *harmonydb.Tx, deal *mk20
 
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				// Piece does not exist, attempt to insert
-				err = tx.QueryRow(`
-							WITH existing_piece AS (
-							  SELECT id
-							  FROM parked_pieces
-							  WHERE piece_cid = $1
-								AND piece_padded_size = $2
-								AND long_term = TRUE
-								AND cleanup_task_id IS NULL
-							),
-							inserted_piece AS (
-							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-							  SELECT $1, $2, $3, TRUE
-							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
-							  RETURNING id
-							)
-							SELECT id FROM existing_piece
-							UNION ALL
-							SELECT id FROM inserted_piece
-							LIMIT 1;`, pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&pieceID)
+				pieceID, err = parkpiece.Upsert(tx, pi.PieceCIDV1.String(), int64(pi.Size), int64(pi.RawSize), true)
 				if err != nil {
 					return xerrors.Errorf("inserting new parked piece and getting id: %w", err)
 				}

--- a/tasks/storage-market/task_aggregation.go
+++ b/tasks/storage-market/task_aggregation.go
@@ -22,6 +22,7 @@ import (
 	"github.com/filecoin-project/curio/harmony/resources"
 	"github.com/filecoin-project/curio/harmony/taskhelp"
 	"github.com/filecoin-project/curio/lib/ffi"
+	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/lib/paths"
 	"github.com/filecoin-project/curio/lib/storiface"
 	"github.com/filecoin-project/curio/market/mk20"
@@ -229,26 +230,7 @@ func (a *AggregateDealTask) Do(taskID harmonytask.TaskID, stillOwned func() bool
 				return false, fmt.Errorf("failed to check if piece already exists: %w", err)
 			}
 			// If piece does not exist then let's create one
-			err = tx.QueryRow(`
-							WITH existing_piece AS (
-							  SELECT id
-							  FROM parked_pieces
-							  WHERE piece_cid = $1
-								AND piece_padded_size = $2
-								AND long_term = TRUE
-								AND cleanup_task_id IS NULL
-							),
-							inserted_piece AS (
-							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-							  SELECT $1, $2, $3, TRUE, TRUE
-							  WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
-							  RETURNING id
-							)
-							SELECT id FROM existing_piece
-							UNION ALL
-							SELECT id FROM inserted_piece
-							LIMIT 1;`,
-				pi.PieceCIDV1.String(), pi.Size, pi.RawSize).Scan(&parkedPieceID)
+			parkedPieceID, err = parkpiece.UpsertSkip(tx, pi.PieceCIDV1.String(), int64(pi.Size), int64(pi.RawSize), true, true)
 			if err != nil {
 				return false, fmt.Errorf("failed to create parked_pieces entry: %w", err)
 			}


### PR DESCRIPTION
From an observed (somewhere in the pdpv0 path, error logged from handlers.go:40):

    failed to create parked_pieces entry: ERROR: duplicate key value violates unique constraint "parked_pieces_active_piece_key" (SQLSTATE 23505)

Assuming this is from an update race for an identical piece. Low probability, but possible with the current check-then-execute pattern. I'm not sure how else this could be explained. Replacing with a conflict-safe upsert as a utility.

Caveats:

* market/mk20/mk20.go:887 has one of these as part of a larger batch that I've left alone
* tasks/storage-market/mk20.go:522 and tasks/storage-market/mk20.go:799 has variants as part of a larger construct that I've left alone

@LexLuthr this one's for you to consider.