### PR TITLE
refactor metrics and metrics docs generator

### DIFF
--- a/cmd/curio/run.go
+++ b/cmd/curio/run.go
@@ -123,7 +123,7 @@ var runCmd = &cli.Command{
 			return err
 		}
 		if err := curiometrics.RecordNodeInfo(ctx, dependencies.Name, dependencies.ListenAddr); err != nil {
-			return xerrors.Errorf("recording node info: %w", err)
+			log.Errorf("recording node info, metrics will no longer have correct node label: %s", err)
 		}
 
 		go ffiSelfTest() // Panics on failure

--- a/cmd/curio/run.go
+++ b/cmd/curio/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/curio/cmd/curio/rpc"
 	"github.com/filecoin-project/curio/cmd/curio/tasks"
 	"github.com/filecoin-project/curio/deps"
+	curiometrics "github.com/filecoin-project/curio/lib/metrics"
 	"github.com/filecoin-project/curio/lib/shutdown"
 
 	"github.com/filecoin-project/lotus/lib/ulimit"
@@ -120,6 +121,9 @@ var runCmd = &cli.Command{
 		err = dependencies.PopulateRemainingDeps(ctx, cctx, true)
 		if err != nil {
 			return err
+		}
+		if err := curiometrics.RecordNodeInfo(ctx, dependencies.Name, dependencies.ListenAddr); err != nil {
+			return xerrors.Errorf("recording node info: %w", err)
 		}
 
 		go ffiSelfTest() // Panics on failure

--- a/deps/stats/wallet_exporter.go
+++ b/deps/stats/wallet_exporter.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
-	promclient "github.com/prometheus/client_golang/prometheus"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -42,7 +41,7 @@ var WalletExporterMeasures = struct {
 	SentNFil    *stats.Int64Measure // landed messages
 	GasPaidNFil *stats.Int64Measure // landed messages (gasUsed * (basefee + tip))
 
-	MessageLandDuration promclient.Histogram
+	MessageLandDuration *stats.Float64Measure
 }{
 	BalanceNFil: stats.Int64(pre+"balance_nfil", "Balance in NanoFIL", stats.UnitDimensionless),
 	Power:       stats.Int64(pre+"power", "Power in Bytes", stats.UnitBytes),
@@ -56,11 +55,7 @@ var WalletExporterMeasures = struct {
 	SentNFil:    stats.Int64(pre+"sent_nfil", "Sent NanoFIL", stats.UnitDimensionless),
 	GasPaidNFil: stats.Int64(pre+"gas_paid_nfil", "Gas paid NanoFIL", stats.UnitDimensionless),
 
-	MessageLandDuration: promclient.NewHistogram(promclient.HistogramOpts{
-		Name:    pre + "message_land_duration_seconds",
-		Buckets: []float64{30 * 1, 30 * 2, 30 * 4, 30 * 5, 30 * 7, 30 * 15, 30 * 45, 30 * 120, 30 * 300, 30 * 1000, 30 * 2880},
-		Help:    "The histogram of message land durations in seconds.",
-	}),
+	MessageLandDuration: stats.Float64(pre+"message_land_duration_seconds", "The histogram of message land durations in seconds.", stats.UnitSeconds),
 }
 
 func init() {
@@ -104,6 +99,10 @@ func init() {
 			Measure:     WalletExporterMeasures.GasPaidNFil,
 			Aggregation: view.Sum(),
 			TagKeys:     []tag.Key{tagFromKey, tagFromName, tagToKey, tagToName, tagMethodKey, tagSendReasonKey, tagExitCodeKey},
+		},
+		&view.View{
+			Measure:     WalletExporterMeasures.MessageLandDuration,
+			Aggregation: view.Distribution(30*1, 30*2, 30*4, 30*5, 30*7, 30*15, 30*45, 30*120, 30*300, 30*1000, 30*2880),
 		},
 	)
 	if err != nil {
@@ -467,7 +466,7 @@ func walletExporterObserveLandedMsgs(ctx context.Context, db *harmonydb.DB, api 
 			if durationSeconds < 0 {
 				durationSeconds = 0
 			}
-			WalletExporterMeasures.MessageLandDuration.Observe(durationSeconds)
+			stats.Record(ctx, WalletExporterMeasures.MessageLandDuration.M(durationSeconds))
 		}
 
 		_ = stats.RecordWithTags(ctx, []tag.Mutator{

--- a/documentation/en/configuration/metrics-reference.md
+++ b/documentation/en/configuration/metrics-reference.md
@@ -4,207 +4,232 @@
 
 # Metrics Reference
 
-This document lists all Prometheus metrics exported by Curio. All metrics use the `curio_` namespace prefix.
+This document lists Prometheus metrics exported by Curio using the exact metric names exposed on the scrape endpoint.
 
 > **Note**: This file is auto-generated from source code. Run `make docsgen-metrics` to update.
+## Node Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_node_info` | gauge | `node`, `version` | Curio node identity and version. Value is always 1. |
+
 ## Task Metrics (HarmonyTask)
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `curio_harmonytask_active_tasks` | gauge/counter | Current number of active tasks. |
-| `curio_harmonytask_added_tasks` | gauge/counter | Total number of tasks added. |
-| `curio_harmonytask_cpu_usage` | gauge | Percentage of CPU in use. |
-| `curio_harmonytask_gpu_usage` | gauge | Percentage of GPU in use. |
-| `curio_harmonytask_poller_iterations` | gauge/counter | Total number of poller iterations. |
-| `curio_harmonytask_ram_usage` | gauge | Percentage of RAM in use. |
-| `curio_harmonytask_task_duration_seconds` | histogram | The histogram of task durations in seconds. |
-| `curio_harmonytask_tasks_completed` | gauge/counter | Total number of tasks completed successfully. |
-| `curio_harmonytask_tasks_failed` | gauge/counter | Total number of tasks that failed. |
-| `curio_harmonytask_tasks_started` | gauge/counter | Total number of tasks started. |
-| `curio_harmonytask_uptime` | gauge/counter | Total uptime of the node in seconds. |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_harmonytask_active_tasks` | gauge | `task_name` | Current number of active tasks. |
+| `curio_harmonytask_added_tasks` | counter | `task_name` | Total number of tasks added. |
+| `curio_harmonytask_cpu_usage` | gauge | — | Percentage of CPU in use. |
+| `curio_harmonytask_gpu_usage` | gauge | — | Percentage of GPU in use. |
+| `curio_harmonytask_poller_iterations` | counter | — | Total number of poller iterations. |
+| `curio_harmonytask_ram_usage` | gauge | — | Percentage of RAM in use. |
+| `curio_harmonytask_task_duration_seconds` | histogram | — | The histogram of task durations in seconds. |
+| `curio_harmonytask_task_runtime_seconds` | histogram | `task_name` | The histogram of task runtimes in seconds. |
+| `curio_harmonytask_task_scheduled_wait_seconds` | histogram | `task_name` | The histogram of task wait times between posting and work start in seconds. |
+| `curio_harmonytask_tasks_completed` | counter | `task_name` | Total number of tasks completed successfully. |
+| `curio_harmonytask_tasks_failed` | counter | `task_name` | Total number of tasks that failed. |
+| `curio_harmonytask_tasks_started` | counter | `task_name`, `source` | Total number of tasks started. |
+| `curio_harmonytask_uptime` | gauge | `version` | Total uptime of the node in seconds. |
 
 ## Wallet Exporter Metrics (Optional)
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `curio_wallet_balance_nfil` | gauge/counter | Balance in NanoFIL |
-| `curio_wallet_gas_paid_nfil` | gauge/counter | Gas paid NanoFIL |
-| `curio_wallet_gas_units_requested` | gauge/counter | Gas units requested |
-| `curio_wallet_gas_units_used` | gauge/counter | Gas units used |
-| `curio_wallet_message_land_duration_seconds` | histogram | The histogram of message land durations in seconds. |
-| `curio_wallet_message_landed` | gauge/counter | Message landed |
-| `curio_wallet_message_sent` | gauge/counter | Message sent |
-| `curio_wallet_power` | gauge/counter | Power in Bytes |
-| `curio_wallet_sent_nfil` | gauge/counter | Sent NanoFIL |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_wallet_balance_nfil` | gauge | `address`, `type`, `name` | Balance in NanoFIL |
+| `curio_wallet_gas_paid_nfil` | counter | `from`, `from_name`, `to`, `to_name`, `method`, `send_reason`, `exit_code` | Gas paid NanoFIL |
+| `curio_wallet_gas_units_requested` | counter | `from`, `from_name`, `to`, `to_name`, `method`, `send_reason` | Gas units requested |
+| `curio_wallet_gas_units_used` | counter | `from`, `from_name`, `to`, `to_name`, `method`, `send_reason`, `exit_code` | Gas units used |
+| `curio_wallet_message_land_duration_seconds` | histogram | — | The histogram of message land durations in seconds. |
+| `curio_wallet_message_landed` | counter | `from`, `from_name`, `to`, `to_name`, `method`, `send_reason`, `exit_code` | Message landed |
+| `curio_wallet_message_sent` | counter | `from`, `from_name`, `to`, `to_name`, `method`, `send_reason` | Message sent |
+| `curio_wallet_power` | gauge | `address`, `type` | Power in Bytes |
+| `curio_wallet_sent_nfil` | counter | `from`, `from_name`, `to`, `to_name`, `method`, `send_reason`, `exit_code` | Sent NanoFIL |
 
 ## Proof Share Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `curio_psvc_proofshare_adder_commits_total` | counter | — | Total number of successful task additions scheduled by Adder |
-| `curio_psvc_proofshare_adder_hold_decisions_total` | countervec | `hold` | Total number of hold decisions made by Adder |
+| `curio_psvc_proofshare_adder_hold_decisions_total` | counter | `hold` | Total number of hold decisions made by Adder |
 | `curio_psvc_proofshare_create_asks_seconds` | histogram | — | Duration of create asks inner loop |
-| `curio_psvc_proofshare_duration_seconds` | histogramvec | `call` | Duration of proofshare client_common operations |
+| `curio_psvc_proofshare_duration_seconds` | histogram | `call` | Duration of proofshare client_common operations |
 | `curio_psvc_proofshare_need_asks` | gauge | — | Number of asks still needed in current Do loop iteration |
 | `curio_psvc_proofshare_newly_added_total` | counter | — | Total number of new work requests inserted locally |
 | `curio_psvc_proofshare_queue_count` | gauge | — | Current proofshare request queue count |
-| `curio_psvc_proofshare_retry_count` | histogramvec | `call` | Retry count per call in proofshare client_common operations |
+| `curio_psvc_proofshare_retry_count` | histogram | `call` | Retry count per call in proofshare client_common operations |
 | `curio_psvc_proofshare_to_request_remaining` | gauge | — | Remaining requests to fulfill for high-water mark |
 
 ## Proof Service Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `curio_psvc_clientctl_duration_seconds` | histogramvec | `call` | Duration of proofsvc clientctl operations |
-| `curio_psvc_l1ops_duration_seconds` | histogramvec | `call` | Duration of L1 operations |
-| `curio_psvc_provictl_duration_seconds` | histogramvec | `call` | Duration of proofsvc provider control operations |
+| `curio_psvc_clientctl_duration_seconds` | histogram | `call` | Duration of proofsvc clientctl operations |
+| `curio_psvc_l1ops_duration_seconds` | histogram | `call` | Duration of L1 operations |
+| `curio_psvc_provictl_duration_seconds` | histogram | `call` | Duration of proofsvc provider control operations |
 
 ## Sealing Metrics
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `curio_seal_commit_submitted_total` | gauge/counter | Commit messages submitted. |
-| `curio_seal_finalize_completed_total` | gauge/counter | Finalizations completed. |
-| `curio_seal_movestorage_completed_total` | gauge/counter | Move storage operations completed. |
-| `curio_seal_porep_completed_total` | gauge/counter | PoRep computations completed. |
-| `curio_seal_precommit_submitted_total` | gauge/counter | Precommit messages submitted. |
-| `curio_seal_sdr_completed_total` | gauge/counter | SDR computations completed. |
-| `curio_seal_synth_completed_total` | gauge/counter | Synthetic proofs completed. |
-| `curio_seal_treed_completed_total` | gauge/counter | Tree D computations completed. |
-| `curio_seal_treerc_completed_total` | gauge/counter | Tree R/C computations completed. |
-| `curio_sealsupra_nvme_available_spare` | gauge/counter | NVMe Available Spare |
-| `curio_sealsupra_nvme_bytes_read` | gauge/counter | NVMe Bytes Read |
-| `curio_sealsupra_nvme_bytes_written` | gauge/counter | NVMe Bytes Written |
-| `curio_sealsupra_nvme_critical_warning` | gauge/counter | NVMe Critical Warning Flags |
-| `curio_sealsupra_nvme_error_log_entries` | gauge/counter | NVMe Error Log Entries |
-| `curio_sealsupra_nvme_media_errors` | gauge/counter | NVMe Media Errors |
-| `curio_sealsupra_nvme_percentage_used` | gauge/counter | NVMe Percentage Used |
-| `curio_sealsupra_nvme_power_cycles` | gauge/counter | NVMe Power Cycles |
-| `curio_sealsupra_nvme_power_on_hours` | gauge | NVMe Power On Hours |
-| `curio_sealsupra_nvme_read_io` | gauge/counter | NVMe Read IOs |
-| `curio_sealsupra_nvme_temperature_celsius` | gauge | NVMe Temperature in Celsius |
-| `curio_sealsupra_nvme_unsafe_shutdowns` | gauge/counter | NVMe Unsafe Shutdowns |
-| `curio_sealsupra_nvme_write_io` | gauge/counter | NVMe Write IOs |
-| `curio_sealsupra_phase_avg_duration` | gauge | Average duration of each phase in seconds |
-| `curio_sealsupra_phase_duration_so_far` | gauge | Duration of the phase so far in seconds |
-| `curio_sealsupra_phase_lock_count` | gauge/counter | Number of active locks in each phase |
-| `curio_sealsupra_phase_waiting_count` | gauge/counter | Number of goroutines waiting for a phase lock |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_seal_commit_submitted_total` | counter | `miner` | Commit messages submitted. |
+| `curio_seal_finalize_completed_total` | counter | `miner` | Finalizations completed. |
+| `curio_seal_movestorage_completed_total` | counter | `miner` | Move storage operations completed. |
+| `curio_seal_porep_completed_total` | counter | `miner` | PoRep computations completed. |
+| `curio_seal_precommit_submitted_total` | counter | `miner` | Precommit messages submitted. |
+| `curio_seal_sdr_completed_total` | counter | `miner` | SDR computations completed. |
+| `curio_seal_synth_completed_total` | counter | `miner` | Synthetic proofs completed. |
+| `curio_seal_treed_completed_total` | counter | `miner` | Tree D computations completed. |
+| `curio_seal_treerc_completed_total` | counter | `miner` | Tree R/C computations completed. |
 
 ## Snap Pipeline Metrics
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `curio_snap_encode_completed_total` | gauge/counter | Snap encodes completed. |
-| `curio_snap_movestorage_completed_total` | gauge/counter | Snap move storage operations completed. |
-| `curio_snap_prove_completed_total` | gauge/counter | Snap proves completed. |
-| `curio_snap_submit_completed_total` | gauge/counter | Snap submissions completed. |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_snap_encode_completed_total` | counter | `miner` | Snap encodes completed. |
+| `curio_snap_movestorage_completed_total` | counter | `miner` | Snap move storage operations completed. |
+| `curio_snap_prove_completed_total` | counter | `miner` | Snap proves completed. |
+| `curio_snap_submit_completed_total` | counter | `miner` | Snap submissions completed. |
 
 ## Mining Metrics
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `curio_mining_blocks_included_total` | gauge/counter | Blocks included in the chain. |
-| `curio_mining_blocks_submitted_total` | gauge/counter | Blocks submitted to the network. |
-| `curio_mining_compute_time_seconds` | histogram | Histogram of winning post compute times in seconds. |
-| `curio_mining_wins_total` | gauge/counter | Blocks won (election success). |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_mining_blocks_included_total` | counter | `miner` | Blocks included in the chain. |
+| `curio_mining_blocks_submitted_total` | counter | `miner` | Blocks submitted to the network. |
+| `curio_mining_compute_time_seconds` | histogram | — | Histogram of winning post compute times in seconds. |
+| `curio_mining_wins_total` | counter | `miner` | Blocks won (election success). |
 
 ## Storage Metrics
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `curio_slotmgr_slot_errors` | gauge/counter | Total number of slot errors (e.g., failed to put). |
-| `curio_slotmgr_slot_in_use` | gauge/counter | Slot actively in use (batch sealing). 1=in use, 0=not in use |
-| `curio_slotmgr_slot_sector_count` | gauge/counter | Number of sectors in the slot |
-| `curio_slotmgr_slots_acquired` | gauge/counter | Total number of slots acquired. |
-| `curio_slotmgr_slots_available` | gauge/counter | Number of available slots. |
-| `curio_slotmgr_slots_released` | gauge/counter | Total number of slots released. |
-| `curio_stor_available_bytes` | gauge/counter | Available storage capacity in bytes |
-| `curio_stor_capacity_bytes` | gauge/counter | Total storage capacity in bytes |
-| `curio_stor_find_sector_cache_hits` | gauge/counter | Number of findSectorCache hits |
-| `curio_stor_find_sector_cache_misses` | gauge/counter | Number of findSectorCache misses |
-| `curio_stor_find_sector_uncached` | gauge/counter | Number of findSector uncached calls |
-| `curio_stor_generate_single_vanilla_proof_calls` | gauge/counter | Number of calls to GenerateSingleVanillaProof |
-| `curio_stor_generate_single_vanilla_proof_duration_seconds` | gauge/counter | Duration of GenerateSingleVanillaProof in seconds |
-| `curio_stor_generate_single_vanilla_proof_errors` | gauge/counter | Number of errors in GenerateSingleVanillaProof |
-| `curio_stor_used_bytes` | gauge/counter | Used storage capacity in bytes |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_stor_available_bytes` | gauge | `id`, `can_seal`, `can_store` | Available storage capacity in bytes |
+| `curio_stor_capacity_bytes` | gauge | `id`, `can_seal`, `can_store` | Total storage capacity in bytes |
+| `curio_stor_find_sector_cache_hits` | counter | — | Number of findSectorCache hits |
+| `curio_stor_find_sector_cache_misses` | counter | — | Number of findSectorCache misses |
+| `curio_stor_find_sector_uncached` | counter | — | Number of findSector uncached calls |
+| `curio_stor_generate_single_vanilla_proof_calls` | counter | `update`, `cache_id`, `sealed_id` | Number of calls to GenerateSingleVanillaProof |
+| `curio_stor_generate_single_vanilla_proof_duration_seconds` | histogram | `update`, `cache_id`, `sealed_id` | Duration of GenerateSingleVanillaProof in seconds |
+| `curio_stor_generate_single_vanilla_proof_errors` | counter | `update`, `cache_id`, `sealed_id` | Number of errors in GenerateSingleVanillaProof |
+| `curio_stor_used_bytes` | gauge | `id`, `can_seal`, `can_store` | Used storage capacity in bytes |
 
 ## Cache Metrics
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `curio_cachedreader_cache_evictions` | gauge/counter | Number of cache evictions. |
-| `curio_cachedreader_cache_hits` | gauge/counter | Number of cache hits. |
-| `curio_cachedreader_cache_misses` | gauge/counter | Number of cache misses. |
-| `curio_cachedreader_cache_refs` | gauge/counter | Number of active references to cached readers. |
-| `curio_cachedreader_cache_size` | gauge/counter | Current number of entries in cache. |
-| `curio_cachedreader_reader_errors` | gauge/counter | Total number of piece reader errors. |
-| `curio_cachedreader_reader_successes` | gauge/counter | Total number of successful piece reader creations. |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_cachedreader_cache_evictions` | counter | `cache_type`, `reason` | Number of cache evictions. |
+| `curio_cachedreader_cache_hits` | counter | `cache_type` | Number of cache hits. |
+| `curio_cachedreader_cache_misses` | counter | `cache_type` | Number of cache misses. |
+| `curio_cachedreader_cache_refs` | gauge | — | Number of active references to cached readers. |
+| `curio_cachedreader_cache_size` | gauge | `cache_type` | Current number of entries in cache. |
+| `curio_cachedreader_reader_errors` | counter | `reason` | Total number of piece reader errors. |
+| `curio_cachedreader_reader_successes` | counter | — | Total number of successful piece reader creations. |
 
 ## Network Metrics
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `curio_dealdata_data_read` | gauge/counter | Number of bytes read from data URLs |
-| `curio_robusthttp_active_transfers` | gauge/counter | Current number of active robusthttp transfers |
-| `curio_robusthttp_bytes_read` | gauge/counter | Total bytes delivered by robusthttp readers |
-| `curio_robusthttp_read_errors` | gauge/counter | Total number of robusthttp read/request errors (non-EOF) |
-| `curio_robusthttp_read_failures` | gauge/counter | Number of robusthttp requests that failed after retries |
-| `curio_robusthttp_requests_started` | gauge/counter | Number of robusthttp logical requests started |
-| `curio_robusthttp_retries` | gauge/counter | Total number of robusthttp retries across requests |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_dealdata_data_read` | gauge | `kind` | Number of bytes read from data URLs |
+| `curio_robusthttp_active_transfers` | gauge | — | Current number of active robusthttp transfers |
+| `curio_robusthttp_bytes_read` | counter | — | Total bytes delivered by robusthttp readers |
+| `curio_robusthttp_read_errors` | counter | — | Total number of robusthttp read/request errors (non-EOF) |
+| `curio_robusthttp_read_failures` | counter | — | Number of robusthttp requests that failed after retries |
+| `curio_robusthttp_requests_started` | counter | — | Number of robusthttp logical requests started |
+| `curio_robusthttp_retries` | counter | — | Total number of robusthttp retries across requests |
 
 ## FFI Metrics
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `curio_cuffi_snap_enc_active` | gauge/counter | Number of tasks in each phase |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_cuffi_snap_enc_active` | gauge | `phase` | Number of tasks in each phase |
 
 ## HTTP/Retrieval Metrics
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `curio_http/active_requests` | gauge/counter | Number of active/in-flight HTTP requests |
-| `curio_http/blockstore_cache_hits` | gauge/counter | Counter of blockstore cache hits |
-| `curio_http/blockstore_cache_misses` | gauge/counter | Counter of blockstore cache misses |
-| `curio_http/piece_by_cid_200_response_count` | gauge/counter | Counter of /piece/<piece-cid> 200 responses |
-| `curio_http/piece_by_cid_400_response_count` | gauge/counter | Counter of /piece/<piece-cid> 400 responses |
-| `curio_http/piece_by_cid_404_response_count` | gauge/counter | Counter of /piece/<piece-cid> 404 responses |
-| `curio_http/piece_by_cid_500_response_count` | gauge/counter | Counter of /piece/<piece-cid> 500 responses |
-| `curio_http/piece_by_cid_request_count` | gauge/counter | Counter of /piece/<piece-cid> requests |
-| `curio_http/piece_by_cid_request_duration_ms` | gauge | Time spent retrieving a piece by cid |
-| `curio_http/rbls_bytes_sent_count` | gauge/counter | Counter of the number of bytes sent by bitswap since startup |
-| `curio_http/rbls_get_fail_response_count` | gauge/counter | Counter of failed RemoteBlockstore Get responses |
-| `curio_http/rbls_get_request_count` | gauge/counter | Counter of RemoteBlockstore Get requests |
-| `curio_http/rbls_get_success_response_count` | gauge/counter | Counter of successful RemoteBlockstore Get responses |
-| `curio_http/rbls_getsize_fail_response_count` | gauge/counter | Counter of failed RemoteBlockstore GetSize responses |
-| `curio_http/rbls_getsize_request_count` | gauge/counter | Counter of RemoteBlockstore GetSize requests |
-| `curio_http/rbls_getsize_success_response_count` | gauge/counter | Counter of successful RemoteBlockstore GetSize responses |
-| `curio_http/rbls_has_fail_response_count` | gauge/counter | Counter of failed RemoteBlockstore Has responses |
-| `curio_http/rbls_has_request_count` | gauge/counter | Counter of RemoteBlockstore Has requests |
-| `curio_http/rbls_has_success_response_count` | gauge/counter | Counter of successful RemoteBlockstore Has responses |
-| `curio_http/request_count` | gauge/counter | Counter of HTTP requests |
-| `curio_http/response_bytes_count` | gauge/counter | Sum of HTTP response content-length |
-| `curio_http/response_status_count` | gauge/counter | Counter of HTTP response status codes |
-| `curio_ipni_announce_attempts_total` | gauge/counter | Total number of IPNI direct announce attempts. |
-| `curio_ipni_announce_http_roundtrip_seconds` | gauge | Duration of outbound IPNI announce HTTP round trips in seconds. |
-| `curio_ipni_entry_cache_hit_wait_seconds` | gauge | Duration callers wait after hitting the IPNI entry cache. |
-| `curio_ipni_entry_cache_hits_total` | gauge/counter | Total number of IPNI entry cache hits by request type, cache origin, and readiness state. |
-| `curio_ipni_entry_cache_lookups_total` | gauge/counter | Total number of IPNI entry cache lookups. |
-| `curio_ipni_entry_reconstruction_seconds` | gauge | Duration of IPNI entry reconstruction after cache miss. |
-| `curio_ipni_entry_requests_total` | gauge/counter | Total number of IPNI entry requests handled by the serve chunker. |
-| `curio_ipni_entry_speculative_unused_total` | gauge/counter | Total number of speculative IPNI entry cache fills evicted without being consumed by a demand request. |
-| `curio_ipni_provider_http_request_seconds` | gauge | Duration of inbound IPNI provider HTTP requests in seconds. |
-| `curio_ipni_provider_http_requests_total` | gauge/counter | Total number of inbound IPNI provider HTTP requests. |
-| `curio_pdp/piece_by_cid_200_response_count` | gauge/counter | Counter of /piece/<piece-cid> 200 responses for PDP |
-| `curio_pdp/piece_by_cid_request_count` | gauge/counter | Counter of /piece/<piece-cid> requests for PDP |
-| `curio_pdp/piece_by_cid_request_duration_ms` | gauge | Time spent retrieving a piece by cid for PDP |
-| `curio_pdp/piece_bytes_served_count` | gauge/counter | Counter of the number of bytes served by PDP since startup |
-| `curio_retrieval_info` | gauge/counter | Arbitrary counter to tag node info to |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_dagstore_pr_at_cache_fill_count` | counter | `network` | PieceReader ReadAt full cache fill count |
+| `curio_dagstore_pr_at_hit_bytes` | counter | `network` | PieceReader ReadAt bytes from cache |
+| `curio_dagstore_pr_at_hit_count` | counter | `network` | PieceReader ReadAt from cache hits |
+| `curio_dagstore_pr_at_read_bytes` | counter | `pr_size`, `network` | PieceReader ReadAt bytes read from source |
+| `curio_dagstore_pr_at_read_count` | counter | `pr_size`, `network` | PieceReader ReadAt reads from source |
+| `curio_dagstore_pr_discard_count` | counter | `network` | PieceReader discard count |
+| `curio_dagstore_pr_discarded_bytes` | counter | `network` | PieceReader discarded bytes |
+| `curio_dagstore_pr_init_count` | counter | `network` | PieceReader init count |
+| `curio_dagstore_pr_requested_bytes` | counter | `pr_type`, `network` | PieceReader requested bytes |
+| `curio_dagstore_pr_seek_back_bytes` | counter | `network` | PieceReader seek back bytes |
+| `curio_dagstore_pr_seek_back_count` | counter | `network` | PieceReader seek back count |
+| `curio_dagstore_pr_seek_forward_bytes` | counter | `network` | PieceReader seek forward bytes |
+| `curio_dagstore_pr_seek_forward_count` | counter | `network` | PieceReader seek forward count |
+| `curio_http_active_requests` | gauge | `path`, `method` | Number of active/in-flight HTTP requests |
+| `curio_http_blockstore_cache_hits` | counter | — | Counter of blockstore cache hits |
+| `curio_http_blockstore_cache_misses` | counter | — | Counter of blockstore cache misses |
+| `curio_http_piece_by_cid_200_response_count` | counter | — | Counter of /piece/<piece-cid> 200 responses |
+| `curio_http_piece_by_cid_400_response_count` | counter | — | Counter of /piece/<piece-cid> 400 responses |
+| `curio_http_piece_by_cid_404_response_count` | counter | — | Counter of /piece/<piece-cid> 404 responses |
+| `curio_http_piece_by_cid_500_response_count` | counter | — | Counter of /piece/<piece-cid> 500 responses |
+| `curio_http_piece_by_cid_request_count` | counter | — | Counter of /piece/<piece-cid> requests |
+| `curio_http_piece_by_cid_request_duration_ms` | histogram | — | Time spent retrieving a piece by cid |
+| `curio_http_rbls_bytes_sent_count` | counter | — | Counter of the number of bytes sent by bitswap since startup |
+| `curio_http_rbls_get_fail_response_count` | counter | — | Counter of failed RemoteBlockstore Get responses |
+| `curio_http_rbls_get_request_count` | counter | — | Counter of RemoteBlockstore Get requests |
+| `curio_http_rbls_get_success_response_count` | counter | — | Counter of successful RemoteBlockstore Get responses |
+| `curio_http_rbls_getsize_fail_response_count` | counter | — | Counter of failed RemoteBlockstore GetSize responses |
+| `curio_http_rbls_getsize_request_count` | counter | — | Counter of RemoteBlockstore GetSize requests |
+| `curio_http_rbls_getsize_success_response_count` | counter | — | Counter of successful RemoteBlockstore GetSize responses |
+| `curio_http_rbls_has_fail_response_count` | counter | — | Counter of failed RemoteBlockstore Has responses |
+| `curio_http_rbls_has_request_count` | counter | — | Counter of RemoteBlockstore Has requests |
+| `curio_http_rbls_has_success_response_count` | counter | — | Counter of successful RemoteBlockstore Has responses |
+| `curio_http_request_count` | counter | `path`, `method` | Counter of HTTP requests |
+| `curio_http_response_bytes_count` | counter | `status_code`, `path` | Sum of HTTP response content-length |
+| `curio_http_response_status_count` | counter | `status_code`, `path`, `method` | Counter of HTTP response status codes |
+| `curio_ipni_announce_attempts_total` | counter | `provider`, `result` | Total number of IPNI direct announce attempts. |
+| `curio_ipni_announce_http_roundtrip_milliseconds` | histogram | `provider`, `status` | Duration of outbound IPNI announce HTTP round trips in milliseconds. |
+| `curio_ipni_entry_cache_hit_wait_milliseconds` | histogram | `request`, `origin`, `state` | Duration callers wait after hitting the IPNI entry cache. |
+| `curio_ipni_entry_cache_hits_total` | counter | `request`, `origin`, `state` | Total number of IPNI entry cache hits by request type, cache origin, and readiness state. |
+| `curio_ipni_entry_cache_lookups_total` | counter | `request`, `result` | Total number of IPNI entry cache lookups. |
+| `curio_ipni_entry_reconstruction_milliseconds` | histogram | `request`, `source`, `result` | Duration of IPNI entry reconstruction after cache miss. |
+| `curio_ipni_entry_requests_total` | counter | `request` | Total number of IPNI entry requests handled by the serve chunker. |
+| `curio_ipni_entry_speculative_unused_total` | counter | — | Total number of speculative IPNI entry cache fills evicted without being consumed by a demand request. |
+| `curio_ipni_provider_http_request_milliseconds` | histogram | `provider`, `content`, `status` | Duration of inbound IPNI provider HTTP requests in milliseconds. |
+| `curio_ipni_provider_http_requests_total` | counter | `provider`, `content`, `status` | Total number of inbound IPNI provider HTTP requests. |
+| `curio_pdp_piece_by_cid_200_response_count` | counter | — | Counter of /piece/<piece-cid> 200 responses for PDP |
+| `curio_pdp_piece_by_cid_request_count` | counter | — | Counter of /piece/<piece-cid> requests for PDP |
+| `curio_pdp_piece_by_cid_request_duration_ms` | histogram | — | Time spent retrieving a piece by cid for PDP |
+| `curio_pdp_piece_bytes_served_count` | counter | — | Counter of the number of bytes served by PDP since startup |
 
 ## GC Metrics
 
-| Metric | Type | Description |
-|--------|------|-------------|
-| `curio_gc_sectors_marked_total` | gauge/counter | Sectors marked for GC. |
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_gc_sectors_marked_total` | counter | `miner`, `filetype` | Sectors marked for GC. |
+
+## Batching Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `curio_sealsupra_nvme_available_spare` | gauge | `nvme_device` | NVMe Available Spare |
+| `curio_sealsupra_nvme_bytes_read` | counter | `nvme_device` | NVMe Bytes Read |
+| `curio_sealsupra_nvme_bytes_written` | counter | `nvme_device` | NVMe Bytes Written |
+| `curio_sealsupra_nvme_critical_warning` | gauge | `nvme_device` | NVMe Critical Warning Flags |
+| `curio_sealsupra_nvme_error_log_entries` | gauge | `nvme_device` | NVMe Error Log Entries |
+| `curio_sealsupra_nvme_media_errors` | gauge | `nvme_device` | NVMe Media Errors |
+| `curio_sealsupra_nvme_percentage_used` | gauge | `nvme_device` | NVMe Percentage Used |
+| `curio_sealsupra_nvme_power_cycles` | gauge | `nvme_device` | NVMe Power Cycles |
+| `curio_sealsupra_nvme_power_on_hours` | gauge | `nvme_device` | NVMe Power On Hours |
+| `curio_sealsupra_nvme_read_io` | counter | `nvme_device` | NVMe Read IOs |
+| `curio_sealsupra_nvme_temperature_celsius` | gauge | `nvme_device` | NVMe Temperature in Celsius |
+| `curio_sealsupra_nvme_unsafe_shutdowns` | gauge | `nvme_device` | NVMe Unsafe Shutdowns |
+| `curio_sealsupra_nvme_write_io` | counter | `nvme_device` | NVMe Write IOs |
+| `curio_sealsupra_phase_avg_duration` | gauge | `phase` | Average duration of each phase in seconds |
+| `curio_sealsupra_phase_duration_so_far` | gauge | `phase` | Duration of the phase so far in seconds |
+| `curio_sealsupra_phase_lock_count` | gauge | `phase` | Number of active locks in each phase |
+| `curio_sealsupra_phase_waiting_count` | gauge | `phase` | Number of goroutines waiting for a phase lock |
+| `curio_slotmgr_slot_errors` | counter | — | Total number of slot errors (e.g., failed to put). |
+| `curio_slotmgr_slot_in_use` | gauge | `slot_offset` | Slot actively in use (batch sealing). 1=in use, 0=not in use |
+| `curio_slotmgr_slot_sector_count` | gauge | `slot_offset` | Number of sectors in the slot |
+| `curio_slotmgr_slots_acquired` | counter | — | Total number of slots acquired. |
+| `curio_slotmgr_slots_available` | gauge | — | Number of available slots. |
+| `curio_slotmgr_slots_released` | counter | — | Total number of slots released. |
 
 ---
 

--- a/documentation/en/configuration/metrics-reference.md
+++ b/documentation/en/configuration/metrics-reference.md
@@ -23,9 +23,8 @@ This document lists Prometheus metrics exported by Curio using the exact metric 
 | `curio_harmonytask_gpu_usage` | gauge | — | Percentage of GPU in use. |
 | `curio_harmonytask_poller_iterations` | counter | — | Total number of poller iterations. |
 | `curio_harmonytask_ram_usage` | gauge | — | Percentage of RAM in use. |
-| `curio_harmonytask_task_duration_seconds` | histogram | — | The histogram of task durations in seconds. |
-| `curio_harmonytask_task_runtime_seconds` | histogram | `task_name` | The histogram of task runtimes in seconds. |
-| `curio_harmonytask_task_scheduled_wait_seconds` | histogram | `task_name` | The histogram of task wait times between posting and work start in seconds. |
+| `curio_harmonytask_task_duration_seconds` | histogram | `task_name` | The histogram of task durations in seconds. |
+| `curio_harmonytask_task_scheduled_wait_seconds` | histogram | `task_name` | The histogram of task wait times from posting or previous attempt completion to work start in seconds. |
 | `curio_harmonytask_tasks_completed` | counter | `task_name` | Total number of tasks completed successfully. |
 | `curio_harmonytask_tasks_failed` | counter | `task_name` | Total number of tasks that failed. |
 | `curio_harmonytask_tasks_started` | counter | `task_name`, `source` | Total number of tasks started. |
@@ -109,7 +108,7 @@ This document lists Prometheus metrics exported by Curio using the exact metric 
 | `curio_stor_find_sector_cache_misses` | counter | — | Number of findSectorCache misses |
 | `curio_stor_find_sector_uncached` | counter | — | Number of findSector uncached calls |
 | `curio_stor_generate_single_vanilla_proof_calls` | counter | `update`, `cache_id`, `sealed_id` | Number of calls to GenerateSingleVanillaProof |
-| `curio_stor_generate_single_vanilla_proof_duration_seconds` | histogram | `update`, `cache_id`, `sealed_id` | Duration of GenerateSingleVanillaProof in seconds |
+| `curio_stor_generate_single_vanilla_proof_duration_milliseconds` | histogram | `update`, `cache_id`, `sealed_id` | Duration of GenerateSingleVanillaProof in milliseconds |
 | `curio_stor_generate_single_vanilla_proof_errors` | counter | `update`, `cache_id`, `sealed_id` | Number of errors in GenerateSingleVanillaProof |
 | `curio_stor_used_bytes` | gauge | `id`, `can_seal`, `can_store` | Used storage capacity in bytes |
 

--- a/harmony/harmonytask/metrics.go
+++ b/harmony/harmonytask/metrics.go
@@ -28,7 +28,6 @@ var TaskMeasures = struct {
 	TasksCompleted    *stats.Int64Measure
 	TasksFailed       *stats.Int64Measure
 	TaskDuration      *stats.Float64Measure
-	TaskRuntime       *stats.Float64Measure
 	TaskScheduledWait *stats.Float64Measure
 	ActiveTasks       *stats.Int64Measure
 	CpuUsage          *stats.Float64Measure
@@ -42,8 +41,7 @@ var TaskMeasures = struct {
 	TasksCompleted:    stats.Int64(pre+"tasks_completed", "Total number of tasks completed successfully.", stats.UnitDimensionless),
 	TasksFailed:       stats.Int64(pre+"tasks_failed", "Total number of tasks that failed.", stats.UnitDimensionless),
 	TaskDuration:      stats.Float64(pre+"task_duration_seconds", "The histogram of task durations in seconds.", stats.UnitSeconds),
-	TaskRuntime:       stats.Float64(pre+"task_runtime_seconds", "The histogram of task runtimes in seconds.", stats.UnitSeconds),
-	TaskScheduledWait: stats.Float64(pre+"task_scheduled_wait_seconds", "The histogram of task wait times between posting and work start in seconds.", stats.UnitSeconds),
+	TaskScheduledWait: stats.Float64(pre+"task_scheduled_wait_seconds", "The histogram of task wait times from posting or previous attempt completion to work start in seconds.", stats.UnitSeconds),
 	ActiveTasks:       stats.Int64(pre+"active_tasks", "Current number of active tasks.", stats.UnitDimensionless),
 	CpuUsage:          stats.Float64(pre+"cpu_usage", "Percentage of CPU in use.", stats.UnitDimensionless),
 	GpuUsage:          stats.Float64(pre+"gpu_usage", "Percentage of GPU in use.", stats.UnitDimensionless),
@@ -77,10 +75,6 @@ func init() {
 		},
 		&view.View{
 			Measure:     TaskMeasures.TaskDuration,
-			Aggregation: view.Distribution(durationBuckets...),
-		},
-		&view.View{
-			Measure:     TaskMeasures.TaskRuntime,
 			Aggregation: view.Distribution(durationBuckets...),
 			TagKeys:     []tag.Key{taskNameTag},
 		},

--- a/harmony/harmonytask/metrics.go
+++ b/harmony/harmonytask/metrics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	promclient "github.com/prometheus/client_golang/prometheus"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -24,33 +23,33 @@ var (
 
 // TaskMeasures groups all harmonytask metrics.
 var TaskMeasures = struct {
-	Uptime           *stats.Int64Measure
-	TasksStarted     *stats.Int64Measure
-	TasksCompleted   *stats.Int64Measure
-	TasksFailed      *stats.Int64Measure
-	TaskDuration     promclient.Histogram
-	ActiveTasks      *stats.Int64Measure
-	CpuUsage         *stats.Float64Measure
-	GpuUsage         *stats.Float64Measure
-	RamUsage         *stats.Float64Measure
-	PollerIterations *stats.Int64Measure
-	AddedTasks       *stats.Int64Measure
+	Uptime            *stats.Int64Measure
+	TasksStarted      *stats.Int64Measure
+	TasksCompleted    *stats.Int64Measure
+	TasksFailed       *stats.Int64Measure
+	TaskDuration      *stats.Float64Measure
+	TaskRuntime       *stats.Float64Measure
+	TaskScheduledWait *stats.Float64Measure
+	ActiveTasks       *stats.Int64Measure
+	CpuUsage          *stats.Float64Measure
+	GpuUsage          *stats.Float64Measure
+	RamUsage          *stats.Float64Measure
+	PollerIterations  *stats.Int64Measure
+	AddedTasks        *stats.Int64Measure
 }{
-	Uptime:         stats.Int64(pre+"uptime", "Total uptime of the node in seconds.", stats.UnitSeconds),
-	TasksStarted:   stats.Int64(pre+"tasks_started", "Total number of tasks started.", stats.UnitDimensionless),
-	TasksCompleted: stats.Int64(pre+"tasks_completed", "Total number of tasks completed successfully.", stats.UnitDimensionless),
-	TasksFailed:    stats.Int64(pre+"tasks_failed", "Total number of tasks that failed.", stats.UnitDimensionless),
-	TaskDuration: promclient.NewHistogram(promclient.HistogramOpts{
-		Name:    pre + "task_duration_seconds",
-		Buckets: durationBuckets,
-		Help:    "The histogram of task durations in seconds.",
-	}),
-	ActiveTasks:      stats.Int64(pre+"active_tasks", "Current number of active tasks.", stats.UnitDimensionless),
-	CpuUsage:         stats.Float64(pre+"cpu_usage", "Percentage of CPU in use.", stats.UnitDimensionless),
-	GpuUsage:         stats.Float64(pre+"gpu_usage", "Percentage of GPU in use.", stats.UnitDimensionless),
-	RamUsage:         stats.Float64(pre+"ram_usage", "Percentage of RAM in use.", stats.UnitDimensionless),
-	PollerIterations: stats.Int64(pre+"poller_iterations", "Total number of poller iterations.", stats.UnitDimensionless),
-	AddedTasks:       stats.Int64(pre+"added_tasks", "Total number of tasks added.", stats.UnitDimensionless),
+	Uptime:            stats.Int64(pre+"uptime", "Total uptime of the node in seconds.", stats.UnitSeconds),
+	TasksStarted:      stats.Int64(pre+"tasks_started", "Total number of tasks started.", stats.UnitDimensionless),
+	TasksCompleted:    stats.Int64(pre+"tasks_completed", "Total number of tasks completed successfully.", stats.UnitDimensionless),
+	TasksFailed:       stats.Int64(pre+"tasks_failed", "Total number of tasks that failed.", stats.UnitDimensionless),
+	TaskDuration:      stats.Float64(pre+"task_duration_seconds", "The histogram of task durations in seconds.", stats.UnitSeconds),
+	TaskRuntime:       stats.Float64(pre+"task_runtime_seconds", "The histogram of task runtimes in seconds.", stats.UnitSeconds),
+	TaskScheduledWait: stats.Float64(pre+"task_scheduled_wait_seconds", "The histogram of task wait times between posting and work start in seconds.", stats.UnitSeconds),
+	ActiveTasks:       stats.Int64(pre+"active_tasks", "Current number of active tasks.", stats.UnitDimensionless),
+	CpuUsage:          stats.Float64(pre+"cpu_usage", "Percentage of CPU in use.", stats.UnitDimensionless),
+	GpuUsage:          stats.Float64(pre+"gpu_usage", "Percentage of GPU in use.", stats.UnitDimensionless),
+	RamUsage:          stats.Float64(pre+"ram_usage", "Percentage of RAM in use.", stats.UnitDimensionless),
+	PollerIterations:  stats.Int64(pre+"poller_iterations", "Total number of poller iterations.", stats.UnitDimensionless),
+	AddedTasks:        stats.Int64(pre+"added_tasks", "Total number of tasks added.", stats.UnitDimensionless),
 }
 
 // TaskViews groups all harmonytask-related default views.
@@ -74,6 +73,20 @@ func init() {
 		&view.View{
 			Measure:     TaskMeasures.TasksFailed,
 			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{taskNameTag},
+		},
+		&view.View{
+			Measure:     TaskMeasures.TaskDuration,
+			Aggregation: view.Distribution(durationBuckets...),
+		},
+		&view.View{
+			Measure:     TaskMeasures.TaskRuntime,
+			Aggregation: view.Distribution(durationBuckets...),
+			TagKeys:     []tag.Key{taskNameTag},
+		},
+		&view.View{
+			Measure:     TaskMeasures.TaskScheduledWait,
+			Aggregation: view.Distribution(durationBuckets...),
 			TagKeys:     []tag.Key{taskNameTag},
 		},
 		&view.View{
@@ -107,11 +120,6 @@ func init() {
 			TagKeys:     []tag.Key{taskNameTag},
 		},
 	)
-	if err != nil {
-		panic(err)
-	}
-
-	err = promclient.Register(TaskMeasures.TaskDuration)
 	if err != nil {
 		panic(err)
 	}

--- a/harmony/harmonytask/task_type_handler.go
+++ b/harmony/harmonytask/task_type_handler.go
@@ -309,7 +309,9 @@ func (h *taskTypeHandler) recordCompletion(tID TaskID, sectorID *abi.SectorID, w
 		}, TaskMeasures.ActiveTasks.M(int64(h.Max.ActiveThis())))
 
 		duration := workEnd.Sub(workStart).Seconds()
-		stats.Record(context.Background(), TaskMeasures.TaskDuration.M(duration))
+		_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+			tag.Upsert(taskNameTag, h.Name),
+		}, TaskMeasures.TaskDuration.M(duration))
 
 		if done {
 			_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
@@ -322,13 +324,19 @@ func (h *taskTypeHandler) recordCompletion(tID TaskID, sectorID *abi.SectorID, w
 		}
 	}
 
-	var postedTime time.Time
+	var waitStartTime time.Time
 retryRecordCompletion:
 	cm, err := h.TaskEngine.db.BeginTransaction(h.TaskEngine.ctx, func(tx *harmonydb.Tx) (bool, error) {
+		var postedTime time.Time
 		var retries uint
-		err := tx.QueryRow(`SELECT posted_time, retries FROM harmony_task WHERE id=$1`, tID).Scan(&postedTime, &retries)
+		var updateTime time.Time
+		err := tx.QueryRow(`SELECT posted_time, update_time, retries FROM harmony_task WHERE id=$1`, tID).Scan(&postedTime, &updateTime, &retries)
 		if err != nil {
 			return false, fmt.Errorf("could not log completion: %w ", err)
+		}
+		waitStartTime = postedTime
+		if retries > 0 {
+			waitStartTime = updateTime
 		}
 		result := "unspecified error"
 		if done {
@@ -389,12 +397,13 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`, tID, h.Name, postedTime.U
 		goto retryRecordCompletion
 	}
 
+	scheduledWait := workStart.Sub(waitStartTime).Seconds()
+	if scheduledWait < 0 {
+		scheduledWait = 0
+	}
 	_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
 		tag.Upsert(taskNameTag, h.Name),
-	},
-		TaskMeasures.TaskRuntime.M(workEnd.Sub(workStart).Seconds()),
-		TaskMeasures.TaskScheduledWait.M(workStart.Sub(postedTime).Seconds()),
-	)
+	}, TaskMeasures.TaskScheduledWait.M(scheduledWait))
 }
 
 // MaxHeadroom controls the maximum number of tasks per type that can be active on this node.

