### PR TITLE
fix: pdpv0 deletion pipeline

### DIFF
--- a/tasks/pay/settle_task.go
+++ b/tasks/pay/settle_task.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/curio/lib/filecoinpayment"
 	"github.com/filecoin-project/curio/pdp/contract"
 	"github.com/filecoin-project/curio/tasks/message"
+	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
 var log = logging.Logger("filecoin-pay-settle")
@@ -92,7 +93,7 @@ func (s *SettleTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.Tas
 
 func (s *SettleTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
-		Name: "Settle",
+		Name: tasknames.Settle,
 		Cost: resources.Resources{
 			Cpu: 1,
 			Gpu: 0,

--- a/tasks/pdpv0/task_chain_sync.go
+++ b/tasks/pdpv0/task_chain_sync.go
@@ -44,14 +44,14 @@ func (t *TaskChainSync) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 		return false, xerrors.Errorf("syncing stale PDP deletion task ids: %w", err)
 	}
 
-	if !stillOwned(){
+	if !stillOwned() {
 		return false, nil
 	}
 	if err := t.syncMissingDataSetTerminationMessageWaits(ctx); err != nil {
 		return false, xerrors.Errorf("syncing missing PDP termination message waits: %w", err)
 	}
 
-	if !stillOwned(){
+	if !stillOwned() {
 		return false, nil
 	}
 	if err := t.syncMissingDataSetDeleteMessageWaits(ctx); err != nil {

--- a/tasks/pdpv0/task_chain_sync.go
+++ b/tasks/pdpv0/task_chain_sync.go
@@ -44,11 +44,18 @@ func (t *TaskChainSync) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 		return false, xerrors.Errorf("syncing stale PDP deletion task ids: %w", err)
 	}
 
-	if !stillOwned() {
+	if !stillOwned(){
 		return false, nil
 	}
-	if err := t.syncMissingDeletionMessageWaits(ctx); err != nil {
-		return false, xerrors.Errorf("syncing missing PDP deletion message waits: %w", err)
+	if err := t.syncMissingDataSetTerminationMessageWaits(ctx); err != nil {
+		return false, xerrors.Errorf("syncing missing PDP termination message waits: %w", err)
+	}
+
+	if !stillOwned(){
+		return false, nil
+	}
+	if err := t.syncMissingDataSetDeleteMessageWaits(ctx); err != nil {
+		return false, xerrors.Errorf("syncing missing PDP delete message waits: %w", err)
 	}
 
 	if !stillOwned() {
@@ -151,17 +158,7 @@ type missingDeleteMessageWait struct {
 	TxHash string `db:"delete_tx_hash"`
 }
 
-// syncMissingDeletionMessageWaits repairs deletion pipeline rows whose tx hash was recorded
-// without a matching message_waits_eth row. The tx may no longer be available from the
-// connected node, so this reconciles from contract state instead of tx history.
-func (t *TaskChainSync) syncMissingDeletionMessageWaits(ctx context.Context) error {
-	if err := t.syncMissingTerminationMessageWaits(ctx); err != nil {
-		return err
-	}
-	return t.syncMissingDeleteMessageWaits(ctx)
-}
-
-func (t *TaskChainSync) syncMissingTerminationMessageWaits(ctx context.Context) error {
+func (t *TaskChainSync) syncMissingDataSetTerminationMessageWaits(ctx context.Context) error {
 	var missing []missingTerminationMessageWait
 	if err := t.db.Select(ctx, &missing, `
 		SELECT id, terminate_tx_hash
@@ -239,13 +236,15 @@ func (t *TaskChainSync) syncMissingTerminationMessageWaits(ctx context.Context) 
 		}
 		if n == 1 {
 			log.Warnw("reset service termination missing message wait for retry", "dataSetId", detail.ID, "txHash", detail.TxHash)
+		} else {
+			continue
 		}
 	}
 
 	return nil
 }
 
-func (t *TaskChainSync) syncMissingDeleteMessageWaits(ctx context.Context) error {
+func (t *TaskChainSync) syncMissingDataSetDeleteMessageWaits(ctx context.Context) error {
 	var missing []missingDeleteMessageWait
 	if err := t.db.Select(ctx, &missing, `
 		SELECT id, delete_tx_hash
@@ -306,6 +305,8 @@ func (t *TaskChainSync) syncMissingDeleteMessageWaits(ctx context.Context) error
 		}
 		if n == 1 {
 			log.Warnw("reset data set delete missing message wait for retry", "dataSetId", detail.ID, "txHash", detail.TxHash)
+		} else {
+			continue
 		}
 	}
 

--- a/tasks/pdpv0/task_chain_sync.go
+++ b/tasks/pdpv0/task_chain_sync.go
@@ -47,6 +47,13 @@ func (t *TaskChainSync) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 	if !stillOwned() {
 		return false, nil
 	}
+	if err := t.syncMissingDeletionMessageWaits(ctx); err != nil {
+		return false, xerrors.Errorf("syncing missing PDP deletion message waits: %w", err)
+	}
+
+	if !stillOwned() {
+		return false, nil
+	}
 	if err := t.syncProvenDataSetFailureState(ctx); err != nil {
 		return false, xerrors.Errorf("syncing proven PDP data set failure state: %w", err)
 	}
@@ -129,6 +136,177 @@ func (t *TaskChainSync) syncStaleDeletionTaskIDs(ctx context.Context) error {
 	}
 	if !comm {
 		return xerrors.Errorf("failed to commit stale task id cleanup")
+	}
+
+	return nil
+}
+
+type missingTerminationMessageWait struct {
+	ID     int64  `db:"id"`
+	TxHash string `db:"terminate_tx_hash"`
+}
+
+type missingDeleteMessageWait struct {
+	ID     int64  `db:"id"`
+	TxHash string `db:"delete_tx_hash"`
+}
+
+// syncMissingDeletionMessageWaits repairs deletion pipeline rows whose tx hash was recorded
+// without a matching message_waits_eth row. The tx may no longer be available from the
+// connected node, so this reconciles from contract state instead of tx history.
+func (t *TaskChainSync) syncMissingDeletionMessageWaits(ctx context.Context) error {
+	if err := t.syncMissingTerminationMessageWaits(ctx); err != nil {
+		return err
+	}
+	return t.syncMissingDeleteMessageWaits(ctx)
+}
+
+func (t *TaskChainSync) syncMissingTerminationMessageWaits(ctx context.Context) error {
+	var missing []missingTerminationMessageWait
+	if err := t.db.Select(ctx, &missing, `
+		SELECT id, terminate_tx_hash
+		FROM pdp_delete_data_set pdds
+		WHERE pdds.service_termination_epoch IS NULL
+		  AND pdds.after_terminate_service = TRUE
+		  AND pdds.terminate_tx_hash IS NOT NULL
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM message_waits_eth mwe
+			WHERE mwe.signed_tx_hash = pdds.terminate_tx_hash
+		  )
+		ORDER BY id
+	`); err != nil {
+		return xerrors.Errorf("failed to select terminations missing message wait rows: %w", err)
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	sAddr := contract.ContractAddresses().AllowedPublicRecordKeepers.FWSService
+	viewAddr, err := contract.ResolveViewAddress(ctx, sAddr, t.ethClient)
+	if err != nil {
+		return xerrors.Errorf("failed to get FWSS view address: %w", err)
+	}
+	fwssv, err := FWSS.NewFilecoinWarmStorageServiceStateView(viewAddr, t.ethClient)
+	if err != nil {
+		return xerrors.Errorf("failed to instantiate FWSS service state view: %w", err)
+	}
+
+	for _, detail := range missing {
+		ds, err := fwssv.GetDataSet(contract.EthCallOpts(ctx), big.NewInt(detail.ID))
+		if err != nil {
+			return xerrors.Errorf("failed to get data set %d from FWSS view: %w", detail.ID, err)
+		}
+
+		if ds.PdpEndEpoch.Int64() != 0 {
+			n, err := t.db.Exec(ctx, `
+				UPDATE pdp_delete_data_set
+				SET service_termination_epoch = $1,
+				    terminate_service_task_id = NULL
+				WHERE id = $2
+				  AND terminate_tx_hash = $3
+				  AND after_terminate_service = TRUE
+				  AND service_termination_epoch IS NULL
+			`, ds.PdpEndEpoch.Int64(), detail.ID, detail.TxHash)
+			if err != nil {
+				return xerrors.Errorf("failed to reconcile terminated data set %d: %w", detail.ID, err)
+			}
+			if n > 1 {
+				return xerrors.Errorf("expected to update 0 or 1 rows for data set %d, updated %d", detail.ID, n)
+			}
+			if n == 1 {
+				log.Infow("reconciled missing service termination message wait from chain state", "dataSetId", detail.ID, "txHash", detail.TxHash, "epoch", ds.PdpEndEpoch.Int64())
+			}
+			continue
+		}
+
+		n, err := t.db.Exec(ctx, `
+			UPDATE pdp_delete_data_set
+			SET terminate_tx_hash = NULL,
+			    after_terminate_service = FALSE,
+			    terminate_service_task_id = NULL
+			WHERE id = $1
+			  AND terminate_tx_hash = $2
+			  AND after_terminate_service = TRUE
+			  AND service_termination_epoch IS NULL
+		`, detail.ID, detail.TxHash)
+		if err != nil {
+			return xerrors.Errorf("failed to reset service termination missing message wait for data set %d: %w", detail.ID, err)
+		}
+		if n > 1 {
+			return xerrors.Errorf("expected to update 0 or 1 rows for data set %d, updated %d", detail.ID, n)
+		}
+		if n == 1 {
+			log.Warnw("reset service termination missing message wait for retry", "dataSetId", detail.ID, "txHash", detail.TxHash)
+		}
+	}
+
+	return nil
+}
+
+func (t *TaskChainSync) syncMissingDeleteMessageWaits(ctx context.Context) error {
+	var missing []missingDeleteMessageWait
+	if err := t.db.Select(ctx, &missing, `
+		SELECT id, delete_tx_hash
+		FROM pdp_delete_data_set pdds
+		WHERE pdds.service_termination_epoch IS NOT NULL
+		  AND pdds.terminated = FALSE
+		  AND pdds.after_delete_data_set = TRUE
+		  AND pdds.delete_tx_hash IS NOT NULL
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM message_waits_eth mwe
+			WHERE mwe.signed_tx_hash = pdds.delete_tx_hash
+		  )
+		ORDER BY id
+	`); err != nil {
+		return xerrors.Errorf("failed to select data set deletes missing message wait rows: %w", err)
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	verifier, err := contract.NewPDPVerifier(contract.ContractAddresses().PDPVerifier, t.ethClient)
+	if err != nil {
+		return xerrors.Errorf("failed to instantiate PDPVerifier contract: %w", err)
+	}
+
+	for _, detail := range missing {
+		live, err := verifier.DataSetLive(contract.EthCallOpts(ctx), big.NewInt(detail.ID))
+		if err != nil {
+			return xerrors.Errorf("failed to check if data set %d is live: %w", detail.ID, err)
+		}
+
+		if !live {
+			if err := cleanupDeletedDataSet(ctx, t.db, detail.ID, detail.TxHash); err != nil {
+				return xerrors.Errorf("failed to reconcile deleted data set %d: %w", detail.ID, err)
+			}
+			log.Infow("reconciled missing data set delete message wait from chain state", "dataSetId", detail.ID, "txHash", detail.TxHash)
+			continue
+		}
+
+		n, err := t.db.Exec(ctx, `
+			UPDATE pdp_delete_data_set
+			SET delete_tx_hash = NULL,
+			    after_delete_data_set = FALSE,
+			    delete_data_set_task_id = NULL
+			WHERE id = $1
+			  AND delete_tx_hash = $2
+			  AND after_delete_data_set = TRUE
+			  AND service_termination_epoch IS NOT NULL
+			  AND terminated = FALSE
+		`, detail.ID, detail.TxHash)
+		if err != nil {
+			return xerrors.Errorf("failed to reset data set delete missing message wait for data set %d: %w", detail.ID, err)
+		}
+		if n > 1 {
+			return xerrors.Errorf("expected to update 0 or 1 rows for data set %d, updated %d", detail.ID, n)
+		}
+		if n == 1 {
+			log.Warnw("reset data set delete missing message wait for retry", "dataSetId", detail.ID, "txHash", detail.TxHash)
+		}
 	}
 
 	return nil

--- a/tasks/pdpv0/task_delete_data_set.go
+++ b/tasks/pdpv0/task_delete_data_set.go
@@ -64,6 +64,9 @@ func (t *DeleteDataSetTask) Do(taskID harmonytask.TaskID, stillOwned func() bool
 	}
 
 	if !live {
+		// TODO: When the post-delete cleanup stage lands, route already-deleted. Currently, this missed the DB cleanup
+		// TODO: In the upcoming PR to handle https://github.com/filecoin-project/curio/issues/1236 this will be fixed
+		// data sets into that stage instead of marking this pipeline terminal here.
 		n, err := t.db.Exec(ctx, `UPDATE pdp_delete_data_set SET 
                                after_delete_data_set = TRUE,
                                delete_data_set_task_id = NULL,

--- a/tasks/pdpv0/task_terminate_fwss.go
+++ b/tasks/pdpv0/task_terminate_fwss.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/curiostorage/harmonyquery"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/yugabyte/pgx/v5"
@@ -76,6 +77,7 @@ func (t *TerminateFWSSTask) Do(taskID harmonytask.TaskID, stillOwned func() bool
 		if n != 1 {
 			return false, xerrors.Errorf("expected to update 1 row but got %d", n)
 		}
+		return true, nil
 	}
 
 	sender, err := getPDPOwner(ctx, t.db)
@@ -90,6 +92,8 @@ func (t *TerminateFWSSTask) Do(taskID harmonytask.TaskID, stillOwned func() bool
 		return false, xerrors.Errorf("failed to get FWSS ABI: %w", err)
 	}
 
+	// TODO: Regenerate the FWSS ABI for terminateService(uint256,bytes)
+	// and pass empty extraData here for provider-initiated termination.
 	data, err := fwssABi.Pack("terminateService", big.NewInt(dataSetId))
 	if err != nil {
 		return false, xerrors.Errorf("failed to pack data: %w", err)
@@ -109,17 +113,34 @@ func (t *TerminateFWSSTask) Do(taskID harmonytask.TaskID, stillOwned func() bool
 		return false, xerrors.Errorf("failed to send transaction: %w", err)
 	}
 
-	n, err := t.db.Exec(ctx, `UPDATE pdp_delete_data_set 
+	comm, err := t.db.BeginTransaction(ctx, func(tx *harmonyquery.Tx) (commit bool, err error) {
+		n, err := tx.Exec(`UPDATE pdp_delete_data_set 
 									SET terminate_tx_hash = $2, 
 									    after_terminate_service = TRUE,
 									    terminate_service_task_id = NULL
 									WHERE terminate_service_task_id = $1`, taskID, txHash.Hex())
+		if err != nil {
+			return false, xerrors.Errorf("failed to update pdp_delete_data_set: %w", err)
+		}
+
+		if n != 1 {
+			return false, xerrors.Errorf("expected to update 1 row but got %d", n)
+		}
+
+		_, err = tx.Exec(`INSERT INTO message_waits_eth (signed_tx_hash, tx_status) VALUES ($1, $2)`, txHash.Hex(), "pending")
+		if err != nil {
+			return false, xerrors.Errorf("failed to insert into message_waits_eth: %w", err)
+		}
+
+		return true, nil
+	}, harmonydb.OptionRetry())
+
 	if err != nil {
-		return false, xerrors.Errorf("failed to update pdp_delete_data_set: %w", err)
+		return false, err
 	}
 
-	if n != 1 {
-		return false, xerrors.Errorf("expected to update 1 row but got %d", n)
+	if !comm {
+		return false, xerrors.Errorf("failed to commit transaction")
 	}
 
 	return true, nil

--- a/tasks/pdpv0/watch_data_set_delete.go
+++ b/tasks/pdpv0/watch_data_set_delete.go
@@ -103,10 +103,10 @@ func processPendingDeletes(ctx context.Context, db *harmonydb.DB, ethClient ethc
 
 	successErr := processSuccessfulDeletes(ctx, db, ethClient, successes)
 	failureErr := processFailedDeletes(ctx, db, failures)
-	if successErr != nil {
-		return successErr
+	if successErr != nil || failureErr != nil {
+		return xerrors.Errorf("failed to delete data sets: %w", errors.Join(successErr, failureErr))
 	}
-	return failureErr
+	return nil
 }
 
 func processSuccessfulDeletes(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient, successes []pendingDataSetDelete) error {

--- a/tasks/pdpv0/watch_data_set_delete.go
+++ b/tasks/pdpv0/watch_data_set_delete.go
@@ -28,28 +28,89 @@ func NewDataSetDeleteWatcher(db *harmonydb.DB, ethClient ethchain.EthClient, pcs
 	}
 }
 
-func processPendingDeletes(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient) error {
-	var deletes []struct {
-		ID      int64        `db:"id"`
-		TxHash  string       `db:"delete_tx_hash"`
-		Success sql.NullBool `db:"tx_success"`
-	}
+type pendingDataSetDelete struct {
+	ID     int64  `db:"id"`
+	TxHash string `db:"delete_tx_hash"`
+}
 
-	err := db.Select(ctx, &deletes, `SELECT
-    										pdds.id,
-    										pdds.delete_tx_hash,
-    										mwe.tx_success
-										FROM pdp_delete_data_set pdds
-										LEFT JOIN message_waits_eth mwe ON mwe.signed_tx_hash = pdds.delete_tx_hash
-										WHERE pdds.service_termination_epoch IS NOT NULL
-										  AND pdds.terminated = FALSE
-										  AND pdds.after_delete_data_set = TRUE
-										  AND pdds.delete_tx_hash IS NOT NULL`)
+type dataSetDeleteMessageWait struct {
+	TxHash  string       `db:"signed_tx_hash"`
+	Status  string       `db:"tx_status"`
+	Success sql.NullBool `db:"tx_success"`
+}
+
+func processPendingDeletes(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient) error {
+	var pending []pendingDataSetDelete
+	err := db.Select(ctx, &pending, `
+		SELECT id, delete_tx_hash
+		FROM pdp_delete_data_set
+		WHERE service_termination_epoch IS NOT NULL
+		  AND terminated = FALSE
+		  AND after_delete_data_set = TRUE
+		  AND delete_tx_hash IS NOT NULL
+	`)
 	if err != nil {
 		return xerrors.Errorf("failed to select pending data sets: %w", err)
 	}
 
-	if len(deletes) == 0 {
+	if len(pending) == 0 {
+		return nil
+	}
+
+	byHash := make(map[string]pendingDataSetDelete, len(pending))
+	hashes := make([]string, 0, len(pending))
+	for _, detail := range pending {
+		hashes = append(hashes, detail.TxHash)
+		byHash[detail.TxHash] = detail
+	}
+
+	var waits []dataSetDeleteMessageWait
+	err = db.Select(ctx, &waits, `
+		SELECT signed_tx_hash, tx_status, tx_success
+		FROM message_waits_eth
+		WHERE signed_tx_hash = ANY($1)
+	`, hashes)
+	if err != nil {
+		return xerrors.Errorf("failed to select data set delete message waits: %w", err)
+	}
+
+	seen := map[string]struct{}{}
+	var successes []pendingDataSetDelete
+	var failures []pendingDataSetDelete
+	for _, wait := range waits {
+		seen[wait.TxHash] = struct{}{}
+		detail, ok := byHash[wait.TxHash]
+		if !ok {
+			continue
+		}
+
+		if wait.Status == "confirmed" && wait.Success.Valid && wait.Success.Bool {
+			successes = append(successes, detail)
+			continue
+		}
+
+		if wait.Status == "failed" || (wait.Status == "confirmed" && wait.Success.Valid && !wait.Success.Bool) {
+			failures = append(failures, detail)
+		}
+	}
+
+	for _, detail := range pending {
+		if _, ok := seen[detail.TxHash]; ok {
+			continue
+		}
+		log.Warnw("data set delete tx missing message_waits_eth row", "txHash", detail.TxHash, "dataSetId", detail.ID)
+	}
+
+	successErr := processSuccessfulDeletes(ctx, db, ethClient, successes)
+	failureErr := processFailedDeletes(ctx, db, failures)
+	if successErr != nil {
+		return successErr
+	}
+	return failureErr
+}
+
+func processSuccessfulDeletes(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient, successes []pendingDataSetDelete) error {
+	if len(successes) == 0 {
 		return nil
 	}
 
@@ -60,16 +121,7 @@ func processPendingDeletes(ctx context.Context, db *harmonydb.DB, ethClient ethc
 		return xerrors.Errorf("failed to instantiate PDPVerifier contract: %w", err)
 	}
 
-	for _, detail := range deletes {
-		if !detail.Success.Valid {
-			log.Debugw("data set delete tx not yet mined", "txHash", detail.TxHash, "dataSetId", detail.ID)
-			continue
-		}
-
-		if !detail.Success.Bool {
-			return xerrors.Errorf("data set delete tx %s failed for data set %d", detail.TxHash, detail.ID)
-		}
-
+	for _, detail := range successes {
 		live, err := verifier.DataSetLive(contract.EthCallOpts(ctx), big.NewInt(detail.ID))
 		if err != nil {
 			return xerrors.Errorf("failed to check if data set is live: %w", err)
@@ -79,60 +131,93 @@ func processPendingDeletes(ctx context.Context, db *harmonydb.DB, ethClient ethc
 			return errors.New("data set is still live")
 		}
 
-		comm, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (commit bool, err error) {
-			// Using a transaction as there are foreign key constraints and triggers.
+		if err := cleanupDeletedDataSet(ctx, db, detail.ID, detail.TxHash); err != nil {
+			return err
+		}
+	}
 
-			// Delete all piece refs for this data set
-			/*
-				pdp_data_sets (id)
-				│   ON DELETE CASCADE
-				├── pdp_data_set_pieces.data_set           -- CASCADE
-				│      ├─(TRIGGER) increment/decrement_data_set_refcount()
-				│      └─ pdp_data_set_pieces.pdp_pieceref → pdp_piecerefs(id)  -- ON DELETE SET NULL
-				│
-				├── pdp_data_set_piece_adds.data_set       -- CASCADE
-				│
-				└── pdp_prove_tasks.data_set               -- CASCADE
+	return nil
+}
 
-				What this means at delete time:
-				1. We run:
-				 "DELETE FROM curio.pdp_data_sets WHERE id = $1;"
-
-				2. Postgres automatically:
-					a. Deletes all matching rows in pdp_data_set_pieces (CASCADE).
-					b. Deletes all matching rows in pdp_data_set_piece_adds (CASCADE).
-					c. Deletes all matching rows in pdp_prove_tasks (CASCADE).
-
-				3. While removing pdp_data_set_pieces rows:
-					a. The row’s FK pdp_data_set_pieces.pdp_pieceref → pdp_piecerefs(id) is ON DELETE SET NULL (so we do not delete pdp_piecerefs).
-					b. Triggers on pdp_data_set_pieces
-						pdp_data_set_piece_insert (increments refcount)
-						pdp_data_set_piece_delete (decrements refcount)
-						pdp_data_set_piece_update (adjusts)
-					update pdp_piecerefs.data_set_refcount accordingly, so refcounts drop when pieces are removed.
-
-				pdp_pieceRefs will be cleaned up by watch_piece_delete.go process. It will also remove index entries and publish IPNI announcements.
-			*/
-
-			_, err = tx.Exec(`DELETE FROM pdp_data_sets WHERE id = $1`, detail.ID)
-			if err != nil {
-				return false, xerrors.Errorf("failed to delete data set %d: %w", detail.ID, err)
-			}
-
-			_, err = tx.Exec(`DELETE FROM  pdp_delete_data_set WHERE id = $1 AND delete_tx_hash = $2`, detail.ID, detail.TxHash)
-			if err != nil {
-				return false, xerrors.Errorf("failed to delete row from pdp_delete_data_set: %w", err)
-			}
-
-			return true, nil
-		}, harmonydb.OptionRetry())
-
+func processFailedDeletes(ctx context.Context, db *harmonydb.DB, failures []pendingDataSetDelete) error {
+	for _, detail := range failures {
+		_, err := db.Exec(ctx, `
+			UPDATE pdp_delete_data_set
+			SET delete_tx_hash = NULL,
+			    after_delete_data_set = FALSE,
+			    delete_data_set_task_id = NULL
+			WHERE id = $1
+			  AND delete_tx_hash = $2
+			  AND after_delete_data_set = TRUE
+			  AND service_termination_epoch IS NOT NULL
+			  AND terminated = FALSE
+		`, detail.ID, detail.TxHash)
 		if err != nil {
-			return xerrors.Errorf("failed to commit transaction: %w", err)
+			return xerrors.Errorf("failed to reset failed data set delete for data set %d: %w", detail.ID, err)
 		}
-		if !comm {
-			return xerrors.Errorf("failed to commit transaction")
+
+		log.Warnw("reset failed data set delete for retry", "dataSetId", detail.ID, "txHash", detail.TxHash)
+	}
+
+	return nil
+}
+
+func cleanupDeletedDataSet(ctx context.Context, db *harmonydb.DB, dataSetID int64, deleteTxHash string) error {
+	comm, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (commit bool, err error) {
+		// TODO: When the post-delete cleanup stage lands, route successful
+		// deleteDataSet confirmations there instead of removing local rows here.
+		// Using a transaction as there are foreign key constraints and triggers.
+
+		// Delete all piece refs for this data set
+		/*
+			pdp_data_sets (id)
+			│   ON DELETE CASCADE
+			├── pdp_data_set_pieces.data_set           -- CASCADE
+			│      ├─(TRIGGER) increment/decrement_data_set_refcount()
+			│      └─ pdp_data_set_pieces.pdp_pieceref → pdp_piecerefs(id)  -- ON DELETE SET NULL
+			│
+			├── pdp_data_set_piece_adds.data_set       -- CASCADE
+			│
+			└── pdp_prove_tasks.data_set               -- CASCADE
+
+			What this means at delete time:
+			1. We run:
+			 "DELETE FROM curio.pdp_data_sets WHERE id = $1;"
+
+			2. Postgres automatically:
+				a. Deletes all matching rows in pdp_data_set_pieces (CASCADE).
+				b. Deletes all matching rows in pdp_data_set_piece_adds (CASCADE).
+				c. Deletes all matching rows in pdp_prove_tasks (CASCADE).
+
+			3. While removing pdp_data_set_pieces rows:
+				a. The row’s FK pdp_data_set_pieces.pdp_pieceref → pdp_piecerefs(id) is ON DELETE SET NULL (so we do not delete pdp_piecerefs).
+				b. Triggers on pdp_data_set_pieces
+					pdp_data_set_piece_insert (increments refcount)
+					pdp_data_set_piece_delete (decrements refcount)
+					pdp_data_set_piece_update (adjusts)
+				update pdp_piecerefs.data_set_refcount accordingly, so refcounts drop when pieces are removed.
+
+			pdp_pieceRefs will be cleaned up by watch_piece_delete.go process. It will also remove index entries and publish IPNI announcements.
+		*/
+
+		_, err = tx.Exec(`DELETE FROM pdp_data_sets WHERE id = $1`, dataSetID)
+		if err != nil {
+			return false, xerrors.Errorf("failed to delete data set %d: %w", dataSetID, err)
 		}
+
+		_, err = tx.Exec(`DELETE FROM  pdp_delete_data_set WHERE id = $1 AND delete_tx_hash = $2`, dataSetID, deleteTxHash)
+		if err != nil {
+			return false, xerrors.Errorf("failed to delete row from pdp_delete_data_set: %w", err)
+		}
+
+		return true, nil
+	}, harmonydb.OptionRetry())
+
+	if err != nil {
+		return xerrors.Errorf("failed to commit transaction: %w", err)
+	}
+	if !comm {
+		return xerrors.Errorf("failed to commit transaction")
 	}
 
 	return nil

--- a/tasks/pdpv0/watch_fwss_terminate.go
+++ b/tasks/pdpv0/watch_fwss_terminate.go
@@ -16,9 +16,20 @@ import (
 	chainTypes "github.com/filecoin-project/lotus/chain/types"
 )
 
+type pendingServiceTermination struct {
+	DataSetId int64  `db:"id"`
+	TxHash    string `db:"terminate_tx_hash"`
+}
+
+type serviceTerminationMessageWait struct {
+	TxHash  string       `db:"signed_tx_hash"`
+	Status  string       `db:"tx_status"`
+	Success sql.NullBool `db:"tx_success"`
+}
+
 func NewTerminateServiceWatcher(db *harmonydb.DB, ethClient ethchain.EthClient, pcs *chainsched.CurioChainSched) {
 	if err := pcs.AddHandler(func(ctx context.Context, revert, apply *chainTypes.TipSet) error {
-		err := processPendingTerminations(ctx, db, ethClient)
+		err := processTerminations(ctx, db, ethClient)
 		if err != nil {
 			log.Warnf("Failed to process pending service termination transactions: %s", err)
 		}
@@ -28,27 +39,77 @@ func NewTerminateServiceWatcher(db *harmonydb.DB, ethClient ethchain.EthClient, 
 	}
 }
 
-func processPendingTerminations(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient) error {
-
-	var details []struct {
-		DataSetId int64        `db:"id"`
-		TxHash    string       `db:"terminate_tx_hash"`
-		Success   sql.NullBool `db:"tx_success"`
-	}
-
-	err := db.Select(ctx, &details, `SELECT 
-    										pdds.id, 
-    										pdds.terminate_tx_hash,
-    										mwe.tx_success
-										FROM pdp_delete_data_set pdds
-										LEFT JOIN message_waits_eth mwe ON mwe.signed_tx_hash = pdds.terminate_tx_hash
-										WHERE pdds.service_termination_epoch IS NULL 
-										  AND pdds.after_terminate_service = TRUE`)
+func processTerminations(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient) error {
+	var pending []pendingServiceTermination
+	err := db.Select(ctx, &pending, `
+		SELECT id, terminate_tx_hash
+		FROM pdp_delete_data_set
+		WHERE service_termination_epoch IS NULL
+		  AND after_terminate_service = TRUE
+		  AND terminate_tx_hash IS NOT NULL
+	`)
 	if err != nil {
-		return xerrors.Errorf("failed to select pending data sets: %w", err)
+		return xerrors.Errorf("failed to select pending data set terminations: %w", err)
 	}
 
-	if len(details) == 0 {
+	if len(pending) == 0 {
+		return nil
+	}
+
+	byHash := make(map[string]pendingServiceTermination, len(pending))
+	hashes := make([]string, 0, len(pending))
+	for _, detail := range pending {
+		hashes = append(hashes, detail.TxHash)
+		byHash[detail.TxHash] = detail
+	}
+
+	var waits []serviceTerminationMessageWait
+	err = db.Select(ctx, &waits, `
+		SELECT signed_tx_hash, tx_status, tx_success
+		FROM message_waits_eth
+		WHERE signed_tx_hash = ANY($1)
+	`, hashes)
+	if err != nil {
+		return xerrors.Errorf("failed to select service termination message waits: %w", err)
+	}
+
+	seen := map[string]struct{}{}
+	var successes []pendingServiceTermination
+	var failures []pendingServiceTermination
+	for _, wait := range waits {
+		seen[wait.TxHash] = struct{}{}
+		detail, ok := byHash[wait.TxHash]
+		if !ok {
+			continue
+		}
+
+		if wait.Status == "confirmed" && wait.Success.Valid && wait.Success.Bool {
+			successes = append(successes, detail)
+			continue
+		}
+
+		if wait.Status == "failed" || (wait.Status == "confirmed" && wait.Success.Valid && !wait.Success.Bool) {
+			failures = append(failures, detail)
+		}
+	}
+
+	for _, detail := range pending {
+		if _, ok := seen[detail.TxHash]; ok {
+			continue
+		}
+		log.Warnw("filecoin warm storage service termination tx missing message_waits_eth row", "txHash", detail.TxHash, "dataSetId", detail.DataSetId)
+	}
+
+	successErr := processSuccessfulTerminations(ctx, db, ethClient, successes)
+	failureErr := processFailedTerminations(ctx, db, failures)
+	if successErr != nil {
+		return successErr
+	}
+	return failureErr
+}
+
+func processSuccessfulTerminations(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient, successes []pendingServiceTermination) error {
+	if len(successes) == 0 {
 		return nil
 	}
 
@@ -62,16 +123,7 @@ func processPendingTerminations(ctx context.Context, db *harmonydb.DB, ethClient
 		return xerrors.Errorf("failed to instantiate FWSS service state view: %w", err)
 	}
 
-	for _, detail := range details {
-		if !detail.Success.Valid {
-			log.Debugw("filecoin warm storage service termination tx not yet mined", "txHash", detail.TxHash, "dataSetId", detail.DataSetId)
-			continue
-		}
-
-		if !detail.Success.Bool {
-			return xerrors.Errorf("filecoin warm storage service termination tx %s failed for data set %d", detail.TxHash, detail.DataSetId)
-		}
-
+	for _, detail := range successes {
 		ds, err := fwssv.GetDataSet(contract.EthCallOpts(ctx), big.NewInt(detail.DataSetId))
 		if err != nil {
 			return xerrors.Errorf("failed to get data set %d: %w", detail.DataSetId, err)
@@ -93,5 +145,27 @@ func processPendingTerminations(ctx context.Context, db *harmonydb.DB, ethClient
 
 		log.Infow("Successfully confirmed data set termination", "dataSetId", detail.DataSetId, "epoch", ds.PdpEndEpoch.Int64(), "txHash", detail.TxHash)
 	}
+	return nil
+}
+
+func processFailedTerminations(ctx context.Context, db *harmonydb.DB, failures []pendingServiceTermination) error {
+	for _, detail := range failures {
+		_, err := db.Exec(ctx, `
+			UPDATE pdp_delete_data_set
+			SET terminate_tx_hash = NULL,
+			    after_terminate_service = FALSE,
+			    terminate_service_task_id = NULL
+			WHERE id = $1
+			  AND terminate_tx_hash = $2
+			  AND after_terminate_service = TRUE
+			  AND service_termination_epoch IS NULL
+		`, detail.DataSetId, detail.TxHash)
+		if err != nil {
+			return xerrors.Errorf("failed to reset failed service termination for data set %d: %w", detail.DataSetId, err)
+		}
+
+		log.Warnw("reset failed provider service termination for retry", "dataSetId", detail.DataSetId, "txHash", detail.TxHash)
+	}
+
 	return nil
 }

--- a/tasks/tasknames/names.go
+++ b/tasks/tasknames/names.go
@@ -34,4 +34,5 @@ const (
 	PDPv0_DelDataSet = "PDPv0_DelDataSet"
 	PDPv0_TermFWSS   = "PDPv0_TermFWSS"
 	PDPv0_ChainSync  = "PDPv0_ChainSync"
+	Settle           = "Settle"
 )


### PR DESCRIPTION
In prepreration for implementing #1236  and #1235 , I found a few problems in current termination and deletion pipeline.

## Summary
• Fixes TerminateFWSSTask so it records an already-terminated FWSS dataset locally and exits instead of submitting another terminate transaction.
• Records FWSS terminate txs and their message_waits_eth rows atomically.
• Updates terminate and delete watchers to avoid joining against message_waits_eth; they now load pipeline rows first, fetch wait rows by tx hash, then group success/failure states in memory.
• Resets failed terminate/delete tx pipeline rows so the existing schedulers can retry them.
• Adds TaskChainSync reconciliation for rows with tx hashes but missing message_waits_eth rows, using current contract state instead of tx lookup.
• Keeps task-name constants consistent by moving Settle into tasknames.
• Adds TODOs for the upcoming post-delete cleanup stage and future FWSS ABI update.