### PR TITLE
pdpv0: set PDPv0_DelDataSet CPU to 0 and max concurrency to 10

### DIFF
--- a/tasks/pdpv0/task_delete_data_set.go
+++ b/tasks/pdpv0/task_delete_data_set.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/harmony/resources"
+	"github.com/filecoin-project/curio/harmony/taskhelp"
 	"github.com/filecoin-project/curio/lib/ethchain"
 	"github.com/filecoin-project/curio/lib/passcall"
 	"github.com/filecoin-project/curio/pdp/contract"
@@ -142,9 +143,10 @@ func (t *DeleteDataSetTask) CanAccept(ids []harmonytask.TaskID, engine *harmonyt
 
 func (t *DeleteDataSetTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
+		Max:  taskhelp.Max(10),
 		Name: tasknames.PDPv0_DelDataSet,
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Gpu: 0,
 			Ram: 64 << 20,
 		},


### PR DESCRIPTION
After 16cce66acc84a5347c11a17496e28665e20ebeea, the old PDP node will have a large number of tasks because of data synchronization, and these tasks will block other tasks. This part itself doesn't have much work, so reduce the CPU resources to 0 and set a concurrency limit.

```
<html>
<body>
<!--StartFragment-->
SpID | Task | ID | Posted | Owner
-- | -- | -- | -- | --
n/a | PDPv0_DelDataSet | 29282378 | 2h17m10s |  
615 similar tasks
n/a | PDPv0_DelDataSet | 29282198 | 20m26s |  
n/a | PDPv0_DelDataSet | 29282349 | 2h17m11s | 127.0.0.1:12300
22 similar tasks
n/a | PDPv0_DelDataSet | 29282377 | 2h17m10s | 127.0.0.1:12300
n/a | PDPv0_Prove | 29295881 | 2m0s | 127.0.0.1:12300
2 similar tasks
n/a | PDPv0_Prove | 29297192 | 7s | 127.0.0.1:12300
n/a | PDPv0_ProvPeriod | 29295882 | 2m0s | 127.0.0.1:12300
n/a | PDPv0_ProvPeriod | 29297783 | 47s | 127.0.0.1:12300
n/a | PDPv0_ProvPeriod | 29297186 | 32s | 127.0.0.1:12300
n/a | PDPv0_PullPiece | 29295664 | 1m10s |  
n/a | PDPv0_PullPiece | 29297194 | 5s |  
n/a | PDPv0_SaveCache | 29292202 | 52m30s |  
n/a | PDPv0_SaveCache | 29294509 | 39m20s |  
n/a | PDPv0_SaveCache | 29295837 | 19m21s |  
n/a | SendTransaction | 29298565 | 2s |  

<br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>SpID	Task	ID	Posted	Owner
n/a	PDPv0_DelDataSet	[29282378](http://127.0.0.1:4701/pages/task/id/?id=29282378)	2h17m10s	
615 similar tasks
n/a	PDPv0_DelDataSet	[29282198](http://127.0.0.1:4701/pages/task/id/?id=29282198)	20m26s	
n/a	PDPv0_DelDataSet	[29282349](http://127.0.0.1:4701/pages/task/id/?id=29282349)	2h17m11s	[127.0.0.1:12300](http://127.0.0.1:4701/pages/node_info/?id=701)
22 similar tasks
n/a	PDPv0_DelDataSet	[29282377](http://127.0.0.1:4701/pages/task/id/?id=29282377)	2h17m10s	[127.0.0.1:12300](http://127.0.0.1:4701/pages/node_info/?id=701)
n/a	PDPv0_Prove	[29295881](http://127.0.0.1:4701/pages/task/id/?id=29295881)	2m0s	[127.0.0.1:12300](http://127.0.0.1:4701/pages/node_info/?id=701)
2 similar tasks
n/a	PDPv0_Prove	[29297192](http://127.0.0.1:4701/pages/task/id/?id=29297192)	7s	[127.0.0.1:12300](http://127.0.0.1:4701/pages/node_info/?id=701)
n/a	PDPv0_ProvPeriod	[29295882](http://127.0.0.1:4701/pages/task/id/?id=29295882)	2m0s	[127.0.0.1:12300](http://127.0.0.1:4701/pages/node_info/?id=701)
n/a	PDPv0_ProvPeriod	[29297783](http://127.0.0.1:4701/pages/task/id/?id=29297783)	47s	[127.0.0.1:12300](http://127.0.0.1:4701/pages/node_info/?id=701)
n/a	PDPv0_ProvPeriod	[29297186](http://127.0.0.1:4701/pages/task/id/?id=29297186)	32s	[127.0.0.1:12300](http://127.0.0.1:4701/pages/node_info/?id=701)
n/a	PDPv0_PullPiece	[29295664](http://127.0.0.1:4701/pages/task/id/?id=29295664)	1m10s	
n/a	PDPv0_PullPiece	[29297194](http://127.0.0.1:4701/pages/task/id/?id=29297194)	5s	
n/a	PDPv0_SaveCache	[29292202](http://127.0.0.1:4701/pages/task/id/?id=29292202)	52m30s	
n/a	PDPv0_SaveCache	[29294509](http://127.0.0.1:4701/pages/task/id/?id=29294509)	39m20s	
n/a	PDPv0_SaveCache	[29295837](http://127.0.0.1:4701/pages/task/id/?id=29295837)	19m21s	
n/a	SendTransaction	[29298565](http://127.0.0.1:4701/pages/task/id/?id=29298565)	2s
```