--- a/harmony/harmonytask/task_type_handler.go
+++ b/harmony/harmonytask/task_type_handler.go
@@ -309,7 +309,7 @@ func (h *taskTypeHandler) recordCompletion(tID TaskID, sectorID *abi.SectorID, w
 		}, TaskMeasures.ActiveTasks.M(int64(h.Max.ActiveThis())))
 
 		duration := workEnd.Sub(workStart).Seconds()
-		TaskMeasures.TaskDuration.Observe(duration)
+		stats.Record(context.Background(), TaskMeasures.TaskDuration.M(duration))
 
 		if done {
 			_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
@@ -322,9 +322,9 @@ func (h *taskTypeHandler) recordCompletion(tID TaskID, sectorID *abi.SectorID, w
 		}
 	}
 
+	var postedTime time.Time
 retryRecordCompletion:
 	cm, err := h.TaskEngine.db.BeginTransaction(h.TaskEngine.ctx, func(tx *harmonydb.Tx) (bool, error) {
-		var postedTime time.Time
 		var retries uint
 		err := tx.QueryRow(`SELECT posted_time, retries FROM harmony_task WHERE id=$1`, tID).Scan(&postedTime, &retries)
 		if err != nil {
@@ -388,6 +388,13 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`, tID, h.Name, postedTime.U
 		}
 		goto retryRecordCompletion
 	}
+
+	_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+		tag.Upsert(taskNameTag, h.Name),
+	},
+		TaskMeasures.TaskRuntime.M(workEnd.Sub(workStart).Seconds()),
+		TaskMeasures.TaskScheduledWait.M(workStart.Sub(postedTime).Seconds()),
+	)
 }
 
 // MaxHeadroom controls the maximum number of tasks per type that can be active on this node.

--- a/lib/cachedreader/metrics.go
+++ b/lib/cachedreader/metrics.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	pre = "curio_cachedreader_"
+	pre = "cachedreader_"
 
 	// Tag keys
 	cacheTypeKey, _ = tag.NewKey("cache_type") // "piece_reader" or "piece_error"

--- a/lib/metrics/node.go
+++ b/lib/metrics/node.go
@@ -1,0 +1,41 @@
+package metrics
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+
+	curiobuild "github.com/filecoin-project/curio/build"
+)
+
+var (
+	nodeTag, _        = tag.NewKey("node")
+	nodeVersionTag, _ = tag.NewKey("version")
+
+	NodeInfo = stats.Int64("node_info", "Curio node identity and version. Value is always 1.", stats.UnitDimensionless)
+)
+
+func init() {
+	err := view.Register(&view.View{
+		Measure:     NodeInfo,
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{nodeTag, nodeVersionTag},
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func RecordNodeInfo(ctx context.Context, nodeName, listenAddr string) error {
+	node := nodeName
+	if node == "" {
+		node = listenAddr
+	}
+
+	return stats.RecordWithTags(ctx, []tag.Mutator{
+		tag.Upsert(nodeTag, node),
+		tag.Upsert(nodeVersionTag, curiobuild.UserVersion()),
+	}, NodeInfo.M(1))
+}

--- a/lib/paths/metrics.go
+++ b/lib/paths/metrics.go
@@ -14,7 +14,7 @@ var (
 	CanSealTag, _     = tag.NewKey("can_seal")
 	CanStoreTag, _    = tag.NewKey("can_store")
 
-	pre = "curio_stor_"
+	pre = "stor_"
 
 	// Buckets for the duration histogram (in seconds)
 	durationBuckets = []float64{0.1, 1, 5, 12, 20, 60, 90, 150, 300, 500, 900, 1500, 3000, 6000, 15000, 30000, 60000, 90000, 200_000, 600_000, 1000_000}

--- a/lib/paths/metrics.go
+++ b/lib/paths/metrics.go
@@ -16,7 +16,7 @@ var (
 
 	pre = "stor_"
 
-	// Buckets for the duration histogram (in seconds)
+	// Buckets for the duration histogram (in milliseconds)
 	durationBuckets = []float64{0.1, 1, 5, 12, 20, 60, 90, 150, 300, 500, 900, 1500, 3000, 6000, 15000, 30000, 60000, 90000, 200_000, 600_000, 1000_000}
 )
 
@@ -24,7 +24,7 @@ var (
 	// Measures
 	GenerateSingleVanillaProofCalls    = stats.Int64(pre+"generate_single_vanilla_proof_calls", "Number of calls to GenerateSingleVanillaProof", stats.UnitDimensionless)
 	GenerateSingleVanillaProofErrors   = stats.Int64(pre+"generate_single_vanilla_proof_errors", "Number of errors in GenerateSingleVanillaProof", stats.UnitDimensionless)
-	GenerateSingleVanillaProofDuration = stats.Int64(pre+"generate_single_vanilla_proof_duration_seconds", "Duration of GenerateSingleVanillaProof in seconds", stats.UnitMilliseconds)
+	GenerateSingleVanillaProofDuration = stats.Int64(pre+"generate_single_vanilla_proof_duration_milliseconds", "Duration of GenerateSingleVanillaProof in milliseconds", stats.UnitMilliseconds)
 	FindSectorUncached                 = stats.Int64(pre+"find_sector_uncached", "Number of findSector uncached calls", stats.UnitDimensionless)
 	FindSectorCacheHits                = stats.Int64(pre+"find_sector_cache_hits", "Number of findSectorCache hits", stats.UnitDimensionless)
 	FindSectorCacheMisses              = stats.Int64(pre+"find_sector_cache_misses", "Number of findSectorCache misses", stats.UnitDimensionless)

--- a/lib/proofsvc/clientctl.go
+++ b/lib/proofsvc/clientctl.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
-	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -41,25 +40,6 @@ var (
 	lastPriceCheck = time.Now().Add(-time.Hour)
 	lastPrice      = PriceResponse{}
 )
-
-// --- Metrics ---
-
-var (
-	clientctlBuckets  = []float64{0.05, 0.2, 0.5, 1, 5} // seconds
-	clientctlDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "curio_psvc_clientctl_duration_seconds",
-		Help:    "Duration of proofsvc clientctl operations",
-		Buckets: clientctlBuckets,
-	}, []string{"call"})
-)
-
-func init() {
-	_ = prometheus.Register(clientctlDuration)
-}
-
-func recordClientctlDuration(call string, start time.Time) {
-	clientctlDuration.WithLabelValues(call).Observe(time.Since(start).Seconds())
-}
 
 // NfilFromTokenAmount converts a token amount in attoFIL to nanoFIL (nFIL).
 // It returns an error if the token amount is not divisible by 1 nFIL.

--- a/lib/proofsvc/common/l1ops.go
+++ b/lib/proofsvc/common/l1ops.go
@@ -10,7 +10,6 @@ import (
 
 	eabi "github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ipfs/go-cid"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -306,25 +305,6 @@ const AcceptServiceActorABI = `[
 		"type": "function"
 	}
 ]`
-
-// --- Metrics ---
-
-var (
-	l1OpBuckets  = []float64{0.05, 0.2, 0.5, 1, 5} // seconds
-	l1OpDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "curio_psvc_l1ops_duration_seconds",
-		Help:    "Duration of L1 operations",
-		Buckets: l1OpBuckets,
-	}, []string{"call"})
-)
-
-func init() {
-	_ = prometheus.Register(l1OpDuration) // ignore AlreadyRegisteredError
-}
-
-func recordL1OpDuration(call string, start time.Time) {
-	l1OpDuration.WithLabelValues(call).Observe(time.Since(start).Seconds())
-}
 
 type Service struct {
 	router      address.Address

--- a/lib/proofsvc/common/metrics.go
+++ b/lib/proofsvc/common/metrics.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"context"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	l1OpCallTag, _ = tag.NewKey("call")
+
+	l1OpBuckets = []float64{0.05, 0.2, 0.5, 1, 5} // seconds
+
+	l1OpDuration = stats.Float64(
+		"psvc_l1ops_duration_seconds",
+		"Duration of L1 operations",
+		stats.UnitSeconds,
+	)
+)
+
+func init() {
+	_ = view.Register(&view.View{
+		Measure:     l1OpDuration,
+		Aggregation: view.Distribution(l1OpBuckets...),
+		TagKeys:     []tag.Key{l1OpCallTag},
+	})
+}
+
+func recordL1OpDuration(call string, start time.Time) {
+	_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+		tag.Upsert(l1OpCallTag, call),
+	}, l1OpDuration.M(time.Since(start).Seconds()))
+}

--- a/lib/proofsvc/metrics.go
+++ b/lib/proofsvc/metrics.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: CCL-1.0
+
+package proofsvc
+
+import (
+	"context"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	proofsvcCallTag, _ = tag.NewKey("call")
+
+	clientctlBuckets = []float64{0.05, 0.2, 0.5, 1, 5} // seconds
+	provictlBuckets  = []float64{0.05, 0.2, 0.5, 1, 5, 15, 45}
+
+	clientctlDuration = stats.Float64(
+		"psvc_clientctl_duration_seconds",
+		"Duration of proofsvc clientctl operations",
+		stats.UnitSeconds,
+	)
+	provictlDuration = stats.Float64(
+		"psvc_provictl_duration_seconds",
+		"Duration of proofsvc provider control operations",
+		stats.UnitSeconds,
+	)
+)
+
+func init() {
+	_ = view.Register(
+		&view.View{
+			Measure:     clientctlDuration,
+			Aggregation: view.Distribution(clientctlBuckets...),
+			TagKeys:     []tag.Key{proofsvcCallTag},
+		},
+		&view.View{
+			Measure:     provictlDuration,
+			Aggregation: view.Distribution(provictlBuckets...),
+			TagKeys:     []tag.Key{proofsvcCallTag},
+		},
+	)
+}
+
+func recordClientctlDuration(call string, start time.Time) {
+	recordProofsvcDuration(clientctlDuration, call, start)
+}
+
+func recordProvictlDuration(call string, start time.Time) {
+	recordProofsvcDuration(provictlDuration, call, start)
+}
+
+func recordProofsvcDuration(measure *stats.Float64Measure, call string, start time.Time) {
+	_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+		tag.Upsert(proofsvcCallTag, call),
+	}, measure.M(time.Since(start).Seconds()))
+}

--- a/lib/proofsvc/provictl.go
+++ b/lib/proofsvc/provictl.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
@@ -27,25 +26,6 @@ import (
 var MaxRetryTime = 30 * time.Minute
 
 var log = logging.Logger("proofsvc")
-
-// --- Metrics ---
-
-var (
-	provictlBuckets  = []float64{0.05, 0.2, 0.5, 1, 5, 15, 45} // seconds
-	provictlDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "curio_psvc_provictl_duration_seconds",
-		Help:    "Duration of proofsvc provider control operations",
-		Buckets: provictlBuckets,
-	}, []string{"call"})
-)
-
-func init() {
-	_ = prometheus.Register(provictlDuration)
-}
-
-func recordProvictlDuration(call string, start time.Time) {
-	provictlDuration.WithLabelValues(call).Observe(time.Since(start).Seconds())
-}
 
 const marketUrl = "https://mainnet.snass.fsp.sh/v0/proofs"
 

--- a/lib/slotmgr/metrics.go
+++ b/lib/slotmgr/metrics.go
@@ -60,14 +60,12 @@ func init() {
 
 		// Register per-slot metrics
 		&view.View{
-			Name:        pre + "slot_in_use",
 			Measure:     SlotMgrSlotMeasures.SlotInUse,
 			Description: "Slot is in use (1) or not (0)",
 			TagKeys:     []tag.Key{KeySlotOffset},
 			Aggregation: view.LastValue(),
 		},
 		&view.View{
-			Name:        pre + "slot_sector_count",
 			Measure:     SlotMgrSlotMeasures.SlotSectorCount,
 			Description: "Number of sectors in a slot",
 			TagKeys:     []tag.Key{KeySlotOffset},

--- a/market/ipni/chunker/metrics.go
+++ b/market/ipni/chunker/metrics.go
@@ -56,7 +56,7 @@ var (
 		stats.UnitDimensionless,
 	)
 	entryCacheHitWaitDuration = stats.Float64(
-		"ipni_entry_cache_hit_wait_seconds",
+		"ipni_entry_cache_hit_wait_milliseconds",
 		"Duration callers wait after hitting the IPNI entry cache.",
 		stats.UnitMilliseconds,
 	)
@@ -66,7 +66,7 @@ var (
 		stats.UnitDimensionless,
 	)
 	entryReconstructionDuration = stats.Float64(
-		"ipni_entry_reconstruction_seconds",
+		"ipni_entry_reconstruction_milliseconds",
 		"Duration of IPNI entry reconstruction after cache miss.",
 		stats.UnitMilliseconds,
 	)

--- a/market/ipni/chunker/metrics.go
+++ b/market/ipni/chunker/metrics.go
@@ -31,8 +31,8 @@ const (
 )
 
 var (
-	entryCacheHitWaitBuckets       = []float64{0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
-	entryReconstructionTimeBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60}
+	entryCacheHitWaitBuckets       = []float64{0.5, 1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000}
+	entryReconstructionTimeBuckets = []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000}
 
 	requestTag, _ = tag.NewKey("request")
 	resultTag, _  = tag.NewKey("result")
@@ -149,7 +149,7 @@ func observeEntryCacheHitWait(request, origin, state string, took time.Duration)
 		tag.Upsert(requestTag, request),
 		tag.Upsert(originTag, origin),
 		tag.Upsert(stateTag, state),
-	}, entryCacheHitWaitDuration.M(took.Seconds()))
+	}, entryCacheHitWaitDuration.M(float64(took)/float64(time.Millisecond)))
 }
 
 func recordEntrySpeculativeUnused() {
@@ -165,5 +165,5 @@ func observeEntryReconstruction(request, source string, took time.Duration, err 
 		tag.Upsert(requestTag, request),
 		tag.Upsert(sourceTag, source),
 		tag.Upsert(resultTag, result),
-	}, entryReconstructionDuration.M(took.Seconds()))
+	}, entryReconstructionDuration.M(float64(took)/float64(time.Millisecond)))
 }

--- a/market/ipni/ipni-provider/metrics.go
+++ b/market/ipni/ipni-provider/metrics.go
@@ -53,9 +53,9 @@ var (
 		stats.UnitDimensionless,
 	)
 	ipniProviderHTTPRequestDuration = stats.Float64(
-		"ipni_provider_http_request_seconds",
-		"Duration of inbound IPNI provider HTTP requests in seconds.",
-		stats.UnitSeconds,
+		"ipni_provider_http_request_milliseconds",
+		"Duration of inbound IPNI provider HTTP requests in milliseconds.",
+		stats.UnitMilliseconds,
 	)
 	ipniAnnounceAttempts = stats.Int64(
 		"ipni_announce_attempts_total",
@@ -63,9 +63,9 @@ var (
 		stats.UnitDimensionless,
 	)
 	ipniAnnounceHTTPRoundTripDuration = stats.Float64(
-		"ipni_announce_http_roundtrip_seconds",
-		"Duration of outbound IPNI announce HTTP round trips in seconds.",
-		stats.UnitSeconds,
+		"ipni_announce_http_roundtrip_milliseconds",
+		"Duration of outbound IPNI announce HTTP round trips in milliseconds.",
+		stats.UnitMilliseconds,
 	)
 )
 

--- a/market/ipni/ipni-provider/metrics.go
+++ b/market/ipni/ipni-provider/metrics.go
@@ -39,8 +39,8 @@ func (w *metricResponseWriter) Status() int {
 }
 
 var (
-	ipniProviderHTTPRequestBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
-	ipniAnnounceRoundTripBuckets   = []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60}
+	ipniProviderHTTPRequestBuckets = []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000}
+	ipniAnnounceRoundTripBuckets   = []float64{10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000}
 
 	providerTag, _ = tag.NewKey("provider")
 	contentTag, _  = tag.NewKey("content")
@@ -105,7 +105,7 @@ func recordProviderHTTPRequest(provider, content string, status int, took time.D
 		tag.Upsert(statusTag, statusLabel),
 	},
 		ipniProviderHTTPRequests.M(1),
-		ipniProviderHTTPRequestDuration.M(took.Seconds()),
+		ipniProviderHTTPRequestDuration.M(float64(took)/float64(time.Millisecond)),
 	)
 }
 
@@ -120,5 +120,5 @@ func observeAnnounceHTTPRoundTrip(provider, status string, took time.Duration) {
 	_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
 		tag.Upsert(providerTag, provider),
 		tag.Upsert(statusTag, status),
-	}, ipniAnnounceHTTPRoundTripDuration.M(took.Seconds()))
+	}, ipniAnnounceHTTPRoundTripDuration.M(float64(took)/float64(time.Millisecond)))
 }

--- a/scripts/metricsdocgen/metricsdocgen.go
+++ b/scripts/metricsdocgen/metricsdocgen.go
@@ -29,20 +29,22 @@ import (
 // Key format: "NN_Category Name" where NN is sort order (01-99)
 // Value: list of path prefixes that belong to this category
 var categoryConfig = map[string][]string{
+	"00_Node Metrics":                       {"lib/metrics"},
 	"01_Database Metrics (HarmonyDB)":       {"harmony/harmonydb"},
 	"02_Task Metrics (HarmonyTask)":         {"harmony/harmonytask"},
 	"03_Wallet Exporter Metrics (Optional)": {"deps/stats"},
 	"04_Proof Share Metrics":                {"tasks/proofshare"},
 	"05_Proof Service Metrics":              {"lib/proofsvc"},
-	"06_Sealing Metrics":                    {"tasks/seal", "tasks/sealsupra"},
+	"06_Sealing Metrics":                    {"tasks/seal"},
 	"07_Snap Pipeline Metrics":              {"tasks/snap"},
 	"08_Mining Metrics":                     {"tasks/winning"},
-	"09_Storage Metrics":                    {"lib/paths", "lib/slotmgr"},
+	"09_Storage Metrics":                    {"lib/paths"},
 	"10_Cache Metrics":                      {"lib/cachedreader"},
 	"11_Network Metrics":                    {"lib/robusthttp", "lib/dealdata"},
 	"12_FFI Metrics":                        {"lib/ffi"},
 	"13_HTTP/Retrieval Metrics":             {"market/"},
 	"14_GC Metrics":                         {"tasks/gc"},
+	"15_Batching Metrics":                   {"tasks/sealsupra", "lib/slotmgr"},
 }
 
 // ============================================================================
@@ -66,6 +68,29 @@ type Category struct {
 type fileResult struct {
 	file    string
 	metrics []Metric
+}
+
+type viewDef struct {
+	Name        string
+	MeasureExpr string
+	Type        string
+	Labels      []string
+}
+
+var registeredLotusMetricViews = map[string]Metric{
+	"DagStorePRAtCacheFillCountView": externalOpenCensusMetric("dagstore/pr_at_cache_fill_count", "Counter", "PieceReader ReadAt full cache fill count", []string{"network"}),
+	"DagStorePRAtHitBytesView":       externalOpenCensusMetric("dagstore/pr_at_hit_bytes", "Counter", "PieceReader ReadAt bytes from cache", []string{"network"}),
+	"DagStorePRAtHitCountView":       externalOpenCensusMetric("dagstore/pr_at_hit_count", "Counter", "PieceReader ReadAt from cache hits", []string{"network"}),
+	"DagStorePRAtReadBytesView":      externalOpenCensusMetric("dagstore/pr_at_read_bytes", "Counter", "PieceReader ReadAt bytes read from source", []string{"pr_size", "network"}),
+	"DagStorePRAtReadCountView":      externalOpenCensusMetric("dagstore/pr_at_read_count", "Counter", "PieceReader ReadAt reads from source", []string{"pr_size", "network"}),
+	"DagStorePRBytesDiscardedView":   externalOpenCensusMetric("dagstore/pr_discarded_bytes", "Counter", "PieceReader discarded bytes", []string{"network"}),
+	"DagStorePRBytesRequestedView":   externalOpenCensusMetric("dagstore/pr_requested_bytes", "Counter", "PieceReader requested bytes", []string{"pr_type", "network"}),
+	"DagStorePRDiscardCountView":     externalOpenCensusMetric("dagstore/pr_discard_count", "Counter", "PieceReader discard count", []string{"network"}),
+	"DagStorePRInitCountView":        externalOpenCensusMetric("dagstore/pr_init_count", "Counter", "PieceReader init count", []string{"network"}),
+	"DagStorePRSeekBackBytesView":    externalOpenCensusMetric("dagstore/pr_seek_back_bytes", "Counter", "PieceReader seek back bytes", []string{"network"}),
+	"DagStorePRSeekBackCountView":    externalOpenCensusMetric("dagstore/pr_seek_back_count", "Counter", "PieceReader seek back count", []string{"network"}),
+	"DagStorePRSeekForwardBytesView": externalOpenCensusMetric("dagstore/pr_seek_forward_bytes", "Counter", "PieceReader seek forward bytes", []string{"network"}),
+	"DagStorePRSeekForwardCountView": externalOpenCensusMetric("dagstore/pr_seek_forward_count", "Counter", "PieceReader seek forward count", []string{"network"}),
 }
 
 func main() {
@@ -188,23 +213,21 @@ func processFile(path string) []Metric {
 	}
 	defer func() { _ = f.Close() }()
 
-	// Read first 4KB to check imports
+	// Read the file once before checking imports. Relying only on a small
+	// header can miss files with long package comments or generated headers.
 	buf := make([]byte, 4096)
 	n, _ := f.Read(buf)
 	if n == 0 {
 		return nil
 	}
+	rest, _ := io.ReadAll(f)
+	content := append(buf[:n], rest...)
 
-	// Quick check for prometheus imports
-	header := buf[:n]
-	if !bytes.Contains(header, []byte("prometheus")) &&
-		!bytes.Contains(header, []byte("opencensus.io/stats")) {
+	// Quick check for metrics imports before parsing.
+	if !bytes.Contains(content, []byte("prometheus")) &&
+		!bytes.Contains(content, []byte("opencensus.io/stats")) {
 		return nil
 	}
-
-	// Has prometheus - read rest of file and parse
-	rest, _ := io.ReadAll(f)
-	content := append(header, rest...)
 
 	return parseMetricsFromSource(path, content)
 }
@@ -219,6 +242,11 @@ func parseMetricsFromSource(path string, content []byte) []Metric {
 
 	var metrics []Metric
 	seen := make(map[string]bool)
+	measures := make(map[string]Metric)
+	tagKeys := make(map[string]string)
+	aggregationVars := make(map[string]string)
+	viewVars := make(map[string]viewDef)
+	lotusMetricsAliases := importAliases(node, "github.com/filecoin-project/lotus/metrics")
 
 	// Find prefix variable value
 	prefix := "curio_"
@@ -235,32 +263,117 @@ func parseMetricsFromSource(path string, content []byte) []Metric {
 		return true
 	})
 
-	// Collect metrics
+	// Collect local symbols first so view registrations can resolve measure
+	// names, aggregation types, and tag labels.
 	ast.Inspect(node, func(n ast.Node) bool {
-		switch x := n.(type) {
-		case *ast.CallExpr:
-			if m := parseMetricCall(x, prefix); m != nil && !seen[m.Name] {
-				m.Source = path
-				seen[m.Name] = true
-				metrics = append(metrics, *m)
+		vs, ok := n.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+
+		for i, value := range vs.Values {
+			var assignName string
+			if i < len(vs.Names) {
+				assignName = vs.Names[i].Name
 			}
-			if m := parseStatsCall(x, prefix); m != nil && !seen[m.Name] {
-				m.Source = path
-				seen[m.Name] = true
-				metrics = append(metrics, *m)
+
+			if label, ok := parseTagKeyCall(value); ok && assignName != "" {
+				tagKeys[assignName] = label
 			}
-		case *ast.KeyValueExpr:
-			if call, ok := x.Value.(*ast.CallExpr); ok {
-				if m := parseStatsCall(call, prefix); m != nil && !seen[m.Name] {
-					m.Source = path
-					seen[m.Name] = true
-					metrics = append(metrics, *m)
+
+			if aggType := aggregationType(value, aggregationVars); aggType != "" && assignName != "" {
+				aggregationVars[assignName] = aggType
+			}
+
+			if view := parseView(value, aggregationVars, tagKeys); view != nil && assignName != "" {
+				viewVars[assignName] = *view
+			}
+
+			if metric := parseStatsMeasure(value, prefix); metric != nil && assignName != "" {
+				measures[assignName] = *metric
+			}
+
+			if composite, ok := indirectCompositeLit(value); ok && assignName != "" {
+				for _, elt := range composite.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					fieldName := exprName(kv.Key)
+					if fieldName == "" {
+						continue
+					}
+					if metric := parseStatsMeasure(kv.Value, prefix); metric != nil {
+						measures[assignName+"."+fieldName] = *metric
+					}
+					if view := parseView(kv.Value, aggregationVars, tagKeys); view != nil {
+						viewVars[assignName+"."+fieldName] = *view
+					}
 				}
-				if m := parseMetricCall(call, prefix); m != nil && !seen[m.Name] {
-					m.Source = path
-					seen[m.Name] = true
-					metrics = append(metrics, *m)
+			}
+		}
+		return true
+	})
+
+	// Direct Prometheus collectors are exported by the collector itself.
+	ast.Inspect(node, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if m := parseMetricCall(call, prefix); m != nil && !seen[m.Name] {
+			m.Source = path
+			seen[m.Name] = true
+			metrics = append(metrics, *m)
+		}
+		return true
+	})
+
+	// OpenCensus metrics are exported through registered views, so the view
+	// aggregation decides the Prometheus type and TagKeys decide labels.
+	ast.Inspect(node, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || !isSelector(call.Fun, "view", "Register") {
+			return true
+		}
+		for _, arg := range call.Args {
+			view := parseView(arg, aggregationVars, tagKeys)
+			if view == nil {
+				if name := exprName(arg); name != "" {
+					if registeredView, ok := viewVars[name]; ok {
+						view = &registeredView
+					} else if metric, ok := registeredLotusMetricView(arg, lotusMetricsAliases); ok {
+						metric.Source = path
+						if !seen[metric.Name] {
+							seen[metric.Name] = true
+							metrics = append(metrics, metric)
+						}
+						continue
+					} else {
+						fmt.Fprintf(os.Stderr, "WARN: unresolved registered view %s in %s\n", name, path)
+					}
 				}
+			}
+			if view == nil {
+				continue
+			}
+
+			measure, ok := measures[view.MeasureExpr]
+			if !ok {
+				fmt.Fprintf(os.Stderr, "WARN: unresolved measure %s for registered view in %s\n", view.MeasureExpr, path)
+				continue
+			}
+			viewName := measure.Name
+			if view.Name != "" {
+				viewName = view.Name
+			}
+			measure.Name = exportedOpenCensusName(viewName)
+			measure.Type = view.Type
+			measure.Labels = view.Labels
+			measure.Source = path
+			if !seen[measure.Name] {
+				seen[measure.Name] = true
+				metrics = append(metrics, measure)
 			}
 		}
 		return true
@@ -269,27 +382,97 @@ func parseMetricsFromSource(path string, content []byte) []Metric {
 	return metrics
 }
 
+func externalOpenCensusMetric(name, typ, help string, labels []string) Metric {
+	return Metric{
+		Name:   exportedOpenCensusName(name),
+		Type:   typ,
+		Help:   help,
+		Labels: labels,
+	}
+}
+
+func importAliases(node *ast.File, importPath string) map[string]bool {
+	aliases := make(map[string]bool)
+	for _, spec := range node.Imports {
+		if strings.Trim(spec.Path.Value, `"`) != importPath {
+			continue
+		}
+		if spec.Name != nil {
+			if spec.Name.Name != "." && spec.Name.Name != "_" {
+				aliases[spec.Name.Name] = true
+			}
+			continue
+		}
+		aliases[lastImportPathPart(importPath)] = true
+	}
+	return aliases
+}
+
+func lastImportPathPart(importPath string) string {
+	idx := strings.LastIndex(importPath, "/")
+	if idx < 0 {
+		return importPath
+	}
+	return importPath[idx+1:]
+}
+
+func registeredLotusMetricView(expr ast.Expr, lotusMetricsAliases map[string]bool) (Metric, bool) {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return Metric{}, false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || !lotusMetricsAliases[pkg.Name] {
+		return Metric{}, false
+	}
+	metric, ok := registeredLotusMetricViews[sel.Sel.Name]
+	return metric, ok
+}
+
 // categoryFromPath derives a category name and key from the file path.
 // Falls back to "99_Uncategorized" with a warning if no match found.
 func categoryFromPath(path string) (key, name string) {
 	cleanPath := filepath.Clean(path)
 
-	for catKey, prefixes := range categoryConfig {
+	var bestKey string
+	bestPrefixLen := -1
+
+	keys := make([]string, 0, len(categoryConfig))
+	for catKey := range categoryConfig {
+		keys = append(keys, catKey)
+	}
+	sort.Strings(keys)
+
+	for _, catKey := range keys {
+		prefixes := categoryConfig[catKey]
 		for _, prefix := range prefixes {
-			if strings.Contains(cleanPath, prefix) {
-				// Extract display name by removing the "NN_" prefix
-				name = catKey
-				if len(catKey) > 3 && catKey[2] == '_' {
-					name = catKey[3:]
-				}
-				return catKey, name
+			if pathMatchesPrefix(cleanPath, prefix) && len(prefix) > bestPrefixLen {
+				bestKey = catKey
+				bestPrefixLen = len(prefix)
 			}
 		}
+	}
+
+	if bestKey != "" {
+		name = bestKey
+		if len(bestKey) > 3 && bestKey[2] == '_' {
+			name = bestKey[3:]
+		}
+		return bestKey, name
 	}
 
 	// Fallback for uncategorized files - warn but don't fail
 	fmt.Fprintf(os.Stderr, "WARN: no category for %s (add entry to categoryConfig)\n", path)
 	return "99_Uncategorized (" + filepath.Dir(path) + ")", "Uncategorized (" + filepath.Dir(path) + ")"
+}
+
+func pathMatchesPrefix(path, prefix string) bool {
+	path = filepath.ToSlash(filepath.Clean(path))
+	prefix = filepath.ToSlash(filepath.Clean(prefix))
+
+	return path == prefix ||
+		strings.HasPrefix(path, prefix+"/") ||
+		strings.Contains(path, "/"+prefix+"/")
 }
 
 func printHeader() {
@@ -299,7 +482,7 @@ func printHeader() {
 
 # Metrics Reference
 
-This document lists all Prometheus metrics exported by Curio. All metrics use the ` + "`curio_`" + ` namespace prefix.
+This document lists Prometheus metrics exported by Curio using the exact metric names exposed on the scrape endpoint.
 
 > **Note**: This file is auto-generated from source code. Run ` + "`make docsgen-metrics`" + ` to update.`)
 }
@@ -364,24 +547,17 @@ func parseMetricCall(call *ast.CallExpr, prefix string) *Metric {
 
 	funcName := sel.Sel.Name
 	var metricType string
+	isVec := strings.HasSuffix(funcName, "Vec")
 
 	switch funcName {
-	case "NewHistogram":
+	case "NewHistogram", "NewHistogramVec":
 		metricType = "Histogram"
-	case "NewHistogramVec":
-		metricType = "HistogramVec"
-	case "NewCounter":
+	case "NewCounter", "NewCounterVec":
 		metricType = "Counter"
-	case "NewCounterVec":
-		metricType = "CounterVec"
-	case "NewGauge":
+	case "NewGauge", "NewGaugeVec":
 		metricType = "Gauge"
-	case "NewGaugeVec":
-		metricType = "GaugeVec"
-	case "NewSummary":
+	case "NewSummary", "NewSummaryVec":
 		metricType = "Summary"
-	case "NewSummaryVec":
-		metricType = "SummaryVec"
 	default:
 		return nil
 	}
@@ -426,7 +602,7 @@ func parseMetricCall(call *ast.CallExpr, prefix string) *Metric {
 	}
 
 	// Parse labels for Vec types (second argument)
-	if strings.HasSuffix(metricType, "Vec") && len(call.Args) > 1 {
+	if isVec && len(call.Args) > 1 {
 		if labels, ok := call.Args[1].(*ast.CompositeLit); ok {
 			for _, elt := range labels.Elts {
 				if lit, ok := elt.(*ast.BasicLit); ok {
@@ -441,15 +617,15 @@ func parseMetricCall(call *ast.CallExpr, prefix string) *Metric {
 		return nil
 	}
 
-	// Add curio_ prefix if not present
-	if !strings.HasPrefix(metric.Name, "curio_") {
-		metric.Name = "curio_" + metric.Name
-	}
-
 	return metric
 }
 
-func parseStatsCall(call *ast.CallExpr, prefix string) *Metric {
+func parseStatsMeasure(expr ast.Expr, prefix string) *Metric {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
 		return nil
@@ -464,7 +640,7 @@ func parseStatsCall(call *ast.CallExpr, prefix string) *Metric {
 	var metricType string
 	switch sel.Sel.Name {
 	case "Int64":
-		metricType = "Gauge/Counter"
+		metricType = "Counter"
 	case "Float64":
 		metricType = "Gauge"
 	default:
@@ -494,12 +670,201 @@ func parseStatsCall(call *ast.CallExpr, prefix string) *Metric {
 		return nil
 	}
 
-	// Add curio_ prefix if not present
-	if !strings.HasPrefix(metric.Name, "curio_") {
-		metric.Name = "curio_" + metric.Name
+	return metric
+}
+
+func parseTagKeyCall(expr ast.Expr) (string, bool) {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || !isSelector(call.Fun, "tag", "NewKey") || len(call.Args) == 0 {
+		return "", false
+	}
+	lit, ok := call.Args[0].(*ast.BasicLit)
+	if !ok {
+		return "", false
+	}
+	return strings.Trim(lit.Value, `"`), true
+}
+
+func parseView(expr ast.Expr, aggregationVars map[string]string, tagKeys map[string]string) *viewDef {
+	composite, ok := indirectCompositeLit(expr)
+	if !ok || !isViewComposite(composite) {
+		return nil
 	}
 
-	return metric
+	view := &viewDef{}
+	for _, elt := range composite.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key := exprName(kv.Key)
+		switch key {
+		case "Name":
+			view.Name = stringExpr(kv.Value, "curio_")
+		case "Measure":
+			view.MeasureExpr = exprName(kv.Value)
+		case "Aggregation":
+			view.Type = aggregationType(kv.Value, aggregationVars)
+		case "TagKeys":
+			view.Labels = parseTagKeys(kv.Value, tagKeys)
+		}
+	}
+	if view.MeasureExpr == "" || view.Type == "" {
+		return nil
+	}
+	return view
+}
+
+func aggregationType(expr ast.Expr, aggregationVars map[string]string) string {
+	switch x := expr.(type) {
+	case *ast.CallExpr:
+		sel, ok := x.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return ""
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok || pkg.Name != "view" {
+			return ""
+		}
+		switch sel.Sel.Name {
+		case "Distribution":
+			return "Histogram"
+		case "LastValue":
+			return "Gauge"
+		case "Sum", "Count":
+			return "Counter"
+		default:
+			return ""
+		}
+	case *ast.Ident:
+		return aggregationVars[x.Name]
+	default:
+		return ""
+	}
+}
+
+func parseTagKeys(expr ast.Expr, tagKeys map[string]string) []string {
+	composite, ok := expr.(*ast.CompositeLit)
+	if !ok {
+		return nil
+	}
+
+	var labels []string
+	for _, elt := range composite.Elts {
+		key := exprName(elt)
+		if key == "" {
+			continue
+		}
+		label, ok := tagKeys[key]
+		if !ok {
+			label = lastNamePart(key)
+		}
+		labels = append(labels, sanitizePrometheusName(label))
+	}
+	return labels
+}
+
+func indirectCompositeLit(expr ast.Expr) (*ast.CompositeLit, bool) {
+	switch x := expr.(type) {
+	case *ast.CompositeLit:
+		return x, true
+	case *ast.UnaryExpr:
+		if x.Op == token.AND {
+			return indirectCompositeLit(x.X)
+		}
+	}
+	return nil, false
+}
+
+func isViewComposite(composite *ast.CompositeLit) bool {
+	switch typ := composite.Type.(type) {
+	case *ast.SelectorExpr:
+		return isSelector(typ, "view", "View")
+	case *ast.StarExpr:
+		if sel, ok := typ.X.(*ast.SelectorExpr); ok {
+			return isSelector(sel, "view", "View")
+		}
+	}
+	return false
+}
+
+func isSelector(expr ast.Expr, pkg, name string) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != name {
+		return false
+	}
+	x, ok := sel.X.(*ast.Ident)
+	return ok && x.Name == pkg
+}
+
+func exprName(expr ast.Expr) string {
+	switch x := expr.(type) {
+	case *ast.Ident:
+		return x.Name
+	case *ast.SelectorExpr:
+		parent := exprName(x.X)
+		if parent == "" {
+			return x.Sel.Name
+		}
+		return parent + "." + x.Sel.Name
+	case *ast.UnaryExpr:
+		return exprName(x.X)
+	case *ast.ParenExpr:
+		return exprName(x.X)
+	default:
+		return ""
+	}
+}
+
+func lastNamePart(name string) string {
+	parts := strings.Split(name, ".")
+	return parts[len(parts)-1]
+}
+
+func exportedOpenCensusName(name string) string {
+	return "curio_" + sanitizePrometheusName(name)
+}
+
+func sanitizePrometheusName(name string) string {
+	if name == "" {
+		return name
+	}
+	if len(name) > 100 {
+		name = name[:100]
+	}
+
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '_' || r == ':':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+
+	out := b.String()
+	if strings.HasPrefix(out, "_") {
+		return "key" + out
+	}
+	return out
+}
+
+func stringExpr(expr ast.Expr, prefix string) string {
+	switch x := expr.(type) {
+	case *ast.BasicLit:
+		return strings.Trim(x.Value, `"`)
+	case *ast.BinaryExpr:
+		return extractConcatString(x, prefix)
+	default:
+		return ""
+	}
 }
 
 func extractConcatString(bin *ast.BinaryExpr, prefix string) string {

--- a/scripts/metricsdocgen/metricsdocgen_test.go
+++ b/scripts/metricsdocgen/metricsdocgen_test.go
@@ -1,0 +1,171 @@
+package main
+
+import "testing"
+
+func TestOpenCensusViewAggregationDefinesPrometheusTypeAndLabels(t *testing.T) {
+	source := []byte(`
+package sample
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	callTag, _ = tag.NewKey("call")
+	latency = stats.Float64("psvc_latency_seconds", "latency", stats.UnitSeconds)
+	total = stats.Int64("psvc_total", "total", stats.UnitDimensionless)
+	current = stats.Int64("psvc_current", "current", stats.UnitDimensionless)
+)
+
+func init() {
+	_ = view.Register(
+		&view.View{Measure: latency, Aggregation: view.Distribution(1, 2), TagKeys: []tag.Key{callTag}},
+		&view.View{Measure: total, Aggregation: view.Sum()},
+		&view.View{Measure: current, Aggregation: view.LastValue()},
+	)
+}
+`)
+
+	metrics := metricMap(parseMetricsFromSource("tasks/proofshare/metrics.go", source))
+
+	assertMetric(t, metrics, "curio_psvc_latency_seconds", "Histogram", []string{"call"})
+	assertMetric(t, metrics, "curio_psvc_total", "Counter", nil)
+	assertMetric(t, metrics, "curio_psvc_current", "Gauge", nil)
+}
+
+func TestOpenCensusExporterNameMatchesNamespaceAndSanitization(t *testing.T) {
+	source := []byte(`
+package sample
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+var (
+	withSlash = stats.Int64("http/request_count", "requests", stats.UnitDimensionless)
+	withPrefix = stats.Int64("curio_cachedreader_cache_hits", "hits", stats.UnitDimensionless)
+)
+
+func init() {
+	_ = view.Register(
+		&view.View{Measure: withSlash, Aggregation: view.Sum()},
+		&view.View{Measure: withPrefix, Aggregation: view.Sum()},
+	)
+}
+`)
+
+	metrics := metricMap(parseMetricsFromSource("market/retrieval/remoteblockstore/metric.go", source))
+
+	assertMetric(t, metrics, "curio_http_request_count", "Counter", nil)
+	assertMetric(t, metrics, "curio_curio_cachedreader_cache_hits", "Counter", nil)
+}
+
+func TestViewVariablesAndAggregationVariablesAreResolved(t *testing.T) {
+	source := []byte(`
+package sample
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var pathKey, _ = tag.NewKey("path")
+var defaultDistribution = view.Distribution(1, 5)
+var latency = stats.Float64("http/latency_ms", "latency", stats.UnitMilliseconds)
+var latencyView = &view.View{
+	Measure: latency,
+	Aggregation: defaultDistribution,
+	TagKeys: []tag.Key{pathKey},
+}
+
+func init() {
+	_ = view.Register(latencyView)
+}
+`)
+
+	metrics := metricMap(parseMetricsFromSource("market/retrieval/remoteblockstore/metric.go", source))
+
+	assertMetric(t, metrics, "curio_http_latency_ms", "Histogram", []string{"path"})
+}
+
+func TestRegisteredExternalLotusViewsAreDocumented(t *testing.T) {
+	source := []byte(`
+package sample
+
+import (
+	"go.opencensus.io/stats/view"
+	lm "github.com/filecoin-project/lotus/metrics"
+)
+
+func init() {
+	_ = view.Register(
+		lm.DagStorePRInitCountView,
+		lm.DagStorePRBytesRequestedView,
+	)
+}
+`)
+
+	metrics := metricMap(parseMetricsFromSource("market/retrieval/remoteblockstore/metric.go", source))
+
+	assertMetric(t, metrics, "curio_dagstore_pr_init_count", "Counter", []string{"network"})
+	assertMetric(t, metrics, "curio_dagstore_pr_requested_bytes", "Counter", []string{"pr_type", "network"})
+}
+
+func TestDirectPrometheusVecUsesPrometheusTypeAndLabels(t *testing.T) {
+	source := []byte(`
+package sample
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var retries = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Name: "curio_psvc_retry_count",
+	Help: "retries",
+}, []string{"call"})
+`)
+
+	metrics := metricMap(parseMetricsFromSource("tasks/proofshare/metrics.go", source))
+
+	assertMetric(t, metrics, "curio_psvc_retry_count", "Histogram", []string{"call"})
+}
+
+func TestCategoryFromPathUsesLongestPrefix(t *testing.T) {
+	key, name := categoryFromPath("tasks/sealsupra/metrics.go")
+	if key != "15_Batching Metrics" {
+		t.Fatalf("key = %s, want 15_Batching Metrics", key)
+	}
+	if name != "Batching Metrics" {
+		t.Fatalf("name = %s, want Batching Metrics", name)
+	}
+}
+
+func metricMap(metrics []Metric) map[string]Metric {
+	out := make(map[string]Metric, len(metrics))
+	for _, metric := range metrics {
+		out[metric.Name] = metric
+	}
+	return out
+}
+
+func assertMetric(t *testing.T, metrics map[string]Metric, name, typ string, labels []string) {
+	t.Helper()
+
+	metric, ok := metrics[name]
+	if !ok {
+		t.Fatalf("missing metric %s in %#v", name, metrics)
+	}
+	if metric.Type != typ {
+		t.Fatalf("metric %s type = %s, want %s", name, metric.Type, typ)
+	}
+	if len(metric.Labels) != len(labels) {
+		t.Fatalf("metric %s labels = %#v, want %#v", name, metric.Labels, labels)
+	}
+	for i := range labels {
+		if metric.Labels[i] != labels[i] {
+			t.Fatalf("metric %s labels = %#v, want %#v", name, metric.Labels, labels)
+		}
+	}
+}

--- a/tasks/gc/metrics.go
+++ b/tasks/gc/metrics.go
@@ -11,7 +11,7 @@ var (
 	MinerTag, _    = tag.NewKey("miner")
 	FileTypeTag, _ = tag.NewKey("filetype")
 
-	pre = "curio_gc_"
+	pre = "gc_"
 )
 
 // GCMeasures groups all GC metrics.

--- a/tasks/proofshare/metrics.go
+++ b/tasks/proofshare/metrics.go
@@ -1,0 +1,160 @@
+package proofshare
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	proofshareDurationBuckets = []float64{0.05, 0.2, 0.5, 1, 5, 15, 45} // seconds
+	proofshareRetryBuckets    = []float64{0, 1, 3, 8, 20, 50, 200}
+
+	proofshareCallTag, _ = tag.NewKey("call")
+	proofshareHoldTag, _ = tag.NewKey("hold")
+
+	proofshareQueueCount = stats.Float64(
+		"psvc_proofshare_queue_count",
+		"Current proofshare request queue count",
+		stats.UnitDimensionless,
+	)
+	proofshareAdderCommits = stats.Int64(
+		"psvc_proofshare_adder_commits_total",
+		"Total number of successful task additions scheduled by Adder",
+		stats.UnitDimensionless,
+	)
+	proofshareAdderHoldDecisions = stats.Int64(
+		"psvc_proofshare_adder_hold_decisions_total",
+		"Total number of hold decisions made by Adder",
+		stats.UnitDimensionless,
+	)
+	proofshareNeedAsks = stats.Float64(
+		"psvc_proofshare_need_asks",
+		"Number of asks still needed in current Do loop iteration",
+		stats.UnitDimensionless,
+	)
+	proofshareToRequestRemaining = stats.Float64(
+		"psvc_proofshare_to_request_remaining",
+		"Remaining requests to fulfill for high-water mark",
+		stats.UnitDimensionless,
+	)
+	proofshareNewlyAdded = stats.Int64(
+		"psvc_proofshare_newly_added_total",
+		"Total number of new work requests inserted locally",
+		stats.UnitDimensionless,
+	)
+	proofshareCreateAsksDuration = stats.Float64(
+		"psvc_proofshare_create_asks_seconds",
+		"Duration of create asks inner loop",
+		stats.UnitSeconds,
+	)
+	proofshareDuration = stats.Float64(
+		"psvc_proofshare_duration_seconds",
+		"Duration of proofshare client_common operations",
+		stats.UnitSeconds,
+	)
+
+	proofshareRetryCounts = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "curio_psvc_proofshare_retry_count",
+		Help:    "Retry count per call in proofshare client_common operations",
+		Buckets: proofshareRetryBuckets,
+	}, []string{"call"})
+)
+
+func init() {
+	_ = view.Register(
+		&view.View{
+			Measure:     proofshareQueueCount,
+			Aggregation: view.LastValue(),
+		},
+		&view.View{
+			Measure:     proofshareAdderCommits,
+			Aggregation: view.Sum(),
+		},
+		&view.View{
+			Measure:     proofshareAdderHoldDecisions,
+			Aggregation: view.Sum(),
+			TagKeys:     []tag.Key{proofshareHoldTag},
+		},
+		&view.View{
+			Measure:     proofshareNeedAsks,
+			Aggregation: view.LastValue(),
+		},
+		&view.View{
+			Measure:     proofshareToRequestRemaining,
+			Aggregation: view.LastValue(),
+		},
+		&view.View{
+			Measure:     proofshareNewlyAdded,
+			Aggregation: view.Sum(),
+		},
+		&view.View{
+			Measure:     proofshareCreateAsksDuration,
+			Aggregation: view.Distribution(proofshareDurationBuckets...),
+		},
+		&view.View{
+			Measure:     proofshareDuration,
+			Aggregation: view.Distribution(proofshareDurationBuckets...),
+			TagKeys:     []tag.Key{proofshareCallTag},
+		},
+	)
+	_ = prometheus.Register(proofshareRetryCounts)
+
+	initProofshareMetricRows()
+}
+
+func initProofshareMetricRows() {
+	// Direct no-label Prometheus gauges and counters exported a zero sample at
+	// registration time. Recording zero preserves that startup scrape surface.
+	stats.Record(context.Background(),
+		proofshareQueueCount.M(0),
+		proofshareAdderCommits.M(0),
+		proofshareNeedAsks.M(0),
+		proofshareToRequestRemaining.M(0),
+		proofshareNewlyAdded.M(0),
+	)
+}
+
+func recordProofshareQueueCount(count int) {
+	stats.Record(context.Background(), proofshareQueueCount.M(float64(count)))
+}
+
+func recordProofshareAdderCommit() {
+	stats.Record(context.Background(), proofshareAdderCommits.M(1))
+}
+
+func recordProofshareAdderHoldDecision(hold string) {
+	_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+		tag.Upsert(proofshareHoldTag, hold),
+	}, proofshareAdderHoldDecisions.M(1))
+}
+
+func recordProofshareNeedAsks(count int) {
+	stats.Record(context.Background(), proofshareNeedAsks.M(float64(count)))
+}
+
+func recordProofshareToRequestRemaining(count int) {
+	stats.Record(context.Background(), proofshareToRequestRemaining.M(float64(count)))
+}
+
+func recordProofshareNewlyAdded() {
+	stats.Record(context.Background(), proofshareNewlyAdded.M(1))
+}
+
+func observeProofshareCreateAsksDuration(took time.Duration) {
+	stats.Record(context.Background(), proofshareCreateAsksDuration.M(took.Seconds()))
+}
+
+func recordPSDuration(call string, start time.Time) {
+	_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+		tag.Upsert(proofshareCallTag, call),
+	}, proofshareDuration.M(time.Since(start).Seconds()))
+}
+
+func recordPSRetries(call string, retries int) {
+	proofshareRetryCounts.WithLabelValues(call).Observe(float64(retries))
+}

