### PR TITLE
fix: CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       matrix:
         test-suite:
           - name: test-all
-            target: "`go list ./... | grep -v curio/itests`"
+            target: "`go list ./... | grep -v curio/itests | grep -v -E 'github.com/filecoin-project/curio/lib/proof($|/)'`"
           - name: test-itest-alertnow
             target: "./itests/alertnow_test.go"
           - name: test-itest-batching
@@ -221,6 +221,43 @@ jobs:
         with:
           name: coverage-${{ matrix.test-suite.name }}
           path: coverage/${{ matrix.test-suite.name }}.out
+          retention-days: 1
+
+  test-lib-proof:
+    runs-on: ["self-hosted", "linux", "x64", "4xlarge+amd+curio"]
+    needs: [ci-lint]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: ./.github/actions/install-go
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-deps
+        with:
+          skip: 'true'
+
+      - name: Install FFI
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          FFI_USE_OPENCL: 1
+        run: |
+          make deps
+        shell: bash
+
+      - name: Run lib/proof tests with coverage
+        env:
+          FFI_USE_OPENCL: 1
+        run: |
+          mkdir -p coverage
+          go test -v --tags="debug,fvm,nosupraseal" -timeout 30m -coverprofile=coverage/test-lib-proof.out -covermode=atomic ./lib/proof/...
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-test-lib-proof
+          path: coverage/test-lib-proof.out
           retention-days: 1
 
   lint:
@@ -575,8 +612,8 @@ jobs:
 
   coverage-report:
     runs-on: ubuntu-latest
-    needs: [test]
-    if: always() && needs.test.result != 'cancelled'
+    needs: [test, test-lib-proof]
+    if: always() && needs.test.result != 'cancelled' && needs['test-lib-proof'].result != 'cancelled'
     permissions:
       contents: read
       checks: write
@@ -632,7 +669,7 @@ jobs:
           echo "### 📊 [View Coverage Report](https://artifact.ci/${{ github.repository }}/actions/runs/${{ github.run_id }}/coverage-merged/coverage.html)" >> $GITHUB_STEP_SUMMARY
 
   required-checks-passed:
-    needs: [ci-lint, build-mainnet, build-calibnet, build-debug, build-2k, build-forest, test, lint, gofmt, build-supraseal-ubuntu24, gen-check, mod-tidy-check, coverage-report]
+    needs: [ci-lint, build-mainnet, build-calibnet, build-debug, build-2k, build-forest, test, test-lib-proof, lint, gofmt, build-supraseal-ubuntu24, gen-check, mod-tidy-check, coverage-report]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All required checks passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
           retention-days: 1
 
   test-lib-proof:
-    runs-on: ["self-hosted", "linux", "x64", "4xlarge+curio"]
+    runs-on: ["self-hosted", "linux", "x64", "4xlarge+amd+curio"]
     needs: [ci-lint]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
           retention-days: 1
 
   test-lib-proof:
-    runs-on: ["self-hosted", "linux", "x64", "4xlarge+amd+curio"]
+    runs-on: ["self-hosted", "linux", "x64", "4xlarge+curio"]
     needs: [ci-lint]
     steps:
       - uses: actions/checkout@v4

--- a/alertmanager/task_alert.go
+++ b/alertmanager/task_alert.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/filecoin-project/curio/build"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
@@ -22,6 +21,7 @@ import (
 
 	"github.com/filecoin-project/curio/alertmanager/curioalerting"
 	"github.com/filecoin-project/curio/alertmanager/plugin"
+	"github.com/filecoin-project/curio/build"
 	"github.com/filecoin-project/curio/deps/config"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"

--- a/alertmanager/task_alert.go
+++ b/alertmanager/task_alert.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/filecoin-project/curio/build"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
@@ -151,7 +152,7 @@ func (a *AlertTask) Problems() bool {
 }
 
 func (a *AlertTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
-	now := time.Now()
+	now := build.Clock.Now()
 	ctx := context.Background()
 	altrs := &alerts{
 		ctx:      ctx,

--- a/itests/alertnow_test.go
+++ b/itests/alertnow_test.go
@@ -2,23 +2,41 @@ package itests
 
 import (
 	"testing"
+	"time"
 
+	"github.com/raulk/clock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/curio/alertmanager"
 	"github.com/filecoin-project/curio/alertmanager/curioalerting"
 	"github.com/filecoin-project/curio/alertmanager/plugin"
+	"github.com/filecoin-project/curio/build"
 	"github.com/filecoin-project/curio/deps/config"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 )
 
 func TestAlertNow(t *testing.T) {
 	// TestAlertNow tests alerting system
+	realClock := build.Clock
+	mockClock := clock.NewMock()
+	// AlertTask runs only ping-health checks during the first AlertManagerInterval
+	// of each FullAlertInterval. Pin this test just after that window so NowCheck
+	// is included and the plugin dispatch path is exercised deterministically.
+	mockClock.Set(time.Unix(int64(alertmanager.AlertManagerInterval/time.Second)+1, 0))
+	build.Clock = mockClock
+	t.Cleanup(func() {
+		build.Clock = realClock
+	})
 
 	tp := &testPlugin{}
+	oldTestPlugins := plugin.TestPlugins
 	plugin.TestPlugins = []plugin.Plugin{
 		tp,
 	}
+	t.Cleanup(func() {
+		plugin.TestPlugins = oldTestPlugins
+	})
+
 	// Create dependencies
 	db, err := harmonydb.NewFromConfigWithITestID(t)
 	require.NoError(t, err)
@@ -27,9 +45,14 @@ func TestAlertNow(t *testing.T) {
 	an.AddAlert("testMessage")
 
 	as := curioalerting.NewAlertingSystem()
+	oldAlertFuncs := alertmanager.AlertFuncs
 	alertmanager.AlertFuncs = map[alertmanager.AlertName]alertmanager.AlertFunc{
 		alertmanager.Name_NowCheck: alertmanager.NowCheck,
 	}
+	t.Cleanup(func() {
+		alertmanager.AlertFuncs = oldAlertFuncs
+	})
+
 	// Create a new alert task
 	at := alertmanager.NewAlertTask(nil, db, config.CurioAlertingConfig{}, as)
 	done, err := at.Do(123, func() bool { return true })


### PR DESCRIPTION
1. Fixes AlertNow itest for a timing bug
2. Moves the lib/proof/ package tests from normal test-all under test matrix to it's own test. AFter merging cuZK, this package is doing c2 which require more compute than matrix one.