### PR TITLE
fix(pdp): recover from INVALID parked_pieces_active_piece_key

### DIFF
--- a/itests/park_piece_test.go
+++ b/itests/park_piece_test.go
@@ -83,17 +83,13 @@ func TestParkPieceCanAccept_SliceBounds(t *testing.T) {
 	require.Nil(t, accepted, "should reject all when at capacity")
 }
 
-// TestParkedPiecesActivePieceKey is a regression guard for the
-// parked_pieces_active_piece_key partial unique index and the parkpiece
-// upsert helpers. The index enforces at most one row per
-// (piece_cid, piece_padded_size, long_term) where cleanup_task_id IS NULL.
-// Loosening it reintroduces the check-then-insert race that produced
-// duplicate rows in production (see task_fix_park_piece_unique.go for the
-// legacy cleanup).
+// TestParkedPiecesActivePieceKey asserts that
+// parked_pieces_active_piece_key enforces at most one row per
+// (piece_cid, piece_padded_size, long_term) where cleanup_task_id IS NULL,
+// and that parkpiece.Upsert / UpsertSkip respect that invariant.
 //
-// Subtests are grouped: NEGATIVE (must fail / preserve invariant),
-// POSITIVE (outside the index predicate, must succeed), HELPER
-// (parkpiece.Upsert / UpsertSkip behaviour).
+// Subtests: NEGATIVE (must fail or preserve invariant), POSITIVE (outside
+// the predicate, must succeed), HELPER (Upsert / UpsertSkip behaviour).
 func TestParkedPiecesActivePieceKey(t *testing.T) {
 	ctx := t.Context()
 	db, err := harmonydb.NewFromConfigWithITestID(t)
@@ -498,7 +494,29 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 		require.Equal(t, 1, activeCountByCID(cid))
 	})
 
