### PR TITLE
fix(ipni): preserve lastPublishTime when refreshing provider info

### DIFF
--- a/market/ipni/ipni-provider/ipni-provider.go
+++ b/market/ipni/ipni-provider/ipni-provider.go
@@ -185,8 +185,11 @@ func (p *Provider) upsertProvider(priv []byte, peerID string, sp int64) error {
 	}
 
 	p.mu.Lock()
-	_, existed := p.providerInfos[peerID]
+	existing, existed := p.providerInfos[peerID]
 	p.providerInfos[peerID] = info
+	if existed {
+		info.lastPublishTime = existing.lastPublishTime
+	}
 	p.mu.Unlock()
 
 	if !existed {


### PR DESCRIPTION
```
{
    "pieceCid": "bafkzcibfr737oaqtaxrwpgm72vnamol4cifs3mvoqhvxwlvduhwqo2mv7rvt25imciqa",
    "status": "retrieved",
    "indexed": true,
    "indexedAt": "2026-05-13T22:23:28.503036+08:00",
    "adCreated": true,
    "adCreatedAt": "2026-05-13T22:23:57.006039+08:00",
    "advertised": false,
    "retrieved": true,
    "retrievedAt": "2026-05-13T22:24:06.6396+08:00"
  }
```

refreshProviders is called on every publish tick and upsertProvider was replacing the entire peerInfo object with a new one, resetting lastPublishTime to nil. This caused the advertised field in piece status to always be false, as the reset happened before publishHead could check for CID changes and only pieces published in that exact tick window would briefly show as advertised.