--- a/tasks/proofshare/task_client_send.go
+++ b/tasks/proofshare/task_client_send.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/yugabyte/pgx/v5"
 	"golang.org/x/xerrors"
 
@@ -24,35 +23,6 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/types"
 )
-
-var (
-	psBuckets  = []float64{0.05, 0.2, 0.5, 1, 5, 15, 45} // seconds
-	psDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "curio_psvc_proofshare_duration_seconds",
-		Help:    "Duration of proofshare client_common operations",
-		Buckets: psBuckets,
-	}, []string{"call"})
-
-	retryBuckets  = []float64{0, 1, 3, 8, 20, 50, 200}
-	psRetryCounts = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "curio_psvc_proofshare_retry_count",
-		Help:    "Retry count per call in proofshare client_common operations",
-		Buckets: retryBuckets,
-	}, []string{"call"})
-)
-
-func init() {
-	_ = prometheus.Register(psDuration)
-	_ = prometheus.Register(psRetryCounts)
-}
-
-func recordPSDuration(call string, start time.Time) {
-	psDuration.WithLabelValues(call).Observe(time.Since(start).Seconds())
-}
-
-func recordPSRetries(call string, retries int) {
-	psRetryCounts.WithLabelValues(call).Observe(float64(retries))
-}
 
 type TaskClientSend struct {
 	db     *harmonydb.DB

--- a/tasks/proofshare/task_request.go
+++ b/tasks/proofshare/task_request.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
@@ -22,55 +21,6 @@ import (
 )
 
 var log = logging.Logger("proofshare")
-
-// --- Metrics ---
-
-var (
-	trBuckets = []float64{0.05, 0.2, 0.5, 1, 5, 15, 45} // seconds
-
-	queueCountGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "curio_psvc_proofshare_queue_count",
-		Help: "Current proofshare request queue count",
-	})
-	adderCommitCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "curio_psvc_proofshare_adder_commits_total",
-		Help: "Total number of successful task additions scheduled by Adder",
-	})
-	adderHoldDecisionCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "curio_psvc_proofshare_adder_hold_decisions_total",
-		Help: "Total number of hold decisions made by Adder",
-	}, []string{"hold"})
-
-	needAsksGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "curio_psvc_proofshare_need_asks",
-		Help: "Number of asks still needed in current Do loop iteration",
-	})
-	toRequestGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "curio_psvc_proofshare_to_request_remaining",
-		Help: "Remaining requests to fulfill for high-water mark",
-	})
-
-	newlyAddedCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "curio_psvc_proofshare_newly_added_total",
-		Help: "Total number of new work requests inserted locally",
-	})
-
-	createAsksDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "curio_psvc_proofshare_create_asks_seconds",
-		Help:    "Duration of create asks inner loop",
-		Buckets: trBuckets,
-	})
-)
-
-func init() {
-	_ = prometheus.Register(queueCountGauge)
-	_ = prometheus.Register(adderCommitCounter)
-	_ = prometheus.Register(needAsksGauge)
-	_ = prometheus.Register(toRequestGauge)
-	_ = prometheus.Register(newlyAddedCounter)
-	_ = prometheus.Register(createAsksDuration)
-	_ = prometheus.Register(adderHoldDecisionCounter)
-}
 
 var ProofRequestPollInterval = time.Second * 3
 var BoredBeforeToStart = time.Second * 7