-	// Final invariant across all subtests above.
+	t.Run("UpsertFallsBackWhenIndexMissing", func(t *testing.T) {
+		// Without the index, ON CONFLICT inference raises 42P10; the helper
+		// must fall back to check-then-insert.
+		const cid = "test-upsert-fallback"
+		dropParkedPieceIndex(t, ctx, db)
+		t.Cleanup(func() {
+			_, err := db.Exec(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS parked_pieces_active_piece_key
+				ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL`)
+			require.NoError(t, err)
+		})
+
+		id1 := upsert(t, cid, 32, 16, true)
+		id2 := upsert(t, cid, 32, 16, true)
+		require.Equal(t, id1, id2)
+		require.Equal(t, 1, activeCountByCID(cid))
+
+		const skipCid = "test-upsert-skip-fallback"
+		idA := upsertSkip(t, skipCid, 32, 16, true, true)
+		idB := upsertSkip(t, skipCid, 32, 16, true, false)
+		require.Equal(t, idA, idB)
+		require.Equal(t, 1, activeCountByCID(skipCid))
+	})
+
 	assertNoActiveDuplicates(t)
 }
 
@@ -514,9 +532,9 @@ func TestFixParkPieceTask_RepairsDuplicateRefs(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name                    string
-		setup                   func(t *testing.T, ctx context.Context, db *harmonydb.DB, sc *ffi.SealCalls) []refExpectation
-		expectIndexAfterCleanup bool
+		name             string
+		setup            func(t *testing.T, ctx context.Context, db *harmonydb.DB, sc *ffi.SealCalls) []refExpectation
+		expectIndexAfter bool
 	}{
 		{
 			name: "moves refs from incomplete row without task",
@@ -539,7 +557,7 @@ func TestFixParkPieceTask_RepairsDuplicateRefs(t *testing.T) {
 					{refID: loserRef, expectedPieceID: winnerID},
 				}
 			},
-			expectIndexAfterCleanup: true,
+			expectIndexAfter: true,
 		},
 		{
 			name: "moves refs from incomplete row with stale task",
@@ -563,7 +581,7 @@ func TestFixParkPieceTask_RepairsDuplicateRefs(t *testing.T) {
 					{refID: loserRef, expectedPieceID: winnerID},
 				}
 			},
-			expectIndexAfterCleanup: true,
+			expectIndexAfter: true,
 		},
 		{
 			name: "skips active incomplete row but moves stale sibling",
@@ -592,7 +610,7 @@ func TestFixParkPieceTask_RepairsDuplicateRefs(t *testing.T) {
 					{refID: staleRef, expectedPieceID: winnerID},
 				}
 			},
-			expectIndexAfterCleanup: false,
+			expectIndexAfter: false,
 		},
 		{
 			name: "chooses readable winner among multiple complete rows",
@@ -620,10 +638,10 @@ func TestFixParkPieceTask_RepairsDuplicateRefs(t *testing.T) {
 					{refID: staleRef, expectedPieceID: readableWinnerID},
 				}
 			},
-			expectIndexAfterCleanup: true,
+			expectIndexAfter: true,
 		},
 		{
-			name: "does not move refs when no readable complete winner exists",
+			name: "falls back to lowest-id non-active when no readable winner exists",
 			setup: func(t *testing.T, ctx context.Context, db *harmonydb.DB, sc *ffi.SealCalls) []refExpectation {
 				const (
 					pieceCID   = "fix-piece-no-readable-winner"
@@ -640,10 +658,36 @@ func TestFixParkPieceTask_RepairsDuplicateRefs(t *testing.T) {
 
 				return []refExpectation{
 					{refID: unreadableRef, expectedPieceID: unreadableCompleteID},
-					{refID: staleRef, expectedPieceID: staleLoserID},
+					{refID: staleRef, expectedPieceID: unreadableCompleteID},
 				}
 			},
-			expectIndexAfterCleanup: false,
+			expectIndexAfter: true,
+		},
+		{
+			name: "consolidates all-incomplete group via lowest-id fallback",
+			setup: func(t *testing.T, ctx context.Context, db *harmonydb.DB, sc *ffi.SealCalls) []refExpectation {
+				const (
+					pieceCID   = "fix-piece-all-incomplete"
+					paddedSize = int64(32)
+					rawSize    = int64(16)
+				)
+
+				winnerID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, false, true, nil)
+				winnerRef := insertParkedPieceRef(t, ctx, db, winnerID, true)
+
+				loser1ID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, false, true, nil)
+				loser1Ref := insertParkedPieceRef(t, ctx, db, loser1ID, true)
+
+				loser2ID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, false, true, nil)
+				loser2Ref := insertParkedPieceRef(t, ctx, db, loser2ID, true)
+
+				return []refExpectation{
+					{refID: winnerRef, expectedPieceID: winnerID},
+					{refID: loser1Ref, expectedPieceID: winnerID},
+					{refID: loser2Ref, expectedPieceID: winnerID},
+				}
+			},
+			expectIndexAfter: true,
 		},
 	}
 
@@ -654,41 +698,63 @@ func TestFixParkPieceTask_RepairsDuplicateRefs(t *testing.T) {
 
 			expectedRefs := tc.setup(t, ctx, db, sc)
 
+			// Active rows in a group block index creation; the task returns
+			// success and leaves the index absent for the next pass.
 			fixTask := piece.NewFixParkPieceTask(db, sc)
 			done, err := fixTask.Do(0, func() bool { return true })
-			require.False(t, done)
-			require.ErrorContains(t, err, "creating index")
+			require.True(t, done)
+			require.NoError(t, err)
 
 			for _, expected := range expectedRefs {
 				require.Equal(t, expected.expectedPieceID, parkedPieceIDForRef(t, ctx, db, expected.refID))
 			}
-
-			cleanupTaskIDs := markOrphanPiecesForCleanup(t, ctx, db)
-			if len(cleanupTaskIDs) > 0 {
-				cleanupTask := piece.NewCleanupPieceTask(db, sc, 0)
-				for _, cleanupTaskID := range cleanupTaskIDs {
-					done, err = cleanupTask.Do(cleanupTaskID, func() bool { return true })
-					require.True(t, done)
-					require.NoError(t, err)
-				}
-			}
-
-			done, err = fixTask.Do(0, func() bool { return true })
-			if tc.expectIndexAfterCleanup {
-				require.True(t, done)
-				require.NoError(t, err)
-				require.True(t, parkedPieceIndexExists(t, ctx, db))
-			} else {
-				require.False(t, done)
-				require.ErrorContains(t, err, "creating index")
-				require.False(t, parkedPieceIndexExists(t, ctx, db))
-			}
-
-			for _, expected := range expectedRefs {
-				require.Equal(t, expected.expectedPieceID, parkedPieceIDForRef(t, ctx, db, expected.refID))
-			}
+			require.Equal(t, tc.expectIndexAfter, parkedPieceIndexExists(t, ctx, db))
 		})
 	}
+}
+
+// TestFixParkPieceTask_RecoversInvalidIndex asserts that an INVALID
+// parked_pieces_active_piece_key is dropped and recreated, not skipped via
+// CREATE UNIQUE INDEX IF NOT EXISTS.
+func TestFixParkPieceTask_RecoversInvalidIndex(t *testing.T) {
+	oldInterval := piece.PieceParkPollInterval
+	piece.PieceParkPollInterval = time.Hour
+	t.Cleanup(func() { piece.PieceParkPollInterval = oldInterval })
+
+	ctx, db, sc, _, _ := setupPieceParkTestEnv(t)
+	dropParkedPieceIndex(t, ctx, db)
+
+	const (
+		pieceCID   = "fix-piece-invalid-index"
+		paddedSize = int64(32)
+		rawSize    = int64(16)
+	)
+	winnerID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, false, true, nil)
+	winnerRef := insertParkedPieceRef(t, ctx, db, winnerID, true)
+	loserID := insertParkedPiece(t, ctx, db, pieceCID, paddedSize, rawSize, false, true, nil)
+	loserRef := insertParkedPieceRef(t, ctx, db, loserID, true)
+
+	// CONCURRENTLY against pre-existing duplicates fails and leaves the
+	// index INVALID, matching the on-disk state from the racy upload era.
+	_, err := db.Exec(ctx, `CREATE UNIQUE INDEX CONCURRENTLY parked_pieces_active_piece_key
+		ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL`)
+	require.Error(t, err)
+
+	var indisvalid bool
+	require.NoError(t, db.QueryRow(ctx, `
+		SELECT indisvalid FROM pg_index
+		WHERE indexrelid = (SELECT oid FROM pg_class WHERE relname = 'parked_pieces_active_piece_key')`).Scan(&indisvalid))
+	require.False(t, indisvalid)
+	require.False(t, parkedPieceIndexExists(t, ctx, db))
+
+	fixTask := piece.NewFixParkPieceTask(db, sc)
+	done, err := fixTask.Do(0, func() bool { return true })
+	require.True(t, done)
+	require.NoError(t, err)
+
+	require.True(t, parkedPieceIndexExists(t, ctx, db))
+	require.Equal(t, winnerID, parkedPieceIDForRef(t, ctx, db, winnerRef))
+	require.Equal(t, winnerID, parkedPieceIDForRef(t, ctx, db, loserRef))
 }
 
 func setupPieceParkTestEnv(t *testing.T) (context.Context, *harmonydb.DB, *ffi.SealCalls, *paths.Remote, storiface.ID) {
@@ -792,34 +858,6 @@ func parkedPieceIDForRef(t *testing.T, ctx context.Context, db *harmonydb.DB, re
 	err := db.QueryRow(ctx, `SELECT piece_id FROM parked_piece_refs WHERE ref_id = $1`, refID).Scan(&pieceID)
 	require.NoError(t, err)
 	return pieceID
-}
-
-func markOrphanPiecesForCleanup(t *testing.T, ctx context.Context, db *harmonydb.DB) []harmonytask.TaskID {
-	t.Helper()
-
-	var orphanPieceIDs []int64
-	err := db.Select(ctx, &orphanPieceIDs, `
-		SELECT pp.id
-		FROM parked_pieces pp
-		WHERE pp.cleanup_task_id IS NULL
-		  AND NOT EXISTS (
-			  SELECT 1
-			  FROM parked_piece_refs ppr
-			  WHERE ppr.piece_id = pp.id
-		  )
-		ORDER BY pp.id
-	`)
-	require.NoError(t, err)
-
-	taskIDs := make([]harmonytask.TaskID, 0, len(orphanPieceIDs))
-	for i, pieceID := range orphanPieceIDs {
-		taskID := harmonytask.TaskID(10_000 + i + int(pieceID))
-		_, err := db.Exec(ctx, `UPDATE parked_pieces SET cleanup_task_id = $1 WHERE id = $2`, taskID, pieceID)
-		require.NoError(t, err)
-		taskIDs = append(taskIDs, taskID)
-	}
-
-	return taskIDs
 }
 
 func parkedPieceIndexExists(t *testing.T, ctx context.Context, db *harmonydb.DB) bool {

--- a/itests/park_piece_test.go
+++ b/itests/park_piece_test.go
@@ -1047,7 +1047,6 @@ func parkedPieceIndexExists(t *testing.T, ctx context.Context, db *harmonydb.DB)
 			  AND tbl.relname = 'parked_pieces'
 			  AND idx.relname = 'parked_pieces_active_piece_key'
 			  AND idx.relkind = 'i'
-			  AND am.amname = 'btree'
 			  AND ix.indisunique
 			  AND ix.indisvalid
 			  AND ix.indisready

--- a/itests/park_piece_test.go
+++ b/itests/park_piece_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/lib/paths"
 	"github.com/filecoin-project/curio/lib/storiface"
+	marketmk20 "github.com/filecoin-project/curio/market/mk20"
 	"github.com/filecoin-project/curio/tasks/piece"
 )
 
@@ -91,6 +93,9 @@ func TestParkPieceCanAccept_SliceBounds(t *testing.T) {
 // Subtests: NEGATIVE (must fail or preserve invariant), POSITIVE (outside
 // the predicate, must succeed), HELPER (Upsert / UpsertSkip behaviour).
 func TestParkedPiecesActivePieceKey(t *testing.T) {
+	parkpiece.ResetActiveIndexValidCacheForTest()
+	t.Cleanup(parkpiece.ResetActiveIndexValidCacheForTest)
+
 	ctx := t.Context()
 	db, err := harmonydb.NewFromConfigWithITestID(t)
 	require.NoError(t, err)
@@ -377,10 +382,9 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 		require.Equal(t, 1, countByCID(cid))
 	})
 
-	t.Run("UpsertWithDifferentRawSizeKeepsSingleRow", func(t *testing.T) {
+	t.Run("UpsertWithDifferentRawSizeKeepsExistingMetadata", func(t *testing.T) {
 		// Calling Upsert twice with different raw_size must converge on
-		// one row. DO UPDATE writes EXCLUDED.piece_raw_size on the
-		// conflict path, so the row's raw_size reflects the latest call.
+		// one row without rewriting existing metadata on the conflict path.
 		const cid = "test-upsert-different-rawsize"
 		id1 := upsert(t, cid, 32, 10, true)
 		id2 := upsert(t, cid, 32, 20, true)
@@ -388,7 +392,7 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 		require.Equal(t, 1, activeCountByCID(cid))
 		var rawSize int64
 		require.NoError(t, db.QueryRow(ctx, `SELECT piece_raw_size FROM parked_pieces WHERE id = $1`, id1).Scan(&rawSize))
-		require.EqualValues(t, 20, rawSize, "DO UPDATE must apply the new raw_size on conflict")
+		require.EqualValues(t, 10, rawSize, "conflict path must preserve existing raw_size")
 	})
 
 	t.Run("UpsertSkipPreservesExistingSkip", func(t *testing.T) {
@@ -498,11 +502,13 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 		// Without the index, ON CONFLICT inference raises 42P10; the helper
 		// must fall back to check-then-insert.
 		const cid = "test-upsert-fallback"
+		parkpiece.ResetActiveIndexValidCacheForTest()
 		dropParkedPieceIndex(t, ctx, db)
 		t.Cleanup(func() {
 			_, err := db.Exec(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS parked_pieces_active_piece_key
 				ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL`)
 			require.NoError(t, err)
+			parkpiece.ResetActiveIndexValidCacheForTest()
 		})
 
 		id1 := upsert(t, cid, 32, 16, true)
@@ -518,6 +524,63 @@ func TestParkedPiecesActivePieceKey(t *testing.T) {
 	})
 
 	assertNoActiveDuplicates(t)
+}
+
+func TestParkedPieceDownloadRefsBatch(t *testing.T) {
+	t.Run("valid index", func(t *testing.T) {
+		parkpiece.ResetActiveIndexValidCacheForTest()
+		t.Cleanup(parkpiece.ResetActiveIndexValidCacheForTest)
+
+		ctx := t.Context()
+		db, err := harmonydb.NewFromConfigWithITestID(t)
+		require.NoError(t, err)
+		require.True(t, parkedPieceIndexExists(t, ctx, db))
+
+		refs := batchDownloadRefs("batch-valid")
+		insertDownloadRefsBatch(t, ctx, db, refs)
+		assertDownloadRefsBatch(t, ctx, db, "batch-valid", refs)
+	})
+
+	t.Run("missing index fallback", func(t *testing.T) {
+		parkpiece.ResetActiveIndexValidCacheForTest()
+		t.Cleanup(parkpiece.ResetActiveIndexValidCacheForTest)
+
+		ctx := t.Context()
+		db, err := harmonydb.NewFromConfigWithITestID(t)
+		require.NoError(t, err)
+		dropParkedPieceIndex(t, ctx, db)
+
+		refs := batchDownloadRefs("batch-missing")
+		insertDownloadRefsBatch(t, ctx, db, refs)
+		assertDownloadRefsBatch(t, ctx, db, "batch-missing", refs)
+	})
+
+	t.Run("invalid index fallback", func(t *testing.T) {
+		parkpiece.ResetActiveIndexValidCacheForTest()
+		t.Cleanup(parkpiece.ResetActiveIndexValidCacheForTest)
+
+		ctx := t.Context()
+		db, err := harmonydb.NewFromConfigWithITestID(t)
+		require.NoError(t, err)
+		dropParkedPieceIndex(t, ctx, db)
+
+		const (
+			dupCID     = "batch-invalid-duplicate"
+			paddedSize = int64(32)
+			rawSize    = int64(16)
+		)
+		insertParkedPiece(t, ctx, db, dupCID, paddedSize, rawSize, false, true, nil)
+		insertParkedPiece(t, ctx, db, dupCID, paddedSize, rawSize, false, true, nil)
+
+		_, err = db.Exec(ctx, `CREATE UNIQUE INDEX CONCURRENTLY parked_pieces_active_piece_key
+			ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL`)
+		require.Error(t, err)
+		require.False(t, parkedPieceIndexExists(t, ctx, db))
+
+		refs := batchDownloadRefs("batch-invalid")
+		insertDownloadRefsBatch(t, ctx, db, refs)
+		assertDownloadRefsBatch(t, ctx, db, "batch-invalid", refs)
+	})
 }
 
 func TestFixParkPieceTask_RepairsDuplicateRefs(t *testing.T) {
@@ -858,6 +921,113 @@ func parkedPieceIDForRef(t *testing.T, ctx context.Context, db *harmonydb.DB, re
 	err := db.QueryRow(ctx, `SELECT piece_id FROM parked_piece_refs WHERE ref_id = $1`, refID).Scan(&pieceID)
 	require.NoError(t, err)
 	return pieceID
+}
+
+const (
+	batchDownloadUniquePieceCount = 9500
+	batchDownloadRefCount         = 10000
+)
+
+func batchDownloadRefs(prefix string) []marketmk20.ParkedPieceDownloadRef {
+	refs := make([]marketmk20.ParkedPieceDownloadRef, 0, batchDownloadRefCount)
+	for refIndex := 0; refIndex < batchDownloadRefCount; refIndex++ {
+		pieceIndex := refIndex
+		if pieceIndex >= batchDownloadUniquePieceCount {
+			pieceIndex -= batchDownloadUniquePieceCount
+		}
+
+		paddedSize := int64(32 + 32*(pieceIndex%32))
+		refs = append(refs, marketmk20.ParkedPieceDownloadRef{
+			ID:         prefix,
+			PieceCIDV2: prefix + "-piece-v2-" + strconv.Itoa(pieceIndex),
+			PieceCID:   prefix + "-piece-v1-" + strconv.Itoa(pieceIndex),
+			PaddedSize: paddedSize,
+			RawSize:    paddedSize / 2,
+			URL:        "https://example.invalid/" + prefix + "/ref/" + strconv.Itoa(refIndex) + "/piece/" + strconv.Itoa(pieceIndex),
+			Headers:    []byte(`{"X-Test":["` + prefix + "-" + strconv.Itoa(refIndex) + `"]}`),
+			LongTerm:   false,
+		})
+	}
+	return refs
+}
+
+func insertDownloadRefsBatch(t *testing.T, ctx context.Context, db *harmonydb.DB, refs []marketmk20.ParkedPieceDownloadRef) {
+	t.Helper()
+
+	_, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		if err := marketmk20.InsertParkedPieceDownloadRefsBatch(ctx, tx, marketmk20.ProductNamePDPV1, refs); err != nil {
+			return false, err
+		}
+		return true, nil
+	}, harmonydb.OptionRetry())
+	require.NoError(t, err)
+}
+
+func assertDownloadRefsBatch(t *testing.T, ctx context.Context, db *harmonydb.DB, prefix string, refs []marketmk20.ParkedPieceDownloadRef) {
+	t.Helper()
+
+	var activePieces int
+	require.NoError(t, db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM parked_pieces
+		WHERE piece_cid LIKE $1
+		  AND cleanup_task_id IS NULL`, prefix+"-piece-v1-%").Scan(&activePieces))
+	require.Equal(t, batchDownloadUniquePieceCount, activePieces)
+
+	var refCount int
+	require.NoError(t, db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM parked_piece_refs
+		WHERE data_url LIKE $1`, "https://example.invalid/"+prefix+"/%").Scan(&refCount))
+	require.Equal(t, len(refs), refCount)
+
+	expectedByURL := map[string]marketmk20.ParkedPieceDownloadRef{}
+	expectedByPieceCIDV2 := map[string]int{}
+	for _, ref := range refs {
+		require.NotContains(t, expectedByURL, ref.URL)
+		expectedByURL[ref.URL] = ref
+		expectedByPieceCIDV2[ref.PieceCIDV2]++
+	}
+	for pieceCIDV2, expectedCount := range expectedByPieceCIDV2 {
+		var refIDs []int64
+		require.NoError(t, db.QueryRow(ctx, `
+			SELECT ref_ids FROM market_mk20_download_pipeline
+			WHERE id = $1 AND piece_cid_v2 = $2 AND product = $3`,
+			prefix, pieceCIDV2, marketmk20.ProductNamePDPV1).Scan(&refIDs))
+		require.Len(t, refIDs, expectedCount)
+	}
+
+	type pipelineRefRow struct {
+		PieceCIDV2  string `db:"piece_cid_v2"`
+		PieceCID    string `db:"piece_cid"`
+		DataURL     string `db:"data_url"`
+		DataHeaders string `db:"data_headers"`
+	}
+	var rows []pipelineRefRow
+	require.NoError(t, db.Select(ctx, &rows, `
+		SELECT mp.piece_cid_v2,
+		       pp.piece_cid,
+		       ppr.data_url,
+		       ppr.data_headers::text AS data_headers
+		FROM market_mk20_download_pipeline mp
+		CROSS JOIN LATERAL unnest(mp.ref_ids) AS refs(ref_id)
+		JOIN parked_piece_refs ppr ON ppr.ref_id = refs.ref_id
+		JOIN parked_pieces pp ON pp.id = ppr.piece_id
+		WHERE mp.id = $1
+		  AND mp.product = $2
+		  AND ppr.data_url LIKE $3`,
+		prefix, marketmk20.ProductNamePDPV1, "https://example.invalid/"+prefix+"/%"))
+	require.Len(t, rows, len(refs))
+
+	seenByURL := map[string]struct{}{}
+	for _, row := range rows {
+		expected, ok := expectedByURL[row.DataURL]
+		require.True(t, ok, "unexpected pipeline ref url %s", row.DataURL)
+		require.NotContains(t, seenByURL, row.DataURL)
+		seenByURL[row.DataURL] = struct{}{}
+		require.Equal(t, expected.PieceCIDV2, row.PieceCIDV2)
+		require.Equal(t, expected.PieceCID, row.PieceCID)
+		require.JSONEq(t, string(expected.Headers), row.DataHeaders)
+	}
+	require.Len(t, seenByURL, len(refs))
 }
 
 func parkedPieceIndexExists(t *testing.T, ctx context.Context, db *harmonydb.DB) bool {

--- a/lib/parkpiece/upsert.go
+++ b/lib/parkpiece/upsert.go
@@ -18,14 +18,17 @@ import (
 // index. Falls back to check-then-insert (not race-safe) if that index is
 // missing or INVALID. Must run inside a transaction.
 func Upsert(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm bool) (int64, error) {
-	var id int64
-	err := tx.QueryRow(`
-		INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
-		-- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
-		DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
-		RETURNING id`, pieceCID, paddedSize, rawSize, longTerm).Scan(&id)
+	id, err := withSavepoint(tx, func() (int64, error) {
+		var id int64
+		err := tx.QueryRow(`
+			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
+			-- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
+			DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
+			RETURNING id`, pieceCID, paddedSize, rawSize, longTerm).Scan(&id)
+		return id, err
+	})
 	if err == nil {
 		return id, nil
 	}
@@ -38,14 +41,17 @@ func Upsert(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTe
 // UpsertSkip is Upsert with an explicit skip value for new rows. Existing
 // rows keep their skip value.
 func UpsertSkip(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm, skip bool) (int64, error) {
-	var id int64
-	err := tx.QueryRow(`
-		INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
-		VALUES ($1, $2, $3, $4, $5)
-		ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
-		-- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
-		DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
-		RETURNING id`, pieceCID, paddedSize, rawSize, longTerm, skip).Scan(&id)
+	id, err := withSavepoint(tx, func() (int64, error) {
+		var id int64
+		err := tx.QueryRow(`
+			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
+			-- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
+			DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
+			RETURNING id`, pieceCID, paddedSize, rawSize, longTerm, skip).Scan(&id)
+		return id, err
+	})
 	if err == nil {
 		return id, nil
 	}
@@ -53,6 +59,26 @@ func UpsertSkip(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, lo
 		return upsertFallback(tx, pieceCID, paddedSize, rawSize, longTerm, &skip)
 	}
 	return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
+}
+
+// withSavepoint wraps run in a SAVEPOINT so an error (notably 42P10 from a
+// missing/INVALID index) doesn't poison the caller's transaction. On error,
+// the savepoint is rolled back and the original error returned.
+func withSavepoint(tx *harmonydb.Tx, run func() (int64, error)) (int64, error) {
+	if _, err := tx.Exec(`SAVEPOINT parkpiece_upsert`); err != nil {
+		return 0, xerrors.Errorf("savepoint: %w", err)
+	}
+	id, err := run()
+	if err != nil {
+		if _, rerr := tx.Exec(`ROLLBACK TO SAVEPOINT parkpiece_upsert`); rerr != nil {
+			return 0, xerrors.Errorf("rollback savepoint: %w (orig: %v)", rerr, err)
+		}
+		return 0, err
+	}
+	if _, rerr := tx.Exec(`RELEASE SAVEPOINT parkpiece_upsert`); rerr != nil {
+		return 0, xerrors.Errorf("release savepoint: %w", rerr)
+	}
+	return id, nil
 }
 
 // upsertFallback is the non-atomic check-then-insert path used when the

--- a/lib/parkpiece/upsert.go
+++ b/lib/parkpiece/upsert.go
@@ -3,16 +3,20 @@
 package parkpiece
 
 import (
+	"errors"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/yugabyte/pgx/v5"
+	"github.com/yugabyte/pgx/v5/pgconn"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 )
 
-// Upsert atomically inserts a parked_pieces row for the given
-// (piece_cid, piece_padded_size, long_term) or returns the id of the existing
-// live row. Safe under concurrent writers.
-//
-// Must be called inside a transaction.
+// Upsert returns the id of the existing live row, or inserts and returns a
+// new one. Race-safe under the parked_pieces_active_piece_key partial unique
+// index. Falls back to check-then-insert (not race-safe) if that index is
+// missing or INVALID. Must run inside a transaction.
 func Upsert(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm bool) (int64, error) {
 	var id int64
 	err := tx.QueryRow(`
@@ -22,17 +26,17 @@ func Upsert(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTe
 		-- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
 		DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
 		RETURNING id`, pieceCID, paddedSize, rawSize, longTerm).Scan(&id)
-	if err != nil {
-		return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
+	if err == nil {
+		return id, nil
 	}
-	return id, nil
+	if isErrInferenceUnmatched(err) {
+		return upsertFallback(tx, pieceCID, paddedSize, rawSize, longTerm, nil)
+	}
+	return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
 }
 
-// UpsertSkip is like Upsert but inserts the row with the given skip value when
-// new. The existing row's skip value is preserved on the conflict path -
-// callers that need to flip skip on an existing row must do so separately.
-//
-// Must be called inside a transaction.
+// UpsertSkip is Upsert with an explicit skip value for new rows. Existing
+// rows keep their skip value.
 func UpsertSkip(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm, skip bool) (int64, error) {
 	var id int64
 	err := tx.QueryRow(`
@@ -42,8 +46,49 @@ func UpsertSkip(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, lo
 		-- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
 		DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
 		RETURNING id`, pieceCID, paddedSize, rawSize, longTerm, skip).Scan(&id)
+	if err == nil {
+		return id, nil
+	}
+	if isErrInferenceUnmatched(err) {
+		return upsertFallback(tx, pieceCID, paddedSize, rawSize, longTerm, &skip)
+	}
+	return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
+}
+
+// upsertFallback is the non-atomic check-then-insert path used when the
+// partial unique index isn't bindable. skip is applied only on insert.
+func upsertFallback(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm bool, skip *bool) (int64, error) {
+	var id int64
+	err := tx.QueryRow(`
+		SELECT id FROM parked_pieces
+		WHERE piece_cid = $1 AND piece_padded_size = $2 AND long_term = $3 AND cleanup_task_id IS NULL
+		ORDER BY id LIMIT 1`, pieceCID, paddedSize, longTerm).Scan(&id)
+	if err == nil {
+		return id, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return 0, xerrors.Errorf("upsert parked_pieces (fallback select): %w", err)
+	}
+	if skip != nil {
+		err = tx.QueryRow(`
+			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
+			VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+			pieceCID, paddedSize, rawSize, longTerm, *skip).Scan(&id)
+	} else {
+		err = tx.QueryRow(`
+			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+			VALUES ($1, $2, $3, $4) RETURNING id`,
+			pieceCID, paddedSize, rawSize, longTerm).Scan(&id)
+	}
 	if err != nil {
-		return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
+		return 0, xerrors.Errorf("upsert parked_pieces (fallback insert): %w", err)
 	}
 	return id, nil
+}
+
+// isErrInferenceUnmatched is PG 42P10 - ON CONFLICT inference could not bind
+// to any unique constraint or VALID unique index.
+func isErrInferenceUnmatched(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == pgerrcode.InvalidColumnReference
 }

--- a/lib/parkpiece/upsert.go
+++ b/lib/parkpiece/upsert.go
@@ -144,7 +144,6 @@ func RefreshActiveIndexValid(tx *harmonydb.Tx) (bool, error) {
 			  AND tbl.relname = 'parked_pieces'
 			  AND idx.relname = 'parked_pieces_active_piece_key'
 			  AND idx.relkind = 'i'
-			  AND am.amname = 'btree'
 			  AND ix.indisunique
 			  AND ix.indisvalid
 			  AND ix.indisready

--- a/lib/parkpiece/upsert.go
+++ b/lib/parkpiece/upsert.go
@@ -4,85 +4,82 @@ package parkpiece
 
 import (
 	"errors"
+	"sync/atomic"
 
-	"github.com/jackc/pgerrcode"
 	"github.com/yugabyte/pgx/v5"
-	"github.com/yugabyte/pgx/v5/pgconn"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 )
 
-// Upsert returns the id of the existing live row, or inserts and returns a
-// new one. Race-safe under the parked_pieces_active_piece_key partial unique
-// index. Falls back to check-then-insert (not race-safe) if that index is
-// missing or INVALID. Must run inside a transaction.
+var activePieceIndexKnownValid atomic.Bool
+
+// Upsert returns the id for the active parked_pieces row matching
+// (piece_cid, piece_padded_size, long_term), inserting it when no active row is
+// present. When parked_pieces_active_piece_key is known valid, this uses the
+// partial unique index as the concurrency guard and performs a no-op conflict
+// update only so RETURNING can report the existing row id. When the index is
+// missing or INVALID, this avoids ON CONFLICT entirely and uses the degraded
+// check-then-insert fallback; that fallback can race and create duplicates
+// until FixParkPieceTask repairs the table/index.
 func Upsert(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm bool) (int64, error) {
-	id, err := withSavepoint(tx, func() (int64, error) {
+	indexValid, err := ActiveIndexValid(tx)
+	if err != nil {
+		return 0, xerrors.Errorf("checking parked_pieces_active_piece_key: %w", err)
+	}
+
+	if indexValid {
 		var id int64
-		err := tx.QueryRow(`
+		err = tx.QueryRow(`
 			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
 			VALUES ($1, $2, $3, $4)
 			ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
 			-- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
-			DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
+			DO UPDATE SET piece_cid = parked_pieces.piece_cid
 			RETURNING id`, pieceCID, paddedSize, rawSize, longTerm).Scan(&id)
-		return id, err
-	})
-	if err == nil {
+		if err != nil {
+			return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
+		}
 		return id, nil
 	}
-	if isErrInferenceUnmatched(err) {
-		return upsertFallback(tx, pieceCID, paddedSize, rawSize, longTerm, nil)
-	}
-	return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
+
+	return upsertFallback(tx, pieceCID, paddedSize, rawSize, longTerm, nil)
 }
 
-// UpsertSkip is Upsert with an explicit skip value for new rows. Existing
-// rows keep their skip value.
+// UpsertSkip is Upsert plus a skip value for newly inserted rows. The skip
+// flag is intentionally insert-only: if the piece already exists, both the
+// valid-index path and fallback path return the existing id without changing
+// the existing row's skip or raw-size metadata.
 func UpsertSkip(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm, skip bool) (int64, error) {
-	id, err := withSavepoint(tx, func() (int64, error) {
+	indexValid, err := ActiveIndexValid(tx)
+	if err != nil {
+		return 0, xerrors.Errorf("checking parked_pieces_active_piece_key: %w", err)
+	}
+
+	if indexValid {
 		var id int64
-		err := tx.QueryRow(`
+		err = tx.QueryRow(`
 			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
 			VALUES ($1, $2, $3, $4, $5)
 			ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
 			-- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
-			DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
+			DO UPDATE SET piece_cid = parked_pieces.piece_cid
 			RETURNING id`, pieceCID, paddedSize, rawSize, longTerm, skip).Scan(&id)
-		return id, err
-	})
-	if err == nil {
+		if err != nil {
+			return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
+		}
 		return id, nil
 	}
-	if isErrInferenceUnmatched(err) {
-		return upsertFallback(tx, pieceCID, paddedSize, rawSize, longTerm, &skip)
-	}
-	return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
+
+	return upsertFallback(tx, pieceCID, paddedSize, rawSize, longTerm, &skip)
 }
 
-// withSavepoint wraps run in a SAVEPOINT so an error (notably 42P10 from a
-// missing/INVALID index) doesn't poison the caller's transaction. On error,
-// the savepoint is rolled back and the original error returned.
-func withSavepoint(tx *harmonydb.Tx, run func() (int64, error)) (int64, error) {
-	if _, err := tx.Exec(`SAVEPOINT parkpiece_upsert`); err != nil {
-		return 0, xerrors.Errorf("savepoint: %w", err)
-	}
-	id, err := run()
-	if err != nil {
-		if _, rerr := tx.Exec(`ROLLBACK TO SAVEPOINT parkpiece_upsert`); rerr != nil {
-			return 0, xerrors.Errorf("rollback savepoint: %w (orig: %v)", rerr, err)
-		}
-		return 0, err
-	}
-	if _, rerr := tx.Exec(`RELEASE SAVEPOINT parkpiece_upsert`); rerr != nil {
-		return 0, xerrors.Errorf("release savepoint: %w", rerr)
-	}
-	return id, nil
-}
-
-// upsertFallback is the non-atomic check-then-insert path used when the
-// partial unique index isn't bindable. skip is applied only on insert.
+// upsertFallback is the non-atomic check-then-insert path used while the
+// partial unique index cannot be bound by ON CONFLICT. It first reuses the
+// lowest-id active row for the key, and inserts only when no active row exists.
+// There is deliberately no lock here; callers accept the same temporary
+// duplicate risk that the cleanup task is responsible for repairing. skip is
+// applied only to the inserted row.
 func upsertFallback(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm bool, skip *bool) (int64, error) {
 	var id int64
 	err := tx.QueryRow(`
@@ -112,9 +109,66 @@ func upsertFallback(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64
 	return id, nil
 }
 
-// isErrInferenceUnmatched is PG 42P10 - ON CONFLICT inference could not bind
-// to any unique constraint or VALID unique index.
-func isErrInferenceUnmatched(err error) bool {
-	var pgErr *pgconn.PgError
-	return errors.As(err, &pgErr) && pgErr.Code == pgerrcode.InvalidColumnReference
+// ActiveIndexValid returns whether parked_pieces_active_piece_key is present,
+// valid, and shaped exactly as the upsert helpers require. It caches only a
+// positive answer: once this process has observed the index as valid, later
+// calls skip the catalog lookup. Missing, invalid, or wrongly-shaped states are
+// rechecked on every call so a repair that drops/recreates the index can be
+// observed without restarting the process.
+func ActiveIndexValid(tx *harmonydb.Tx) (bool, error) {
+	if activePieceIndexKnownValid.Load() {
+		return true, nil
+	}
+
+	return RefreshActiveIndexValid(tx)
+}
+
+// RefreshActiveIndexValid checks the catalog even if this process previously
+// cached the index as valid. Repair code uses this path because it must be
+// authoritative when deciding whether to drop/recreate the index. The result
+// refreshes the positive cache; a false result clears a stale positive cache
+// but is still not a negative cache because ActiveIndexValid will requery while
+// the flag is false.
+func RefreshActiveIndexValid(tx *harmonydb.Tx) (bool, error) {
+	var exists bool
+	err := tx.QueryRow(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_catalog.pg_index ix
+			JOIN pg_catalog.pg_class idx ON idx.oid = ix.indexrelid
+			JOIN pg_catalog.pg_class tbl ON tbl.oid = ix.indrelid
+			JOIN pg_catalog.pg_namespace ns ON ns.oid = tbl.relnamespace
+			JOIN pg_catalog.pg_am am ON am.oid = idx.relam
+			WHERE ns.nspname = current_schema()
+			  AND idx.relnamespace = ns.oid
+			  AND tbl.relname = 'parked_pieces'
+			  AND idx.relname = 'parked_pieces_active_piece_key'
+			  AND idx.relkind = 'i'
+			  AND am.amname = 'btree'
+			  AND ix.indisunique
+			  AND ix.indisvalid
+			  AND ix.indisready
+			  AND ix.indislive
+			  AND ix.indnkeyatts = 3
+			  AND ix.indnatts = 3
+			  AND ix.indexprs IS NULL
+			  AND ARRAY(
+				  SELECT pg_catalog.pg_get_indexdef(ix.indexrelid, n, true)
+				  FROM generate_series(1, ix.indnkeyatts) AS n
+				  ORDER BY n
+			  ) = ARRAY['piece_cid', 'piece_padded_size', 'long_term']
+			  AND pg_catalog.pg_get_expr(ix.indpred, ix.indrelid, false) = '(cleanup_task_id IS NULL)'
+		)`).Scan(&exists)
+	if err != nil {
+		return false, err
+	}
+	activePieceIndexKnownValid.Store(exists)
+	return exists, nil
+}
+
+// ResetActiveIndexValidCacheForTest clears the process-local valid-index cache.
+// Production code should not call this; it exists so tests that drop or corrupt
+// the index are not order-dependent.
+func ResetActiveIndexValidCacheForTest() {
+	activePieceIndexKnownValid.Store(false)
 }

--- a/market/mk20/mk20.go
+++ b/market/mk20/mk20.go
@@ -844,9 +844,9 @@ func insertPDPPipeline(ctx context.Context, tx *harmonydb.Tx, deal *Deal) error 
 			}
 		}
 
-		batch := &pgx.Batch{}
-		batchSize := 5000
-
+		// Per-item rather than batched so parkpiece.Upsert can savepoint
+		// around its ON CONFLICT and fall back when the partial unique
+		// index is missing or INVALID.
 		for k, v := range toDownload {
 			for _, src := range v {
 				headers, err := json.Marshal(src.Headers)
@@ -856,50 +856,28 @@ func insertPDPPipeline(ctx context.Context, tx *harmonydb.Tx, deal *Deal) error 
 				if headers == nil {
 					headers = []byte("{}")
 				}
-				batch.Queue(`
-							WITH selected_piece AS (
-							  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-							  VALUES ($1, $2, $3, FALSE)
-							  ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
-							  -- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
-							  DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
-							  RETURNING id
-							),
-							inserted_ref AS (
-							  INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
-							  SELECT id, $4, $5, FALSE FROM selected_piece
-							  RETURNING ref_id
-							)
-							INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
-							VALUES ($6, $8, $7, ARRAY[(SELECT ref_id FROM inserted_ref)])
-							ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
-							SET ref_ids = array_append(
-							  market_mk20_download_pipeline.ref_ids,
-							  (SELECT ref_id FROM inserted_ref)
-							)
-							WHERE NOT market_mk20_download_pipeline.ref_ids @> ARRAY[(SELECT ref_id FROM inserted_ref)];`,
-					k.PieceCID.String(), k.Size, k.RawSize, src.URL, headers, k.ID, ProductNamePDPV1, k.PieceCIDV2.String())
-			}
-
-			if batch.Len() > batchSize {
-				res, err := tx.SendBatch(ctx, batch)
+				pieceID, err := parkpiece.Upsert(tx, k.PieceCID.String(), int64(k.Size), int64(k.RawSize), false)
 				if err != nil {
-					return xerrors.Errorf("failed to send batch: %w", err)
+					return xerrors.Errorf("upserting parked_pieces: %w", err)
 				}
-				if err := res.Close(); err != nil {
-					return xerrors.Errorf("closing parked piece query batch: %w", err)
+				var refID int64
+				err = tx.QueryRow(`
+					INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
+					VALUES ($1, $2, $3, FALSE)
+					RETURNING ref_id`, pieceID, src.URL, headers).Scan(&refID)
+				if err != nil {
+					return xerrors.Errorf("inserting parked_piece_refs: %w", err)
 				}
-				batch = &pgx.Batch{}
-			}
-		}
-
-		if batch.Len() > 0 {
-			res, err := tx.SendBatch(ctx, batch)
-			if err != nil {
-				return xerrors.Errorf("failed to send batch: %w", err)
-			}
-			if err := res.Close(); err != nil {
-				return xerrors.Errorf("closing parked piece query batch: %w", err)
+				_, err = tx.Exec(`
+					INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
+					VALUES ($1, $2, $3, ARRAY[$4::bigint])
+					ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
+					SET ref_ids = array_append(market_mk20_download_pipeline.ref_ids, $4::bigint)
+					WHERE NOT market_mk20_download_pipeline.ref_ids @> ARRAY[$4::bigint]`,
+					k.ID, k.PieceCIDV2.String(), ProductNamePDPV1, refID)
+				if err != nil {
+					return xerrors.Errorf("upserting market_mk20_download_pipeline: %w", err)
+				}
 			}
 		}
 

--- a/market/mk20/mk20.go
+++ b/market/mk20/mk20.go
@@ -844,9 +844,7 @@ func insertPDPPipeline(ctx context.Context, tx *harmonydb.Tx, deal *Deal) error 
 			}
 		}
 
-		// Per-item rather than batched so parkpiece.Upsert can savepoint
-		// around its ON CONFLICT and fall back when the partial unique
-		// index is missing or INVALID.
+		var downloadRefs []ParkedPieceDownloadRef
 		for k, v := range toDownload {
 			for _, src := range v {
 				headers, err := json.Marshal(src.Headers)
@@ -856,29 +854,20 @@ func insertPDPPipeline(ctx context.Context, tx *harmonydb.Tx, deal *Deal) error 
 				if headers == nil {
 					headers = []byte("{}")
 				}
-				pieceID, err := parkpiece.Upsert(tx, k.PieceCID.String(), int64(k.Size), int64(k.RawSize), false)
-				if err != nil {
-					return xerrors.Errorf("upserting parked_pieces: %w", err)
-				}
-				var refID int64
-				err = tx.QueryRow(`
-					INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
-					VALUES ($1, $2, $3, FALSE)
-					RETURNING ref_id`, pieceID, src.URL, headers).Scan(&refID)
-				if err != nil {
-					return xerrors.Errorf("inserting parked_piece_refs: %w", err)
-				}
-				_, err = tx.Exec(`
-					INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
-					VALUES ($1, $2, $3, ARRAY[$4::bigint])
-					ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
-					SET ref_ids = array_append(market_mk20_download_pipeline.ref_ids, $4::bigint)
-					WHERE NOT market_mk20_download_pipeline.ref_ids @> ARRAY[$4::bigint]`,
-					k.ID, k.PieceCIDV2.String(), ProductNamePDPV1, refID)
-				if err != nil {
-					return xerrors.Errorf("upserting market_mk20_download_pipeline: %w", err)
-				}
+				downloadRefs = append(downloadRefs, ParkedPieceDownloadRef{
+					ID:         k.ID,
+					PieceCIDV2: k.PieceCIDV2.String(),
+					PieceCID:   k.PieceCID.String(),
+					PaddedSize: int64(k.Size),
+					RawSize:    int64(k.RawSize),
+					URL:        src.URL,
+					Headers:    headers,
+					LongTerm:   false,
+				})
 			}
+		}
+		if err := InsertParkedPieceDownloadRefsBatch(ctx, tx, ProductNamePDPV1, downloadRefs); err != nil {
+			return xerrors.Errorf("inserting parked piece download refs: %w", err)
 		}
 
 		pBatch := &pgx.Batch{}

--- a/market/mk20/parkpiece_batch.go
+++ b/market/mk20/parkpiece_batch.go
@@ -1,0 +1,142 @@
+package mk20
+
+import (
+	"context"
+
+	"github.com/yugabyte/pgx/v5"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/lib/parkpiece"
+)
+
+const parkedPieceDownloadBatchSize = 5000
+
+// ParkedPieceDownloadRef is one download URL that must become exactly one
+// parked_piece_refs row and exactly one appended ref_id in
+// market_mk20_download_pipeline. Do not dedupe values of this type: duplicate
+// URLs, duplicate headers, or duplicate piece keys are still distinct download
+// refs that must be represented by distinct ref_ids.
+type ParkedPieceDownloadRef struct {
+	ID         string
+	PieceCIDV2 string
+	PieceCID   string
+	PaddedSize int64
+	RawSize    int64
+	URL        string
+	Headers    []byte
+	LongTerm   bool
+}
+
+// InsertParkedPieceDownloadRefsBatch preserves the original per-URL semantics
+// while still using pgx.Batch to reduce round trips. Each queued statement is
+// one logical download source: it resolves or creates the parked_pieces row,
+// inserts exactly one parked_piece_refs row, and appends that exact returned
+// ref_id to market_mk20_download_pipeline. This deliberately avoids bulk ref
+// insertion plus post-hoc ref_id remapping because (piece_id, data_url) is not
+// a unique identity for a ref when duplicate URLs or headers are present.
+func InsertParkedPieceDownloadRefsBatch(ctx context.Context, tx *harmonydb.Tx, product ProductName, refs []ParkedPieceDownloadRef) error {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	indexValid, err := parkpiece.ActiveIndexValid(tx)
+	if err != nil {
+		return xerrors.Errorf("checking parked_pieces_active_piece_key: %w", err)
+	}
+
+	query := parkedPieceDownloadRefInsertSQL(indexValid)
+	for start := 0; start < len(refs); start += parkedPieceDownloadBatchSize {
+		end := min(start+parkedPieceDownloadBatchSize, len(refs))
+		batch := &pgx.Batch{}
+		for _, ref := range refs[start:end] {
+			batch.Queue(query, ref.PieceCID, ref.PaddedSize, ref.RawSize, ref.LongTerm, ref.URL, ref.Headers, ref.ID, product, ref.PieceCIDV2)
+		}
+
+		res, err := tx.SendBatch(ctx, batch)
+		if err != nil {
+			return xerrors.Errorf("sending parked piece download ref batch: %w", err)
+		}
+		for i := 0; i < batch.Len(); i++ {
+			if _, err := res.Exec(); err != nil {
+				_ = res.Close()
+				return xerrors.Errorf("executing parked piece download ref batch item %d: %w", start+i, err)
+			}
+		}
+		if err := res.Close(); err != nil {
+			return xerrors.Errorf("closing parked piece download ref batch: %w", err)
+		}
+	}
+	return nil
+}
+
+// parkedPieceDownloadRefInsertSQL returns one self-contained SQL statement for
+// one ParkedPieceDownloadRef. The valid-index statement uses the partial unique
+// index for atomic parked_pieces upsert. The invalid/missing-index statement
+// never references ON CONFLICT on parked_pieces, avoiding 42P10; it has the
+// same degraded duplicate risk as parkpiece.Upsert fallback until
+// FixParkPieceTask repairs the table/index. The CTEs here are statement-local
+// only: they thread the exact inserted ref_id into the pipeline upsert for this
+// one URL, and do not perform cross-row bridge/remap logic.
+func parkedPieceDownloadRefInsertSQL(indexValid bool) string {
+	if indexValid {
+		return `
+			WITH selected_piece AS (
+				INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+				VALUES ($1, $2, $3, $4)
+				ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
+				DO UPDATE SET piece_cid = parked_pieces.piece_cid
+				RETURNING id
+			),
+			inserted_ref AS (
+				INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
+				SELECT id, $5, $6, $4 FROM selected_piece
+				RETURNING ref_id
+			)
+			INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
+			VALUES ($7, $9, $8, ARRAY[(SELECT ref_id FROM inserted_ref)])
+			ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
+			SET ref_ids = array_append(
+				market_mk20_download_pipeline.ref_ids,
+				(SELECT ref_id FROM inserted_ref)
+			)
+			WHERE NOT market_mk20_download_pipeline.ref_ids @> ARRAY[(SELECT ref_id FROM inserted_ref)]`
+	}
+
+	return `
+		WITH existing_piece AS (
+			SELECT id
+			FROM parked_pieces
+			WHERE piece_cid = $1
+			  AND piece_padded_size = $2
+			  AND long_term = $4
+			  AND cleanup_task_id IS NULL
+			ORDER BY id
+			LIMIT 1
+		),
+		inserted_piece AS (
+			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
+			SELECT $1, $2, $3, $4
+			WHERE NOT EXISTS (SELECT 1 FROM existing_piece)
+			RETURNING id
+		),
+		selected_piece AS (
+			SELECT id FROM existing_piece
+			UNION ALL
+			SELECT id FROM inserted_piece
+			LIMIT 1
+		),
+		inserted_ref AS (
+			INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
+			SELECT id, $5, $6, $4 FROM selected_piece
+			RETURNING ref_id
+		)
+		INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
+		VALUES ($7, $9, $8, ARRAY[(SELECT ref_id FROM inserted_ref)])
+		ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
+		SET ref_ids = array_append(
+			market_mk20_download_pipeline.ref_ids,
+			(SELECT ref_id FROM inserted_ref)
+		)
+		WHERE NOT market_mk20_download_pipeline.ref_ids @> ARRAY[(SELECT ref_id FROM inserted_ref)]`
+}

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -73,22 +73,11 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		return true, nil
 	}
 
-	/*
-		Look at duplicate groups across all active parked_pieces rows, not just completed rows,
-		but only processes groups that have at least one complete row.
-		It picks a readable complete row as the winner, moves refs from stale/no-task losers to that winner,
-		and skips losers whose task_id still exists in harmony_task.
-
-		Covered Cases:
-		1. complete + incomplete with task_id IS NULL
-		2. complete + incomplete with stale task_id
-		3. multiple complete rows
-		4. active incomplete rows are left alone
-
-		Ignored:
-		1. unique incomplete rows
-		2. duplicate groups with no complete row
-	*/
+	// For each duplicate group, pick a winner (complete+readable, else
+	// lowest-id non-active), move non-active refs onto it, delete the
+	// now-refless losers. Active rows are left alone and revisited next
+	// pass. Then drop and recreate the index unconditionally - IF NOT
+	// EXISTS is a no-op against an existing INVALID index.
 	type duplicateKey struct {
 		PieceCid  string
 		PieceSize int64
@@ -118,7 +107,6 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 									WHERE cleanup_task_id IS NULL
 									GROUP BY 1,2,3
 									HAVING count(*) > 1
-									   AND bool_or(complete)
 								) dup ON dup.piece_cid = pp.piece_cid
 									 AND dup.piece_padded_size = pp.piece_padded_size
 									 AND dup.long_term = pp.long_term
@@ -144,56 +132,81 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 	}
 
 	for _, key := range keys {
-		dup := duplicates[key]
-		if stillOwned() {
-			var winner *int64
-			for _, row := range dup {
-				if !row.Complete {
-					continue
-				}
-
-				// Verify that the piece is still parked
-				// If piece exists then check if we can access the data
-				pr, err := f.sc.PieceReader(ctx, storiface.PieceNumber(row.ID))
-				if err != nil {
-					// If piece does not exist then we check the next one
-					continue
-				}
-				_ = pr.Close()
-				winner = new(row.ID)
-				break
-			}
-
-			if winner == nil {
-				continue
-			}
-
-			var loserIDs []int64
-			for _, row := range dup {
-				if row.ID == *winner {
-					continue
-				}
-				if row.TaskActive {
-					continue
-				}
-				loserIDs = append(loserIDs, row.ID)
-			}
-
-			if len(loserIDs) == 0 {
-				continue
-			}
-
-			_, err = f.db.Exec(ctx, `UPDATE parked_piece_refs SET piece_id = $1 WHERE piece_id = ANY($2::bigint[]);`, *winner, loserIDs)
-			if err != nil {
-				return false, xerrors.Errorf("updating parked piece refs: %w", err)
-			}
-		} else {
+		if !stillOwned() {
 			return false, nil
+		}
+		dup := duplicates[key]
+
+		// Prefer complete + readable; ORDER BY puts complete rows first, so
+		// the first non-active row is the lowest-id fallback.
+		var winner, fallback *int64
+		for _, row := range dup {
+			if row.TaskActive {
+				continue
+			}
+			if fallback == nil {
+				fallback = new(row.ID)
+			}
+			if !row.Complete {
+				continue
+			}
+			pr, err := f.sc.PieceReader(ctx, storiface.PieceNumber(row.ID))
+			if err != nil {
+				continue
+			}
+			_ = pr.Close()
+			winner = new(row.ID)
+			break
+		}
+		if winner == nil {
+			winner = fallback
+		}
+		if winner == nil {
+			// All rows active; retry next pass.
+			continue
+		}
+
+		var loserIDs []int64
+		for _, row := range dup {
+			if row.ID == *winner {
+				continue
+			}
+			if row.TaskActive {
+				continue
+			}
+			loserIDs = append(loserIDs, row.ID)
+		}
+		if len(loserIDs) == 0 {
+			continue
+		}
+
+		// Move refs and delete refless losers atomically so the partial
+		// index sees a clean state.
+		_, err = f.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+			if _, terr := tx.Exec(`UPDATE parked_piece_refs SET piece_id = $1 WHERE piece_id = ANY($2::bigint[]);`, *winner, loserIDs); terr != nil {
+				return false, xerrors.Errorf("updating parked_piece_refs: %w", terr)
+			}
+			if _, terr := tx.Exec(`DELETE FROM parked_pieces WHERE id = ANY($1::bigint[]);`, loserIDs); terr != nil {
+				return false, xerrors.Errorf("deleting refless loser rows: %w", terr)
+			}
+			return true, nil
+		}, harmonydb.OptionRetry())
+		if err != nil {
+			return false, xerrors.Errorf("consolidating duplicate group: %w", err)
 		}
 	}
 
-	_, err = f.db.Exec(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS parked_pieces_active_piece_key ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL;`)
-	if err != nil {
+	// IF NOT EXISTS is a no-op against an existing INVALID index, so drop
+	// unconditionally before creating.
+	if _, err = f.db.Exec(ctx, `DROP INDEX IF EXISTS parked_pieces_active_piece_key;`); err != nil {
+		return false, xerrors.Errorf("dropping parked_pieces_active_piece_key: %w", err)
+	}
+	if _, err = f.db.Exec(ctx, `CREATE UNIQUE INDEX parked_pieces_active_piece_key ON parked_pieces (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL;`); err != nil {
+		if harmonydb.IsErrUniqueContraint(err) {
+			// Active rows in some groups blocked consolidation; retry next pass.
+			log.Warnf("parked_pieces_active_piece_key not yet creatable: %s", err)
+			return true, nil
+		}
 		return false, xerrors.Errorf("creating index: %w", err)
 	}
 

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -194,6 +194,15 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		if err != nil {
 			return false, xerrors.Errorf("consolidating duplicate group: %w", err)
 		}
+
+		// Best-effort: remove the on-disk piece data for losers we just
+		// deleted from the DB. Errors are logged; orphan cleanup will
+		// catch any stragglers.
+		for _, loserID := range loserIDs {
+			if rerr := f.sc.RemovePiece(ctx, storiface.PieceNumber(loserID)); rerr != nil {
+				log.Errorw("removing piece after consolidation", "piece_id", loserID, "error", rerr)
+			}
+		}
 	}
 
 	// IF NOT EXISTS is a no-op against an existing INVALID index, so drop

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -49,6 +49,7 @@ func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 	}
 
 	if exists {
+		log.Infow("parked_pieces_active_piece_key already exists", "task_id", taskID)
 		return true, nil
 	}
 

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -2,7 +2,6 @@ package piece
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/harmony/resources"
 	"github.com/filecoin-project/curio/lib/ffi"
+	"github.com/filecoin-project/curio/lib/parkpiece"
 	"github.com/filecoin-project/curio/lib/promise"
 	"github.com/filecoin-project/curio/lib/storiface"
 )
@@ -35,38 +35,17 @@ func NewFixParkPieceTask(db *harmonydb.DB, sc *ffi.SealCalls) *FixParkPieceTask 
 func (f *FixParkPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
 	ctx := context.Background()
 
-	// Check index first
 	var exists bool
-	err = f.db.QueryRow(ctx, `
-					SELECT EXISTS (
-						SELECT 1
-						FROM pg_catalog.pg_index ix
-						JOIN pg_catalog.pg_class idx ON idx.oid = ix.indexrelid
-						JOIN pg_catalog.pg_class tbl ON tbl.oid = ix.indrelid
-						JOIN pg_catalog.pg_namespace ns ON ns.oid = tbl.relnamespace
-						JOIN pg_catalog.pg_am am ON am.oid = idx.relam
-						WHERE ns.nspname = current_schema()
-						  AND idx.relnamespace = ns.oid
-						  AND tbl.relname = 'parked_pieces'
-						  AND idx.relname = 'parked_pieces_active_piece_key'
-						  AND idx.relkind = 'i'
-						  AND am.amname = 'btree'
-						  AND ix.indisunique
-						  AND ix.indisvalid
-						  AND ix.indisready
-						  AND ix.indislive
-						  AND ix.indnkeyatts = 3
-						  AND ix.indnatts = 3
-						  AND ix.indexprs IS NULL
-						  AND ARRAY(
-							  SELECT pg_catalog.pg_get_indexdef(ix.indexrelid, n, true)
-							  FROM generate_series(1, ix.indnkeyatts) AS n
-							  ORDER BY n
-						  ) = ARRAY['piece_cid', 'piece_padded_size', 'long_term']
-						  AND pg_catalog.pg_get_expr(ix.indpred, ix.indrelid, false) = '(cleanup_task_id IS NULL)'
-					);`).Scan(&exists)
+	_, err = f.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		var terr error
+		exists, terr = parkpiece.RefreshActiveIndexValid(tx)
+		if terr != nil {
+			return false, terr
+		}
+		return true, nil
+	}, harmonydb.OptionRetry())
 	if err != nil {
-		return false, fmt.Errorf("checking if index exists: %w", err)
+		return false, xerrors.Errorf("checking if index exists: %w", err)
 	}
 
 	if exists {

--- a/tasks/storage-market/mk20.go
+++ b/tasks/storage-market/mk20.go
@@ -480,9 +480,9 @@ func insertPiecesInTransaction(ctx context.Context, tx *harmonydb.Tx, deal *mk20
 			}
 		}
 
-		batch := &pgx.Batch{}
-		batchSize := 5000
-
+		// Per-item rather than batched so parkpiece.Upsert can savepoint
+		// around its ON CONFLICT and fall back when the partial unique
+		// index is missing or INVALID.
 		for k, v := range toDownload {
 			for _, src := range v {
 				headers, err := json.Marshal(src.Headers)
@@ -492,49 +492,28 @@ func insertPiecesInTransaction(ctx context.Context, tx *harmonydb.Tx, deal *mk20
 				if headers == nil {
 					headers = []byte("{}")
 				}
-				batch.Queue(`WITH selected_piece AS (
-									  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-									  VALUES ($1, $2, $3, FALSE)
-									  ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
-									  -- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
-									  DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
-									  RETURNING id
-									),
-									inserted_ref AS (
-									  INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
-									  SELECT id, $4, $5, FALSE FROM selected_piece
-									  RETURNING ref_id
-									)
-									INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
-									VALUES ($6, $8, $7, ARRAY[(SELECT ref_id FROM inserted_ref)])
-									ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
-									SET ref_ids = array_append(
-									  market_mk20_download_pipeline.ref_ids,
-									  (SELECT ref_id FROM inserted_ref)
-									)
-									WHERE NOT market_mk20_download_pipeline.ref_ids @> ARRAY[(SELECT ref_id FROM inserted_ref)];`,
-					k.PieceCID.String(), k.Size, k.RawSize, src.URL, headers, k.ID, mk20.ProductNameDDOV1, k.PieceCIDV2.String())
-			}
-
-			if batch.Len() > batchSize {
-				res, err := tx.SendBatch(ctx, batch)
+				pieceID, err := parkpiece.Upsert(tx, k.PieceCID.String(), int64(k.Size), int64(k.RawSize), false)
 				if err != nil {
-					return xerrors.Errorf("failed to send batch: %w", err)
+					return xerrors.Errorf("upserting parked_pieces: %w", err)
 				}
-				if err := res.Close(); err != nil {
-					return xerrors.Errorf("closing parked piece query batch: %w", err)
+				var refID int64
+				err = tx.QueryRow(`
+					INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
+					VALUES ($1, $2, $3, FALSE)
+					RETURNING ref_id`, pieceID, src.URL, headers).Scan(&refID)
+				if err != nil {
+					return xerrors.Errorf("inserting parked_piece_refs: %w", err)
 				}
-				batch = &pgx.Batch{}
-			}
-		}
-
-		if batch.Len() > 0 {
-			res, err := tx.SendBatch(ctx, batch)
-			if err != nil {
-				return xerrors.Errorf("failed to send batch: %w", err)
-			}
-			if err := res.Close(); err != nil {
-				return xerrors.Errorf("closing parked piece query batch: %w", err)
+				_, err = tx.Exec(`
+					INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
+					VALUES ($1, $2, $3, ARRAY[$4::bigint])
+					ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
+					SET ref_ids = array_append(market_mk20_download_pipeline.ref_ids, $4::bigint)
+					WHERE NOT market_mk20_download_pipeline.ref_ids @> ARRAY[$4::bigint]`,
+					k.ID, k.PieceCIDV2.String(), mk20.ProductNameDDOV1, refID)
+				if err != nil {
+					return xerrors.Errorf("upserting market_mk20_download_pipeline: %w", err)
+				}
 			}
 		}
 
@@ -744,49 +723,53 @@ func (d *CurioStorageDealMarket) findOfflineURLMk20Deal(ctx context.Context, pie
 					continue
 				}
 
-				_, err = tx.Exec(`WITH pipeline_piece AS (
-										  SELECT id, piece_cid, piece_size, deal_aggregation
-										  FROM market_mk20_pipeline
-										  WHERE id = $1 AND piece_cid = $2 AND piece_size = $3
-										),
-										selected_piece AS (
-										  INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term)
-										  SELECT $2, $3, $4, NOT (p.deal_aggregation > 0)
-										  FROM pipeline_piece p
-										  ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
-										  -- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
-										  DO UPDATE SET piece_raw_size = EXCLUDED.piece_raw_size
-										  RETURNING id AS piece_id
-										),
-										inserted_ref AS (
-										  INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
-										  SELECT
-											s.piece_id,
-											$5,
-											$6,
-											NOT (p.deal_aggregation > 0)
-										  FROM selected_piece s
-										  JOIN pipeline_piece p ON true
-										  RETURNING ref_id
-										),
-										upsert_pipeline AS (
-										  INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
-										  SELECT $1, $8, $7, array_agg(ref_id)
-										  FROM inserted_ref
-										  ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
-										  SET ref_ids = (
-											SELECT array(
-											  SELECT DISTINCT r
-												FROM unnest(market_mk20_download_pipeline.ref_ids || excluded.ref_ids) AS r
-											)
-										  )
-										)
-										UPDATE market_mk20_pipeline
-										SET started = TRUE
-										WHERE id = $1 AND piece_cid = $2 AND piece_size = $3 AND started = FALSE;`,
-					piece.ID, piece.PieceCID, piece.PieceSize, rawSize, urlString, hdrs, mk20.ProductNameDDOV1, piece.PieceCIDV2)
+				// Read deal_aggregation so long_term can be passed to
+				// parkpiece.Upsert (which savepoints around its ON CONFLICT
+				// and falls back when the partial unique index is broken).
+				var dealAggregation int
+				err = tx.QueryRow(`
+					SELECT deal_aggregation FROM market_mk20_pipeline
+					WHERE id = $1 AND piece_cid = $2 AND piece_size = $3`,
+					piece.ID, piece.PieceCID, piece.PieceSize).Scan(&dealAggregation)
 				if err != nil {
-					return false, xerrors.Errorf("failed to start download for offline deal using PieceLocator: %w", err)
+					return false, xerrors.Errorf("reading market_mk20_pipeline: %w", err)
+				}
+				longTerm := dealAggregation <= 0
+
+				pieceID, err := parkpiece.Upsert(tx, piece.PieceCID, piece.PieceSize, rawSize, longTerm)
+				if err != nil {
+					return false, xerrors.Errorf("upserting parked_pieces: %w", err)
+				}
+
+				var refID int64
+				err = tx.QueryRow(`
+					INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
+					VALUES ($1, $2, $3, $4)
+					RETURNING ref_id`, pieceID, urlString, hdrs, longTerm).Scan(&refID)
+				if err != nil {
+					return false, xerrors.Errorf("inserting parked_piece_refs: %w", err)
+				}
+
+				_, err = tx.Exec(`
+					INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
+					VALUES ($1, $2, $3, ARRAY[$4::bigint])
+					ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
+					SET ref_ids = (
+						SELECT array(
+							SELECT DISTINCT r
+							FROM unnest(market_mk20_download_pipeline.ref_ids || excluded.ref_ids) AS r
+						)
+					)`, piece.ID, piece.PieceCIDV2, mk20.ProductNameDDOV1, refID)
+				if err != nil {
+					return false, xerrors.Errorf("upserting market_mk20_download_pipeline: %w", err)
+				}
+
+				_, err = tx.Exec(`
+					UPDATE market_mk20_pipeline SET started = TRUE
+					WHERE id = $1 AND piece_cid = $2 AND piece_size = $3 AND started = FALSE`,
+					piece.ID, piece.PieceCID, piece.PieceSize)
+				if err != nil {
+					return false, xerrors.Errorf("marking market_mk20_pipeline started: %w", err)
 				}
 
 				return true, nil

--- a/tasks/storage-market/mk20.go
+++ b/tasks/storage-market/mk20.go
@@ -480,9 +480,7 @@ func insertPiecesInTransaction(ctx context.Context, tx *harmonydb.Tx, deal *mk20
 			}
 		}
 
-		// Per-item rather than batched so parkpiece.Upsert can savepoint
-		// around its ON CONFLICT and fall back when the partial unique
-		// index is missing or INVALID.
+		var downloadRefs []mk20.ParkedPieceDownloadRef
 		for k, v := range toDownload {
 			for _, src := range v {
 				headers, err := json.Marshal(src.Headers)
@@ -492,29 +490,20 @@ func insertPiecesInTransaction(ctx context.Context, tx *harmonydb.Tx, deal *mk20
 				if headers == nil {
 					headers = []byte("{}")
 				}
-				pieceID, err := parkpiece.Upsert(tx, k.PieceCID.String(), int64(k.Size), int64(k.RawSize), false)
-				if err != nil {
-					return xerrors.Errorf("upserting parked_pieces: %w", err)
-				}
-				var refID int64
-				err = tx.QueryRow(`
-					INSERT INTO parked_piece_refs (piece_id, data_url, data_headers, long_term)
-					VALUES ($1, $2, $3, FALSE)
-					RETURNING ref_id`, pieceID, src.URL, headers).Scan(&refID)
-				if err != nil {
-					return xerrors.Errorf("inserting parked_piece_refs: %w", err)
-				}
-				_, err = tx.Exec(`
-					INSERT INTO market_mk20_download_pipeline (id, piece_cid_v2, product, ref_ids)
-					VALUES ($1, $2, $3, ARRAY[$4::bigint])
-					ON CONFLICT (id, piece_cid_v2, product) DO UPDATE
-					SET ref_ids = array_append(market_mk20_download_pipeline.ref_ids, $4::bigint)
-					WHERE NOT market_mk20_download_pipeline.ref_ids @> ARRAY[$4::bigint]`,
-					k.ID, k.PieceCIDV2.String(), mk20.ProductNameDDOV1, refID)
-				if err != nil {
-					return xerrors.Errorf("upserting market_mk20_download_pipeline: %w", err)
-				}
+				downloadRefs = append(downloadRefs, mk20.ParkedPieceDownloadRef{
+					ID:         k.ID,
+					PieceCIDV2: k.PieceCIDV2.String(),
+					PieceCID:   k.PieceCID.String(),
+					PaddedSize: int64(k.Size),
+					RawSize:    int64(k.RawSize),
+					URL:        src.URL,
+					Headers:    headers,
+					LongTerm:   false,
+				})
 			}
+		}
+		if err := mk20.InsertParkedPieceDownloadRefsBatch(ctx, tx, mk20.ProductNameDDOV1, downloadRefs); err != nil {
+			return xerrors.Errorf("inserting parked piece download refs: %w", err)
 		}
 
 		pBatch := &pgx.Batch{}
@@ -723,9 +712,7 @@ func (d *CurioStorageDealMarket) findOfflineURLMk20Deal(ctx context.Context, pie
 					continue
 				}
 
-				// Read deal_aggregation so long_term can be passed to
-				// parkpiece.Upsert (which savepoints around its ON CONFLICT
-				// and falls back when the partial unique index is broken).
+				// Read deal_aggregation so long_term can be passed to parkpiece.Upsert.
 				var dealAggregation int
 				err = tx.QueryRow(`
 					SELECT deal_aggregation FROM market_mk20_pipeline


### PR DESCRIPTION
Fixes: #1199 (🤞)

`FixParkPieceTask` had three bugs that left affected SPs unable to rebuild `parked_pieces_active_piece_key`:

- `HAVING bool_or(complete)` skipped all-incomplete groups (likely for the in-flight uploads under the pre-#1195 racy condition?).
- Refs were re-pointed but losers never deleted, so duplicates persisted and blocked index creation.
- `CREATE UNIQUE INDEX IF NOT EXISTS` is a no-op against an existing INVALID index (apparently Yugabyte's online build can leave one behind on a failed validation).

Fix: process every duplicate group, pick lowest-id non-active when no readable winner exists, delete refless losers, `DROP INDEX IF EXISTS` before `CREATE`.

Plus in the new `parkpiece.Upsert`/`UpsertSkip` fall back to check-then-insert on PG 42P10 so uploads stay up while the index is being rebuilt.

Tests cover all-incomplete consolidation, INVALID-index recovery via failed `CREATE UNIQUE INDEX CONCURRENTLY`, and the helper fallback.

This might be good for @TippyFlitsUK to try out live, unless he's already cleaned up his DB so none of this applies now.