### PR TITLE
Telemetry logging for state changing pdp handlers

### DIFF
--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -115,12 +115,6 @@ func kvUploadUUID(r *http.Request) []any {
 }
 
 // Routes registers the HTTP routes with the provided router.
-//
-// State-changing routes (POST/PUT/DELETE) are wrapped with the `instrument`
-// middleware so each request emits "[Begin <event>]" / "[End <event>]" lines
-// on the `pdp-lifecycle` logger. GET routes are intentionally not wrapped:
-// they are high-volume reads that would dilute the lifecycle signal used by
-// centralized log viewers (e.g. Betterstack) to detect inbound-request issues.
 func Routes(r *chi.Mux, p *PDPService) {
 	// Routes for data sets
 	r.Route(path.Join(PDPRoutePath, "/data-sets"), func(r chi.Router) {

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -99,15 +99,36 @@ func NewPDPService(ctx context.Context, db *harmonydb.DB, stor paths.StashStore,
 	return p
 }
 
-// Routes registers the HTTP routes with the provided router
+// kvDataSetID extracts the dataset URL param for lifecycle logging.
+func kvDataSetID(r *http.Request) []any {
+	return []any{"dataset", chi.URLParam(r, "dataSetId")}
+}
+
+// kvDataSetPiece extracts dataset + piece URL params for lifecycle logging.
+func kvDataSetPiece(r *http.Request) []any {
+	return []any{"dataset", chi.URLParam(r, "dataSetId"), "piece_id", chi.URLParam(r, "pieceID")}
+}
+
+// kvUploadUUID extracts the upload UUID URL param for lifecycle logging.
+func kvUploadUUID(r *http.Request) []any {
+	return []any{"upload_uuid", chi.URLParam(r, "uploadUUID")}
+}
+
+// Routes registers the HTTP routes with the provided router.
+//
+// State-changing routes (POST/PUT/DELETE) are wrapped with the `instrument`
+// middleware so each request emits "[Begin <event>]" / "[End <event>]" lines
+// on the `pdp-lifecycle` logger. GET routes are intentionally not wrapped:
+// they are high-volume reads that would dilute the lifecycle signal used by
+// centralized log viewers (e.g. Betterstack) to detect inbound-request issues.
 func Routes(r *chi.Mux, p *PDPService) {
 	// Routes for data sets
 	r.Route(path.Join(PDPRoutePath, "/data-sets"), func(r chi.Router) {
 		// POST /pdp/data-sets - Create a new data set
-		r.Post("/", p.handleCreateDataSet)
+		r.Post("/", instrument("dataSetCreate", p.handleCreateDataSet, nil))
 
 		// POST /pdp/data-sets/create-and-add - Create a new data set and add pieces at the same time
-		r.Post("/create-and-add", p.handleCreateDataSetAndAddPieces)
+		r.Post("/create-and-add", instrument("dataSetCreateAndAdd", p.handleCreateDataSetAndAddPieces, nil))
 
 		// GET /pdp/data-sets/created/{txHash} - Get the status of a data set creation
 		r.Get("/created/{txHash}", p.handleGetDataSetCreationStatus)
@@ -118,12 +139,12 @@ func Routes(r *chi.Mux, p *PDPService) {
 			r.Get("/", p.handleGetDataSet)
 
 			// DEL /pdp/data-sets/{set-id}
-			r.Delete("/", p.handleDeleteDataSet)
+			r.Delete("/", instrument("dataSetDelete", p.handleDeleteDataSet, kvDataSetID))
 
 			// Routes for pieces within a data set
 			r.Route("/pieces", func(r chi.Router) {
 				// POST /pdp/data-sets/{set-id}/pieces
-				r.Post("/", p.handleAddPieceToDataSet)
+				r.Post("/", instrument("pieceAdd", p.handleAddPieceToDataSet, kvDataSetID))
 
 				// GET /pdp/data-sets/{set-id}/pieces/added/{txHash}
 				r.Get("/added/{txHash}", p.handleGetPieceAdditionStatus)
@@ -134,7 +155,7 @@ func Routes(r *chi.Mux, p *PDPService) {
 					r.Get("/", p.handleGetDataSetPiece)
 
 					// DEL /pdp/data-sets/{set-id}/pieces/{piece-id}
-					r.Delete("/", p.handleDeleteDataSetPiece)
+					r.Delete("/", instrument("pieceDelete", p.handleDeleteDataSetPiece, kvDataSetPiece))
 				})
 			})
 		})
@@ -147,29 +168,25 @@ func Routes(r *chi.Mux, p *PDPService) {
 
 	// Routes for piece storage and retrieval
 	// POST /pdp/piece
-	r.Post(path.Join(PDPRoutePath, "/piece"), p.handlePiecePost)
+	r.Post(path.Join(PDPRoutePath, "/piece"), instrument("pieceUploadInit", p.handlePiecePost, nil))
 
 	// GET /pdp/piece/
 	r.Get(path.Join(PDPRoutePath, "/piece/"), p.handleFindPiece)
 
 	// PUT /pdp/piece/upload/{uploadUUID}
-	r.Put(path.Join(PDPRoutePath, "/piece/upload/{uploadUUID}"), func(w http.ResponseWriter, r *http.Request) {
-		log.Debugw("[handlePieceUpload] -- router says upload started", "uploadUUID", chi.URLParam(r, "uploadUUID"))
-		p.handlePieceUpload(w, r)
-		log.Debugw("[handlePieceUpload] -- router says its done", "uploadUUID", chi.URLParam(r, "uploadUUID"))
-	})
+	r.Put(path.Join(PDPRoutePath, "/piece/upload/{uploadUUID}"), instrument("pieceUpload", p.handlePieceUpload, kvUploadUUID))
 
 	// POST /pdp/piece/uploads
-	r.Post(path.Join(PDPRoutePath, "/piece/uploads"), p.handleStreamingUploadURL)
+	r.Post(path.Join(PDPRoutePath, "/piece/uploads"), instrument("pieceStreamInit", p.handleStreamingUploadURL, nil))
 
 	// PUT /pdp/piece/uploads/{uploadUUID}
-	r.Put(path.Join(PDPRoutePath, "/piece/uploads/{uploadUUID}"), p.handleStreamingUpload)
+	r.Put(path.Join(PDPRoutePath, "/piece/uploads/{uploadUUID}"), instrument("pieceStreamUpload", p.handleStreamingUpload, kvUploadUUID))
 
 	// POST /pdp/piece/uploads/{uploadUUID}
-	r.Post(path.Join(PDPRoutePath, "/piece/uploads/{uploadUUID}"), p.handleFinalizeStreamingUpload)
+	r.Post(path.Join(PDPRoutePath, "/piece/uploads/{uploadUUID}"), instrument("pieceStreamFinalize", p.handleFinalizeStreamingUpload, kvUploadUUID))
 
 	// POST /pdp/piece/pull - Pull pieces from other SPs
-	r.Post(path.Join(PDPRoutePath, "/piece/pull"), p.pullHandler.HandlePull)
+	r.Post(path.Join(PDPRoutePath, "/piece/pull"), instrument("piecePull", p.pullHandler.HandlePull, nil))
 }
 
 // Handler functions

--- a/pdp/lifecycle.go
+++ b/pdp/lifecycle.go
@@ -42,10 +42,6 @@ func (s *statusRecorder) Write(b []byte) (int, error) {
 //
 // kvFn, if non-nil, is invoked at request time to extract additional context
 // (typically chi URL params) included on both the Begin and End lines.
-//
-// Only state-changing verbs (POST/PUT/DELETE) should be instrumented; GET
-// traffic is intentionally excluded to keep the lifecycle stream signal-rich
-// for centralized log viewers.
 func instrument(event string, h http.HandlerFunc, kvFn func(*http.Request) []any) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		rec := newStatusRecorder(w)
@@ -53,8 +49,8 @@ func instrument(event string, h http.HandlerFunc, kvFn func(*http.Request) []any
 		if kvFn != nil {
 			extra = kvFn(r)
 		}
-		base := make([]any, 0, 6+len(extra))
-		base = append(base, "event", event, "method", r.Method, "path", r.URL.Path)
+		base := make([]any, 0, 4+len(extra))
+		base = append(base, "method", r.Method, "path", r.URL.Path)
 		base = append(base, extra...)
 		lifecycleLog.Debugw("[Begin "+event+"]", base...)
 		start := time.Now()

--- a/pdp/lifecycle.go
+++ b/pdp/lifecycle.go
@@ -1,0 +1,75 @@
+package pdp
+
+import (
+	"net/http"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+// lifecycleLog emits standardized "[Begin <event>]" / "[End <event>]" lines for
+// every state-changing PDP HTTP handler. Filterable independently from the
+// general-purpose `pdpv0` subsystem so operators can subscribe to inbound
+// request lifecycle events alone (e.g. in Betterstack).
+var lifecycleLog = logging.Logger("pdp-lifecycle")
+
+// statusRecorder is a minimal http.ResponseWriter wrapper that captures the
+// final status code so the End log line can record it.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func newStatusRecorder(w http.ResponseWriter) *statusRecorder {
+	return &statusRecorder{ResponseWriter: w}
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}
+
+func (s *statusRecorder) Write(b []byte) (int, error) {
+	if s.status == 0 {
+		s.status = http.StatusOK
+	}
+	return s.ResponseWriter.Write(b)
+}
+
+// instrument wraps a state-changing PDP HTTP handler with standardized
+// "[Begin <event>]" / "[End <event>]" logging at Debug level. The End line
+// records the response status code, duration, and outcome (success|failure).
+//
+// kvFn, if non-nil, is invoked at request time to extract additional context
+// (typically chi URL params) included on both the Begin and End lines.
+//
+// Only state-changing verbs (POST/PUT/DELETE) should be instrumented; GET
+// traffic is intentionally excluded to keep the lifecycle stream signal-rich
+// for centralized log viewers.
+func instrument(event string, h http.HandlerFunc, kvFn func(*http.Request) []any) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		rec := newStatusRecorder(w)
+		var extra []any
+		if kvFn != nil {
+			extra = kvFn(r)
+		}
+		base := make([]any, 0, 6+len(extra))
+		base = append(base, "event", event, "method", r.Method, "path", r.URL.Path)
+		base = append(base, extra...)
+		lifecycleLog.Debugw("[Begin "+event+"]", base...)
+		start := time.Now()
+		defer func() {
+			status := rec.status
+			if status == 0 {
+				status = http.StatusOK
+			}
+			outcome := "success"
+			if status >= 400 {
+				outcome = "failure"
+			}
+			end := append(base, "status", status, "dur_ms", time.Since(start).Milliseconds(), "outcome", outcome)
+			lifecycleLog.Debugw("[End "+event+"]", end...)
+		}()
+		h(rec, r)
+	}
+}


### PR DESCRIPTION
Addresses first part of #1093.  Instrument all state changing pdp http handlers in a systematic way.

Perhaps we want to log as info but for now I think debug is a good place to start.