@@ -108,10 +58,10 @@ func (t *TaskRequestProofs) Adder(taskTx harmonytask.AddTaskFunc) {
 			// check if snap/porep tasks were bored recently
 			if ShouldHoldProofShare(ctx, t.db) {
 				log.Infow("TaskRequestProofs.Adder() HOLDING OFF")
-				adderHoldDecisionCounter.WithLabelValues("hold").Inc()
+				recordProofshareAdderHoldDecision("hold")
 				continue
 			}
-			adderHoldDecisionCounter.WithLabelValues("pass").Inc()
+			recordProofshareAdderHoldDecision("pass")
 
 			taskTx(func(taskID harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
 				// Get current state from proofshare_meta
@@ -144,7 +94,7 @@ func (t *TaskRequestProofs) Adder(taskTx harmonytask.AddTaskFunc) {
 					return false, err
 				}
 
-				queueCountGauge.Set(float64(queueCount))
+				recordProofshareQueueCount(queueCount)
 
 				if queueCount > RequestQueueLowWaterMark {
 					log.Debugw("TaskRequestProofs.Adder() queue is at or above low water mark, not scheduling", "queueCount", queueCount)
@@ -162,7 +112,7 @@ func (t *TaskRequestProofs) Adder(taskTx harmonytask.AddTaskFunc) {
 				}
 
 				// Successful commit
-				adderCommitCounter.Inc()
+				recordProofshareAdderCommit()
 
 				return true, nil
 			})
@@ -220,7 +170,7 @@ func (t *TaskRequestProofs) Do(taskID harmonytask.TaskID, stillOwned func() bool
 	log.Infow("checked queue count", "count", queueCount)
 
 	toRequest := RequestQueueHighWaterMark - queueCount
-	toRequestGauge.Set(float64(toRequest))
+	recordProofshareToRequestRemaining(toRequest)
 	if toRequest <= 0 {
 		log.Infow("queue is at or above high water mark, nothing to request")
 		return true, nil
@@ -331,7 +281,7 @@ func (t *TaskRequestProofs) Do(taskID harmonytask.TaskID, stillOwned func() bool
 		// If we still need more requests, create new work asks
 		neededAsks := toRequest - len(work.ActiveAsks)
 		log.Infow("checking if more asks needed", "neededAsks", neededAsks, "toRequest", toRequest, "activeAsks", len(work.ActiveAsks))
-		needAsksGauge.Set(float64(neededAsks))
+		recordProofshareNeedAsks(neededAsks)
 
 		// Prepare signing material once, outside the ask-creation loop.
 		var (
@@ -372,10 +322,10 @@ func (t *TaskRequestProofs) Do(taskID harmonytask.TaskID, stillOwned func() bool
 			}
 			asksCreated++
 			log.Infow("created new work ask", "askID", askID)
-			newlyAddedCounter.Inc()
+			recordProofshareNewlyAdded()
 		}
-		if asksCreated > 0 {
-			createAsksDuration.Observe(time.Since(startCreate).Seconds())
+		if neededAsks > 0 {
+			observeProofshareCreateAsksDuration(time.Since(startCreate))
 		}
 
 		// Track whether we made forward progress this iteration.
@@ -396,7 +346,7 @@ func (t *TaskRequestProofs) Do(taskID harmonytask.TaskID, stillOwned func() bool
 		// (If !madeProgress && !rateLimited we keep the current backoff;
 		// the service may just be slow matching asks to work.)
 
-		toRequestGauge.Set(float64(toRequest))
+		recordProofshareToRequestRemaining(toRequest)
 
 		log.Infow("waiting before next poll", "interval", pollBackoff, "madeProgress", madeProgress, "rateLimited", rateLimited)
 		time.Sleep(pollBackoff)

--- a/tasks/proofshare/task_request.go
+++ b/tasks/proofshare/task_request.go
@@ -324,7 +324,7 @@ func (t *TaskRequestProofs) Do(taskID harmonytask.TaskID, stillOwned func() bool
 			log.Infow("created new work ask", "askID", askID)
 			recordProofshareNewlyAdded()
 		}
-		if neededAsks > 0 {
+		if asksCreated > 0 {
 			observeProofshareCreateAsksDuration(time.Since(startCreate))
 		}
 

--- a/tasks/seal/metrics.go
+++ b/tasks/seal/metrics.go
@@ -10,7 +10,7 @@ var (
 	// Tags for seal metrics
 	MinerTag, _ = tag.NewKey("miner")
 
-	pre = "curio_seal_"
+	pre = "seal_"
 )
 
 // SealMeasures groups all seal pipeline metrics.

--- a/tasks/snap/metrics.go
+++ b/tasks/snap/metrics.go
@@ -10,7 +10,7 @@ var (
 	// Tags for snap metrics
 	MinerTag, _ = tag.NewKey("miner")
 
-	pre = "curio_snap_"
+	pre = "snap_"
 )
 
 // SnapMeasures groups all snap pipeline metrics.

--- a/tasks/winning/metrics.go
+++ b/tasks/winning/metrics.go
@@ -1,7 +1,6 @@
 package winning
 
 import (
-	promclient "github.com/prometheus/client_golang/prometheus"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -11,7 +10,7 @@ var (
 	// Tags for winning metrics
 	MinerTag, _ = tag.NewKey("miner")
 
-	pre = "curio_mining_"
+	pre = "mining_"
 
 	// Histogram buckets for compute time (in seconds)
 	computeTimeBuckets = []float64{0.1, 0.5, 1, 2, 5, 10, 20, 30, 60}
@@ -22,16 +21,12 @@ var MiningMeasures = struct {
 	WinsTotal            *stats.Int64Measure
 	BlocksSubmittedTotal *stats.Int64Measure
 	BlocksIncludedTotal  *stats.Int64Measure
-	ComputeTime          promclient.Histogram
+	ComputeTime          *stats.Float64Measure
 }{
 	WinsTotal:            stats.Int64(pre+"wins_total", "Blocks won (election success).", stats.UnitDimensionless),
 	BlocksSubmittedTotal: stats.Int64(pre+"blocks_submitted_total", "Blocks submitted to the network.", stats.UnitDimensionless),
 	BlocksIncludedTotal:  stats.Int64(pre+"blocks_included_total", "Blocks included in the chain.", stats.UnitDimensionless),
-	ComputeTime: promclient.NewHistogram(promclient.HistogramOpts{
-		Name:    pre + "compute_time_seconds",
-		Buckets: computeTimeBuckets,
-		Help:    "Histogram of winning post compute times in seconds.",
-	}),
+	ComputeTime:          stats.Float64("mining_compute_time_seconds", "Histogram of winning post compute times in seconds.", stats.UnitSeconds),
 }
 
 func init() {
@@ -51,12 +46,11 @@ func init() {
 			Aggregation: view.Sum(),
 			TagKeys:     []tag.Key{MinerTag},
 		},
+		&view.View{
+			Measure:     MiningMeasures.ComputeTime,
+			Aggregation: view.Distribution(computeTimeBuckets...),
+		},
 	)
-	if err != nil {
-		panic(err)
-	}
-
-	err = promclient.Register(MiningMeasures.ComputeTime)
 	if err != nil {
 		panic(err)
 	}

--- a/tasks/winning/winning_task.go
+++ b/tasks/winning/winning_task.go
@@ -317,7 +317,7 @@ func (t *WinPostTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 			return false, err
 		}
 
-		MiningMeasures.ComputeTime.Observe(computeDuration.Seconds())
+		stats.Record(ctx, MiningMeasures.ComputeTime.M(computeDuration.Seconds()))
 	}
 
 	log.Infow("WinPostTask winning PoSt computed", "tipset", types.LogCids(base.TipSet.Cids()), "miner", maddr, "round", round, "proofs", wpostProof, "compute_time", computeDuration)


### PR DESCRIPTION
This PR does a big refactor of how metrics are generated and exported in Curio.

- Added targeted Curio metrics for IPNI provider performance, deterministic node identity, HarmonyTask scheduling delay/runtime, wallet message landing, proof service/share, and winning compute time.
- Standardized metrics export through OpenCensus while preserving Prometheus-facing names, labels, metric types, and histogram buckets where applicable.
- Improved metrics documentation generation so exported names, labels, and types are derived from registered views/collectors, and regenerated the metrics reference.


**Disclaimer: Some of the old metric name have been updated to remove the incorrect prefix or double `curio` prefix. This PR will definitely impact the existing dashboards if any.**