### PR TITLE
fix(sptool): make 'sectors extend --max-sectors' actually bound per-message sector count

### DIFF
--- a/cmd/sptool/sector.go
+++ b/cmd/sptool/sector.go
@@ -789,6 +789,7 @@ Extensions will be clamped at either the maximum sector extension of 3.5 years/1
 		&cli.Int64Flag{
 			Name:  "max-sectors",
 			Usage: "the maximum number of sectors contained in each message",
+			Value: 500,
 		},
 		&cli.BoolFlag{
 			Name:  "really-do-it",
@@ -1076,95 +1077,98 @@ Extensions will be clamped at either the maximum sector extension of 3.5 years/1
 
 		var params []miner.ExtendSectorExpiration2Params
 
-		p := miner.ExtendSectorExpiration2Params{}
-		scount := 0
-
 		for l, exts := range extensions {
 			for newExp, numbers := range exts {
-				sectorsWithoutClaimsToExtend := bitfield.New()
-				numbersToExtend := make([]abi.SectorNumber, 0, len(numbers))
-				var sectorsWithClaims []miner.SectorClaim
-				for _, sectorNumber := range numbers {
-					claimIdsToMaintain := make([]verifreg.ClaimId, 0)
-					claimIdsToDrop := make([]verifreg.ClaimId, 0)
-					cannotExtendSector := false
-					claimIds, ok := claimIdsBySector[sectorNumber]
-					// Nothing to check, add to ccSectors
-					if !ok {
-						sectorsWithoutClaimsToExtend.Set(uint64(sectorNumber))
-						numbersToExtend = append(numbersToExtend, sectorNumber)
-					} else {
-						for _, claimId := range claimIds {
-							claim, ok := claimsMap[claimId]
-							if !ok {
-								return xerrors.Errorf("failed to find claim for claimId %d", claimId)
-							}
-							claimExpiration := claim.TermStart + claim.TermMax
-							// can be maintained in the extended sector
-							if claimExpiration > newExp {
-								claimIdsToMaintain = append(claimIdsToMaintain, claimId)
-							} else {
-								sectorInfo, ok := activeSectorsInfo[sectorNumber]
-								if !ok {
-									return xerrors.Errorf("failed to find sector in active sector set: %w", err)
-								}
-								if !cctx.Bool("drop-claims") ||
-									// FIP-0045 requires the claim minimum duration to have passed
-									currEpoch <= (claim.TermStart+claim.TermMin) ||
-									// FIP-0045 requires the sector to be in its last 30 days of life
-									(currEpoch <= sectorInfo.Expiration-builtin.EndOfLifeClaimDropPeriod) {
-									fmt.Printf("skipping sector %d because claim %d (client f0%s, piece %s) does not live long enough \n", sectorNumber, claimId, claim.Client, claim.Data)
-									cannotExtendSector = true
-									break
-								}
+				batchSize := addrSectors
 
-								claimIdsToDrop = append(claimIdsToDrop, claimId)
-							}
+				// Slice each (deadline, partition, new-expiration) group into
+				// chunks of at most batchSize sectors, and emit one message
+				// (one ExtendSectorExpiration2Params with one ExpirationExtension2)
+				// per chunk. This is what makes --max-sectors actually bound the
+				// number of sectors per message, instead of letting a single
+				// partition's worth of sectors all land in one declaration.
+				//
+				// Trade-off: small leftover batches from different partitions
+				// don't get aggregated into a single message. This is the same
+				// trade-off Lotus accepted in filecoin-project/lotus#11928.
+				for i := 0; i < len(numbers); i += batchSize {
+					end := i + batchSize
+					if end > len(numbers) {
+						end = len(numbers)
+					}
 
+					batch := numbers[i:end]
+
+					numbersToExtend := make([]abi.SectorNumber, 0, len(batch))
+					var sectorsWithClaims []miner.SectorClaim
+					p := miner.ExtendSectorExpiration2Params{}
+
+					for _, sectorNumber := range batch {
+						claimIdsToMaintain := make([]verifreg.ClaimId, 0)
+						claimIdsToDrop := make([]verifreg.ClaimId, 0)
+						cannotExtendSector := false
+						claimIds, ok := claimIdsBySector[sectorNumber]
+						// Nothing to check, add to ccSectors
+						if !ok {
 							numbersToExtend = append(numbersToExtend, sectorNumber)
-						}
-						if cannotExtendSector {
-							continue
-						}
+						} else {
+							for _, claimId := range claimIds {
+								claim, ok := claimsMap[claimId]
+								if !ok {
+									return xerrors.Errorf("failed to find claim for claimId %d", claimId)
+								}
+								claimExpiration := claim.TermStart + claim.TermMax
+								// can be maintained in the extended sector
+								if claimExpiration > newExp {
+									claimIdsToMaintain = append(claimIdsToMaintain, claimId)
+								} else {
+									sectorInfo, ok := activeSectorsInfo[sectorNumber]
+									if !ok {
+										return xerrors.Errorf("failed to find sector in active sector set: %w", err)
+									}
+									if !cctx.Bool("drop-claims") ||
+										// FIP-0045 requires the claim minimum duration to have passed
+										currEpoch <= (claim.TermStart+claim.TermMin) ||
+										// FIP-0045 requires the sector to be in its last 30 days of life
+										(currEpoch <= sectorInfo.Expiration-builtin.EndOfLifeClaimDropPeriod) {
+										fmt.Printf("skipping sector %d because claim %d (client f0%s, piece %s) does not live long enough \n", sectorNumber, claimId, claim.Client, claim.Data)
+										cannotExtendSector = true
+										break
+									}
 
-						if len(claimIdsToMaintain)+len(claimIdsToDrop) != 0 {
-							sectorsWithClaims = append(sectorsWithClaims, miner.SectorClaim{
-								SectorNumber:   sectorNumber,
-								MaintainClaims: claimIdsToMaintain,
-								DropClaims:     claimIdsToDrop,
-							})
+									claimIdsToDrop = append(claimIdsToDrop, claimId)
+								}
+
+								numbersToExtend = append(numbersToExtend, sectorNumber)
+							}
+							if cannotExtendSector {
+								continue
+							}
+
+							if len(claimIdsToMaintain)+len(claimIdsToDrop) != 0 {
+								sectorsWithClaims = append(sectorsWithClaims, miner.SectorClaim{
+									SectorNumber:   sectorNumber,
+									MaintainClaims: claimIdsToMaintain,
+									DropClaims:     claimIdsToDrop,
+								})
+							}
 						}
 					}
-				}
 
-				sectorsWithoutClaimsCount, err := sectorsWithoutClaimsToExtend.Count()
-				if err != nil {
-					return xerrors.Errorf("failed to count cc sectors: %w", err)
-				}
+					if len(numbersToExtend) == 0 && len(sectorsWithClaims) == 0 {
+						continue
+					}
 
-				sectorsInDecl := int(sectorsWithoutClaimsCount) + len(sectorsWithClaims)
-				scount += sectorsInDecl
-
-				if scount > addrSectors || len(p.Extensions) >= policy.DeclarationsMax {
+					p.Extensions = append(p.Extensions, miner.ExpirationExtension2{
+						Deadline:          l.Deadline,
+						Partition:         l.Partition,
+						Sectors:           spcli.SectorNumsToBitfield(numbersToExtend),
+						SectorsWithClaims: sectorsWithClaims,
+						NewExpiration:     newExp,
+					})
 					params = append(params, p)
-					p = miner.ExtendSectorExpiration2Params{}
-					scount = sectorsInDecl
 				}
-
-				p.Extensions = append(p.Extensions, miner.ExpirationExtension2{
-					Deadline:          l.Deadline,
-					Partition:         l.Partition,
-					Sectors:           spcli.SectorNumsToBitfield(numbersToExtend),
-					SectorsWithClaims: sectorsWithClaims,
-					NewExpiration:     newExp,
-				})
-
 			}
-		}
-
-		// if we have any sectors, then one last append is needed here
-		if scount != 0 {
-			params = append(params, p)
 		}
 
 		if len(params) == 0 {

--- a/documentation/en/curio-cli/sptool.md
+++ b/documentation/en/curio-cli/sptool.md
@@ -383,7 +383,7 @@ OPTIONS:
    --drop-claims           drop claims for sectors that can be extended, but only by dropping some of their verified power claims (default: false)
    --tolerance value       don't try to extend sectors by fewer than this number of epochs, defaults to 7 days (default: 20160)
    --max-fee value         use up to this amount of FIL for one message. pass this flag to avoid message congestion. (default: "0")
-   --max-sectors value     the maximum number of sectors contained in each message (default: 0)
+   --max-sectors value     the maximum number of sectors contained in each message (default: 500)
    --really-do-it          pass this flag to really extend sectors, otherwise will only print out json representation of parameters (default: false)
    --help, -h              show help
 ```


### PR DESCRIPTION
## Problem

`sptool sectors extend --max-sectors N` does not actually bound the number of sectors per message. SPs trying to use the flag to keep gas under the message limit produce messages well above their stated limit and trip `call ran out of gas`.

Reported in #587 by @Trevor-K-Smith. Concrete repro from his logs:

```
sptool ... sectors extend --to +40320 --extension 518400 --max-sectors 50 --max-fee 1
Extending 1198 sectors: { ... }    GasLimit: 10 G
Extending 2151 sectors: { ... }    "call ran out of gas"
```

`--max-sectors 50` produced messages with 1,198 and 2,151 sectors. Same shape as the Lotus bug @beck-8 surfaced upthread: filecoin-project/lotus#11927 (fixed in filecoin-project/lotus#11928).

## Root cause

In `cmd/sptool/sector.go`, the message-batching loop collects an **entire** `(deadline, partition, new-expiration)` group of sectors before checking `--max-sectors`:

```go
p := miner.ExtendSectorExpiration2Params{}
scount := 0

for l, exts := range extensions {
    for newExp, numbers := range exts {
        // ... process ALL `numbers` (could be 2000+ sectors) into one
        // numbersToExtend slice and one sectorsWithClaims slice ...

        sectorsInDecl := int(sectorsWithoutClaimsCount) + len(sectorsWithClaims)
        scount += sectorsInDecl

        // Check runs AFTER the group is already packed
        if scount > addrSectors || len(p.Extensions) >= policy.DeclarationsMax {
            params = append(params, p)
            p = miner.ExtendSectorExpiration2Params{}
            scount = sectorsInDecl
        }

        // Append ONE Extension with the ENTIRE numbersToExtend slice
        p.Extensions = append(p.Extensions, miner.ExpirationExtension2{
            ...
            Sectors: spcli.SectorNumsToBitfield(numbersToExtend),
            ...
        })
    }
}
```

The `scount > addrSectors` check triggers a message-boundary **between** groups, not within them. A single partition's worth of sectors all land in one `ExpirationExtension2`, gas estimate explodes, and the message bounces.

## Fix

Port filecoin-project/lotus#11928 (merged 2025-07-02): slice each `(deadline, partition, new-expiration)` group into chunks of at most `addrSectors` first, then build one `ExtendSectorExpiration2Params` with one `ExpirationExtension2` per chunk. `--max-sectors` now means exactly what it says.

Also set the flag's default to `500` to match Lotus, so operators who don't pass `--max-sectors` still get a bounded message instead of "whatever fits in the network limit."

```go
for l, exts := range extensions {
    for newExp, numbers := range exts {
        batchSize := addrSectors
        for i := 0; i < len(numbers); i += batchSize {
            end := i + batchSize
            if end > len(numbers) {
                end = len(numbers)
            }
            batch := numbers[i:end]

            // process `batch` (not all `numbers`) into numbersToExtend +
            // sectorsWithClaims, build one Extension, append one Params.
            params = append(params, p)
        }
    }
}
```

The accumulator (`p := ...; scount := 0`) and late-flush block are removed entirely — they're no longer needed.

## Trade-off

Same one Lotus accepted in #11928: small leftover batches from different `(deadline, partition, newExp)` groups don't get aggregated into a single message. For the worst case (every group is exactly 1 sector, all in different partitions) this produces more messages than strictly necessary. In practice the extension command is run on aging partitions where each group is in the hundreds, so the aggregation loss is minimal and the gas-safety win is huge.

## Verification

- `gofmt` clean.
- File parses with `go/parser` cleanly (`PARSE OK`).
- Logic is a direct structural port of filecoin-project/lotus#11928 which has been live in Lotus for ~10 months.

I did not run a full Curio build locally (CGO + filcrypto on macOS is a separate yak). Will defer that to CI here.

## Related history

- This is a re-do of #593 which I closed after @beck-8's review pointed out the original approach interacted badly with `policy.DeclarationsMax` semantics. The Lotus #11928 pattern handles that correctly by construction — the slicing happens inside the `(deadline, partition, newExp)` loop, so each batch produces exactly one declaration with at most `batchSize` sectors, preserving the per-declaration count semantics @beck-8 was worried about.
- Closes #587.
