### PR TITLE
docs(market): expand DDO deal cookbook with explicit URL-resolution flow

### DIFF
--- a/documentation/en/curio-market/storage-market.md
+++ b/documentation/en/curio-market/storage-market.md
@@ -293,4 +293,59 @@ Storage providers can onboard the DDO deal using the below command.
 curio market ddo --actor <MINER ID> <client-address> <allocation-id>
 ```
 
-Since this is an offline deal, user must either make the data available via PieceLocator or add a data URL for this offline deal.
+This command does **not** fetch any data. It only:
+
+1. Validates the allocation against the chain and the actor.
+2. Generates a fresh deal UUID.
+3. Inserts a row into `market_direct_deals` and a corresponding offline-deal row into `market_mk12_deal_pipeline` (with `offline=true` and `started=false`).
+4. Prints the deal UUID to stdout, for example:
+
+   ```
+   Direct deals inserted successfully: 0f1b2c3d-...
+   ```
+
+Because the pipeline row is created with `started=false`, the commP task will not run until Curio has resolved a source URL for the piece. There are two supported ways to provide that URL:
+
+#### Option A: PieceLocator (preferred for bulk / automated ingestion)
+
+If `[Market.StorageMarketConfig.PieceLocator]` is configured, Curio will automatically discover the piece by issuing a `HEAD <PieceLocator URL>?id=<PieceCID>` against each configured locator. The first locator that returns `200 OK` with a valid `Content-Length` wins, and Curio writes that URL and `raw_size` into the pipeline row, flips `started=true`, and the commP task picks it up on its next tick.
+
+This is the only path you need if your locator already has the piece. You do not need to (and should not) also call `add-url` for the same deal; see the warning in [Add data URL for offline deals](#add-data-url-for-offline-deals).
+
+#### Option B: `curio market add-url` (manual / one-off)
+
+If you do not run a PieceLocator (or the locator does not have this particular piece), pass the UUID printed by `curio market ddo` to `add-url`:
+
+```shell
+curio market add-url \
+    --url "https://data.server/pieces?id=<PieceCID>" \
+    <UUID printed by 'curio market ddo'> \
+    <raw size in bytes>
+```
+
+This inserts a row into `market_offline_urls` keyed on the UUID. On its next pass, the storage-market poller calls `findURLForOfflineDeals`, joins `market_offline_urls` into `market_mk12_deal_pipeline`, flips `started=true`, and the commP task proceeds.
+
+#### Troubleshooting CommP mismatches on DDO deals
+
+If the commP task finishes much faster than expected (for example, a few seconds for a 32 GiB piece) and reports `commP mismatch calculated <X> and supplied <Y>`, the most common causes are:
+
+- **PieceLocator returned a misleading response.** A locator that answers `200 OK` with a `Content-Length` on HEAD but serves wrong, partial, or unrelated bytes on GET will look healthy to Curio's URL resolver and only fail later during commP. This shows up as a subset of deals failing while most succeed, because the locator happens to have valid data for some PieceCIDs and not others. Verify each locator with:
+
+  ```bash
+  curl -I '<locator-url>?id=<PieceCID>'
+  curl -s -o /tmp/piece.bin '<locator-url>?id=<PieceCID>' && wc -c /tmp/piece.bin
+  ```
+
+  Confirm the body length matches the expected raw size and that `Content-Type` is what you expect. Bad or stale `PieceLocator` entries are a frequent culprit.
+- **Wrong `raw size` passed to `add-url`.** The commP task pads the fetched stream up to the declared raw size using `padreader.New(reader, rawSize)`. If `rawSize` is smaller than the real piece payload, the padder will truncate; if it is larger, the padder will append zeros. Either way the final CommP will not match the allocation's PieceCID. Always use the unpadded CAR / raw byte size from the same source that produced the PieceCID.
+- **Both `add-url` and a PieceLocator hit on the same deal.** Only one source is used per deal; if you call `add-url` for a deal that the PieceLocator can already serve, the two URL writers can race depending on which poller pass runs first. Pick one method per deal.
+
+You can inspect the resolved state directly:
+
+```sql
+SELECT uuid, started, after_commp, url, raw_size, piece_cid, piece_size
+FROM market_mk12_deal_pipeline
+WHERE uuid = '<UUID>';
+```
+
+If `url` is `NULL` after several poller cycles, neither PieceLocator nor `add-url` has produced a source yet, and the deal will not advance.


### PR DESCRIPTION
## Motivation

This came up in the Curio Slack today: an SP (Jon Geater) hit repeated `commP mismatch` errors on `curio market ddo` deals, with the harmony commP task completing in seconds (vs the expected ~8 min for a 32 GiB piece). LexLuthr diagnosed it as a likely `PieceLocator` misconfiguration where the locator answers `HEAD` with `200 OK` and a valid `Content-Length` but serves wrong/short bytes on `GET`. Jon also asked, reasonably:

- Is there a default piece source that `curio market ddo` uses when neither `add-url` nor `PieceLocator` is set?
- What is the actual recipe? `add-url` requires a UUID that `ddo` only prints at the end, which feels chicken-and-egg.
- Is there an end-to-end DDO flow documented anywhere?

Reading the current `documentation/en/curio-market/storage-market.md`, the "Offline Verified DDO deals" section ends with one line: *"Since this is an offline deal, user must either make the data available via PieceLocator or add a data URL for this offline deal."* — which is correct but leaves the actual sequence, the failure modes, and the debugging path implicit.

## What this PR changes

Expands the "Start a DDO deal" subsection in `documentation/en/curio-market/storage-market.md` to cover:

1. **What `curio market ddo` actually does.** It only validates the allocation, generates a UUID, inserts rows into `market_direct_deals` and `market_mk12_deal_pipeline` (with `offline=true`, `started=false`), and prints the UUID. It does **not** fetch any data.

2. **Two explicit URL-resolution paths**, with the chicken-and-egg question resolved:
   - **Option A — PieceLocator** (preferred, automatic): how the resolver issues `HEAD <locator>?id=<PieceCID>`, when it flips `started=true`, and that this is the only path you need if your locator has the piece.
   - **Option B — `curio market add-url`** (manual): the explicit `ddo`-prints-UUID-then-pass-to-`add-url` ordering, and what gets written where (`market_offline_urls`).

3. **A troubleshooting subsection for the `commP mismatch` failure mode** Jon hit, ordered by frequency:
   - PieceLocator returning a misleading response (the Lex diagnosis), with concrete `curl` commands to verify locators by hand.
   - Wrong `raw size` passed to `add-url`, with an explanation of how `padreader.New(reader, rawSize)` truncates or pads with zeros to match the declared size.
   - Both `add-url` and `PieceLocator` configured for the same deal racing each other.

4. **A small SQL snippet** for inspecting `market_mk12_deal_pipeline` to see whether `url` has been resolved and `started` flipped.

## Verification

All claims above were verified against the current `main`:

- `cmd/curio/market.go::ddoCmd` (the deal-row inserts and the `Direct deals inserted successfully: <uuid>` print) and `marketAddOfflineURLCmd` (`market_offline_urls` insert keyed on UUID).
- `tasks/storage-market/storage_market.go::processMk12Deal` (the `started=false` gate that blocks the commP task) and `findURLForOfflineDeals` (the `market_offline_urls` first, then `PieceLocator` HEAD fallback).
- `tasks/storage-market/task_commp.go` (the `padreader.New(reader, uint64(piece.RawSize))` call that explains why a wrong `raw_size` or a misleading locator produces a deterministic-but-wrong CommP).

## Notes

- Docs-only change. No code, no migrations, no API surface changes.
- I tried to keep the wording aligned with the existing style in this file (level of detail, examples, "Why this exists" framing, etc.).
