### PR TITLE
Move C1 check to FFISelect

### DIFF
--- a/lib/ffi/sdr_funcs.go
+++ b/lib/ffi/sdr_funcs.go
@@ -318,7 +318,7 @@ func (sb *SealCalls) TreeRC(ctx context.Context, task *harmonytask.TaskID, secto
 		for range C1CheckNumber {
 			var sd [32]byte
 			_, _ = rand.Read(sd[:])
-			_, err = ffi.SealCommitPhase1(sector.ProofType, out.Sealed, unsealed, fspaths.Cache, fspaths.Sealed, sector.ID.Number, sector.ID.Miner, randomness, sd[:], pieces)
+			err = ffiselect.FFISelect.CheckSealCommitPhase1(ctx, sector.ProofType, out.Sealed, unsealed, fspaths.Cache, fspaths.Sealed, sector.ID.Number, sector.ID.Miner, randomness, sd[:], pieces)
 			if err != nil {
 				return cid.Undef, cid.Undef, xerrors.Errorf("checking PreCommit for sector num:%d tkt:%v seed:%v sealedCID:%v, unsealedCID:%v failed: %w", sector.ID.Number, randomness, sd[:], out.Sealed, unsealed, err)
 			}
@@ -812,7 +812,7 @@ func (sb *SealCalls) SyntheticProofs(ctx context.Context, task *harmonytask.Task
 	for range C1CheckNumber {
 		var sd [32]byte
 		_, _ = rand.Read(sd[:])
-		_, err = ffi.SealCommitPhase1(sector.ProofType, sealed, unsealed, fspaths.Cache, fspaths.Sealed, sector.ID.Number, sector.ID.Miner, randomness, sd[:], pieces)
+		err = ffiselect.FFISelect.CheckSealCommitPhase1(ctx, sector.ProofType, sealed, unsealed, fspaths.Cache, fspaths.Sealed, sector.ID.Number, sector.ID.Miner, randomness, sd[:], pieces)
 		if err != nil {
 			return xerrors.Errorf("checking PreCommit for synthetic proofs for num:%d tkt:%v seed:%v sealedCID:%v, unsealedCID:%v failed: %w", sector.ID.Number, randomness, sd[:], sealed, unsealed, err)
 		}

--- a/lib/ffiselect/ffidirect/ffi-direct.go
+++ b/lib/ffiselect/ffidirect/ffi-direct.go
@@ -53,6 +53,22 @@ func (FFI) SealPreCommitPhase2(
 	}, nil
 }
 
+func (FFI) CheckSealCommitPhase1(
+	proofType abi.RegisteredSealProof,
+	sealedCID cid.Cid,
+	unsealedCID cid.Cid,
+	cacheDirPath string,
+	sealedSectorPath string,
+	sectorNum abi.SectorNumber,
+	minerID abi.ActorID,
+	ticket abi.SealRandomness,
+	seed abi.InteractiveSealRandomness,
+	pieces []abi.PieceInfo,
+) error {
+	_, err := ffi.SealCommitPhase1(proofType, sealedCID, unsealedCID, cacheDirPath, sealedSectorPath, sectorNum, minerID, ticket, seed, pieces)
+	return err
+}
+
 func (FFI) SealCommitPhase2(
 	phase1Output []byte,
 	sectorNum abi.SectorNumber,

--- a/lib/ffiselect/ffiselect.go
+++ b/lib/ffiselect/ffiselect.go
@@ -224,6 +224,20 @@ var FFISelect struct {
 		sealedSectorPath string,
 	) (out storiface.SectorCids, err error)
 
+	CheckSealCommitPhase1 func(
+		ctx context.Context,
+		proofType abi.RegisteredSealProof,
+		sealedCID cid.Cid,
+		unsealedCID cid.Cid,
+		cacheDirPath string,
+		sealedSectorPath string,
+		sectorNum abi.SectorNumber,
+		minerID abi.ActorID,
+		ticket abi.SealRandomness,
+		seed abi.InteractiveSealRandomness,
+		pieces []abi.PieceInfo,
+	) error
+
 	SealCommitPhase2 func(
 		ctx context.Context,
 		phase1Output []byte,


### PR DESCRIPTION
This PR moves Curio’s C1 validation checks behind the existing short-lived curio ffi process boundary.
TreeRC already runs PC2 through ffiselect, but the follow-up C1 “checking PreCommit” loop still called ffi.SealCommitPhase1 directly from the long-running parent process. SyntheticProofs had the same direct C1 validation path. 

Those calls can leave large freed native/Rust allocations retained in the parent process by glibc arenas, causing idle RSS to stay high after sealing work completes.

The change adds CheckSealCommitPhase1 to ffiselect and routes both TreeRC and SyntheticProofs C1 validation loops through it. The C1 proof bytes are discarded in the child, preserving validation behavior while keeping native allocator retention out of the parent.