### PR TITLE
fix: synthetic proof finalize

### DIFF
--- a/lib/ffi/sdr_funcs.go
+++ b/lib/ffi/sdr_funcs.go
@@ -640,8 +640,17 @@ func TruncateAndMoveUnsealed(tempUnsealed, unsealed string, ssize abi.SectorSize
 	return nil
 }
 
+func finalizeExistingFileTypes(proofType abi.RegisteredSealProof, keepUnsealed bool) storiface.SectorFileType {
+	existing := storiface.FTCache
+	if abi.Synthetic[proofType] && keepUnsealed {
+		existing |= storiface.FTUnsealed
+	}
+
+	return existing
+}
+
 func (sb *SealCalls) FinalizeSector(ctx context.Context, sector storiface.SectorRef, keepUnsealed bool) error {
-	sectorPaths, pathIDs, releaseSector, err := sb.Sectors.AcquireSector(ctx, nil, sector, storiface.FTCache, storiface.FTNone, storiface.PathSealing)
+	sectorPaths, pathIDs, releaseSector, err := sb.Sectors.AcquireSector(ctx, nil, sector, finalizeExistingFileTypes(sector.ProofType, keepUnsealed), storiface.FTNone, storiface.PathSealing)
 	if err != nil {
 		return xerrors.Errorf("acquiring sector paths: %w", err)
 	}

--- a/lib/ffi/sdr_funcs_test.go
+++ b/lib/ffi/sdr_funcs_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/filecoin-project/go-state-types/abi"
+
 	"github.com/filecoin-project/curio/lib/storiface"
 )
 
@@ -79,6 +81,48 @@ func TestChangePathType(t *testing.T) {
 				if filepath.IsAbs(tt.path) != filepath.IsAbs(result) {
 					t.Errorf("Absolute/relative nature of path not preserved. Original: %s, Result: %s", tt.path, result)
 				}
+			}
+		})
+	}
+}
+
+func TestFinalizeExistingFileTypes(t *testing.T) {
+	tests := []struct {
+		name         string
+		proofType    abi.RegisteredSealProof
+		keepUnsealed bool
+		expected     storiface.SectorFileType
+	}{
+		{
+			name:         "non synthetic without unsealed",
+			proofType:    abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+			keepUnsealed: false,
+			expected:     storiface.FTCache,
+		},
+		{
+			name:         "non synthetic with unsealed generated from cache",
+			proofType:    abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+			keepUnsealed: true,
+			expected:     storiface.FTCache,
+		},
+		{
+			name:         "synthetic without unsealed",
+			proofType:    abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
+			keepUnsealed: false,
+			expected:     storiface.FTCache,
+		},
+		{
+			name:         "synthetic with existing unsealed",
+			proofType:    abi.RegisteredSealProof_StackedDrg32GiBV1_1_Feat_SyntheticPoRep,
+			keepUnsealed: true,
+			expected:     storiface.FTCache | storiface.FTUnsealed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if actual := finalizeExistingFileTypes(tt.proofType, tt.keepUnsealed); actual != tt.expected {
+				t.Fatalf("expected %s, got %s", tt.expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
We were acquiring the sector for synthetic proof incorrectly. This leads to below error:

` ensure one copy: not all paths are set`