### PR TITLE
Refactor PDPv0 PullPiece scheduling, parking, and backpressure

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -355,7 +355,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 			pdpNextProvingPeriodTask := pdpv0.NewNextProvingPeriodTask(db, must.One(dependencies.EthClient.Val()), dependencies.Chain, chainSched, es)
 			pdpInitProvingPeriodTask := pdpv0.NewInitProvingPeriodTask(db, must.One(dependencies.EthClient.Val()), dependencies.Chain, chainSched, es)
 			pdpNotifTask := pdpv0.NewPDPNotifyTask(ctx, db)
-			pdpPullPieceTask := pdpv0.NewPDPPullPieceTask(ctx, db, sc)
+			pdpPullPieceTask := pdpv0.NewPDPPullPieceTask(ctx, db, sc, cfg.Subsystems.PDPPullPieceMaxTasks)
 
 			pdpTerminate := pdpv0.NewTerminateServiceTask(db, must.One(dependencies.EthClient.Val()), senderEth)
 			pdpDelete := pdpv0.NewDeleteDataSetTask(db, must.One(dependencies.EthClient.Val()), senderEth)

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -355,7 +355,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 			pdpNextProvingPeriodTask := pdpv0.NewNextProvingPeriodTask(db, must.One(dependencies.EthClient.Val()), dependencies.Chain, chainSched, es)
 			pdpInitProvingPeriodTask := pdpv0.NewInitProvingPeriodTask(db, must.One(dependencies.EthClient.Val()), dependencies.Chain, chainSched, es)
 			pdpNotifTask := pdpv0.NewPDPNotifyTask(ctx, db)
-			pdpPullPieceTask := pdpv0.NewPDPPullPieceTask(ctx, db, lstor, 4)
+			pdpPullPieceTask := pdpv0.NewPDPPullPieceTask(ctx, db, sc)
 
 			pdpTerminate := pdpv0.NewTerminateServiceTask(db, must.One(dependencies.EthClient.Val()), senderEth)
 			pdpDelete := pdpv0.NewDeleteDataSetTask(db, must.One(dependencies.EthClient.Val()), senderEth)

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -857,6 +857,13 @@ PDP deals allow the node to directly store and prove unsealed data with "PDP Ser
 This feature is BETA and should only be enabled on nodes which are part of a PDP network.`,
 		},
 		{
+			Name: "PDPPullPieceMaxTasks",
+			Type: "int",
+
+			Comment: `PDPPullPieceMaxTasks is the maximum number of PDPv0 pull-piece download tasks that can run simultaneously.
+Set 0 for unlimited. (Default: 20)`,
+		},
+		{
 			Name: "EnableCommP",
 			Type: "bool",
 

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -16,6 +16,7 @@ func DefaultCurioConfig() *CurioConfig {
 			GuiAddress:                     "0.0.0.0:4701",
 			RequireActivationSuccess:       true,
 			RequireNotificationSuccess:     true,
+			PDPPullPieceMaxTasks:           20,
 			IndexingMaxTasks:               8,
 			RemoteProofMaxUploads:          15,
 			ParkPieceMinFreeStoragePercent: 5,
@@ -410,6 +411,10 @@ type CurioSubsystemsConfig struct {
 	// PDP deals allow the node to directly store and prove unsealed data with "PDP Services" like Storacha.
 	// This feature is BETA and should only be enabled on nodes which are part of a PDP network.
 	EnablePDP bool
+
+	// PDPPullPieceMaxTasks is the maximum number of PDPv0 pull-piece download tasks that can run simultaneously.
+	// Set 0 for unlimited. (Default: 20)
+	PDPPullPieceMaxTasks int
 
 	// EnableCommP enables the commP task on te node. CommP is calculated before sending PublishDealMessage for a Mk12 deal
 	// Must have EnableDealMarket = True (Default: false)

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -280,6 +280,12 @@ description: The default curio configuration
   # type: bool
   #EnablePDP = false
 
+  # PDPPullPieceMaxTasks is the maximum number of PDPv0 pull-piece download tasks that can run simultaneously.
+  # Set 0 for unlimited. (Default: 20)
+  #
+  # type: int
+  #PDPPullPieceMaxTasks = 20
+
   # EnableCommP enables the commP task on te node. CommP is calculated before sending PublishDealMessage for a Mk12 deal
   # Must have EnableDealMarket = True (Default: false)
   #

--- a/harmony/harmonydb/downgrade/20260521-pdp-v0-pull-refactor.sql
+++ b/harmony/harmonydb/downgrade/20260521-pdp-v0-pull-refactor.sql
@@ -1,1 +1,3 @@
--- no-op downgrade: added columns and pull item state migration are retained
+DROP INDEX IF EXISTS idx_pdp_piece_pull_items_pull_parked_piece_id;
+DROP INDEX IF EXISTS idx_pdp_piece_pull_items_parked_piece_ref;
+

--- a/harmony/harmonydb/downgrade/20260521-pdp-v0-pull-refactor.sql
+++ b/harmony/harmonydb/downgrade/20260521-pdp-v0-pull-refactor.sql
@@ -1,0 +1,1 @@
+-- no-op downgrade: added columns and pull item state migration are retained

--- a/harmony/harmonydb/sql/20240228-piece-park.sql
+++ b/harmony/harmonydb/sql/20240228-piece-park.sql
@@ -31,12 +31,12 @@ create table if not exists parked_pieces (
  *
  * data_url is optional for refs which also act as data sources.
  *
- * Refs are ADDED when:
- * 1. MK12 market accepts a non-offline deal
+ * Refs are ADDED when a subsystem needs to keep a parked piece alive or
+ * provide a source URL for parking. This includes market, PDP upload, and
+ * PDP pull flows.
  *
- * Refs are REMOVED when:
- * 1. (MK12) A sector related to a pieceref: url piece is finalized
- * 2. (MK12) A deal pipeline not yet assigned to a sector is deleted
+ * Refs are REMOVED by the subsystem that created them once that reference is
+ * no longer needed.
  *
  */
 create table if not exists parked_piece_refs (

--- a/harmony/harmonydb/sql/20240930-pdp.sql
+++ b/harmony/harmonydb/sql/20240930-pdp.sql
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS pdp_piece_uploads (
 CREATE TABLE IF NOT EXISTS pdp_piecerefs (
     id BIGSERIAL PRIMARY KEY,
     service TEXT NOT NULL, -- pdp_services.id
-    piece_cid TEXT NOT NULL, -- piece cid v2
+    piece_cid TEXT NOT NULL, -- piece cid v1
     piece_ref BIGINT NOT NULL, -- parked_piece_refs.ref_id
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
 

--- a/harmony/harmonydb/sql/20260109-pdp-v0-pull.sql
+++ b/harmony/harmonydb/sql/20260109-pdp-v0-pull.sql
@@ -1,7 +1,7 @@
 -- PDP piece pull tables for SP-to-SP transfer
 --
 -- Provides idempotency and piece tracking for pull requests.
--- Status is derived dynamically from parked_pieces, not stored here.
+-- Later migrations add explicit pull item terminal state.
 CREATE TABLE IF NOT EXISTS pdp_piece_pulls (
     id BIGSERIAL PRIMARY KEY,
     service TEXT NOT NULL REFERENCES pdp_services(service_label) ON DELETE CASCADE,
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS pdp_piece_pull_items (
     failed BOOLEAN NOT NULL DEFAULT FALSE,  -- true if piece permanently failed
     fail_reason TEXT,               -- error message when failed
 
-    PRIMARY KEY (fetch_id, piece_cid)
+    PRIMARY KEY (fetch_id, piece_cid) -- later changed to (fetch_id, piece_cid, source_url)
 );
 
 -- Index for cleanup queries

--- a/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
+++ b/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
@@ -8,10 +8,22 @@ ALTER TABLE pdp_piece_pull_items
     ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
 ALTER TABLE pdp_piece_pull_items
+    ADD COLUMN IF NOT EXISTS attempt_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE pdp_piece_pull_items
+    ADD COLUMN IF NOT EXISTS next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+ALTER TABLE pdp_piece_pull_items
     ADD COLUMN IF NOT EXISTS parked_piece_ref BIGINT REFERENCES parked_piece_refs(ref_id) ON DELETE SET NULL;
 
 ALTER TABLE pdp_piece_pull_items
     ADD COLUMN IF NOT EXISTS pull_parked_piece_id BIGINT REFERENCES parked_pieces(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN pdp_piece_pull_items.parked_piece_ref IS
+    'Per-pull-item parked_piece_refs row; preserves the item source URL and is promoted into pdp_piecerefs on success.';
+
+COMMENT ON COLUMN pdp_piece_pull_items.pull_parked_piece_id IS
+    'Set only when PullPiece created the parked_pieces row; ownership marker for retry/expiry cleanup, distinct from parked_piece_ref.piece_id for refs attached to rows owned by other flows.';
 
 ALTER TABLE pdp_piece_pull_items
     DROP CONSTRAINT IF EXISTS pdp_piece_pull_items_pkey;

--- a/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
+++ b/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
@@ -1,9 +1,3 @@
--- PDPv0 pull pipeline refactor.
---
--- Pull items are now scheduled by unique piece key and written directly to
--- long-term piece storage. Pull item terminal state is explicit so status no
--- longer has to be inferred from StorePiece/parked_pieces task state.
-
 ALTER TABLE pdp_piece_pulls
     ADD COLUMN IF NOT EXISTS client_address TEXT NOT NULL DEFAULT '';
 
@@ -31,6 +25,14 @@ ALTER TABLE pdp_piece_pull_items
 ALTER TABLE pdp_piece_pull_items
     ADD CONSTRAINT pdp_piece_pull_items_terminal_state_check
     CHECK (NOT (complete AND failed));
+
+-- Support ON DELETE SET NULL from parked_piece_refs and parked_pieces without
+-- scanning all pull items for each deleted parent row.
+CREATE INDEX IF NOT EXISTS idx_pdp_piece_pull_items_parked_piece_ref
+    ON pdp_piece_pull_items (parked_piece_ref);
+
+CREATE INDEX IF NOT EXISTS idx_pdp_piece_pull_items_pull_parked_piece_id
+    ON pdp_piece_pull_items (pull_parked_piece_id);
 
 UPDATE pdp_piece_pull_items fi
 SET created_at = COALESCE(pp.created_at, fi.created_at)

--- a/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
+++ b/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
@@ -1,0 +1,54 @@
+-- PDPv0 pull pipeline refactor.
+--
+-- Pull items are now scheduled by unique piece key and written directly to
+-- long-term piece storage. Pull item terminal state is explicit so status no
+-- longer has to be inferred from StorePiece/parked_pieces task state.
+
+ALTER TABLE pdp_piece_pulls
+    ADD COLUMN IF NOT EXISTS client_address TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE pdp_piece_pull_items
+    ADD COLUMN IF NOT EXISTS complete BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE pdp_piece_pull_items
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ;
+
+UPDATE pdp_piece_pull_items fi
+SET created_at = COALESCE(pp.created_at, NOW())
+FROM pdp_piece_pulls pp
+WHERE pp.id = fi.fetch_id
+    AND fi.created_at IS NULL;
+
+ALTER TABLE pdp_piece_pull_items
+    ALTER COLUMN created_at SET DEFAULT NOW();
+
+ALTER TABLE pdp_piece_pull_items
+    ALTER COLUMN created_at SET NOT NULL;
+
+ALTER TABLE pdp_piece_pull_items
+    ADD COLUMN IF NOT EXISTS parked_piece_ref BIGINT REFERENCES parked_piece_refs(ref_id) ON DELETE SET NULL;
+
+ALTER TABLE pdp_piece_pull_items
+    ADD COLUMN IF NOT EXISTS pull_parked_piece_id BIGINT REFERENCES parked_pieces(id) ON DELETE SET NULL;
+
+ALTER TABLE pdp_piece_pull_items
+    DROP CONSTRAINT IF EXISTS pdp_piece_pull_items_pkey;
+
+ALTER TABLE pdp_piece_pull_items
+    ADD CONSTRAINT pdp_piece_pull_items_pkey PRIMARY KEY (fetch_id, piece_cid, source_url);
+
+UPDATE pdp_piece_pull_items fi
+SET task_id = NULL
+WHERE fi.task_id IS NOT NULL
+    AND NOT EXISTS (
+        SELECT 1
+        FROM harmony_task ht
+        WHERE ht.id = fi.task_id
+    );
+
+ALTER TABLE pdp_piece_pull_items
+    DROP CONSTRAINT IF EXISTS pdp_piece_pull_items_terminal_state_check;
+
+ALTER TABLE pdp_piece_pull_items
+    ADD CONSTRAINT pdp_piece_pull_items_terminal_state_check
+    CHECK (NOT (complete AND failed));

--- a/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
+++ b/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
@@ -13,11 +13,6 @@ ALTER TABLE pdp_piece_pull_items
 ALTER TABLE pdp_piece_pull_items
     ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
-UPDATE pdp_piece_pull_items fi
-SET created_at = COALESCE(pp.created_at, fi.created_at)
-FROM pdp_piece_pulls pp
-WHERE pp.id = fi.fetch_id;
-
 ALTER TABLE pdp_piece_pull_items
     ADD COLUMN IF NOT EXISTS parked_piece_ref BIGINT REFERENCES parked_piece_refs(ref_id) ON DELETE SET NULL;
 
@@ -30,18 +25,23 @@ ALTER TABLE pdp_piece_pull_items
 ALTER TABLE pdp_piece_pull_items
     ADD CONSTRAINT pdp_piece_pull_items_pkey PRIMARY KEY (fetch_id, piece_cid, source_url);
 
-UPDATE pdp_piece_pull_items fi
-SET task_id = NULL
-WHERE fi.task_id IS NOT NULL
-    AND NOT EXISTS (
-        SELECT 1
-        FROM harmony_task ht
-        WHERE ht.id = fi.task_id
-    );
-
 ALTER TABLE pdp_piece_pull_items
     DROP CONSTRAINT IF EXISTS pdp_piece_pull_items_terminal_state_check;
 
 ALTER TABLE pdp_piece_pull_items
     ADD CONSTRAINT pdp_piece_pull_items_terminal_state_check
     CHECK (NOT (complete AND failed));
+
+UPDATE pdp_piece_pull_items fi
+SET created_at = COALESCE(pp.created_at, fi.created_at)
+    FROM pdp_piece_pulls pp
+WHERE pp.id = fi.fetch_id;
+
+UPDATE pdp_piece_pull_items fi
+SET task_id = NULL
+WHERE fi.task_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM harmony_task ht
+    WHERE ht.id = fi.task_id
+);

--- a/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
+++ b/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
@@ -11,23 +11,12 @@ ALTER TABLE pdp_piece_pull_items
     ADD COLUMN IF NOT EXISTS complete BOOLEAN NOT NULL DEFAULT FALSE;
 
 ALTER TABLE pdp_piece_pull_items
-    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ;
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
 UPDATE pdp_piece_pull_items fi
-SET created_at = COALESCE(pp.created_at, NOW())
+SET created_at = COALESCE(pp.created_at, fi.created_at)
 FROM pdp_piece_pulls pp
-WHERE pp.id = fi.fetch_id
-    AND fi.created_at IS NULL;
-
-UPDATE pdp_piece_pull_items
-SET created_at = NOW()
-WHERE created_at IS NULL;
-
-ALTER TABLE pdp_piece_pull_items
-    ALTER COLUMN created_at SET DEFAULT NOW();
-
-ALTER TABLE pdp_piece_pull_items
-    ALTER COLUMN created_at SET NOT NULL;
+WHERE pp.id = fi.fetch_id;
 
 ALTER TABLE pdp_piece_pull_items
     ADD COLUMN IF NOT EXISTS parked_piece_ref BIGINT REFERENCES parked_piece_refs(ref_id) ON DELETE SET NULL;

--- a/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
+++ b/harmony/harmonydb/sql/20260521-pdp-v0-pull-refactor.sql
@@ -19,6 +19,10 @@ FROM pdp_piece_pulls pp
 WHERE pp.id = fi.fetch_id
     AND fi.created_at IS NULL;
 
+UPDATE pdp_piece_pull_items
+SET created_at = NOW()
+WHERE created_at IS NULL;
+
 ALTER TABLE pdp_piece_pull_items
     ALTER COLUMN created_at SET DEFAULT NOW();
 

--- a/lib/parkpiece/upsert.go
+++ b/lib/parkpiece/upsert.go
@@ -51,9 +51,18 @@ func Upsert(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTe
 // valid-index path and fallback path return the existing id without changing
 // the existing row's skip or raw-size metadata.
 func UpsertSkip(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm, skip bool) (int64, error) {
+	id, _, err := UpsertSkipWithInserted(tx, pieceCID, paddedSize, rawSize, longTerm, skip)
+	return id, err
+}
+
+// UpsertSkipWithInserted is UpsertSkip plus a flag reporting whether this call
+// inserted the active parked_pieces row. The flag is useful for callers that may
+// attach refs to an existing row but should only write piece data when they
+// created the row themselves.
+func UpsertSkipWithInserted(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm, skip bool) (int64, bool, error) {
 	indexValid, err := ActiveIndexValid(tx)
 	if err != nil {
-		return 0, xerrors.Errorf("checking parked_pieces_active_piece_key: %w", err)
+		return 0, false, xerrors.Errorf("checking parked_pieces_active_piece_key: %w", err)
 	}
 
 	if indexValid {
@@ -62,16 +71,26 @@ func UpsertSkip(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, lo
 			INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, long_term, skip)
 			VALUES ($1, $2, $3, $4, $5)
 			ON CONFLICT (piece_cid, piece_padded_size, long_term) WHERE cleanup_task_id IS NULL
-			-- no-op SET so RETURNING fires on the conflict path (DO NOTHING returns no rows)
-			DO UPDATE SET piece_cid = parked_pieces.piece_cid
+			DO NOTHING
 			RETURNING id`, pieceCID, paddedSize, rawSize, longTerm, skip).Scan(&id)
-		if err != nil {
-			return 0, xerrors.Errorf("upsert parked_pieces: %w", err)
+		if err == nil {
+			return id, true, nil
 		}
-		return id, nil
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return 0, false, xerrors.Errorf("upsert parked_pieces: %w", err)
+		}
+
+		err = tx.QueryRow(`
+			SELECT id FROM parked_pieces
+			WHERE piece_cid = $1 AND piece_padded_size = $2 AND long_term = $3 AND cleanup_task_id IS NULL
+			ORDER BY id LIMIT 1`, pieceCID, paddedSize, longTerm).Scan(&id)
+		if err != nil {
+			return 0, false, xerrors.Errorf("upsert parked_pieces (select existing): %w", err)
+		}
+		return id, false, nil
 	}
 
-	return upsertFallback(tx, pieceCID, paddedSize, rawSize, longTerm, &skip)
+	return upsertFallbackWithInserted(tx, pieceCID, paddedSize, rawSize, longTerm, &skip)
 }
 
 // upsertFallback is the non-atomic check-then-insert path used while the
@@ -81,16 +100,21 @@ func UpsertSkip(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, lo
 // duplicate risk that the cleanup task is responsible for repairing. skip is
 // applied only to the inserted row.
 func upsertFallback(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm bool, skip *bool) (int64, error) {
+	id, _, err := upsertFallbackWithInserted(tx, pieceCID, paddedSize, rawSize, longTerm, skip)
+	return id, err
+}
+
+func upsertFallbackWithInserted(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64, longTerm bool, skip *bool) (int64, bool, error) {
 	var id int64
 	err := tx.QueryRow(`
 		SELECT id FROM parked_pieces
 		WHERE piece_cid = $1 AND piece_padded_size = $2 AND long_term = $3 AND cleanup_task_id IS NULL
 		ORDER BY id LIMIT 1`, pieceCID, paddedSize, longTerm).Scan(&id)
 	if err == nil {
-		return id, nil
+		return id, false, nil
 	}
 	if !errors.Is(err, pgx.ErrNoRows) {
-		return 0, xerrors.Errorf("upsert parked_pieces (fallback select): %w", err)
+		return 0, false, xerrors.Errorf("upsert parked_pieces (fallback select): %w", err)
 	}
 	if skip != nil {
 		err = tx.QueryRow(`
@@ -104,9 +128,9 @@ func upsertFallback(tx *harmonydb.Tx, pieceCID string, paddedSize, rawSize int64
 			pieceCID, paddedSize, rawSize, longTerm).Scan(&id)
 	}
 	if err != nil {
-		return 0, xerrors.Errorf("upsert parked_pieces (fallback insert): %w", err)
+		return 0, false, xerrors.Errorf("upsert parked_pieces (fallback insert): %w", err)
 	}
-	return id, nil
+	return id, true, nil
 }
 
 // ActiveIndexValid returns whether parked_pieces_active_piece_key is present,

--- a/lib/robusthttp/ssrf.go
+++ b/lib/robusthttp/ssrf.go
@@ -52,6 +52,15 @@ func DefaultSSRFPolicy() SSRFPolicy {
 
 var globalSSRFOverride atomic.Pointer[SSRFPolicy]
 
+// NoResolvedAddressError reports a DNS result with no usable IP addresses.
+type NoResolvedAddressError struct {
+	Host string
+}
+
+func (e *NoResolvedAddressError) Error() string {
+	return "host " + strconv.Quote(e.Host) + " resolved to no addresses"
+}
+
 // SetGlobalSSRFOverride installs a fallback SSRFPolicy that is used whenever
 // a caller passes a nil policy. Call with nil to clear the override.
 func SetGlobalSSRFOverride(p *SSRFPolicy) {
@@ -243,7 +252,7 @@ func ssrfSafeDial(ctx context.Context, network, addr string, policy *SSRFPolicy)
 		return nil, err
 	}
 	if len(ips) == 0 {
-		return nil, xerrors.Errorf("host %q resolved to no addresses", host)
+		return nil, &NoResolvedAddressError{Host: host}
 	}
 
 	if !allowed {

--- a/lib/robusthttp/ssrf.go
+++ b/lib/robusthttp/ssrf.go
@@ -58,6 +58,12 @@ func SetGlobalSSRFOverride(p *SSRFPolicy) {
 	globalSSRFOverride.Store(p)
 }
 
+// CurrentSSRFPolicy returns the effective SSRF policy, including any global
+// override installed from config.
+func CurrentSSRFPolicy() SSRFPolicy {
+	return *withSSRFDefaults(nil)
+}
+
 // ValidateClientFetchURL is for early deal/proposal validation.
 func ValidateClientFetchURL(raw string, headers http.Header, policy *SSRFPolicy) (*url.URL, error) {
 	policy = withSSRFDefaults(policy)

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -1256,9 +1256,44 @@ func (p *PDPService) cleanup(ctx context.Context) {
 			}
 		}
 
-		// Clean up old piece pull records (older than 5 days)
-		// CASCADE deletes pdp_piece_pull_items automatically
-		_, err = db.Exec(ctx, `DELETE FROM pdp_piece_pulls WHERE created_at < NOW() - INTERVAL '5 days'`)
+		// Clean up old piece pull records (older than 5 days). Pull items only
+		// store refs created by PullPiece, so delete unused refs first;
+		// otherwise the CASCADE from pdp_piece_pulls removes the pointer to
+		// those refs.
+		_, err = db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+			_, err = tx.Exec(`
+				WITH old_pull_refs AS (
+					SELECT DISTINCT fi.parked_piece_ref AS ref_id
+					FROM pdp_piece_pull_items fi
+					JOIN pdp_piece_pulls pp ON pp.id = fi.fetch_id
+					WHERE pp.created_at < NOW() - INTERVAL '5 days'
+						AND fi.parked_piece_ref IS NOT NULL
+				)
+				DELETE FROM parked_piece_refs pr
+				USING old_pull_refs old
+				WHERE pr.ref_id = old.ref_id
+					AND NOT EXISTS (
+						SELECT 1 FROM pdp_piecerefs ppr WHERE ppr.piece_ref = pr.ref_id
+					)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM pdp_piece_pull_items live_fi
+						JOIN pdp_piece_pulls live_pp ON live_pp.id = live_fi.fetch_id
+						WHERE live_fi.parked_piece_ref = pr.ref_id
+							AND live_pp.created_at >= NOW() - INTERVAL '5 days'
+					)
+				`)
+			if err != nil {
+				return false, fmt.Errorf("delete old pull refs: %w", err)
+			}
+
+			_, err = tx.Exec(`DELETE FROM pdp_piece_pulls WHERE created_at < NOW() - INTERVAL '5 days'`)
+			if err != nil {
+				return false, fmt.Errorf("delete old pull records: %w", err)
+			}
+
+			return true, nil
+		}, harmonydb.OptionRetry())
 		if err != nil {
 			log.Errorw("failed to delete old piece pull records", "error", err)
 		}

--- a/pdp/handlers_add.go
+++ b/pdp/handlers_add.go
@@ -99,6 +99,7 @@ func (p *PDPService) transformAddPiecesRequest(ctx context.Context, serviceLabel
             JOIN parked_piece_refs pprf ON pprf.ref_id = ppr.piece_ref
             JOIN parked_pieces pp ON pp.id = pprf.piece_id
             WHERE ppr.service = $1 AND ppr.piece_cid = ANY($2)
+            ORDER BY ppr.created_at ASC, ppr.id ASC
         `, serviceLabel, subPieceCidList)
 		if err != nil {
 			return false, err
@@ -115,6 +116,9 @@ func (p *PDPService) transformAddPiecesRequest(ctx context.Context, serviceLabel
 			err := rows.Scan(&pieceCIDStr, &pdpPieceRefID, &pieceRefID, &piecePaddedSize, &pieceRawSize)
 			if err != nil {
 				return false, err
+			}
+			if _, found := foundSubPieces[pieceCIDStr]; found {
+				continue
 			}
 
 			// Parse the piece CID

--- a/pdp/handlers_pull.go
+++ b/pdp/handlers_pull.go
@@ -177,22 +177,19 @@ func NewPullHandler(auth Auth, store PullStore, validator AddPiecesValidator) *P
 //  1. Client calls POST /pdp/piece/pull with piece CIDs and source URLs
 //  2. Server validates extraData via eth_call (ensures authorization)
 //  3. Server creates pull tracking records; duplicate pieces with different
-//     source URLs are kept so PullPiece can try each supplied source.
-//  4. PDPPullPieceTask groups work by piece, attaches pull refs to the active
-//     long-term parked_pieces row, and downloads directly when it created that row.
-//  5. Client polls the same endpoint to check status (idempotent)
-//  6. Once all pieces are "complete", client calls the contract to add pieces to dataset
+//     source URLs are kept so the server can try each supplied source.
+//  4. Client polls the same endpoint to check status (idempotent)
+//  5. Once all pieces are "complete", client calls the contract to add pieces to dataset
 //
 // # Status Progression
 //
 // Each piece progresses through these statuses:
 //
-//   - pending: Piece is queued or waiting on an existing parked_pieces row
-//   - inProgress: PullPiece task is actively running
-//   - retrying: The current task row has a retry count greater than zero
+//   - pending: Piece has been accepted and is waiting for processing
+//   - inProgress: Server is actively processing the piece
+//   - retrying: Server hit a transient failure and will retry
 //   - complete: Piece successfully downloaded and verified
-//   - failed: Piece permanently failed; the task enforces this through explicit
-//     item state rather than inferring it from parked_pieces.
+//   - failed: Piece cannot be completed from the supplied request data
 //
 // The overall response status reflects the worst-case across all pieces:
 // failed > retrying > inProgress > pending > complete
@@ -346,7 +343,7 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build pull pieces for database storage (v1 CID + raw size + source URL for task to pick up)
+	// Build normalized pull pieces for persistence.
 	pullPieces := make([]PullPiece, len(pieceInfos))
 	for i, info := range pieceInfos {
 		pullPieces[i] = PullPiece{
@@ -379,11 +376,7 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// PDPPullPieceTask will pick up items from pdp_piece_pull_items, group them
-	// by piece, attach refs to parked_pieces, and download when PullPiece owns
-	// the parked row.
-
-	// Return status
+	// The pull has been accepted; return the current status.
 	h.respondWithStatus(ctx, w, pullID)
 }
 

--- a/pdp/handlers_pull.go
+++ b/pdp/handlers_pull.go
@@ -372,9 +372,9 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if backpressure {
-		log.Warnw("pull queue backpressure", "client", pullRecord.ClientAddress)
-		w.Header().Set("Retry-After", "60")
+	if backpressure != nil {
+		log.Warnw("pull queue backpressure", "client", pullRecord.ClientAddress, "retryAfter", backpressure.RetryAfter)
+		w.Header().Set("Retry-After", fmt.Sprint(int(backpressure.RetryAfter.Seconds())))
 		http.Error(w, "pull queue backpressure", http.StatusTooManyRequests)
 		return
 	}

--- a/pdp/handlers_pull.go
+++ b/pdp/handlers_pull.go
@@ -11,9 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ipfs/go-cid"
-
-	commcid "github.com/filecoin-project/go-fil-commcid"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/lib/ethchain"
@@ -35,77 +32,6 @@ func getPDPSenderAddress(ctx context.Context, db *harmonydb.DB) (common.Address,
 	}
 
 	return crypto.PubkeyToAddress(privateKey.PublicKey), nil
-}
-
-// PullRecord represents a pull request record from the database
-type PullRecord struct {
-	ID            int64
-	Service       string
-	ExtraDataHash []byte
-	DataSetId     uint64 // 0 = create new
-	RecordKeeper  string // address, required when DataSetId is 0
-}
-
-// PieceStatus represents the status of a piece in storage
-type PieceStatus struct {
-	PieceCid   string
-	Complete   bool
-	TaskID     *int64 // task_id from parked_pieces (may point to deleted task)
-	TaskExists bool   // true if task_id exists in harmony_task
-	Retries    int    // retry count from harmony_task (0 if task doesn't exist)
-}
-
-// ParkedPieceEntry represents the data needed to create a parked piece entry
-type ParkedPieceEntry struct {
-	PieceCid        string
-	PiecePaddedSize int64
-	PieceRawSize    int64
-	DataURL         string
-}
-
-// PullPiece represents a piece stored in a pull request (v1 CID + raw size for v2 reconstruction)
-type PullPiece struct {
-	CidV1      cid.Cid
-	RawSize    uint64
-	SourceURL  string // external SP URL to pull from
-	Failed     bool   // true if piece permanently failed
-	FailReason string // error message when failed
-}
-
-// PullItemStatus represents the status of a pull item
-type PullItemStatus struct {
-	TaskID     *int64 // task_id from pdp_piece_pull_items
-	TaskExists bool   // true if task_id exists in harmony_task
-	Retries    int    // retry count from harmony_task (0 if task doesn't exist)
-	Failed     bool   // true if piece permanently failed
-}
-
-// PullStore abstracts database operations for the pull handler
-type PullStore interface {
-	// GetPullByKey retrieves a pull record by its idempotency key
-	GetPullByKey(ctx context.Context, service string, hash []byte, dataSetId uint64, recordKeeper string) (*PullRecord, error)
-
-	// CreatePullWithPieces creates a pull record and its associated piece items in a transaction
-	// Returns the created pull ID
-	CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, error)
-
-	// GetPieceStatuses retrieves the status of multiple pieces from parked_pieces (keyed by v1 CID string)
-	// This checks if pieces have been successfully stored (complete=true)
-	GetPieceStatuses(ctx context.Context, pieceCids []cid.Cid) (map[string]*PieceStatus, error)
-
-	// GetPullItemStatuses retrieves the status of pull items (keyed by v1 CID string)
-	// This checks the pull task state (task_id, failed)
-	GetPullItemStatuses(ctx context.Context, pullID int64, pieceCids []cid.Cid) (map[string]*PullItemStatus, error)
-
-	// GetPullPieces retrieves all pieces associated with a pull record (includes failure info)
-	GetPullPieces(ctx context.Context, pullID int64) ([]PullPiece, error)
-
-	// MarkPieceFailed marks a piece as permanently failed in the pull items table
-	MarkPieceFailed(ctx context.Context, pullID int64, pieceCid string, reason string) error
-
-	// CheckTaskExhaustedRetries checks if a task exhausted its retries by looking at harmony_task_history
-	// Returns true if the task failed permanently, along with the error message
-	CheckTaskExhaustedRetries(ctx context.Context, taskID int64) (bool, string, error)
 }
 
 // AddPiecesValidatorParams contains parameters for eth_call validation
@@ -250,8 +176,10 @@ func NewPullHandler(auth Auth, store PullStore, validator AddPiecesValidator) *P
 //
 //  1. Client calls POST /pdp/piece/pull with piece CIDs and source URLs
 //  2. Server validates extraData via eth_call (ensures authorization)
-//  3. Server creates pull tracking record and queues pieces for download
-//  4. Background task (StorePiece) downloads pieces from source URLs
+//  3. Server creates pull tracking records; duplicate pieces with different
+//     source URLs are kept so PullPiece can try each supplied source.
+//  4. PDPPullPieceTask groups work by piece, attaches pull refs to the active
+//     long-term parked_pieces row, and downloads directly when it created that row.
 //  5. Client polls the same endpoint to check status (idempotent)
 //  6. Once all pieces are "complete", client calls the contract to add pieces to dataset
 //
@@ -259,11 +187,12 @@ func NewPullHandler(auth Auth, store PullStore, validator AddPiecesValidator) *P
 //
 // Each piece progresses through these statuses:
 //
-//   - pending: Piece is queued but download hasn't started
-//   - inProgress: Download task is actively running (first attempt)
-//   - retrying: Download task is running after one or more failures
+//   - pending: Piece is queued or waiting on an existing parked_pieces row
+//   - inProgress: PullPiece task is actively running
+//   - retrying: The current task row has a retry count greater than zero
 //   - complete: Piece successfully downloaded and verified
-//   - failed: Piece permanently failed after exhausting retries (currently 5 attempts)
+//   - failed: Piece permanently failed; the task enforces this through explicit
+//     item state rather than inferring it from parked_pieces.
 //
 // The overall response status reflects the worst-case across all pieces:
 // failed > retrying > inProgress > pending > complete
@@ -355,6 +284,11 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	extraDataHash := sha256.Sum256(extraDataBytes)
+	payer, err := FWSSPayerFromExtraData(extraDataBytes)
+	if err != nil {
+		httpServerError(w, http.StatusBadRequest, "Invalid extraData payer: "+err.Error(), err)
+		return
+	}
 
 	// Build idempotency key components
 	var dataSetId uint64
@@ -428,17 +362,26 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 		ExtraDataHash: extraDataHash[:],
 		DataSetId:     dataSetId,
 		RecordKeeper:  recordKeeperStr,
+		ClientAddress: payer.Hex(),
 	}
 
-	pullID, err := h.store.CreatePullWithPieces(ctx, pullRecord, pullPieces)
+	pullID, backpressure, err := h.store.CreatePullWithPieces(ctx, pullRecord, pullPieces)
 	if err != nil {
 		log.Errorw("failed to create pull record", "error", err)
 		httpServerError(w, http.StatusInternalServerError, "Internal error", err)
 		return
 	}
 
-	// PDPPullPieceTask will pick up items from pdp_piece_pull_items,
-	// download pieces, verify CommP, and create parked_pieces entries.
+	if backpressure {
+		log.Warnw("pull queue backpressure", "client", pullRecord.ClientAddress)
+		w.Header().Set("Retry-After", "60")
+		http.Error(w, "pull queue backpressure", http.StatusTooManyRequests)
+		return
+	}
+
+	// PDPPullPieceTask will pick up items from pdp_piece_pull_items, group them
+	// by piece, attach refs to parked_pieces, and download when PullPiece owns
+	// the parked row.
 
 	// Return status
 	h.respondWithStatus(ctx, w, pullID)
@@ -447,57 +390,15 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 // respondWithStatus queries piece statuses and returns a JSON response
 func (h *PullHandler) respondWithStatus(ctx context.Context, w http.ResponseWriter, pullID int64) {
 	// Get pieces for this pull
-	pieces, err := h.store.GetPullPieces(ctx, pullID)
+	pieces, err := h.store.GetPullStatus(ctx, pullID)
 	if err != nil {
 		log.Errorw("failed to get pull pieces", "error", err)
 		httpServerError(w, http.StatusInternalServerError, "Internal error", err)
 		return
 	}
 
-	// Extract v1 CIDs for status lookup
-	cidV1s := make([]cid.Cid, len(pieces))
-	for i, p := range pieces {
-		cidV1s[i] = p.CidV1
-	}
-
-	// Get parked_pieces statuses (keyed by v1 CID string)
-	pieceStatuses, err := h.store.GetPieceStatuses(ctx, cidV1s)
-	if err != nil {
-		log.Errorw("failed to get piece statuses", "error", err)
-		httpServerError(w, http.StatusInternalServerError, "Internal error", err)
-		return
-	}
-
-	// Get pull item statuses (keyed by v1 CID string)
-	pullItemStatuses, err := h.store.GetPullItemStatuses(ctx, pullID, cidV1s)
-	if err != nil {
-		log.Errorw("failed to get pull item statuses", "error", err)
-		httpServerError(w, http.StatusInternalServerError, "Internal error", err)
-		return
-	}
-
-	// Build response with v2 CIDs for API
 	resp := &PullResponse{
-		Pieces: make([]PullPieceStatus, len(pieces)),
-	}
-
-	for i, piece := range pieces {
-		// Determine status based on pull item and parked piece state
-		cidV1Str := piece.CidV1.String()
-		status := h.determinePieceStatus(ctx, pullID, piece, pullItemStatuses[cidV1Str], pieceStatuses[cidV1Str])
-
-		// Reconstruct v2 CID for API response
-		cidV2, err := commcid.PieceCidV2FromV1(piece.CidV1, piece.RawSize)
-		if err != nil {
-			log.Errorw("failed to reconstruct v2 CID", "error", err, "cidV1", piece.CidV1.String())
-			httpServerError(w, http.StatusInternalServerError, "Internal error", err)
-			return
-		}
-
-		resp.Pieces[i] = PullPieceStatus{
-			PieceCid: cidV2.String(),
-			Status:   status,
-		}
+		Pieces: pieces,
 	}
 
 	resp.ComputeOverallStatus()
@@ -506,354 +407,4 @@ func (h *PullHandler) respondWithStatus(ctx context.Context, w http.ResponseWrit
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		log.Errorw("failed to encode response", "error", err)
 	}
-}
-
-// determinePieceStatus determines the status of a piece based on pull item and parked piece state.
-//
-// Status priority:
-// 1. Check pull item failed flag: if true, return failed
-// 2. Check pull item task_id: if not null, the pull task is running
-// 3. Check parked_pieces complete: if true, return complete
-// 4. Check parked_pieces task_id: if not null, StorePiece is running
-// 5. Otherwise return pending (waiting for pull task to pick up)
-func (h *PullHandler) determinePieceStatus(ctx context.Context, pullID int64, piece PullPiece, fis *PullItemStatus, ps *PieceStatus) PullStatus {
-	cidV1Str := piece.CidV1.String()
-
-	// Already marked failed in pull_items (from PullPiece struct)
-	if piece.Failed {
-		return PullStatusFailed
-	}
-
-	// Check pull item status (PDPPullPieceTask)
-	if fis != nil {
-		if fis.Failed {
-			return PullStatusFailed
-		}
-
-		// Pull task is assigned
-		if fis.TaskID != nil {
-			if fis.TaskExists {
-				// Task is alive
-				if fis.Retries > 0 {
-					return PullStatusRetrying
-				}
-				return PullStatusInProgress
-			}
-
-			// Task was deleted (orphaned), check if it failed permanently
-			exhausted, reason, err := h.store.CheckTaskExhaustedRetries(ctx, *fis.TaskID)
-			if err != nil {
-				log.Errorw("failed to check task history", "error", err, "taskId", *fis.TaskID)
-				return PullStatusPending
-			}
-
-			if exhausted {
-				// Mark as failed in our tracking table
-				if err := h.store.MarkPieceFailed(ctx, pullID, cidV1Str, reason); err != nil {
-					log.Errorw("failed to mark piece as failed", "error", err, "pieceCid", cidV1Str)
-				}
-				return PullStatusFailed
-			}
-
-			// Task deleted but not due to exhausted retries, mark as failed
-			if err := h.store.MarkPieceFailed(ctx, pullID, cidV1Str, "pull task orphaned without failure record"); err != nil {
-				log.Errorw("failed to mark piece as failed", "error", err, "pieceCid", cidV1Str)
-			}
-			return PullStatusFailed
-		}
-	}
-
-	// Pull task completed successfully, check parked_pieces status
-	if ps != nil {
-		// Complete
-		if ps.Complete {
-			return PullStatusComplete
-		}
-
-		// StorePiece task is assigned
-		if ps.TaskID != nil {
-			if ps.TaskExists {
-				// Task is alive
-				if ps.Retries > 0 {
-					return PullStatusRetrying
-				}
-				return PullStatusInProgress
-			}
-
-			// StorePiece task was deleted, check if it failed permanently
-			exhausted, reason, err := h.store.CheckTaskExhaustedRetries(ctx, *ps.TaskID)
-			if err != nil {
-				log.Errorw("failed to check task history", "error", err, "taskId", *ps.TaskID)
-				return PullStatusPending
-			}
-
-			if exhausted {
-				// Mark as failed
-				if err := h.store.MarkPieceFailed(ctx, pullID, cidV1Str, "StorePiece: "+reason); err != nil {
-					log.Errorw("failed to mark piece as failed", "error", err, "pieceCid", cidV1Str)
-				}
-				return PullStatusFailed
-			}
-
-			// StorePiece task orphaned, mark as failed
-			if err := h.store.MarkPieceFailed(ctx, pullID, cidV1Str, "StorePiece task orphaned without failure record"); err != nil {
-				log.Errorw("failed to mark piece as failed", "error", err, "pieceCid", cidV1Str)
-			}
-			return PullStatusFailed
-		}
-
-		// parked_pieces exists but task_id is NULL and not complete, waiting for StorePiece to pick up
-		return PullStatusInProgress
-	}
-
-	// No parked_pieces yet, waiting for pull task to pick up
-	return PullStatusPending
-}
-
-// dbPullStore implements PullStore using harmonydb
-type dbPullStore struct {
-	db *harmonydb.DB
-}
-
-// NewDBPullStore creates a PullStore backed by harmonydb
-func NewDBPullStore(db *harmonydb.DB) PullStore {
-	return &dbPullStore{db: db}
-}
-
-func (s *dbPullStore) GetPullByKey(ctx context.Context, service string, hash []byte, dataSetId uint64, recordKeeper string) (*PullRecord, error) {
-	var records []struct {
-		ID            int64  `db:"id"`
-		Service       string `db:"service"`
-		ExtraDataHash []byte `db:"extra_data_hash"`
-		DataSetId     uint64 `db:"data_set_id"`
-		RecordKeeper  string `db:"record_keeper"`
-	}
-
-	err := s.db.Select(ctx, &records, `
-		SELECT id, service, extra_data_hash, data_set_id, record_keeper
-		FROM pdp_piece_pulls
-		WHERE service = $1 AND extra_data_hash = $2 AND data_set_id = $3 AND record_keeper = $4
-	`, service, hash, dataSetId, recordKeeper)
-	if err != nil {
-		return nil, fmt.Errorf("query pull by key: %w", err)
-	}
-
-	if len(records) == 0 {
-		return nil, nil
-	}
-
-	return &PullRecord{
-		ID:            records[0].ID,
-		Service:       records[0].Service,
-		ExtraDataHash: records[0].ExtraDataHash,
-		DataSetId:     records[0].DataSetId,
-		RecordKeeper:  records[0].RecordKeeper,
-	}, nil
-}
-
-func (s *dbPullStore) CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, error) {
-	var pullID int64
-
-	_, err := s.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
-		// Insert pull record and get the auto-generated ID
-		err := tx.QueryRow(`
-			INSERT INTO pdp_piece_pulls (service, extra_data_hash, data_set_id, record_keeper)
-			VALUES ($1, $2, $3, $4)
-			RETURNING id
-		`, pull.Service, pull.ExtraDataHash, pull.DataSetId, pull.RecordKeeper).Scan(&pullID)
-		if err != nil {
-			return false, fmt.Errorf("insert pull: %w", err)
-		}
-
-		// Insert piece items with raw size and source_url for task to pick up
-		for _, piece := range pieces {
-			_, err := tx.Exec(`
-				INSERT INTO pdp_piece_pull_items (fetch_id, piece_cid, piece_raw_size, source_url)
-				VALUES ($1, $2, $3, $4)
-			`, pullID, piece.CidV1.String(), piece.RawSize, piece.SourceURL)
-			if err != nil {
-				return false, fmt.Errorf("insert pull item: %w", err)
-			}
-		}
-
-		return true, nil
-	}, harmonydb.OptionRetry())
-
-	return pullID, err
-}
-
-func (s *dbPullStore) GetPieceStatuses(ctx context.Context, pieceCids []cid.Cid) (map[string]*PieceStatus, error) {
-	if len(pieceCids) == 0 {
-		return make(map[string]*PieceStatus), nil
-	}
-
-	// Build array of CID strings for batch query
-	cidStrs := make([]string, len(pieceCids))
-	for i, c := range pieceCids {
-		cidStrs[i] = c.String()
-	}
-
-	var pieces []struct {
-		PieceCid   string `db:"piece_cid"`
-		Complete   bool   `db:"complete"`
-		TaskID     *int64 `db:"task_id"`
-		TaskExists bool   `db:"task_exists"`
-		Retries    int    `db:"retries"`
-	}
-
-	// Batch query with ANY() for all CIDs at once
-	err := s.db.Select(ctx, &pieces, `
-		SELECT pp.piece_cid, pp.complete, pp.task_id,
-		       (ht.id IS NOT NULL) as task_exists,
-		       COALESCE(ht.retries, 0) as retries
-		FROM parked_pieces pp
-		LEFT JOIN harmony_task ht ON pp.task_id = ht.id
-		WHERE pp.piece_cid = ANY($1) AND pp.long_term = TRUE AND pp.cleanup_task_id IS NULL
-	`, cidStrs)
-	if err != nil {
-		return nil, fmt.Errorf("query piece statuses: %w", err)
-	}
-
-	result := make(map[string]*PieceStatus)
-	for _, p := range pieces {
-		result[p.PieceCid] = &PieceStatus{
-			PieceCid:   p.PieceCid,
-			Complete:   p.Complete,
-			TaskID:     p.TaskID,
-			TaskExists: p.TaskExists,
-			Retries:    p.Retries,
-		}
-	}
-
-	return result, nil
-}
-
-func (s *dbPullStore) GetPullItemStatuses(ctx context.Context, pullID int64, pieceCids []cid.Cid) (map[string]*PullItemStatus, error) {
-	if len(pieceCids) == 0 {
-		return make(map[string]*PullItemStatus), nil
-	}
-
-	// Build array of CID strings for batch query
-	cidStrs := make([]string, len(pieceCids))
-	for i, c := range pieceCids {
-		cidStrs[i] = c.String()
-	}
-
-	var items []struct {
-		PieceCid   string `db:"piece_cid"`
-		TaskID     *int64 `db:"task_id"`
-		TaskExists bool   `db:"task_exists"`
-		Retries    int    `db:"retries"`
-		Failed     bool   `db:"failed"`
-	}
-
-	// Batch query with ANY() for all CIDs at once
-	err := s.db.Select(ctx, &items, `
-		SELECT fi.piece_cid, fi.task_id, fi.failed,
-		       (ht.id IS NOT NULL) as task_exists,
-		       COALESCE(ht.retries, 0) as retries
-		FROM pdp_piece_pull_items fi
-		LEFT JOIN harmony_task ht ON fi.task_id = ht.id
-		WHERE fi.fetch_id = $1 AND fi.piece_cid = ANY($2)
-	`, pullID, cidStrs)
-	if err != nil {
-		return nil, fmt.Errorf("query pull item statuses: %w", err)
-	}
-
-	result := make(map[string]*PullItemStatus)
-	for _, item := range items {
-		result[item.PieceCid] = &PullItemStatus{
-			TaskID:     item.TaskID,
-			TaskExists: item.TaskExists,
-			Retries:    item.Retries,
-			Failed:     item.Failed,
-		}
-	}
-
-	return result, nil
-}
-
-func (s *dbPullStore) GetPullPieces(ctx context.Context, pullID int64) ([]PullPiece, error) {
-	var items []struct {
-		PieceCid     string  `db:"piece_cid"`
-		PieceRawSize uint64  `db:"piece_raw_size"`
-		SourceURL    string  `db:"source_url"`
-		Failed       bool    `db:"failed"`
-		FailReason   *string `db:"fail_reason"`
-	}
-
-	err := s.db.Select(ctx, &items, `
-		SELECT piece_cid, piece_raw_size, source_url, failed, fail_reason
-		FROM pdp_piece_pull_items WHERE fetch_id = $1
-	`, pullID)
-	if err != nil {
-		return nil, fmt.Errorf("query pull items: %w", err)
-	}
-
-	result := make([]PullPiece, len(items))
-	for i, item := range items {
-		c, err := cid.Parse(item.PieceCid)
-		if err != nil {
-			return nil, fmt.Errorf("parse CID %q: %w", item.PieceCid, err)
-		}
-		failReason := ""
-		if item.FailReason != nil {
-			failReason = *item.FailReason
-		}
-		result[i] = PullPiece{
-			CidV1:      c,
-			RawSize:    item.PieceRawSize,
-			SourceURL:  item.SourceURL,
-			Failed:     item.Failed,
-			FailReason: failReason,
-		}
-	}
-
-	return result, nil
-}
-
-func (s *dbPullStore) MarkPieceFailed(ctx context.Context, pullID int64, pieceCid string, reason string) error {
-	_, err := s.db.Exec(ctx, `
-		UPDATE pdp_piece_pull_items
-		SET failed = TRUE, fail_reason = $3
-		WHERE fetch_id = $1 AND piece_cid = $2
-	`, pullID, pieceCid, reason)
-	if err != nil {
-		return fmt.Errorf("mark piece failed: %w", err)
-	}
-	return nil
-}
-
-func (s *dbPullStore) CheckTaskExhaustedRetries(ctx context.Context, taskID int64) (bool, string, error) {
-	// Look up the last history entry for this task to check if it failed
-	var history []struct {
-		Result bool    `db:"result"` // true = success, false = failure
-		Err    *string `db:"err"`    // error message when result is false
-	}
-
-	err := s.db.Select(ctx, &history, `
-		SELECT result, err FROM harmony_task_history
-		WHERE task_id = $1
-		ORDER BY id DESC
-		LIMIT 1
-	`, taskID)
-	if err != nil {
-		return false, "", fmt.Errorf("query task history: %w", err)
-	}
-
-	if len(history) == 0 {
-		// Task may have been cleaned up or never ran
-		return false, "", nil
-	}
-
-	// result=false means the task failed
-	if !history[0].Result {
-		reason := "unknown error"
-		if history[0].Err != nil {
-			reason = *history[0].Err
-		}
-		return true, reason, nil
-	}
-
-	return false, "", nil
 }

--- a/pdp/handlers_pull.go
+++ b/pdp/handlers_pull.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/lib/ethchain"
 	"github.com/filecoin-project/curio/pdp/contract"
+	"github.com/filecoin-project/curio/pdp/contract/FWSS"
 )
 
 // getPDPSenderAddress retrieves the PDP key address from the database
@@ -47,6 +48,9 @@ type AddPiecesValidator interface {
 	// ValidateAddPieces performs an eth_call to validate the extraData
 	// Returns nil if validation passes, error otherwise
 	ValidateAddPieces(ctx context.Context, params *AddPiecesValidatorParams) error
+
+	// GetDataSetPayer returns the FWSS payer for an existing data set.
+	GetDataSetPayer(ctx context.Context, dataSetId uint64) (common.Address, error)
 }
 
 // EthCallValidator validates via eth_call to PDPVerifier contract
@@ -105,6 +109,33 @@ func (v *EthCallValidator) ValidateAddPieces(ctx context.Context, params *AddPie
 	}
 
 	return nil
+}
+
+func (v *EthCallValidator) GetDataSetPayer(ctx context.Context, dataSetId uint64) (common.Address, error) {
+	if dataSetId == 0 {
+		return common.Address{}, fmt.Errorf("dataSetId must be greater than 0")
+	}
+
+	serviceAddr := contract.ContractAddresses().AllowedPublicRecordKeepers.FWSService
+	viewAddr, err := contract.ResolveViewAddress(ctx, serviceAddr, v.ethClient)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("resolve FWSS view address: %w", err)
+	}
+
+	fwssView, err := FWSS.NewFilecoinWarmStorageServiceStateView(viewAddr, v.ethClient)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("bind FWSS state view: %w", err)
+	}
+
+	dataSet, err := fwssView.GetDataSet(contract.EthCallOpts(ctx), new(big.Int).SetUint64(dataSetId))
+	if err != nil {
+		return common.Address{}, fmt.Errorf("get FWSS data set %d: %w", dataSetId, err)
+	}
+	if dataSet.Payer == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("data set %d payer is zero address", dataSetId)
+	}
+
+	return dataSet.Payer, nil
 }
 
 // PullHandler handles piece pull requests
@@ -281,11 +312,6 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	extraDataHash := sha256.Sum256(extraDataBytes)
-	payer, err := FWSSPayerFromExtraData(extraDataBytes)
-	if err != nil {
-		httpServerError(w, http.StatusBadRequest, "Invalid extraData payer: "+err.Error(), err)
-		return
-	}
 
 	// Build idempotency key components
 	var dataSetId uint64
@@ -308,6 +334,17 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 	if existingPull != nil {
 		// Return existing status
 		h.respondWithStatus(ctx, w, existingPull.ID)
+		return
+	}
+
+	var payer common.Address
+	if dataSetId == 0 {
+		payer, err = FWSSPayerFromExtraData(extraDataBytes)
+	} else {
+		payer, err = h.validator.GetDataSetPayer(ctx, dataSetId)
+	}
+	if err != nil {
+		httpServerError(w, http.StatusBadRequest, "Invalid pull payer: "+err.Error(), err)
 		return
 	}
 

--- a/pdp/handlers_pull_backpressure_test.go
+++ b/pdp/handlers_pull_backpressure_test.go
@@ -1,0 +1,366 @@
+package pdp
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+)
+
+const (
+	pullStressGlobalLimit    = 128
+	pullStressPerClientLimit = 10
+)
+
+type pdpPullStressStats struct {
+	mu                      sync.Mutex
+	accepted                int
+	rejected                int
+	completedGroups         int
+	acceptedAfterCompletion int
+	maxGlobalPending        int
+	maxClientPending        int
+	violations              []string
+}
+
+func TestHandlePull_BackpressureStress(t *testing.T) {
+	const (
+		clientCount       = 20
+		attemptsPerClient = 100
+		piecePoolSize     = 512
+		maxBatchSize      = 8
+	)
+
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	rawSizes := []uint64{127, 254, 508, 1016, 2032, 4096, 16384, 65536}
+	piecePool := make([]string, piecePoolSize)
+	for i := range piecePool {
+		piecePool[i] = generatedPieceCIDV2(t, i+1, rawSizes[i%len(rawSizes)])
+	}
+
+	stats := &pdpPullStressStats{}
+	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true})
+	dataSetID := testDataSetId
+
+	testCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, clientCount*attemptsPerClient)
+	var wg sync.WaitGroup
+
+	monitorDone := make(chan struct{})
+	go func() {
+		defer close(monitorDone)
+		ticker := time.NewTicker(2 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-testCtx.Done():
+				return
+			case <-ticker.C:
+				if err := stats.recordDBCounts(testCtx, db, "monitor"); err != nil {
+					if testCtx.Err() != nil {
+						return
+					}
+					errCh <- err
+					return
+				}
+			}
+		}
+	}()
+
+	completeDone := make(chan struct{})
+	go func() {
+		defer close(completeDone)
+		rng := rand.New(rand.NewSource(9001))
+		for {
+			select {
+			case <-testCtx.Done():
+				return
+			default:
+			}
+
+			time.Sleep(time.Duration(2+rng.Intn(5)) * time.Millisecond)
+			completed, err := completeRandomPullPieceGroup(testCtx, db, rng)
+			if err != nil {
+				if testCtx.Err() != nil {
+					return
+				}
+				errCh <- err
+				return
+			}
+			if completed {
+				stats.recordCompletion()
+				if err := stats.recordDBCounts(testCtx, db, "complete"); err != nil {
+					if testCtx.Err() != nil {
+						return
+					}
+					errCh <- err
+					return
+				}
+			}
+		}
+	}()
+
+	for clientIdx := 0; clientIdx < clientCount; clientIdx++ {
+		wg.Add(1)
+		go func(clientIdx int) {
+			defer wg.Done()
+
+			rng := rand.New(rand.NewSource(int64(1000 + clientIdx)))
+			payer := common.BigToAddress(big.NewInt(int64(clientIdx + 1)))
+			for attempt := 0; attempt < attemptsPerClient; attempt++ {
+				select {
+				case <-testCtx.Done():
+					return
+				default:
+				}
+
+				nonce := int64((clientIdx+1)*1_000_000 + attempt)
+				extraData, err := makeTestExtraData(payer, nonce)
+				if err != nil {
+					errCh <- err
+					return
+				}
+
+				pieces := randomPullPieces(rng, piecePool, maxBatchSize)
+				bodyBytes, err := json.Marshal(PullRequest{
+					ExtraData: extraData,
+					DataSetId: &dataSetID,
+					Pieces:    pieces,
+				})
+				if err != nil {
+					errCh <- err
+					return
+				}
+
+				req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+				rec := httptest.NewRecorder()
+				handler.HandlePull(rec, req)
+				switch rec.Code {
+				case http.StatusOK:
+					stats.recordAccepted()
+				case http.StatusTooManyRequests:
+					stats.recordRejected()
+				default:
+					errCh <- fmt.Errorf("unexpected status %d: %s", rec.Code, rec.Body.String())
+					return
+				}
+
+				if err := stats.recordDBCounts(testCtx, db, "request"); err != nil {
+					errCh <- err
+					return
+				}
+				time.Sleep(time.Duration(rng.Intn(3)) * time.Millisecond)
+			}
+		}(clientIdx)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-testCtx.Done():
+		require.NoError(t, testCtx.Err())
+	}
+	cancel()
+	<-monitorDone
+	<-completeDone
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	require.NoError(t, stats.recordDBCounts(ctx, db, "final"))
+
+	snapshot := stats.snapshot()
+	require.Empty(t, snapshot.violations)
+	require.Greater(t, snapshot.accepted, 0)
+	require.Greater(t, snapshot.rejected, 0)
+	require.Greater(t, snapshot.completedGroups, 0)
+	require.Greater(t, snapshot.acceptedAfterCompletion, 0)
+	require.LessOrEqual(t, snapshot.maxGlobalPending, pullStressGlobalLimit)
+	require.LessOrEqual(t, snapshot.maxClientPending, pullStressPerClientLimit)
+	require.GreaterOrEqual(t, snapshot.maxGlobalPending, pullStressGlobalLimit/2)
+	require.GreaterOrEqual(t, snapshot.maxClientPending, pullStressPerClientLimit/2)
+}
+
+func generatedPieceCIDV2(t *testing.T, seed int, rawSize uint64) string {
+	t.Helper()
+
+	var commP [32]byte
+	binary.BigEndian.PutUint64(commP[:8], uint64(seed))
+	binary.BigEndian.PutUint64(commP[8:16], rawSize)
+	pieceCID, err := commcid.DataCommitmentToPieceCidv2(commP[:], rawSize)
+	require.NoError(t, err)
+	return pieceCID.String()
+}
+
+func randomPullPieces(rng *rand.Rand, piecePool []string, maxBatchSize int) []PullPieceRequest {
+	batchSize := 1 + rng.Intn(maxBatchSize)
+	pieces := make([]PullPieceRequest, 0, batchSize)
+	seen := map[string]struct{}{}
+	for len(pieces) < batchSize {
+		pieceCID := piecePool[rng.Intn(len(piecePool))]
+		if _, ok := seen[pieceCID]; ok {
+			continue
+		}
+		seen[pieceCID] = struct{}{}
+		pieces = append(pieces, PullPieceRequest{
+			PieceCid:  pieceCID,
+			SourceURL: "https://source.example/piece/" + pieceCID,
+		})
+	}
+	return pieces
+}
+
+func completeRandomPullPieceGroup(ctx context.Context, db *harmonydb.DB, rng *rand.Rand) (bool, error) {
+	var groups []struct {
+		PieceCID     string `db:"piece_cid"`
+		PieceRawSize uint64 `db:"piece_raw_size"`
+	}
+	err := db.Select(ctx, &groups, `
+		SELECT piece_cid, piece_raw_size
+		FROM pdp_piece_pull_items
+		WHERE complete = FALSE
+			AND failed = FALSE
+		GROUP BY piece_cid, piece_raw_size
+	`)
+	if err != nil {
+		return false, err
+	}
+	if len(groups) == 0 {
+		return false, nil
+	}
+
+	group := groups[rng.Intn(len(groups))]
+	_, err = db.Exec(ctx, `
+		UPDATE pdp_piece_pull_items
+		SET complete = TRUE
+		WHERE piece_cid = $1
+			AND piece_raw_size = $2
+			AND complete = FALSE
+			AND failed = FALSE
+	`, group.PieceCID, group.PieceRawSize)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *pdpPullStressStats) recordAccepted() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.accepted++
+	if s.completedGroups > 0 {
+		s.acceptedAfterCompletion++
+	}
+}
+
+func (s *pdpPullStressStats) recordRejected() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rejected++
+}
+
+func (s *pdpPullStressStats) recordCompletion() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.completedGroups++
+}
+
+func (s *pdpPullStressStats) recordDBCounts(ctx context.Context, db *harmonydb.DB, event string) error {
+	globalPending, maxClientPending, err := pullStressActiveCounts(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if globalPending > s.maxGlobalPending {
+		s.maxGlobalPending = globalPending
+	}
+	if maxClientPending > s.maxClientPending {
+		s.maxClientPending = maxClientPending
+	}
+	if globalPending > pullStressGlobalLimit {
+		s.violations = append(s.violations, fmt.Sprintf("%s: global pending %d > %d", event, globalPending, pullStressGlobalLimit))
+	}
+	if maxClientPending > pullStressPerClientLimit {
+		s.violations = append(s.violations, fmt.Sprintf("%s: per-client pending %d > %d", event, maxClientPending, pullStressPerClientLimit))
+	}
+	return nil
+}
+
+func (s *pdpPullStressStats) snapshot() pdpPullStressStats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return pdpPullStressStats{
+		accepted:                s.accepted,
+		rejected:                s.rejected,
+		completedGroups:         s.completedGroups,
+		acceptedAfterCompletion: s.acceptedAfterCompletion,
+		maxGlobalPending:        s.maxGlobalPending,
+		maxClientPending:        s.maxClientPending,
+		violations:              append([]string(nil), s.violations...),
+	}
+}
+
+func pullStressActiveCounts(ctx context.Context, db *harmonydb.DB) (int, int, error) {
+	var globalPending int
+	err := db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM (
+			SELECT DISTINCT piece_cid, piece_raw_size
+			FROM pdp_piece_pull_items
+			WHERE complete = FALSE
+				AND failed = FALSE
+		) active
+	`).Scan(&globalPending)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	var maxClientPending int
+	err = db.QueryRow(ctx, `
+		SELECT COALESCE(MAX(piece_count), 0)
+		FROM (
+			SELECT client_address, COUNT(*) AS piece_count
+			FROM (
+				SELECT DISTINCT pp.client_address, fi.piece_cid, fi.piece_raw_size
+				FROM pdp_piece_pull_items fi
+				JOIN pdp_piece_pulls pp ON pp.id = fi.fetch_id
+				WHERE fi.complete = FALSE
+					AND fi.failed = FALSE
+			) active
+			GROUP BY client_address
+		) client_counts
+	`).Scan(&maxClientPending)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return globalPending, maxClientPending, nil
+}

--- a/pdp/handlers_pull_backpressure_test.go
+++ b/pdp/handlers_pull_backpressure_test.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	pullStressGlobalLimit    = 128
-	pullStressPerClientLimit = 10
+	pullStressGlobalLimit     = pullGlobalPendingLimit
+	pullStressPerClientLimit  = pullPerClientPendingLimit
+	pullStressSoloClientLimit = pullGlobalPendingLimit * pullSoloClientPendingPercentage / 100
 )
 
 type pdpPullStressStats struct {
@@ -202,9 +203,73 @@ func TestHandlePull_BackpressureStress(t *testing.T) {
 	require.Greater(t, snapshot.completedGroups, 0)
 	require.Greater(t, snapshot.acceptedAfterCompletion, 0)
 	require.LessOrEqual(t, snapshot.maxGlobalPending, pullStressGlobalLimit)
-	require.LessOrEqual(t, snapshot.maxClientPending, pullStressPerClientLimit)
+	require.LessOrEqual(t, snapshot.maxClientPending, pullStressSoloClientLimit)
 	require.GreaterOrEqual(t, snapshot.maxGlobalPending, pullStressGlobalLimit/2)
 	require.GreaterOrEqual(t, snapshot.maxClientPending, pullStressPerClientLimit/2)
+}
+
+func TestHandlePull_BackpressureSoloClientCanUseNinetyPercent(t *testing.T) {
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true})
+	dataSetID := testDataSetId
+	rawSizes := []uint64{127, 254, 508, 1016}
+	piecePool := make([]string, pullStressSoloClientLimit+1)
+	for i := range piecePool {
+		piecePool[i] = generatedPieceCIDV2(t, i+10_000, rawSizes[i%len(rawSizes)])
+	}
+
+	payer := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	rec := submitPullStressRequest(t, handler, payer, 1, dataSetID, pullPiecesFromCIDs(piecePool[:pullStressSoloClientLimit]))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = submitPullStressRequest(t, handler, payer, 2, dataSetID, pullPiecesFromCIDs(piecePool[pullStressSoloClientLimit:]))
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Equal(t, "60", rec.Header().Get("Retry-After"))
+}
+
+func TestHandlePull_BackpressureClientCanBorrowUnusedSlots(t *testing.T) {
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true})
+	dataSetID := testDataSetId
+	rawSizes := []uint64{127, 254, 508, 1016}
+	piecePool := make([]string, 31)
+	for i := range piecePool {
+		piecePool[i] = generatedPieceCIDV2(t, i+20_000, rawSizes[i%len(rawSizes)])
+	}
+
+	firstClient := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	secondClient := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	rec := submitPullStressRequest(t, handler, firstClient, 1, dataSetID, pullPiecesFromCIDs(piecePool[:20]))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = submitPullStressRequest(t, handler, secondClient, 2, dataSetID, pullPiecesFromCIDs(piecePool[20:]))
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandlePull_BackpressureClientLimitAppliesNearGlobalReserve(t *testing.T) {
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true})
+	dataSetID := testDataSetId
+	rawSizes := []uint64{127, 254, 508, 1016}
+	piecePool := make([]string, pullStressSoloClientLimit+1)
+	for i := range piecePool {
+		piecePool[i] = generatedPieceCIDV2(t, i+30_000, rawSizes[i%len(rawSizes)])
+	}
+
+	firstClient := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	secondClient := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	rec := submitPullStressRequest(t, handler, firstClient, 1, dataSetID, pullPiecesFromCIDs(piecePool[:pullStressSoloClientLimit-pullStressPerClientLimit]))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec = submitPullStressRequest(t, handler, secondClient, 2, dataSetID, pullPiecesFromCIDs(piecePool[pullStressSoloClientLimit-pullStressPerClientLimit:]))
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Equal(t, "60", rec.Header().Get("Retry-After"))
 }
 
 func generatedPieceCIDV2(t *testing.T, seed int, rawSize uint64) string {
@@ -308,10 +373,40 @@ func (s *pdpPullStressStats) recordDBCounts(ctx context.Context, db *harmonydb.D
 	if globalPending > pullStressGlobalLimit {
 		s.violations = append(s.violations, fmt.Sprintf("%s: global pending %d > %d", event, globalPending, pullStressGlobalLimit))
 	}
-	if maxClientPending > pullStressPerClientLimit {
-		s.violations = append(s.violations, fmt.Sprintf("%s: per-client pending %d > %d", event, maxClientPending, pullStressPerClientLimit))
+	if maxClientPending > pullStressSoloClientLimit {
+		s.violations = append(s.violations, fmt.Sprintf("%s: per-client pending %d > %d", event, maxClientPending, pullStressSoloClientLimit))
 	}
 	return nil
+}
+
+func pullPiecesFromCIDs(pieceCIDs []string) []PullPieceRequest {
+	pieces := make([]PullPieceRequest, len(pieceCIDs))
+	for i, pieceCID := range pieceCIDs {
+		pieces[i] = PullPieceRequest{
+			PieceCid:  pieceCID,
+			SourceURL: "https://source.example/piece/" + pieceCID,
+		}
+	}
+	return pieces
+}
+
+func submitPullStressRequest(t *testing.T, handler *PullHandler, payer common.Address, nonce int64, dataSetID uint64, pieces []PullPieceRequest) *httptest.ResponseRecorder {
+	t.Helper()
+
+	extraData, err := makeTestExtraData(payer, nonce)
+	require.NoError(t, err)
+
+	bodyBytes, err := json.Marshal(PullRequest{
+		ExtraData: extraData,
+		DataSetId: &dataSetID,
+		Pieces:    pieces,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+	handler.HandlePull(rec, req)
+	return rec
 }
 
 func (s *pdpPullStressStats) snapshot() pdpPullStressStats {

--- a/pdp/handlers_pull_test.go
+++ b/pdp/handlers_pull_test.go
@@ -3,13 +3,17 @@ package pdp
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
-	"github.com/ipfs/go-cid"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/snadrus/must"
 	"github.com/stretchr/testify/require"
 )
@@ -17,81 +21,48 @@ import (
 // mockPullStore implements PullStore for testing
 type mockPullStore struct {
 	// Configuration for mock behavior
-	existingPull     *PullRecord
-	pieceStatuses    map[string]*PieceStatus    // keyed by v1 CID string (from parked_pieces)
-	pullItemStatuses map[string]*PullItemStatus // keyed by v1 CID string (from pdp_piece_pull_items)
-	pullPieces       []PullPiece                // v1 CID + raw size + source_url
-	createError      error
-
-	// Failure tracking configuration
-	exhaustedTasks map[int64]string // taskID -> error reason (for CheckTaskExhaustedRetries)
+	existingPull *PullRecord
+	pullPieces   []PullPieceStatus
+	createError  error
+	backpressure bool
 
 	// Tracking calls
-	createPullCalled          bool
-	createdPull               *PullRecord
-	createdPieces             []PullPiece // v1 CID + raw size + source_url
-	getStatusesCalled         bool
-	getPullItemStatusesCalled bool
-	getPullPiecesCalled       bool
-	lastCreatedID             int64
-	markedFailed              map[string]string // v1 CID -> reason
+	createPullCalled    bool
+	createdPull         *PullRecord
+	createdPieces       []PullPiece // v1 CID + raw size + source_url
+	getPullPiecesCalled bool
+	lastCreatedID       int64
 }
 
 func (m *mockPullStore) GetPullByKey(ctx context.Context, service string, hash []byte, dataSetId uint64, recordKeeper string) (*PullRecord, error) {
 	return m.existingPull, nil
 }
 
-func (m *mockPullStore) CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, error) {
+func (m *mockPullStore) CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, bool, error) {
 	m.createPullCalled = true
 	m.createdPull = pull
 	m.createdPieces = pieces
 	if m.createError != nil {
-		return 0, m.createError
+		return 0, false, m.createError
 	}
 	m.lastCreatedID++
-	return m.lastCreatedID, nil
+	return m.lastCreatedID, m.backpressure, nil
 }
 
-func (m *mockPullStore) GetPieceStatuses(ctx context.Context, pieceCids []cid.Cid) (map[string]*PieceStatus, error) {
-	m.getStatusesCalled = true
-	if m.pieceStatuses == nil {
-		return make(map[string]*PieceStatus), nil
-	}
-	return m.pieceStatuses, nil
-}
-
-func (m *mockPullStore) GetPullItemStatuses(ctx context.Context, pullID int64, pieceCids []cid.Cid) (map[string]*PullItemStatus, error) {
-	m.getPullItemStatusesCalled = true
-	if m.pullItemStatuses == nil {
-		return make(map[string]*PullItemStatus), nil
-	}
-	return m.pullItemStatuses, nil
-}
-
-func (m *mockPullStore) GetPullPieces(ctx context.Context, pullID int64) ([]PullPiece, error) {
+func (m *mockPullStore) GetPullStatus(ctx context.Context, pullID int64) ([]PullPieceStatus, error) {
 	m.getPullPiecesCalled = true
 	if m.pullPieces != nil {
 		return m.pullPieces, nil
 	}
-	// Return the pieces that were created
-	return m.createdPieces, nil
-}
-
-func (m *mockPullStore) MarkPieceFailed(ctx context.Context, pullID int64, pieceCid string, reason string) error {
-	if m.markedFailed == nil {
-		m.markedFailed = make(map[string]string)
-	}
-	m.markedFailed[pieceCid] = reason
-	return nil
-}
-
-func (m *mockPullStore) CheckTaskExhaustedRetries(ctx context.Context, taskID int64) (bool, string, error) {
-	if m.exhaustedTasks != nil {
-		if reason, ok := m.exhaustedTasks[taskID]; ok {
-			return true, reason, nil
+	pieces := make([]PullPieceStatus, len(m.createdPieces))
+	for i, piece := range m.createdPieces {
+		info, err := PieceCidV2FromV1(piece.CidV1, piece.RawSize)
+		if err != nil {
+			return nil, err
 		}
+		pieces[i] = PullPieceStatus{PieceCid: info.CidV2.String(), Status: PullStatusPending}
 	}
-	return false, "", nil
+	return pieces, nil
 }
 
 // mockValidator implements AddPiecesValidator for testing
@@ -120,12 +91,61 @@ const (
 // Test dataSetId for "add to existing dataset" case (avoids recordKeeper requirement)
 var testDataSetId = uint64(1)
 
-// testParsePieceCidV2 is a test helper that parses a v2 CID and returns PullPiece (v1 + raw size)
-func testParsePieceCidV2(t *testing.T, cidV2Str string) PullPiece {
+func testExtraData(t *testing.T) string {
 	t.Helper()
-	info, err := ParsePieceCidV2(cidV2Str)
+
+	extraData, err := makeTestExtraData(common.HexToAddress("0x1111111111111111111111111111111111111111"), 1)
 	require.NoError(t, err)
-	return PullPiece{CidV1: info.CidV1, RawSize: info.RawSize}
+	return extraData
+}
+
+func makeTestExtraData(payer common.Address, nonce int64) (string, error) {
+	bytesType, err := abi.NewType("bytes", "", nil)
+	if err != nil {
+		return "", err
+	}
+	addressType, err := abi.NewType("address", "", nil)
+	if err != nil {
+		return "", err
+	}
+	uint256Type, err := abi.NewType("uint256", "", nil)
+	if err != nil {
+		return "", err
+	}
+	stringArrayType, err := abi.NewType("string[]", "", nil)
+	if err != nil {
+		return "", err
+	}
+
+	createArgs := abi.Arguments{
+		{Type: addressType},
+		{Type: uint256Type},
+		{Type: stringArrayType},
+		{Type: stringArrayType},
+		{Type: bytesType},
+	}
+	createPayload, err := createArgs.Pack(
+		payer,
+		big.NewInt(nonce),
+		[]string{},
+		[]string{},
+		[]byte("signature-"+strconv.FormatInt(nonce, 10)),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	outerArgs := abi.Arguments{{Type: bytesType}, {Type: bytesType}}
+	extraData, err := outerArgs.Pack(createPayload, []byte{})
+	if err != nil {
+		return "", err
+	}
+
+	return "0x" + hex.EncodeToString(extraData), nil
+}
+
+func testPullPieceStatus(cidV2Str string, status PullStatus) PullPieceStatus {
+	return PullPieceStatus{PieceCid: cidV2Str, Status: status}
 }
 
 func TestHandlePull_MethodNotAllowed(t *testing.T) {
@@ -174,7 +194,7 @@ func TestHandlePull_NoPieces(t *testing.T) {
 	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
 
 	body := PullRequest{
-		ExtraData: "0x1234",
+		ExtraData: testExtraData(t),
 		DataSetId: &testDataSetId,
 		Pieces:    []PullPieceRequest{},
 	}
@@ -192,7 +212,7 @@ func TestHandlePull_InvalidSourceURL(t *testing.T) {
 	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
 
 	body := PullRequest{
-		ExtraData: "0x1234",
+		ExtraData: testExtraData(t),
 		DataSetId: &testDataSetId,
 		Pieces: []PullPieceRequest{
 			{PieceCid: testCid1, SourceURL: "http://example.com/piece/" + testCid1}, // HTTP not HTTPS
@@ -214,7 +234,7 @@ func TestHandlePull_ValidatorFails(t *testing.T) {
 	handler := NewPullHandler(&NullAuth{}, store, validator)
 
 	body := PullRequest{
-		ExtraData: "0x1234",
+		ExtraData: testExtraData(t),
 		DataSetId: &testDataSetId,
 		Pieces: []PullPieceRequest{
 			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
@@ -238,7 +258,7 @@ func TestHandlePull_NewRequest_Success(t *testing.T) {
 	handler := NewPullHandler(&NullAuth{}, store, validator)
 
 	body := PullRequest{
-		ExtraData: "0x1234",
+		ExtraData: testExtraData(t),
 		DataSetId: &testDataSetId,
 		Pieces: []PullPieceRequest{
 			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
@@ -283,7 +303,7 @@ func TestHandlePull_CreateNew_MissingRecordKeeper(t *testing.T) {
 
 	// dataSetId omitted (nil) requires recordKeeper
 	body := PullRequest{
-		ExtraData: "0x1234",
+		ExtraData: testExtraData(t),
 		// DataSetId: nil (omitted = create new)
 		// RecordKeeper: nil (missing - should fail)
 		Pieces: []PullPieceRequest{
@@ -318,7 +338,7 @@ func TestHandlePull_CreateNew_Success(t *testing.T) {
 
 	// dataSetId omitted (nil) with recordKeeper = create new dataset
 	body := PullRequest{
-		ExtraData:    "0x1234",
+		ExtraData:    testExtraData(t),
 		RecordKeeper: &testRecordKeeper,
 		Pieces: []PullPieceRequest{
 			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
@@ -340,26 +360,19 @@ func TestHandlePull_CreateNew_Success(t *testing.T) {
 }
 
 func TestHandlePull_Idempotent(t *testing.T) {
-	// Get v1 CID info for test setup
-	piece1 := testParsePieceCidV2(t, testCid1)
-	v1Str1 := piece1.CidV1.String()
-
 	store := &mockPullStore{
 		existingPull: &PullRecord{
 			ID:            123,
 			Service:       "public",
 			ExtraDataHash: []byte("hash"),
 		},
-		pullPieces: []PullPiece{piece1},
-		pieceStatuses: map[string]*PieceStatus{
-			v1Str1: {PieceCid: v1Str1, Complete: true},
-		},
+		pullPieces: []PullPieceStatus{testPullPieceStatus(testCid1, PullStatusComplete)},
 	}
 	validator := &mockValidator{shouldPass: true}
 	handler := NewPullHandler(&NullAuth{}, store, validator)
 
 	body := PullRequest{
-		ExtraData: "0x1234",
+		ExtraData: testExtraData(t),
 		DataSetId: &testDataSetId,
 		Pieces: []PullPieceRequest{
 			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
@@ -387,26 +400,18 @@ func TestHandlePull_Idempotent(t *testing.T) {
 }
 
 func TestHandlePull_MixedStatuses(t *testing.T) {
-	// Get v1 CID info for test setup
-	piece1 := testParsePieceCidV2(t, testCid1)
-	piece2 := testParsePieceCidV2(t, testCid2)
-	piece3 := testParsePieceCidV2(t, testCid3)
-	v1Str1 := piece1.CidV1.String()
-	v1Str2 := piece2.CidV1.String()
-
 	store := &mockPullStore{
-		pullPieces: []PullPiece{piece1, piece2, piece3},
-		pieceStatuses: map[string]*PieceStatus{
-			v1Str1: {PieceCid: v1Str1, Complete: true},
-			v1Str2: {PieceCid: v1Str2, Complete: false, TaskID: new(int64(123)), TaskExists: true}, // inProgress
-			// piece3 not in map - should be pending
+		pullPieces: []PullPieceStatus{
+			testPullPieceStatus(testCid1, PullStatusComplete),
+			testPullPieceStatus(testCid2, PullStatusInProgress),
+			testPullPieceStatus(testCid3, PullStatusPending),
 		},
 	}
 	validator := &mockValidator{shouldPass: true}
 	handler := NewPullHandler(&NullAuth{}, store, validator)
 
 	body := PullRequest{
-		ExtraData: "0x1234",
+		ExtraData: testExtraData(t),
 		DataSetId: &testDataSetId,
 		Pieces: []PullPieceRequest{
 			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
@@ -446,7 +451,7 @@ func TestHandlePull_CreateError(t *testing.T) {
 	handler := NewPullHandler(&NullAuth{}, store, validator)
 
 	body := PullRequest{
-		ExtraData: "0x1234",
+		ExtraData: testExtraData(t),
 		DataSetId: &testDataSetId,
 		Pieces: []PullPieceRequest{
 			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
@@ -459,6 +464,31 @@ func TestHandlePull_CreateError(t *testing.T) {
 	handler.HandlePull(rec, req)
 
 	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestHandlePull_Backpressure(t *testing.T) {
+	store := &mockPullStore{
+		backpressure: true,
+	}
+	validator := &mockValidator{shouldPass: true}
+	handler := NewPullHandler(&NullAuth{}, store, validator)
+
+	body := PullRequest{
+		ExtraData: testExtraData(t),
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.True(t, store.createPullCalled)
+	require.False(t, store.getPullPiecesCalled)
 }
 
 func TestPadPieceSize(t *testing.T) {
@@ -500,30 +530,19 @@ func TestPadPieceSize(t *testing.T) {
 
 func TestHandlePull_RetryingStatus(t *testing.T) {
 	// Piece with task that has retries > 0 should show "retrying" status
-	piece1 := testParsePieceCidV2(t, testCid1)
-	v1Str1 := piece1.CidV1.String()
 	store := &mockPullStore{
 		existingPull: &PullRecord{
 			ID:            123,
 			Service:       "public",
 			ExtraDataHash: []byte("hash"),
 		},
-		pullPieces: []PullPiece{piece1},
-		pieceStatuses: map[string]*PieceStatus{
-			v1Str1: {
-				PieceCid:   v1Str1,
-				Complete:   false,
-				TaskID:     new(int64(999)),
-				TaskExists: true,
-				Retries:    2, // Has been retried twice
-			},
-		},
+		pullPieces: []PullPieceStatus{testPullPieceStatus(testCid1, PullStatusRetrying)},
 	}
 	validator := &mockValidator{shouldPass: true}
 	handler := NewPullHandler(&NullAuth{}, store, validator)
 
 	body := PullRequest{
-		ExtraData: "0x1234",
+		ExtraData: testExtraData(t),
 		DataSetId: &testDataSetId,
 		Pieces: []PullPieceRequest{
 			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
@@ -547,30 +566,19 @@ func TestHandlePull_RetryingStatus(t *testing.T) {
 
 func TestHandlePull_FailedFromPullItems(t *testing.T) {
 	// Piece already marked as failed in pull_items should show "failed" status
-	piece1 := testParsePieceCidV2(t, testCid1)
-
 	store := &mockPullStore{
 		existingPull: &PullRecord{
 			ID:            123,
 			Service:       "public",
 			ExtraDataHash: []byte("hash"),
 		},
-		pullPieces: []PullPiece{
-			{
-				CidV1:      piece1.CidV1,
-				RawSize:    piece1.RawSize,
-				Failed:     true,
-				FailReason: "CommP mismatch: expected X, got Y",
-			},
-		},
-		// No piece status needed - Failed flag in PullPiece takes priority
-		pieceStatuses: map[string]*PieceStatus{},
+		pullPieces: []PullPieceStatus{testPullPieceStatus(testCid1, PullStatusFailed)},
 	}
 	validator := &mockValidator{shouldPass: true}
 	handler := NewPullHandler(&NullAuth{}, store, validator)
 
 	body := PullRequest{
-		ExtraData: "0x1234",
+		ExtraData: testExtraData(t),
 		DataSetId: &testDataSetId,
 		Pieces: []PullPieceRequest{
 			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
@@ -592,38 +600,22 @@ func TestHandlePull_FailedFromPullItems(t *testing.T) {
 	require.Equal(t, PullStatusFailed, resp.Pieces[0].Status)
 }
 
-func TestHandlePull_OrphanedTaskExhausted(t *testing.T) {
-	// Piece with orphaned task (task deleted, exhausted retries) should show "failed"
-	// and trigger MarkPieceFailed call
-	piece1 := testParsePieceCidV2(t, testCid1)
-	v1Str1 := piece1.CidV1.String()
-	taskID := int64(888)
-
+func TestHandlePull_OrphanedTaskWithoutTerminalStateIsPending(t *testing.T) {
+	// Terminal state is explicit in pdp_piece_pull_items. A missing harmony task
+	// is not inferred as failure by the status endpoint.
 	store := &mockPullStore{
 		existingPull: &PullRecord{
 			ID:            123,
 			Service:       "public",
 			ExtraDataHash: []byte("hash"),
 		},
-		pullPieces: []PullPiece{piece1},
-		pieceStatuses: map[string]*PieceStatus{
-			v1Str1: {
-				PieceCid:   v1Str1,
-				Complete:   false,
-				TaskID:     &taskID,
-				TaskExists: false, // Task was deleted
-				Retries:    0,
-			},
-		},
-		exhaustedTasks: map[int64]string{
-			taskID: "size mismatch: expected 1000, got 500", // Task failed permanently
-		},
+		pullPieces: []PullPieceStatus{testPullPieceStatus(testCid1, PullStatusPending)},
 	}
 	validator := &mockValidator{shouldPass: true}
 	handler := NewPullHandler(&NullAuth{}, store, validator)
 
 	body := PullRequest{
-		ExtraData: "0x1234",
+		ExtraData: testExtraData(t),
 		DataSetId: &testDataSetId,
 		Pieces: []PullPieceRequest{
 			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
@@ -640,66 +632,9 @@ func TestHandlePull_OrphanedTaskExhausted(t *testing.T) {
 	var resp PullResponse
 	err := json.Unmarshal(rec.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	require.Equal(t, PullStatusFailed, resp.Status)
+	require.Equal(t, PullStatusPending, resp.Status)
 	require.Len(t, resp.Pieces, 1)
-	require.Equal(t, PullStatusFailed, resp.Pieces[0].Status)
-
-	// Verify MarkPieceFailed was called with the error reason (prefixed with StorePiece:)
-	require.NotNil(t, store.markedFailed)
-	require.Equal(t, "StorePiece: size mismatch: expected 1000, got 500", store.markedFailed[v1Str1])
-}
-
-func TestHandlePull_OrphanedTaskNotExhausted(t *testing.T) {
-	// Piece with orphaned task but no exhaustion record - should show "failed"
-	// because the piece is stuck (poller won't pick it up with task_id still set)
-	piece1 := testParsePieceCidV2(t, testCid1)
-	v1Str1 := piece1.CidV1.String()
-	store := &mockPullStore{
-		existingPull: &PullRecord{
-			ID:            123,
-			Service:       "public",
-			ExtraDataHash: []byte("hash"),
-		},
-		pullPieces: []PullPiece{piece1},
-		pieceStatuses: map[string]*PieceStatus{
-			v1Str1: {
-				PieceCid:   v1Str1,
-				Complete:   false,
-				TaskID:     new(int64(777)),
-				TaskExists: false, // Task was deleted
-				Retries:    0,
-			},
-		},
-		// exhaustedTasks is nil - no history found (purged or never ran)
-	}
-	validator := &mockValidator{shouldPass: true}
-	handler := NewPullHandler(&NullAuth{}, store, validator)
-
-	body := PullRequest{
-		ExtraData: "0x1234",
-		DataSetId: &testDataSetId,
-		Pieces: []PullPieceRequest{
-			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
-		},
-	}
-	bodyBytes := must.One(json.Marshal(body))
-	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
-	rec := httptest.NewRecorder()
-
-	handler.HandlePull(rec, req)
-
-	require.Equal(t, http.StatusOK, rec.Code)
-
-	var resp PullResponse
-	err := json.Unmarshal(rec.Body.Bytes(), &resp)
-	require.NoError(t, err)
-	require.Equal(t, PullStatusFailed, resp.Status)
-	require.Len(t, resp.Pieces, 1)
-	require.Equal(t, PullStatusFailed, resp.Pieces[0].Status)
-
-	// Verify MarkPieceFailed was called with orphan message (for StorePiece task)
-	require.NotNil(t, store.markedFailed)
-	require.Equal(t, "StorePiece task orphaned without failure record", store.markedFailed[v1Str1])
+	require.Equal(t, PullStatusPending, resp.Pieces[0].Status)
 }
 
 func TestComputeOverallStatus_Priority(t *testing.T) {

--- a/pdp/handlers_pull_test.go
+++ b/pdp/handlers_pull_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -24,7 +25,7 @@ type mockPullStore struct {
 	existingPull *PullRecord
 	pullPieces   []PullPieceStatus
 	createError  error
-	backpressure bool
+	backpressure *PullBackpressure
 
 	// Tracking calls
 	createPullCalled    bool
@@ -38,12 +39,12 @@ func (m *mockPullStore) GetPullByKey(ctx context.Context, service string, hash [
 	return m.existingPull, nil
 }
 
-func (m *mockPullStore) CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, bool, error) {
+func (m *mockPullStore) CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, *PullBackpressure, error) {
 	m.createPullCalled = true
 	m.createdPull = pull
 	m.createdPieces = pieces
 	if m.createError != nil {
-		return 0, false, m.createError
+		return 0, nil, m.createError
 	}
 	m.lastCreatedID++
 	return m.lastCreatedID, m.backpressure, nil
@@ -468,7 +469,7 @@ func TestHandlePull_CreateError(t *testing.T) {
 
 func TestHandlePull_Backpressure(t *testing.T) {
 	store := &mockPullStore{
-		backpressure: true,
+		backpressure: &PullBackpressure{RetryAfter: 2 * time.Minute},
 	}
 	validator := &mockValidator{shouldPass: true}
 	handler := NewPullHandler(&NullAuth{}, store, validator)
@@ -487,6 +488,7 @@ func TestHandlePull_Backpressure(t *testing.T) {
 	handler.HandlePull(rec, req)
 
 	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Equal(t, "120", rec.Header().Get("Retry-After"))
 	require.True(t, store.createPullCalled)
 	require.False(t, store.getPullPiecesCalled)
 }

--- a/pdp/handlers_pull_test.go
+++ b/pdp/handlers_pull_test.go
@@ -70,6 +70,9 @@ func (m *mockPullStore) GetPullStatus(ctx context.Context, pullID int64) ([]Pull
 type mockValidator struct {
 	shouldPass bool
 	err        error
+	payer      common.Address
+	payerErr   error
+	payerCalls []uint64
 }
 
 func (m *mockValidator) ValidateAddPieces(ctx context.Context, params *AddPiecesValidatorParams) error {
@@ -80,6 +83,17 @@ func (m *mockValidator) ValidateAddPieces(ctx context.Context, params *AddPieces
 		return m.err
 	}
 	return errors.New("validation failed")
+}
+
+func (m *mockValidator) GetDataSetPayer(ctx context.Context, dataSetId uint64) (common.Address, error) {
+	m.payerCalls = append(m.payerCalls, dataSetId)
+	if m.payerErr != nil {
+		return common.Address{}, m.payerErr
+	}
+	if m.payer != (common.Address{}) {
+		return m.payer, nil
+	}
+	return common.HexToAddress("0x1111111111111111111111111111111111111111"), nil
 }
 
 // Valid test PieceCIDv2s
@@ -98,6 +112,12 @@ func testExtraData(t *testing.T) string {
 	extraData, err := makeTestExtraData(common.HexToAddress("0x1111111111111111111111111111111111111111"), 1)
 	require.NoError(t, err)
 	return extraData
+}
+
+func testAddPiecesOnlyExtraData(t *testing.T) string {
+	t.Helper()
+
+	return "0x" + hex.EncodeToString([]byte("add-pieces-only-extra-data"))
 }
 
 func makeTestExtraData(payer common.Address, nonce int64) (string, error) {
@@ -297,6 +317,32 @@ func TestHandlePull_NewRequest_Success(t *testing.T) {
 	}
 	require.True(t, cidSet[testCid1])
 	require.True(t, cidSet[testCid2])
+}
+
+func TestHandlePull_ExistingDataSetUsesFWSSPayer(t *testing.T) {
+	store := &mockPullStore{}
+	payer := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	validator := &mockValidator{shouldPass: true, payer: payer}
+	handler := NewPullHandler(&NullAuth{}, store, validator)
+
+	body := PullRequest{
+		ExtraData: testAddPiecesOnlyExtraData(t),
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, store.createPullCalled)
+	require.NotNil(t, store.createdPull)
+	require.Equal(t, payer.Hex(), store.createdPull.ClientAddress)
+	require.Equal(t, []uint64{testDataSetId}, validator.payerCalls)
 }
 
 func TestHandlePull_CreateNew_MissingRecordKeeper(t *testing.T) {

--- a/pdp/handlers_pull_test.go
+++ b/pdp/handlers_pull_test.go
@@ -686,7 +686,8 @@ func TestHandlePull_OrphanedTaskWithoutTerminalStateIsPending(t *testing.T) {
 }
 
 func TestComputeOverallStatus_Priority(t *testing.T) {
-	// Test that status priority is: failed > retrying > inProgress > pending > complete
+	// Failed pieces are terminal per-piece results. The batch only becomes
+	// terminal after every piece is complete or failed.
 	tests := []struct {
 		name           string
 		pieceStatuses  []PullStatus
@@ -713,8 +714,18 @@ func TestComputeOverallStatus_Priority(t *testing.T) {
 			expectedStatus: PullStatusRetrying,
 		},
 		{
-			name:           "failed overrides all",
+			name:           "failed does not override active work",
 			pieceStatuses:  []PullStatus{PullStatusComplete, PullStatusInProgress, PullStatusRetrying, PullStatusFailed},
+			expectedStatus: PullStatusRetrying,
+		},
+		{
+			name:           "partial failure with completed pieces is complete",
+			pieceStatuses:  []PullStatus{PullStatusComplete, PullStatusFailed},
+			expectedStatus: PullStatusComplete,
+		},
+		{
+			name:           "all failed makes batch failed",
+			pieceStatuses:  []PullStatus{PullStatusFailed, PullStatusFailed},
 			expectedStatus: PullStatusFailed,
 		},
 		{

--- a/pdp/indexing.go
+++ b/pdp/indexing.go
@@ -2,12 +2,8 @@ package pdp
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"slices"
-
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/lib/ethchain"
@@ -73,101 +69,6 @@ func CheckIfIndexingNeededFromExtraData(extraData []byte) (bool, error) {
 	}
 
 	return false, nil
-}
-
-// FWSSPayerFromExtraData extracts the FilecoinWarmStorageService payer from
-// pull extraData. The expected format is the combined operation payload:
-//
-//	(bytes createPayload, bytes addPayload)
-//
-// where createPayload is:
-//
-//	(address payer, uint256 clientDataSetId, string[] keys, string[] values, bytes signature)
-func FWSSPayerFromExtraData(extraData []byte) (common.Address, error) {
-	payload, err := decodeFWSSCreatePayload(extraData)
-	if err != nil {
-		return common.Address{}, err
-	}
-	if payload.Payer == (common.Address{}) {
-		return common.Address{}, fmt.Errorf("payer is zero address")
-	}
-
-	return payload.Payer, nil
-}
-
-type fwssCreatePayload struct {
-	Payer        common.Address
-	MetadataKeys []string
-}
-
-func decodeFWSSCreatePayload(extraData []byte) (*fwssCreatePayload, error) {
-	if len(extraData) == 0 {
-		return nil, fmt.Errorf("extraData is empty")
-	}
-
-	bytesType, err := abi.NewType("bytes", "", nil)
-	if err != nil {
-		return nil, fmt.Errorf("create bytes ABI type: %w", err)
-	}
-	outerArgs := abi.Arguments{
-		{Type: bytesType}, // createPayload
-		{Type: bytesType}, // addPayload
-	}
-
-	decoded, err := outerArgs.Unpack(extraData)
-	if err != nil {
-		return nil, fmt.Errorf("decode combined extraData: %w", err)
-	}
-	if len(decoded) < 1 {
-		return nil, fmt.Errorf("combined extraData missing createPayload")
-	}
-
-	createPayload, ok := decoded[0].([]byte)
-	if !ok {
-		return nil, fmt.Errorf("createPayload is not bytes")
-	}
-
-	addressType, err := abi.NewType("address", "", nil)
-	if err != nil {
-		return nil, fmt.Errorf("create address ABI type: %w", err)
-	}
-	uint256Type, err := abi.NewType("uint256", "", nil)
-	if err != nil {
-		return nil, fmt.Errorf("create uint256 ABI type: %w", err)
-	}
-	stringArrayType, err := abi.NewType("string[]", "", nil)
-	if err != nil {
-		return nil, fmt.Errorf("create string array ABI type: %w", err)
-	}
-	createArgs := abi.Arguments{
-		{Type: addressType},     // payer
-		{Type: uint256Type},     // clientDataSetId
-		{Type: stringArrayType}, // keys
-		{Type: stringArrayType}, // values
-		{Type: bytesType},       // signature
-	}
-
-	createDecoded, err := createArgs.Unpack(createPayload)
-	if err != nil {
-		return nil, fmt.Errorf("decode createPayload: %w", err)
-	}
-	if len(createDecoded) < 3 {
-		return nil, fmt.Errorf("createPayload missing metadata keys")
-	}
-
-	payer, ok := createDecoded[0].(common.Address)
-	if !ok {
-		return nil, fmt.Errorf("payer is not an address")
-	}
-	keys, ok := createDecoded[2].([]string)
-	if !ok {
-		return nil, fmt.Errorf("keys is not []string")
-	}
-
-	return &fwssCreatePayload{
-		Payer:        payer,
-		MetadataKeys: keys,
-	}, nil
 }
 
 // EnableIndexingForPiecesInTx marks the specified piecerefs as needing indexing within a transaction.

--- a/pdp/indexing.go
+++ b/pdp/indexing.go
@@ -2,10 +2,12 @@ package pdp
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"slices"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/lib/ethchain"
@@ -49,7 +51,7 @@ func CheckIfIndexingNeeded(
 // CheckIfIndexingNeededFromExtraData checks if extraData contains withIPFSIndexing metadata.
 // This is used for the CreateDataSet+AddPieces combined operation where the dataset doesn't exist yet.
 // The extraData format for combined operations is: (bytes createPayload, bytes addPayload)
-// We attempt to decode the createPayload format is is decoded according to the
+// We attempt to decode createPayload according to the
 // FilecoinWarmStorageService format:
 //
 //	(address payer, uint256 clientDataSetId, string[] keys, string[] values, bytes signature)
@@ -58,66 +60,114 @@ func CheckIfIndexingNeededFromExtraData(extraData []byte) (bool, error) {
 		return false, nil
 	}
 
-	// Define the ABI types for nested decoding
-	bytes32Type, _ := abi.NewType("bytes", "", nil)
-	outerArgs := abi.Arguments{
-		{Type: bytes32Type}, // createPayload
-		{Type: bytes32Type}, // addPayload
-	}
-
-	// Decode outer layer: (bytes createPayload, bytes addPayload)
-	decoded, err := outerArgs.Unpack(extraData)
+	payload, err := decodeFWSSCreatePayload(extraData)
 	if err != nil {
 		log.Debugw("Failed to decode extraData as combined operation, not an error", "error", err)
 		return false, nil
 	}
 
-	if len(decoded) < 1 {
-		return false, nil
-	}
-
-	createPayload, ok := decoded[0].([]byte)
-	if !ok {
-		log.Debugw("createPayload is not bytes")
-		return false, nil
-	}
-
-	// Define the ABI types for createPayload decoding
-	addressType, _ := abi.NewType("address", "", nil)
-	uint256Type, _ := abi.NewType("uint256", "", nil)
-	stringArrayType, _ := abi.NewType("string[]", "", nil)
-	createArgs := abi.Arguments{
-		{Type: addressType},     // payer
-		{Type: uint256Type},     // clientDataSetId
-		{Type: stringArrayType}, // keys
-		{Type: stringArrayType}, // values
-		{Type: bytes32Type},     // signature
-	}
-
-	// Decode createPayload: (address payer, uint256 clientDataSetId, string[] keys, string[] values, bytes signature)
-	createDecoded, err := createArgs.Unpack(createPayload)
-	if err != nil {
-		log.Debugw("Failed to decode createPayload", "error", err)
-		return false, nil
-	}
-
-	if len(createDecoded) < 3 {
-		return false, nil
-	}
-
-	keys, ok := createDecoded[2].([]string)
-	if !ok {
-		log.Debugw("keys is not []string")
-		return false, nil
-	}
-
 	// Look for withIPFSIndexing in the keys array
-	if slices.Contains(keys, "withIPFSIndexing") {
+	if slices.Contains(payload.MetadataKeys, "withIPFSIndexing") {
 		log.Debugw("Found withIPFSIndexing in extraData metadata keys")
 		return true, nil
 	}
 
 	return false, nil
+}
+
+// FWSSPayerFromExtraData extracts the FilecoinWarmStorageService payer from
+// pull extraData. The expected format is the combined operation payload:
+//
+//	(bytes createPayload, bytes addPayload)
+//
+// where createPayload is:
+//
+//	(address payer, uint256 clientDataSetId, string[] keys, string[] values, bytes signature)
+func FWSSPayerFromExtraData(extraData []byte) (common.Address, error) {
+	payload, err := decodeFWSSCreatePayload(extraData)
+	if err != nil {
+		return common.Address{}, err
+	}
+	if payload.Payer == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("payer is zero address")
+	}
+
+	return payload.Payer, nil
+}
+
+type fwssCreatePayload struct {
+	Payer        common.Address
+	MetadataKeys []string
+}
+
+func decodeFWSSCreatePayload(extraData []byte) (*fwssCreatePayload, error) {
+	if len(extraData) == 0 {
+		return nil, fmt.Errorf("extraData is empty")
+	}
+
+	bytesType, err := abi.NewType("bytes", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create bytes ABI type: %w", err)
+	}
+	outerArgs := abi.Arguments{
+		{Type: bytesType}, // createPayload
+		{Type: bytesType}, // addPayload
+	}
+
+	decoded, err := outerArgs.Unpack(extraData)
+	if err != nil {
+		return nil, fmt.Errorf("decode combined extraData: %w", err)
+	}
+	if len(decoded) < 1 {
+		return nil, fmt.Errorf("combined extraData missing createPayload")
+	}
+
+	createPayload, ok := decoded[0].([]byte)
+	if !ok {
+		return nil, fmt.Errorf("createPayload is not bytes")
+	}
+
+	addressType, err := abi.NewType("address", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create address ABI type: %w", err)
+	}
+	uint256Type, err := abi.NewType("uint256", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create uint256 ABI type: %w", err)
+	}
+	stringArrayType, err := abi.NewType("string[]", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create string array ABI type: %w", err)
+	}
+	createArgs := abi.Arguments{
+		{Type: addressType},     // payer
+		{Type: uint256Type},     // clientDataSetId
+		{Type: stringArrayType}, // keys
+		{Type: stringArrayType}, // values
+		{Type: bytesType},       // signature
+	}
+
+	createDecoded, err := createArgs.Unpack(createPayload)
+	if err != nil {
+		return nil, fmt.Errorf("decode createPayload: %w", err)
+	}
+	if len(createDecoded) < 3 {
+		return nil, fmt.Errorf("createPayload missing metadata keys")
+	}
+
+	payer, ok := createDecoded[0].(common.Address)
+	if !ok {
+		return nil, fmt.Errorf("payer is not an address")
+	}
+	keys, ok := createDecoded[2].([]string)
+	if !ok {
+		return nil, fmt.Errorf("keys is not []string")
+	}
+
+	return &fwssCreatePayload{
+		Payer:        payer,
+		MetadataKeys: keys,
+	}, nil
 }
 
 // EnableIndexingForPiecesInTx marks the specified piecerefs as needing indexing within a transaction.

--- a/pdp/piece_cid.go
+++ b/pdp/piece_cid.go
@@ -2,12 +2,12 @@ package pdp
 
 import (
 	"fmt"
-	"math/bits"
 
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multicodec"
 
 	commcid "github.com/filecoin-project/go-fil-commcid"
+	"github.com/filecoin-project/go-padreader"
 )
 
 // PieceCidInfo holds all derived information from a piece CID.
@@ -126,12 +126,5 @@ func PadPieceSize(rawSize int64) int64 {
 	if rawSize == 0 {
 		return 0
 	}
-	// Apply FR32 ratio: ceil(rawSize * 128 / 127)
-	fr32Padded := (uint64(rawSize)*128 + 126) / 127
-	// Round up to next power of 2
-	if fr32Padded == 0 {
-		return 1
-	}
-	fr32Padded--
-	return int64(1 << bits.Len64(fr32Padded))
+	return int64(padreader.PaddedSize(uint64(rawSize)).Padded())
 }

--- a/pdp/pull_types.go
+++ b/pdp/pull_types.go
@@ -222,7 +222,7 @@ type PullRecord struct {
 	ExtraDataHash []byte
 	DataSetId     uint64 // 0 = create new
 	RecordKeeper  string // address, required when DataSetId is 0
-	ClientAddress string // FWSS payer address from extraData
+	ClientAddress string // FWSS payer address
 }
 
 // PullPiece represents a piece stored in a pull request (v1 CID + raw size for v2 reconstruction)

--- a/pdp/pull_types.go
+++ b/pdp/pull_types.go
@@ -180,7 +180,7 @@ func (r *PullRequest) Validate() error {
 
 	// Validate each piece (CID format validation is done later by ParsePieceCidV2).
 	// The same piece may appear more than once with different source URLs so
-	// PullPiece can try all supplied sources. An exact duplicate is not useful
+	// the server can try all supplied sources. An exact duplicate is not useful
 	// and would collide with the pull item primary key.
 	seenPieceSources := make(map[string]struct{}, len(r.Pieces))
 	for i, piece := range r.Pieces {
@@ -387,7 +387,7 @@ func (s *dbPullStore) CreatePullWithPieces(ctx context.Context, pull *PullRecord
 			return false, nil
 		}
 
-		// Insert piece items with raw size and source_url for task to pick up
+		// Insert piece items with raw size and source URL for processing.
 		for _, piece := range pieces {
 			_, err := tx.Exec(`
 				INSERT INTO pdp_piece_pull_items (fetch_id, piece_cid, piece_raw_size, source_url)
@@ -482,12 +482,16 @@ func pullStatusFromItem(complete, failed bool, taskID *int64, taskExists bool, r
 	return PullStatusPending
 }
 
+// enforceBackpressure decides whether a new pull can be admitted without
+// exceeding global or per-client pending-piece limits.
 func (s *dbPullStore) enforceBackpressure(tx *harmonydb.Tx, pull *PullRecord, pieces []PullPiece) (*PullBackpressure, error) {
 	type pieceKey struct {
 		cid     string
 		rawSize uint64
 	}
 
+	// Backpressure is counted by unique piece key, not by URL or pull item.
+	// Multiple URLs for the same piece should not consume multiple slots.
 	seen := make(map[pieceKey]struct{}, len(pieces))
 	pieceCids := make([]string, 0, len(pieces))
 	rawSizes := make([]int64, 0, len(pieces))
@@ -506,6 +510,10 @@ func (s *dbPullStore) enforceBackpressure(tx *harmonydb.Tx, pull *PullRecord, pi
 	}
 
 	var globalPending, clientPending, otherPending int
+	// Count the post-admission state in one query:
+	// - globalPending: all active unique pieces plus this request's unique pieces
+	// - clientPending: this client's active unique pieces plus this request
+	// - otherPending: active unique pieces owned by all other clients
 	err := tx.QueryRow(`
 		WITH incoming AS (
 			SELECT DISTINCT piece_cid, piece_raw_size
@@ -551,11 +559,16 @@ func (s *dbPullStore) enforceBackpressure(tx *harmonydb.Tx, pull *PullRecord, pi
 	if err != nil {
 		return nil, fmt.Errorf("count pull pending pieces: %w", err)
 	}
+	// The global limit is absolute. A request is rejected if accepting it would
+	// push total active unique pieces over the node-wide cap.
 	if globalPending > pullGlobalPendingLimit {
 		return &PullBackpressure{RetryAfter: pullRetryAfter(globalPending, pullGlobalPendingLimit)}, nil
 	}
-	clientLimit := pullEffectiveClientPendingLimit(otherPending)
 
+	// The per-client limit is soft while the node is otherwise empty. A client
+	// can borrow unused slots up to the solo-client ceiling, but other clients'
+	// pending pieces reduce that allowance.
+	clientLimit := pullEffectiveClientPendingLimit(otherPending)
 	if clientPending > clientLimit {
 		return &PullBackpressure{RetryAfter: pullRetryAfter(clientPending, clientLimit)}, nil
 	}
@@ -567,6 +580,8 @@ func pullClientBorrowLimit() int {
 	return pullGlobalPendingLimit * pullSoloClientPendingPercentage / 100
 }
 
+// pullEffectiveClientPendingLimit returns how many unique pending pieces one
+// client may hold after accounting for capacity already used by other clients.
 func pullEffectiveClientPendingLimit(otherPending int) int {
 	limit := pullClientBorrowLimit() - otherPending
 	if limit < pullPerClientPendingLimit {
@@ -575,6 +590,8 @@ func pullEffectiveClientPendingLimit(otherPending int) int {
 	return limit
 }
 
+// pullRetryAfter suggests how long a rejected pull should wait: 1 minute per 10
+// pieces over the limit, clamped to [1, 5] minutes.
 func pullRetryAfter(pending, limit int) time.Duration {
 	over := pending - limit
 	if over <= 0 {

--- a/pdp/pull_types.go
+++ b/pdp/pull_types.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/curiostorage/harmonyquery"
 	"github.com/ipfs/go-cid"
@@ -234,9 +235,17 @@ type PullPiece struct {
 const (
 	// Admission counts active unique (piece_cid, piece_raw_size) keys plus
 	// the incoming request's unique keys before inserting new pull rows.
-	pullGlobalPendingLimit    = 128
-	pullPerClientPendingLimit = 10
+	pullGlobalPendingLimit          = 120
+	pullPerClientPendingLimit       = 10
+	pullSoloClientPendingPercentage = 90
+	pullRetryAfterMin               = time.Minute
+	pullRetryAfterMax               = 5 * time.Minute
+	pullRetryAfterStepPieces        = 10
 )
+
+type PullBackpressure struct {
+	RetryAfter time.Duration
+}
 
 // PullStore abstracts database operations for the pull handler
 type PullStore interface {
@@ -244,8 +253,8 @@ type PullStore interface {
 	GetPullByKey(ctx context.Context, service string, hash []byte, dataSetId uint64, recordKeeper string) (*PullRecord, error)
 
 	// CreatePullWithPieces creates a pull record and its associated piece items in a transaction.
-	// It returns the created pull ID and whether admission was rejected due to pull backpressure.
-	CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, bool, error)
+	// It returns the created pull ID and pull backpressure details when admission is rejected.
+	CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, *PullBackpressure, error)
 
 	// GetPullStatus retrieves all piece statuses associated with a pull record.
 	GetPullStatus(ctx context.Context, pullID int64) ([]PullPieceStatus, error)
@@ -335,12 +344,12 @@ func (s *dbPullStore) GetPullByKey(ctx context.Context, service string, hash []b
 	}, nil
 }
 
-func (s *dbPullStore) CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, bool, error) {
+func (s *dbPullStore) CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, *PullBackpressure, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	var pullID int64
-	var backpressure bool
+	var backpressure *PullBackpressure
 	var existing bool
 
 	comm, err := s.db.BeginTransaction(ctx, func(tx *harmonyquery.Tx) (commit bool, err error) {
@@ -374,7 +383,7 @@ func (s *dbPullStore) CreatePullWithPieces(ctx context.Context, pull *PullRecord
 			return false, err
 		}
 
-		if backpressure {
+		if backpressure != nil {
 			return false, nil
 		}
 
@@ -393,22 +402,22 @@ func (s *dbPullStore) CreatePullWithPieces(ctx context.Context, pull *PullRecord
 	}, harmonydb.OptionRetry())
 
 	if err != nil {
-		return pullID, false, xerrors.Errorf("insert pull items: %w", err)
+		return pullID, nil, xerrors.Errorf("insert pull items: %w", err)
 	}
 
 	if existing {
-		return pullID, false, nil
+		return pullID, nil, nil
 	}
 
-	if !comm && !backpressure {
-		return pullID, false, xerrors.Errorf("failed to commit the transaction")
+	if !comm && backpressure == nil {
+		return pullID, nil, xerrors.Errorf("failed to commit the transaction")
 	}
 
-	if backpressure {
-		return pullID, true, nil
+	if backpressure != nil {
+		return pullID, backpressure, nil
 	}
 
-	return pullID, false, nil
+	return pullID, nil, nil
 }
 
 func (s *dbPullStore) GetPullStatus(ctx context.Context, pullID int64) ([]PullPieceStatus, error) {
@@ -473,7 +482,7 @@ func pullStatusFromItem(complete, failed bool, taskID *int64, taskExists bool, r
 	return PullStatusPending
 }
 
-func (s *dbPullStore) enforceBackpressure(tx *harmonydb.Tx, pull *PullRecord, pieces []PullPiece) (bool, error) {
+func (s *dbPullStore) enforceBackpressure(tx *harmonydb.Tx, pull *PullRecord, pieces []PullPiece) (*PullBackpressure, error) {
 	type pieceKey struct {
 		cid     string
 		rawSize uint64
@@ -493,10 +502,10 @@ func (s *dbPullStore) enforceBackpressure(tx *harmonydb.Tx, pull *PullRecord, pi
 	}
 
 	if len(pieceCids) == 0 {
-		return false, nil
+		return nil, nil
 	}
 
-	var globalPending, clientPending int
+	var globalPending, clientPending, otherPending int
 	err := tx.QueryRow(`
 		WITH incoming AS (
 			SELECT DISTINCT piece_cid, piece_raw_size
@@ -516,6 +525,14 @@ func (s *dbPullStore) enforceBackpressure(tx *harmonydb.Tx, pull *PullRecord, pi
 				AND fi.failed = FALSE
 				AND fp.client_address = $3
 		),
+		other_active AS (
+			SELECT DISTINCT fi.piece_cid, fi.piece_raw_size
+			FROM pdp_piece_pull_items fi
+			JOIN pdp_piece_pulls fp ON fp.id = fi.fetch_id
+			WHERE fi.complete = FALSE
+				AND fi.failed = FALSE
+				AND fp.client_address <> $3
+		),
 		global_combined AS (
 			SELECT piece_cid, piece_raw_size FROM global_active
 			UNION
@@ -528,17 +545,49 @@ func (s *dbPullStore) enforceBackpressure(tx *harmonydb.Tx, pull *PullRecord, pi
 		)
 		SELECT
 			(SELECT COUNT(*) FROM global_combined),
-			(SELECT COUNT(*) FROM client_combined)
-	`, pieceCids, rawSizes, pull.ClientAddress).Scan(&globalPending, &clientPending)
+			(SELECT COUNT(*) FROM client_combined),
+			(SELECT COUNT(*) FROM other_active)
+	`, pieceCids, rawSizes, pull.ClientAddress).Scan(&globalPending, &clientPending, &otherPending)
 	if err != nil {
-		return false, fmt.Errorf("count pull pending pieces: %w", err)
+		return nil, fmt.Errorf("count pull pending pieces: %w", err)
 	}
 	if globalPending > pullGlobalPendingLimit {
-		return true, nil
+		return &PullBackpressure{RetryAfter: pullRetryAfter(globalPending, pullGlobalPendingLimit)}, nil
 	}
-	if clientPending > pullPerClientPendingLimit {
-		return true, nil
+	clientLimit := pullEffectiveClientPendingLimit(otherPending)
+
+	if clientPending > clientLimit {
+		return &PullBackpressure{RetryAfter: pullRetryAfter(clientPending, clientLimit)}, nil
 	}
 
-	return false, nil
+	return nil, nil
+}
+
+func pullClientBorrowLimit() int {
+	return pullGlobalPendingLimit * pullSoloClientPendingPercentage / 100
+}
+
+func pullEffectiveClientPendingLimit(otherPending int) int {
+	limit := pullClientBorrowLimit() - otherPending
+	if limit < pullPerClientPendingLimit {
+		return pullPerClientPendingLimit
+	}
+	return limit
+}
+
+func pullRetryAfter(pending, limit int) time.Duration {
+	over := pending - limit
+	if over <= 0 {
+		return pullRetryAfterMin
+	}
+
+	minutes := 1 + (over-1)/pullRetryAfterStepPieces
+	retryAfter := time.Duration(minutes) * time.Minute
+	if retryAfter < pullRetryAfterMin {
+		return pullRetryAfterMin
+	}
+	if retryAfter > pullRetryAfterMax {
+		return pullRetryAfterMax
+	}
+	return retryAfter
 }

--- a/pdp/pull_types.go
+++ b/pdp/pull_types.go
@@ -260,42 +260,53 @@ type PullStore interface {
 	GetPullStatus(ctx context.Context, pullID int64) ([]PullPieceStatus, error)
 }
 
-// ComputeOverallStatus derives the overall status from individual piece statuses.
-// Priority: failed > retrying > inProgress > pending > complete
+// ComputeOverallStatus derives the batch status from individual piece statuses.
+// The batch only reaches a terminal status after every piece is terminal. At
+// that point any successful piece makes the batch complete; failed pieces remain
+// visible in per-piece status.
 func (r *PullResponse) ComputeOverallStatus() {
 	if len(r.Pieces) == 0 {
 		r.Status = PullStatusPending
 		return
 	}
 
-	allComplete := true
-	anyFailed := false
-	anyRetrying := false
-	anyInProgress := false
+	completeCount := 0
+	failedCount := 0
+	hasPending := false
+	hasInProgress := false
+	hasRetrying := false
 
 	for _, p := range r.Pieces {
-		if p.Status != PullStatusComplete {
-			allComplete = false
-		}
 		switch p.Status {
+		case PullStatusComplete:
+			completeCount++
 		case PullStatusFailed:
-			anyFailed = true
+			failedCount++
 		case PullStatusRetrying:
-			anyRetrying = true
+			hasRetrying = true
 		case PullStatusInProgress:
-			anyInProgress = true
+			hasInProgress = true
+		case PullStatusPending:
+			hasPending = true
+		default:
+			hasPending = true
 		}
 	}
 
-	if allComplete {
-		r.Status = PullStatusComplete
-	} else if anyFailed {
-		r.Status = PullStatusFailed
-	} else if anyRetrying {
+	// Non-terminal pieces keep the batch non-terminal. Terminal status is only
+	// chosen after every piece is either complete or failed.
+	switch {
+	case hasRetrying:
 		r.Status = PullStatusRetrying
-	} else if anyInProgress {
+	case hasInProgress:
 		r.Status = PullStatusInProgress
-	} else {
+	case hasPending:
+		r.Status = PullStatusPending
+	case failedCount == len(r.Pieces):
+		r.Status = PullStatusFailed
+	case completeCount > 0:
+		r.Status = PullStatusComplete
+	default:
 		r.Status = PullStatusPending
 	}
 }

--- a/pdp/pull_types.go
+++ b/pdp/pull_types.go
@@ -1,12 +1,24 @@
 package pdp
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
 	"os"
 	"regexp"
 	"strings"
+	"sync"
+
+	"github.com/curiostorage/harmonyquery"
+	"github.com/ipfs/go-cid"
+	"github.com/yugabyte/pgx/v5"
+	"golang.org/x/xerrors"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
 )
 
 // pullAllowInsecure relaxes security validations for development/testing environments.
@@ -16,6 +28,10 @@ import (
 //
 // WARNING: Never enable this in production!
 var pullAllowInsecure = os.Getenv("CURIO_PULL_ALLOW_INSECURE") == "1"
+
+func PullAllowInsecure() bool {
+	return pullAllowInsecure
+}
 
 // PullStatus represents the status of a pull operation or piece
 type PullStatus string
@@ -161,7 +177,11 @@ func (r *PullRequest) Validate() error {
 		return fmt.Errorf("at least one piece is required")
 	}
 
-	// Validate each piece (CID format validation is done later by ParsePieceCidV2)
+	// Validate each piece (CID format validation is done later by ParsePieceCidV2).
+	// The same piece may appear more than once with different source URLs so
+	// PullPiece can try all supplied sources. An exact duplicate is not useful
+	// and would collide with the pull item primary key.
+	seenPieceSources := make(map[string]struct{}, len(r.Pieces))
 	for i, piece := range r.Pieces {
 		if piece.PieceCid == "" {
 			return fmt.Errorf("piece[%d]: pieceCid is required", i)
@@ -169,6 +189,11 @@ func (r *PullRequest) Validate() error {
 		if piece.SourceURL == "" {
 			return fmt.Errorf("piece[%d]: sourceUrl is required", i)
 		}
+		key := piece.PieceCid + "\x00" + piece.SourceURL
+		if _, ok := seenPieceSources[key]; ok {
+			return fmt.Errorf("piece[%d]: duplicate pieceCid/sourceUrl", i)
+		}
+		seenPieceSources[key] = struct{}{}
 		if err := ValidatePullSourceURL(piece.SourceURL, piece.PieceCid); err != nil {
 			return fmt.Errorf("piece[%d]: %w", i, err)
 		}
@@ -187,6 +212,43 @@ type PullPieceStatus struct {
 type PullResponse struct {
 	Status PullStatus        `json:"status"`
 	Pieces []PullPieceStatus `json:"pieces"`
+}
+
+// PullRecord represents a pull request record from the database
+type PullRecord struct {
+	ID            int64
+	Service       string
+	ExtraDataHash []byte
+	DataSetId     uint64 // 0 = create new
+	RecordKeeper  string // address, required when DataSetId is 0
+	ClientAddress string // FWSS payer address from extraData
+}
+
+// PullPiece represents a piece stored in a pull request (v1 CID + raw size for v2 reconstruction)
+type PullPiece struct {
+	CidV1     cid.Cid
+	RawSize   uint64
+	SourceURL string // external SP URL to pull from
+}
+
+const (
+	// Admission counts active unique (piece_cid, piece_raw_size) keys plus
+	// the incoming request's unique keys before inserting new pull rows.
+	pullGlobalPendingLimit    = 128
+	pullPerClientPendingLimit = 10
+)
+
+// PullStore abstracts database operations for the pull handler
+type PullStore interface {
+	// GetPullByKey retrieves a pull record by its idempotency key
+	GetPullByKey(ctx context.Context, service string, hash []byte, dataSetId uint64, recordKeeper string) (*PullRecord, error)
+
+	// CreatePullWithPieces creates a pull record and its associated piece items in a transaction.
+	// It returns the created pull ID and whether admission was rejected due to pull backpressure.
+	CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, bool, error)
+
+	// GetPullStatus retrieves all piece statuses associated with a pull record.
+	GetPullStatus(ctx context.Context, pullID int64) ([]PullPieceStatus, error)
 }
 
 // ComputeOverallStatus derives the overall status from individual piece statuses.
@@ -227,4 +289,256 @@ func (r *PullResponse) ComputeOverallStatus() {
 	} else {
 		r.Status = PullStatusPending
 	}
+}
+
+// dbPullStore implements PullStore using harmonydb
+type dbPullStore struct {
+	db *harmonydb.DB
+	mu sync.Mutex
+}
+
+// NewDBPullStore creates a PullStore backed by harmonydb
+func NewDBPullStore(db *harmonydb.DB) PullStore {
+	return &dbPullStore{db: db}
+}
+
+func (s *dbPullStore) GetPullByKey(ctx context.Context, service string, hash []byte, dataSetId uint64, recordKeeper string) (*PullRecord, error) {
+	var records []struct {
+		ID            int64  `db:"id"`
+		Service       string `db:"service"`
+		ExtraDataHash []byte `db:"extra_data_hash"`
+		DataSetId     uint64 `db:"data_set_id"`
+		RecordKeeper  string `db:"record_keeper"`
+		ClientAddress string `db:"client_address"`
+	}
+
+	err := s.db.Select(ctx, &records, `
+		SELECT id, service, extra_data_hash, data_set_id, record_keeper, client_address
+		FROM pdp_piece_pulls
+		WHERE service = $1 AND extra_data_hash = $2 AND data_set_id = $3 AND record_keeper = $4
+	`, service, hash, dataSetId, recordKeeper)
+	if err != nil {
+		return nil, fmt.Errorf("query pull by key: %w", err)
+	}
+
+	if len(records) == 0 {
+		return nil, nil
+	}
+
+	return &PullRecord{
+		ID:            records[0].ID,
+		Service:       records[0].Service,
+		ExtraDataHash: records[0].ExtraDataHash,
+		DataSetId:     records[0].DataSetId,
+		RecordKeeper:  records[0].RecordKeeper,
+		ClientAddress: records[0].ClientAddress,
+	}, nil
+}
+
+func (s *dbPullStore) CreatePullWithPieces(ctx context.Context, pull *PullRecord, pieces []PullPiece) (int64, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var pullID int64
+	var backpressure bool
+	var existing bool
+
+	comm, err := s.db.BeginTransaction(ctx, func(tx *harmonyquery.Tx) (commit bool, err error) {
+		err = tx.QueryRow(`
+			INSERT INTO pdp_piece_pulls (service, extra_data_hash, data_set_id, record_keeper, client_address)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (service, extra_data_hash, data_set_id, record_keeper) DO NOTHING
+			RETURNING id
+		`, pull.Service, pull.ExtraDataHash, pull.DataSetId, pull.RecordKeeper, pull.ClientAddress).Scan(&pullID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			err = tx.QueryRow(`
+				SELECT id
+				FROM pdp_piece_pulls
+				WHERE service = $1
+					AND extra_data_hash = $2
+					AND data_set_id = $3
+					AND record_keeper = $4
+			`, pull.Service, pull.ExtraDataHash, pull.DataSetId, pull.RecordKeeper).Scan(&pullID)
+			if err != nil {
+				return false, fmt.Errorf("query existing pull after conflict: %w", err)
+			}
+			existing = true
+			return false, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("insert pull: %w", err)
+		}
+
+		backpressure, err = s.enforceBackpressure(tx, pull, pieces)
+		if err != nil {
+			return false, err
+		}
+
+		if backpressure {
+			return false, nil
+		}
+
+		// Insert piece items with raw size and source_url for task to pick up
+		for _, piece := range pieces {
+			_, err := tx.Exec(`
+				INSERT INTO pdp_piece_pull_items (fetch_id, piece_cid, piece_raw_size, source_url)
+				VALUES ($1, $2, $3, $4)
+			`, pullID, piece.CidV1.String(), piece.RawSize, piece.SourceURL)
+			if err != nil {
+				return false, fmt.Errorf("insert pull item: %w", err)
+			}
+		}
+
+		return true, nil
+	}, harmonydb.OptionRetry())
+
+	if err != nil {
+		return pullID, false, xerrors.Errorf("insert pull items: %w", err)
+	}
+
+	if existing {
+		return pullID, false, nil
+	}
+
+	if !comm && !backpressure {
+		return pullID, false, xerrors.Errorf("failed to commit the transaction")
+	}
+
+	if backpressure {
+		return pullID, true, nil
+	}
+
+	return pullID, false, nil
+}
+
+func (s *dbPullStore) GetPullStatus(ctx context.Context, pullID int64) ([]PullPieceStatus, error) {
+	var items []struct {
+		PieceCid     string `db:"piece_cid"`
+		PieceRawSize uint64 `db:"piece_raw_size"`
+		Complete     bool   `db:"complete"`
+		Failed       bool   `db:"failed"`
+		TaskID       *int64 `db:"task_id"`
+		TaskExists   bool   `db:"task_exists"`
+		Retries      int    `db:"retries"`
+	}
+
+	err := s.db.Select(ctx, &items, `
+		SELECT fi.piece_cid, fi.piece_raw_size,
+		       fi.complete, fi.failed,
+		       fi.task_id, (ht.id IS NOT NULL) AS task_exists, COALESCE(ht.retries, 0) AS retries
+		FROM pdp_piece_pull_items fi
+		LEFT JOIN harmony_task ht ON ht.id = fi.task_id
+		WHERE fi.fetch_id = $1
+		ORDER BY fi.piece_cid, fi.source_url
+	`, pullID)
+	if err != nil {
+		return nil, fmt.Errorf("query pull items: %w", err)
+	}
+
+	result := make([]PullPieceStatus, len(items))
+	for i, item := range items {
+		c, err := cid.Parse(item.PieceCid)
+		if err != nil {
+			return nil, fmt.Errorf("parse CID %q: %w", item.PieceCid, err)
+		}
+		cidV2, err := commcid.PieceCidV2FromV1(c, item.PieceRawSize)
+		if err != nil {
+			return nil, fmt.Errorf("reconstruct piece CIDv2 for %q/%d: %w", item.PieceCid, item.PieceRawSize, err)
+		}
+		result[i] = PullPieceStatus{
+			PieceCid: cidV2.String(),
+			Status:   pullStatusFromItem(item.Complete, item.Failed, item.TaskID, item.TaskExists, item.Retries),
+		}
+	}
+
+	return result, nil
+}
+
+func pullStatusFromItem(complete, failed bool, taskID *int64, taskExists bool, retries int) PullStatus {
+	if failed {
+		return PullStatusFailed
+	}
+	if complete {
+		return PullStatusComplete
+	}
+	if taskID == nil {
+		return PullStatusPending
+	}
+	if taskExists {
+		if retries > 0 {
+			return PullStatusRetrying
+		}
+		return PullStatusInProgress
+	}
+	return PullStatusPending
+}
+
+func (s *dbPullStore) enforceBackpressure(tx *harmonydb.Tx, pull *PullRecord, pieces []PullPiece) (bool, error) {
+	type pieceKey struct {
+		cid     string
+		rawSize uint64
+	}
+
+	seen := make(map[pieceKey]struct{}, len(pieces))
+	pieceCids := make([]string, 0, len(pieces))
+	rawSizes := make([]int64, 0, len(pieces))
+	for _, piece := range pieces {
+		key := pieceKey{cid: piece.CidV1.String(), rawSize: piece.RawSize}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		pieceCids = append(pieceCids, key.cid)
+		rawSizes = append(rawSizes, int64(key.rawSize))
+	}
+
+	if len(pieceCids) == 0 {
+		return false, nil
+	}
+
+	var globalPending, clientPending int
+	err := tx.QueryRow(`
+		WITH incoming AS (
+			SELECT DISTINCT piece_cid, piece_raw_size
+			FROM unnest($1::TEXT[], $2::BIGINT[]) AS t(piece_cid, piece_raw_size)
+		),
+		global_active AS (
+			SELECT DISTINCT fi.piece_cid, fi.piece_raw_size
+			FROM pdp_piece_pull_items fi
+			WHERE fi.complete = FALSE
+				AND fi.failed = FALSE
+		),
+		client_active AS (
+			SELECT DISTINCT fi.piece_cid, fi.piece_raw_size
+			FROM pdp_piece_pull_items fi
+			JOIN pdp_piece_pulls fp ON fp.id = fi.fetch_id
+			WHERE fi.complete = FALSE
+				AND fi.failed = FALSE
+				AND fp.client_address = $3
+		),
+		global_combined AS (
+			SELECT piece_cid, piece_raw_size FROM global_active
+			UNION
+			SELECT piece_cid, piece_raw_size FROM incoming
+		),
+		client_combined AS (
+			SELECT piece_cid, piece_raw_size FROM client_active
+			UNION
+			SELECT piece_cid, piece_raw_size FROM incoming
+		)
+		SELECT
+			(SELECT COUNT(*) FROM global_combined),
+			(SELECT COUNT(*) FROM client_combined)
+	`, pieceCids, rawSizes, pull.ClientAddress).Scan(&globalPending, &clientPending)
+	if err != nil {
+		return false, fmt.Errorf("count pull pending pieces: %w", err)
+	}
+	if globalPending > pullGlobalPendingLimit {
+		return true, nil
+	}
+	if clientPending > pullPerClientPendingLimit {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pdp/pull_types_test.go
+++ b/pdp/pull_types_test.go
@@ -408,6 +408,46 @@ func TestPullResponse_ComputeOverallStatus(t *testing.T) {
 			expectedStatus: PullStatusPending,
 		},
 		{
+			name: "some complete some failed is complete",
+			pieces: []PullPieceStatus{
+				{PieceCid: "cid1", Status: PullStatusComplete},
+				{PieceCid: "cid2", Status: PullStatusFailed},
+			},
+			expectedStatus: PullStatusComplete,
+		},
+		{
+			name: "failed with inProgress is inProgress",
+			pieces: []PullPieceStatus{
+				{PieceCid: "cid1", Status: PullStatusFailed},
+				{PieceCid: "cid2", Status: PullStatusInProgress},
+			},
+			expectedStatus: PullStatusInProgress,
+		},
+		{
+			name: "failed with pending is pending",
+			pieces: []PullPieceStatus{
+				{PieceCid: "cid1", Status: PullStatusFailed},
+				{PieceCid: "cid2", Status: PullStatusPending},
+			},
+			expectedStatus: PullStatusPending,
+		},
+		{
+			name: "failed with retrying is retrying",
+			pieces: []PullPieceStatus{
+				{PieceCid: "cid1", Status: PullStatusFailed},
+				{PieceCid: "cid2", Status: PullStatusRetrying},
+			},
+			expectedStatus: PullStatusRetrying,
+		},
+		{
+			name: "all failed",
+			pieces: []PullPieceStatus{
+				{PieceCid: "cid1", Status: PullStatusFailed},
+				{PieceCid: "cid2", Status: PullStatusFailed},
+			},
+			expectedStatus: PullStatusFailed,
+		},
+		{
 			name: "single complete",
 			pieces: []PullPieceStatus{
 				{PieceCid: "cid1", Status: PullStatusComplete},

--- a/pdp/pull_types_test.go
+++ b/pdp/pull_types_test.go
@@ -3,6 +3,7 @@ package pdp
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -320,6 +321,45 @@ func TestPullRequest_Validate(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestPullRetryAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		pending  int
+		limit    int
+		expected time.Duration
+	}{
+		{name: "at limit", pending: 120, limit: 120, expected: time.Minute},
+		{name: "slightly over", pending: 121, limit: 120, expected: time.Minute},
+		{name: "second bucket", pending: 131, limit: 120, expected: 2 * time.Minute},
+		{name: "capped", pending: 200, limit: 120, expected: 5 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, pullRetryAfter(tt.pending, tt.limit))
+		})
+	}
+}
+
+func TestPullEffectiveClientPendingLimit(t *testing.T) {
+	tests := []struct {
+		name         string
+		otherPending int
+		expected     int
+	}{
+		{name: "empty queue", otherPending: 0, expected: 108},
+		{name: "some other work", otherPending: 20, expected: 88},
+		{name: "reserve mostly used", otherPending: 98, expected: 10},
+		{name: "never below normal cap", otherPending: 120, expected: 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, pullEffectiveClientPendingLimit(tt.otherPending))
 		})
 	}
 }

--- a/pdp/pull_types_test.go
+++ b/pdp/pull_types_test.go
@@ -224,6 +224,31 @@ func TestPullRequest_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "valid request with same piece from different sources",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, SourceURL: validURL},
+					{PieceCid: validCid, SourceURL: "https://backup.example.com/piece/" + validCid},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "duplicate piece and source",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, SourceURL: validURL},
+					{PieceCid: validCid, SourceURL: validURL},
+				},
+			},
+			wantErr:     true,
+			errContains: "duplicate pieceCid/sourceUrl",
+		},
+		{
 			name: "missing extraData",
 			req: PullRequest{
 				ExtraData: "",

--- a/pdp/utils.go
+++ b/pdp/utils.go
@@ -1,0 +1,103 @@
+package pdp
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type fwssCreatePayload struct {
+	Payer        common.Address
+	MetadataKeys []string
+}
+
+func decodeFWSSCreatePayload(extraData []byte) (*fwssCreatePayload, error) {
+	if len(extraData) == 0 {
+		return nil, fmt.Errorf("extraData is empty")
+	}
+
+	bytesType, err := abi.NewType("bytes", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create bytes ABI type: %w", err)
+	}
+	outerArgs := abi.Arguments{
+		{Type: bytesType}, // createPayload
+		{Type: bytesType}, // addPayload
+	}
+
+	decoded, err := outerArgs.Unpack(extraData)
+	if err != nil {
+		return nil, fmt.Errorf("decode combined extraData: %w", err)
+	}
+	if len(decoded) < 1 {
+		return nil, fmt.Errorf("combined extraData missing createPayload")
+	}
+
+	createPayload, ok := decoded[0].([]byte)
+	if !ok {
+		return nil, fmt.Errorf("createPayload is not bytes")
+	}
+
+	addressType, err := abi.NewType("address", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create address ABI type: %w", err)
+	}
+	uint256Type, err := abi.NewType("uint256", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create uint256 ABI type: %w", err)
+	}
+	stringArrayType, err := abi.NewType("string[]", "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create string array ABI type: %w", err)
+	}
+	createArgs := abi.Arguments{
+		{Type: addressType},     // payer
+		{Type: uint256Type},     // clientDataSetId
+		{Type: stringArrayType}, // keys
+		{Type: stringArrayType}, // values
+		{Type: bytesType},       // signature
+	}
+
+	createDecoded, err := createArgs.Unpack(createPayload)
+	if err != nil {
+		return nil, fmt.Errorf("decode createPayload: %w", err)
+	}
+	if len(createDecoded) < 3 {
+		return nil, fmt.Errorf("createPayload missing metadata keys")
+	}
+
+	payer, ok := createDecoded[0].(common.Address)
+	if !ok {
+		return nil, fmt.Errorf("payer is not an address")
+	}
+	keys, ok := createDecoded[2].([]string)
+	if !ok {
+		return nil, fmt.Errorf("keys is not []string")
+	}
+
+	return &fwssCreatePayload{
+		Payer:        payer,
+		MetadataKeys: keys,
+	}, nil
+}
+
+// FWSSPayerFromExtraData extracts the FilecoinWarmStorageService payer from
+// pull extraData. The expected format is the combined operation payload:
+//
+//	(bytes createPayload, bytes addPayload)
+//
+// where createPayload is:
+//
+//	(address payer, uint256 clientDataSetId, string[] keys, string[] values, bytes signature)
+func FWSSPayerFromExtraData(extraData []byte) (common.Address, error) {
+	payload, err := decodeFWSSCreatePayload(extraData)
+	if err != nil {
+		return common.Address{}, err
+	}
+	if payload.Payer == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("payer is zero address")
+	}
+
+	return payload.Payer, nil
+}

--- a/pdp/utils.go
+++ b/pdp/utils.go
@@ -83,7 +83,7 @@ func decodeFWSSCreatePayload(extraData []byte) (*fwssCreatePayload, error) {
 }
 
 // FWSSPayerFromExtraData extracts the FilecoinWarmStorageService payer from
-// pull extraData. The expected format is the combined operation payload:
+// create-new pull extraData. The expected format is the combined operation payload:
 //
 //	(bytes createPayload, bytes addPayload)
 //

--- a/tasks/pdp/task_prove.go
+++ b/tasks/pdp/task_prove.go
@@ -481,7 +481,7 @@ func (p *ProveTask) proveRoot(ctx context.Context, dataSetID int64, pieceID int6
 		}
 
 		if padreader.PaddedSize(rawSize).Padded() != pi.Size {
-			return contract.IPDPTypesProof{}, xerrors.Errorf("piece size mismatch: expected %d, got %d", pi.Size, padreader.PaddedSize(rawSize))
+			return contract.IPDPTypesProof{}, xerrors.Errorf("piece size mismatch: expected %d, got %d", pi.Size, padreader.PaddedSize(rawSize).Padded())
 		}
 
 		var r io.Reader = reader

--- a/tasks/pdpv0/task_pull_piece.go
+++ b/tasks/pdpv0/task_pull_piece.go
@@ -2,45 +2,49 @@ package pdpv0
 
 import (
 	"context"
-	"fmt"
+	"database/sql"
+	"errors"
 	"io"
-	"math"
 	"net/http"
 	"net/url"
-	"os"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
 	"github.com/ipfs/go-cid"
+	"github.com/yugabyte/pgx/v5"
 	"golang.org/x/xerrors"
 
-	commcid "github.com/filecoin-project/go-fil-commcid"
-	commp "github.com/filecoin-project/go-fil-commp-hashhash"
+	"github.com/filecoin-project/go-padreader"
+	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/harmony/resources"
 	"github.com/filecoin-project/curio/harmony/taskhelp"
-	"github.com/filecoin-project/curio/lib/dealdata"
+	ffi2 "github.com/filecoin-project/curio/lib/ffi"
 	"github.com/filecoin-project/curio/lib/parkpiece"
-	"github.com/filecoin-project/curio/lib/paths"
 	"github.com/filecoin-project/curio/lib/promise"
+	"github.com/filecoin-project/curio/lib/robusthttp"
+	"github.com/filecoin-project/curio/lib/storiface"
 	"github.com/filecoin-project/curio/pdp"
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
-var (
-	// PullPiecePollInterval is how often to poll for new pull items
-	PullPiecePollInterval = 10 * time.Second
+const maxPullPieceTasks = 15
 
-	// PullTotalBudget is the maximum wall-clock time from pull request creation
-	// before the item is marked as permanently failed. Prevents infinite retry
-	// loops when Harmony tasks exhaust MaxFailures and the item re-enters the
-	// queue with a fresh task (ON DELETE SET NULL on task_id).
-	PullTotalBudget = 1 * time.Hour
+const pullMinPieceSizeForCache = abi.PaddedPieceSize(uint64(32 * 1024 * 1024))
+
+var (
+	// PullPiecePollInterval is how often to poll for new pull items.
+	PullPiecePollInterval = 5 * time.Second
 
 	// PullAttemptTimeout is the maximum duration for a single download attempt.
-	PullAttemptTimeout = 30 * time.Minute
+	PullAttemptTimeout = 10 * time.Minute
+
+	// PullItemBudget is the wall-clock budget for a pull item. It is checked
+	// only at scheduling boundaries so an in-flight successful write can still
+	// complete the item.
+	PullItemBudget = 30 * time.Minute
 
 	// PullIdleReadTimeout cancels a download if no bytes are received for this
 	// duration, detecting stalled connections that hold TCP sockets open
@@ -48,371 +52,981 @@ var (
 	PullIdleReadTimeout = 2 * time.Minute
 )
 
-// PDPPullPieceTask downloads pieces from external SPs, verifies CommP,
-// and stores them in custore:// for StorePiece to pick up.
+// PDPPullPieceTask processes PDPv0 pull items after the handler has accepted a
+// pull request.
 //
-// Flow:
-//  1. Handler creates pdp_piece_pull_items with source_url
-//  2. This task polls for items with task_id IS NULL AND failed = FALSE
-//  3. Task downloads piece, computes CommP, verifies it matches expected
-//  4. On success: stores in StashStore, creates parked_pieces entry with custore:// URL
-//  5. StorePiece task picks up the parked_piece and moves to long-term storage
+// # Overview
 //
-// Future enhancement: implement verified piece retrieval per FRC-XXXX
-// for streaming verification with intermediate tree proofs.
+// The handler only writes pdp_piece_pulls and pdp_piece_pull_items. This task is
+// responsible for scheduling pull work, attaching source URLs to parked_pieces,
+// downloading pieces when PullPiece owns the parked row, and setting terminal
+// pull-item state.
+//
+// Pull work is grouped by (piece_cid, piece_raw_size). A group represents one
+// unique piece, even if multiple pull requests supplied different source URLs
+// for it. Successful completion of one group marks every active pull item for
+// that same piece complete, with each item receiving its own parked_piece_ref
+// and pdp_piecerefs row.
+//
+// # Scheduler Loop
+//
+// Each poll does three things:
+//
+//  1. completeAlreadyParkedItems: if a matching long-term parked_pieces row is
+//     already complete, create missing refs and mark pull items complete.
+//
+//  2. expireStalePullItems: fail unscheduled items older than PullItemBudget and
+//     clean up unused pull-created refs/parked rows.
+//
+//  3. schedulePullItems: assign one Harmony task per pending piece group. A
+//     group with any active task_id is skipped so the same piece is not worked
+//     twice at the same time.
+//
+// # Task Workflow
+//
+// Do first loads every active pull item for the assigned piece group. That includes
+// late arrivals for the same piece, not just rows that originally held this
+// task_id.
+//
+// It then claims the active long-term parked_pieces row for that piece key:
+//
+//   - If an ordinary row already exists, PullPiece attaches one parked_piece_ref
+//     per pull item and exits. ParkPiece/StorePiece continues normal processing,
+//     or a later scheduler pass marks the pull items complete if the row is
+//     already complete.
+//
+//   - If the existing row was created by a previous PullPiece run and is still
+//     incomplete, PullPiece deletes only refs recorded on pull items for that
+//     row, deletes the row when no refs remain, and otherwise flips skip=FALSE
+//     so the normal park task can process remaining refs.
+//
+//   - If no row exists, PullPiece creates a pull-owned parked_pieces row with
+//     skip=TRUE, attaches refs for the pull items, and downloads directly to
+//     long-term storage.
+//
+// Pull-owned rows are marked through pdp_piece_pull_items.pull_parked_piece_id.
+// That marker is what lets retry cleanup distinguish PullPiece-created skip=TRUE
+// rows from other skip=TRUE rows in the system.
+//
+// # Download and Cleanup
+//
+// For pull-owned rows, Do tries each unique source URL until one download
+// succeeds. The downloaded bytes must match the declared raw size, must not have
+// extra trailing bytes, and must compute to the expected CommP.
+//
+// On success, Do marks parked_pieces.complete=TRUE, re-reads active pull items
+// for the piece so refs created during the task are visible, creates pdp_piecerefs,
+// and marks those pull items complete. Rows that arrive after that completion
+// transaction are handled by the next completeAlreadyParkedItems pass.
+//
+// On failure or lost ownership, deferred cleanup removes unused pull-created refs,
+// deletes the incomplete pull-owned parked row when it is unreferenced, and removes
+// the local piece file best-effort. Cleanup errors are logged and do not replace
+// the main task error.
 type PDPPullPieceTask struct {
-	db      *harmonydb.DB
-	storage paths.StashStore
+	db *harmonydb.DB
+	sc *ffi2.SealCalls
 
 	TF promise.Promise[harmonytask.AddTaskFunc]
 
 	max int
 }
 
-// NewPDPPullPieceTask creates a new PDPPullPieceTask
-func NewPDPPullPieceTask(ctx context.Context, db *harmonydb.DB, storage paths.StashStore, max int) *PDPPullPieceTask {
+func NewPDPPullPieceTask(ctx context.Context, db *harmonydb.DB, sc *ffi2.SealCalls) *PDPPullPieceTask {
 	t := &PDPPullPieceTask{
-		db:      db,
-		storage: storage,
-		max:     max,
+		db:  db,
+		sc:  sc,
+		max: maxPullPieceTasks,
 	}
 
 	go t.pollPullItems(ctx)
 	return t
 }
 
-// pollPullItems polls for pull items that need processing
 func (t *PDPPullPieceTask) pollPullItems(ctx context.Context) {
 	ticker := time.NewTicker(PullPiecePollInterval)
 	defer ticker.Stop()
 
-	budgetInterval := fmt.Sprintf("%d Seconds", int(PullTotalBudget.Seconds()))
-
 	for {
-		// Mark expired items as permanently failed before looking for new work.
-		n, err := t.db.Exec(ctx, `
-			UPDATE pdp_piece_pull_items fi
-			SET failed = TRUE, fail_reason = 'pull budget exceeded'
-			FROM pdp_piece_pulls pp
-			WHERE pp.id = fi.fetch_id
-			AND fi.task_id IS NULL AND fi.failed = FALSE
-			AND pp.created_at <= NOW() - $1::interval
-		`, budgetInterval)
-		if err != nil {
-			log.Errorf("failed to expire pull items: %s", err)
-		} else if n > 0 {
-			log.Infow("PDPv0_PullPiece: expired stale pull items", "count", n)
+		if err := t.completeAlreadyParkedItems(ctx); err != nil {
+			log.Errorf("failed to mark already parked pull items complete: %s", err)
 		}
-
-		var items []struct {
-			FetchID      int64  `db:"fetch_id"`
-			PieceCid     string `db:"piece_cid"`
-			PieceRawSize int64  `db:"piece_raw_size"`
-			SourceURL    string `db:"source_url"`
+		if err := t.expireStalePullItems(ctx); err != nil {
+			log.Errorf("failed to expire stale pull items: %s", err)
 		}
-
-		// Select items that:
-		// 1. Have no task assigned (task_id IS NULL)
-		// 2. Have not permanently failed
-		// 3. Do NOT already have a parked_pieces entry (pull already completed)
-		// 4. Pull request is within the total time budget
-		err = t.db.Select(ctx, &items, `
-			SELECT fi.fetch_id, fi.piece_cid, fi.piece_raw_size, fi.source_url
-			FROM pdp_piece_pull_items fi
-			JOIN pdp_piece_pulls pp ON pp.id = fi.fetch_id
-			WHERE fi.task_id IS NULL AND fi.failed = FALSE
-			AND pp.created_at > NOW() - $1::interval
-			AND NOT EXISTS (
-				SELECT 1 FROM parked_pieces pp2
-				WHERE pp2.piece_cid = fi.piece_cid
-				AND pp2.long_term = TRUE
-				AND pp2.cleanup_task_id IS NULL
-			)
-		`, budgetInterval)
-		if err != nil {
-			log.Errorf("failed to query pull items: %s", err)
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				continue
-			}
-		}
-
-		if len(items) == 0 {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				continue
-			}
-		}
-
-		log.Debugw("PDPv0_PullPiece: found pending pull items, scheduling tasks", "count", len(items))
-		for _, item := range items {
-			fetchID := item.FetchID
-			pieceCid := item.PieceCid
-
-			t.TF.Val(ctx)(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, err error) {
-				// Atomically assign task_id, with same checks as the SELECT query
-				// to prevent race with concurrent parked_pieces creation
-				n, err := tx.Exec(`
-					UPDATE pdp_piece_pull_items fi
-					SET task_id = $1
-					FROM pdp_piece_pulls pp
-					WHERE pp.id = fi.fetch_id
-					AND fi.fetch_id = $2 AND fi.piece_cid = $3
-					AND fi.task_id IS NULL AND fi.failed = FALSE
-					AND pp.created_at > NOW() - $4::interval
-					AND NOT EXISTS (
-						SELECT 1 FROM parked_pieces pp2
-						WHERE pp2.piece_cid = fi.piece_cid
-						AND pp2.long_term = TRUE
-						AND pp2.cleanup_task_id IS NULL
-					)
-				`, id, fetchID, pieceCid, budgetInterval)
-				if err != nil {
-					return false, xerrors.Errorf("updating pull item task_id: %w", err)
-				}
-
-				return n > 0, nil
-			})
+		if err := t.schedulePullItems(ctx); err != nil {
+			log.Errorf("failed to schedule pull items: %s", err)
 		}
 
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			// continue to next iteration
 		}
 	}
 }
 
-// pullItemData holds the data for a pull item task
-type pullItemData struct {
-	FetchID      int64  `db:"fetch_id"`
+type pullPieceKey struct {
 	PieceCid     string `db:"piece_cid"`
 	PieceRawSize int64  `db:"piece_raw_size"`
-	SourceURL    string `db:"source_url"`
 }
 
-func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
-	ctx := context.Background()
+type pullItemToComplete struct {
+	FetchID       int64  `db:"fetch_id"`
+	Service       string `db:"service"`
+	PieceCid      string `db:"piece_cid"`
+	PieceRawSize  int64  `db:"piece_raw_size"`
+	SourceURL     string `db:"source_url"`
+	ParkedPieceID int64  `db:"parked_piece_id"`
+	PieceRef      *int64 `db:"parked_piece_ref"`
+}
 
-	// Fetch task data
-	var items []pullItemData
-	err = t.db.Select(ctx, &items, `
-		SELECT fetch_id, piece_cid, piece_raw_size, source_url
-		FROM pdp_piece_pull_items
-		WHERE task_id = $1
-	`, taskID)
-	if err != nil {
-		return false, xerrors.Errorf("fetching task data: %w", err)
-	}
-
-	if len(items) == 0 {
-		return false, xerrors.Errorf("no pull item found for task_id: %d", taskID)
-	}
-
-	item := items[0]
-
-	log.Debugw("PDPv0_PullPiece starting", "taskID", taskID, "pieceCid", item.PieceCid, "sourceUrl", item.SourceURL, "rawSize", item.PieceRawSize)
-
-	// Parse expected CID
-	expectedCid, err := cid.Parse(item.PieceCid)
-	if err != nil {
-		return false, xerrors.Errorf("parsing expected piece CID: %w", err)
-	}
-
-	// Download and verify the piece
-	stashID, err := t.downloadAndVerify(ctx, item.SourceURL, item.PieceRawSize, expectedCid)
-	if err != nil {
-		// Mark as failed and return error (task will retry or exhaust retries)
-		log.Errorw("pull piece failed", "error", err, "pieceCid", item.PieceCid, "sourceUrl", item.SourceURL)
-		return false, xerrors.Errorf("download and verify piece: %w", err)
-	}
-
-	// Get stash URL for creating parked_pieces entry
-	stashURL, err := t.storage.StashURL(stashID)
-	if err != nil {
-		// Clean up stash on failure
-		_ = t.storage.StashRemove(ctx, stashID)
-		return false, xerrors.Errorf("getting stash URL: %w", err)
-	}
-
-	// Change scheme to custore://
-	stashURL.Scheme = dealdata.CustoreScheme
-	custoreURL := stashURL.String()
-
-	// Calculate padded size
-	paddedSize := pdp.PadPieceSize(item.PieceRawSize)
-
-	// Create parked_pieces entry in a transaction
-	_, err = t.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
-		// Get the service from pdp_piece_pulls (via fetch_id)
-		var service string
-		err := tx.QueryRow(`
-			SELECT pp.service
-			FROM pdp_piece_pulls pp
-			JOIN pdp_piece_pull_items ppi ON ppi.fetch_id = pp.id
-			WHERE ppi.fetch_id = $1 AND ppi.piece_cid = $2
-		`, item.FetchID, item.PieceCid).Scan(&service)
+func (t *PDPPullPieceTask) completeAlreadyParkedItems(ctx context.Context) error {
+	_, err := t.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		var items []pullItemToComplete
+		err := tx.Select(&items, `
+			SELECT DISTINCT ON (fi.fetch_id, fi.piece_cid, fi.source_url)
+				fi.fetch_id,
+				pp.service,
+				fi.piece_cid,
+				fi.piece_raw_size,
+				fi.source_url,
+				parked.id AS parked_piece_id,
+				fi.parked_piece_ref
+			FROM pdp_piece_pull_items fi
+			JOIN pdp_piece_pulls pp ON pp.id = fi.fetch_id
+			JOIN parked_pieces parked
+				ON parked.piece_cid = fi.piece_cid
+				AND parked.piece_raw_size = fi.piece_raw_size
+				AND parked.long_term = TRUE
+				AND parked.complete = TRUE
+				AND parked.cleanup_task_id IS NULL
+			WHERE fi.complete = FALSE
+				AND fi.failed = FALSE
+			ORDER BY fi.fetch_id, fi.piece_cid, fi.source_url, parked.created_at ASC, parked.id ASC
+		`)
 		if err != nil {
-			return false, xerrors.Errorf("get service from pull: %w", err)
+			return false, xerrors.Errorf("query already parked pull items: %w", err)
 		}
 
-		// Create parked_pieces entry
-		parkedPieceID, err := parkpiece.Upsert(tx, item.PieceCid, int64(paddedSize), item.PieceRawSize, true)
-		if err != nil {
-			return false, xerrors.Errorf("insert parked_pieces: %w", err)
+		for _, item := range items {
+			existingRef := int64(0)
+			if item.PieceRef != nil {
+				existingRef = *item.PieceRef
+			}
+			err := completePullItemWithParkedPiece(tx, item.Service, item.FetchID, item.PieceCid, uint64(item.PieceRawSize), item.SourceURL, item.ParkedPieceID, existingRef)
+			if err != nil {
+				return false, xerrors.Errorf("complete already parked pull item %d/%s: %w", item.FetchID, item.PieceCid, err)
+			}
 		}
 
-		// Create parked_piece_refs entry with custore:// URL
-		var pieceRef int64
-		err = tx.QueryRow(`
-			INSERT INTO parked_piece_refs (piece_id, data_url, long_term)
-			VALUES ($1, $2, TRUE)
-			RETURNING ref_id
-		`, parkedPieceID, custoreURL).Scan(&pieceRef)
+		return len(items) > 0, nil
+	}, harmonydb.OptionRetry())
+	return err
+}
+
+func (t *PDPPullPieceTask) expireStalePullItems(ctx context.Context) error {
+	type stalePullItem struct {
+		FetchID           int64  `db:"fetch_id"`
+		PieceCid          string `db:"piece_cid"`
+		SourceURL         string `db:"source_url"`
+		PieceRef          *int64 `db:"parked_piece_ref"`
+		PullParkedPieceID *int64 `db:"pull_parked_piece_id"`
+	}
+
+	var expiredCount int64
+	var removedPieces []struct {
+		ID int64 `db:"id"`
+	}
+	comm, err := t.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		var staleItems []stalePullItem
+		err := tx.Select(&staleItems, `
+			SELECT fetch_id,
+				piece_cid,
+				source_url,
+				parked_piece_ref,
+				pull_parked_piece_id
+			FROM pdp_piece_pull_items
+			WHERE complete = FALSE
+				AND failed = FALSE
+				AND task_id IS NULL
+				AND created_at < NOW() - ($1::BIGINT * INTERVAL '1 second')
+		`, int64(PullItemBudget.Seconds()))
 		if err != nil {
-			return false, xerrors.Errorf("insert parked_piece_refs: %w", err)
+			return false, xerrors.Errorf("query stale pull items: %w", err)
+		}
+		if len(staleItems) == 0 {
+			return true, nil
 		}
 
-		// Register piece with service (parallels notify_task.go for uploads)
-		// Set needs_save_cache=TRUE for large pieces to enable proactive caching
-		needsSaveCache := uint64(item.PieceRawSize) >= MinSizeForCache
-		_, err = tx.Exec(`
-			INSERT INTO pdp_piecerefs (service, piece_cid, piece_ref, created_at, needs_save_cache)
-			VALUES ($1, $2, $3, NOW(), $4)
-		`, service, item.PieceCid, pieceRef, needsSaveCache)
-		if err != nil {
-			return false, xerrors.Errorf("insert pdp_piecerefs: %w", err)
+		fetchIDs := make([]int64, 0, len(staleItems))
+		pieceCids := make([]string, 0, len(staleItems))
+		sourceURLs := make([]string, 0, len(staleItems))
+		refIDs := make([]int64, 0, len(staleItems))
+		pieceIDs := make([]int64, 0, len(staleItems))
+		seenRefs := map[int64]struct{}{}
+		seenPieces := map[int64]struct{}{}
+		for _, item := range staleItems {
+			fetchIDs = append(fetchIDs, item.FetchID)
+			pieceCids = append(pieceCids, item.PieceCid)
+			sourceURLs = append(sourceURLs, item.SourceURL)
+			if item.PieceRef != nil {
+				if _, ok := seenRefs[*item.PieceRef]; !ok {
+					refIDs = append(refIDs, *item.PieceRef)
+					seenRefs[*item.PieceRef] = struct{}{}
+				}
+			}
+			if item.PullParkedPieceID != nil {
+				if _, ok := seenPieces[*item.PullParkedPieceID]; !ok {
+					pieceIDs = append(pieceIDs, *item.PullParkedPieceID)
+					seenPieces[*item.PullParkedPieceID] = struct{}{}
+				}
+			}
 		}
 
-		// Clear task_id from pull item (task is done)
-		_, err = tx.Exec(`
-			UPDATE pdp_piece_pull_items
-			SET task_id = NULL
-			WHERE fetch_id = $1 AND piece_cid = $2
-		`, item.FetchID, item.PieceCid)
+		n, err := tx.Exec(`
+			WITH stale(fetch_id, piece_cid, source_url) AS (
+				SELECT * FROM unnest($1::BIGINT[], $2::TEXT[], $3::TEXT[])
+			)
+			UPDATE pdp_piece_pull_items fi
+			SET failed = TRUE,
+				fail_reason = 'pull budget exceeded',
+				task_id = NULL,
+				parked_piece_ref = NULL,
+				pull_parked_piece_id = NULL
+			FROM stale
+			WHERE fi.fetch_id = stale.fetch_id
+				AND fi.piece_cid = stale.piece_cid
+				AND fi.source_url = stale.source_url
+				AND fi.complete = FALSE
+				AND fi.failed = FALSE
+		`, fetchIDs, pieceCids, sourceURLs)
 		if err != nil {
-			return false, xerrors.Errorf("clearing pull item task_id: %w", err)
+			return false, xerrors.Errorf("expire stale pull items: %w", err)
+		}
+		expiredCount = int64(n)
+
+		if len(refIDs) > 0 {
+			_, err = tx.Exec(`
+				DELETE FROM parked_piece_refs pr
+				WHERE pr.ref_id = ANY($1::BIGINT[])
+					AND NOT EXISTS (
+						SELECT 1 FROM pdp_piecerefs ppr WHERE ppr.piece_ref = pr.ref_id
+					)
+					AND NOT EXISTS (
+						SELECT 1
+						FROM pdp_piece_pull_items fi
+						WHERE fi.parked_piece_ref = pr.ref_id
+							AND fi.complete = FALSE
+							AND fi.failed = FALSE
+					)
+			`, refIDs)
+			if err != nil {
+				return false, xerrors.Errorf("delete expired pull refs: %w", err)
+			}
+		}
+
+		if len(pieceIDs) > 0 {
+			err = tx.Select(&removedPieces, `
+				DELETE FROM parked_pieces pp
+				WHERE pp.id = ANY($1::BIGINT[])
+					AND pp.complete = FALSE
+					AND pp.skip = TRUE
+					AND NOT EXISTS (
+						SELECT 1 FROM parked_piece_refs ppr WHERE ppr.piece_id = pp.id
+					)
+				RETURNING id
+			`, pieceIDs)
+			if err != nil {
+				return false, xerrors.Errorf("delete expired pull parked pieces: %w", err)
+			}
+
+			_, err = tx.Exec(`
+				UPDATE parked_pieces pp
+				SET skip = FALSE
+				WHERE pp.id = ANY($1::BIGINT[])
+					AND pp.complete = FALSE
+					AND pp.skip = TRUE
+					AND EXISTS (
+						SELECT 1 FROM parked_piece_refs ppr WHERE ppr.piece_id = pp.id
+					)
+			`, pieceIDs)
+			if err != nil {
+				return false, xerrors.Errorf("enable park task for remaining expired pull refs: %w", err)
+			}
 		}
 
 		return true, nil
 	}, harmonydb.OptionRetry())
 	if err != nil {
-		// Clean up stash on failure
-		_ = t.storage.StashRemove(ctx, stashID)
-		return false, xerrors.Errorf("creating parked piece: %w", err)
+		return err
+	}
+	if !comm {
+		return xerrors.Errorf("failed to commit DB transaction")
 	}
 
-	log.Infow("pull piece complete", "pieceCid", item.PieceCid, "custoreUrl", custoreURL)
-	return true, nil
+	if expiredCount > 0 {
+		log.Infow("PDPv0_PullPiece: expired stale pull items", "count", expiredCount)
+	}
+
+	for _, piece := range removedPieces {
+		if err := t.sc.RemovePiece(context.Background(), storiface.PieceNumber(piece.ID)); err != nil {
+			log.Errorw("failed to remove expired pull piece", "piece_id", piece.ID, "error", err)
+		}
+	}
+
+	return nil
 }
 
-// downloadAndVerify downloads a piece from sourceURL, computes CommP, and verifies it matches expected.
-// On success, returns the stash ID where the piece is stored.
-func (t *PDPPullPieceTask) downloadAndVerify(ctx context.Context, sourceURL string, expectedSize int64, expectedCid cid.Cid) (uuid.UUID, error) {
-	// Validate URL - HTTPS required for security (HTTP allowed only with env var for testing)
-	parsedURL, err := url.Parse(sourceURL)
+func (t *PDPPullPieceTask) schedulePullItems(ctx context.Context) error {
+	var activeGroups int
+	err := t.db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM (
+			SELECT DISTINCT piece_cid, piece_raw_size
+			FROM pdp_piece_pull_items
+			WHERE complete = FALSE
+				AND failed = FALSE
+				AND task_id IS NOT NULL
+		) active
+	`).Scan(&activeGroups)
 	if err != nil {
-		return uuid.UUID{}, xerrors.Errorf("invalid source URL: %w", err)
+		return xerrors.Errorf("count active pull item groups: %w", err)
 	}
-	allowHTTP := os.Getenv("CURIO_PULL_ALLOW_INSECURE") == "1"
-	if parsedURL.Scheme != "https" && (!allowHTTP || parsedURL.Scheme != "http") {
-		return uuid.UUID{}, xerrors.Errorf("source URL must use HTTPS scheme, got: %s", parsedURL.Scheme)
-	}
-
-	log.Debugw("PDPv0_PullPiece: downloading piece from source", "sourceURL", sourceURL, "expectedSize", expectedSize, "expectedCid", expectedCid)
-
-	ctx, cancel := context.WithTimeout(ctx, PullAttemptTimeout)
-	defer cancel()
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			ResponseHeaderTimeout: 2 * time.Minute,
-		},
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
-	if err != nil {
-		return uuid.UUID{}, xerrors.Errorf("creating request: %w", err)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return uuid.UUID{}, xerrors.Errorf("HTTP request failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return uuid.UUID{}, xerrors.Errorf("HTTP status %d from source", resp.StatusCode)
-	}
-
-	// Wrap body with idle-read detection: if no bytes arrive within
-	// PullIdleReadTimeout the context is cancelled, aborting the download.
-	idleReader := newIdleTimeoutReader(resp.Body, PullIdleReadTimeout, cancel)
-	defer idleReader.stop()
-
-	// Limit reader to expected size + 1 to detect oversized data
-	dataReader := io.LimitReader(idleReader, expectedSize+1)
-
-	// Create commp calculator
-	cp := &commp.Calc{}
-	defer cp.Reset()
-	var readSize int64
-
-	// Write to stash while computing CommP
-	writeFunc := func(f *os.File) error {
-		multiWriter := io.MultiWriter(cp, f)
-
-		n, err := io.Copy(multiWriter, dataReader)
-		if err != nil {
-			return xerrors.Errorf("copying piece data: %w", err)
-		}
-
-		readSize = n
+	if activeGroups >= t.max {
 		return nil
 	}
 
-	// Store in StashStore
-	stashID, err := t.storage.StashCreate(ctx, expectedSize, writeFunc)
+	limit := t.max - activeGroups
+	var groups []pullPieceKey
+	err = t.db.Select(ctx, &groups, `
+		SELECT fi.piece_cid, fi.piece_raw_size
+		FROM pdp_piece_pull_items fi
+		WHERE fi.complete = FALSE
+			AND fi.failed = FALSE
+			AND fi.task_id IS NULL
+			AND fi.created_at >= NOW() - ($2::BIGINT * INTERVAL '1 second')
+			AND NOT EXISTS (
+				SELECT 1
+				FROM pdp_piece_pull_items running
+				WHERE running.piece_cid = fi.piece_cid
+					AND running.piece_raw_size = fi.piece_raw_size
+					AND running.complete = FALSE
+					AND running.failed = FALSE
+					AND running.task_id IS NOT NULL
+		)
+		GROUP BY fi.piece_cid, fi.piece_raw_size
+		ORDER BY MIN(fi.created_at) ASC, MIN(fi.fetch_id) ASC, fi.piece_cid ASC
+		LIMIT $1
+	`, limit, int64(PullItemBudget.Seconds()))
 	if err != nil {
-		return uuid.UUID{}, xerrors.Errorf("creating stash: %w", err)
+		return xerrors.Errorf("query pending pull item groups: %w", err)
+	}
+	if len(groups) == 0 {
+		return nil
 	}
 
-	// Check size
-	if readSize != expectedSize {
-		_ = t.storage.StashRemove(ctx, stashID)
-		return uuid.UUID{}, xerrors.Errorf("size mismatch: expected %d, got %d", expectedSize, readSize)
+	log.Debugw("PDPv0_PullPiece: found pending pull item groups", "count", len(groups))
+
+	for _, group := range groups {
+		group := group
+		t.TF.Val(ctx)(func(id harmonytask.TaskID, tx *harmonydb.Tx) (bool, error) {
+			return t.assignGroup(tx, id, group)
+		})
 	}
 
-	log.Debugw("PDPv0_PullPiece: download complete, verifying CommP", "sourceURL", sourceURL, "readSize", readSize, "stashID", stashID)
+	return nil
+}
 
-	// Finalize CommP calculation
-	digest, _, err := cp.Digest()
+func (t *PDPPullPieceTask) assignGroup(tx *harmonydb.Tx, taskID harmonytask.TaskID, group pullPieceKey) (bool, error) {
+	// Let's double check that a complete piece does not exists
+	completePieceID, err := findCompleteParkedPiece(tx, group)
 	if err != nil {
-		_ = t.storage.StashRemove(ctx, stashID)
-		return uuid.UUID{}, xerrors.Errorf("computing CommP digest: %w", err)
+		return false, err
 	}
 
-	// Convert to CID
-	computedCid, err := commcid.DataCommitmentV1ToCID(digest)
+	// If it exists, we exit here
+	if completePieceID != nil {
+		return false, nil
+	}
+
+	// Schedule a single task per piece_cid and not per item
+	n, err := tx.Exec(`
+		UPDATE pdp_piece_pull_items fi
+		SET task_id = $3
+		WHERE fi.piece_cid = $1
+			AND fi.piece_raw_size = $2
+			AND fi.complete = FALSE
+			AND fi.failed = FALSE
+			AND fi.task_id IS NULL
+			AND fi.created_at >= NOW() - ($4::BIGINT * INTERVAL '1 second')
+			AND NOT EXISTS (
+				SELECT 1
+				FROM pdp_piece_pull_items running
+				WHERE running.piece_cid = fi.piece_cid
+					AND running.piece_raw_size = fi.piece_raw_size
+					AND running.complete = FALSE
+					AND running.failed = FALSE
+					AND running.task_id IS NOT NULL
+			)
+	`, group.PieceCid, group.PieceRawSize, taskID, int64(PullItemBudget.Seconds()))
 	if err != nil {
-		_ = t.storage.StashRemove(ctx, stashID)
-		return uuid.UUID{}, xerrors.Errorf("converting digest to CID: %w", err)
+		return false, xerrors.Errorf("assign pull item task: %w", err)
 	}
 
-	// Verify CommP matches
-	if !expectedCid.Equals(computedCid) {
-		_ = t.storage.StashRemove(ctx, stashID)
-		return uuid.UUID{}, xerrors.Errorf("CommP mismatch: expected %s, got %s", expectedCid, computedCid)
+	return n > 0, nil
+}
+
+func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
+	ctx := context.Background()
+
+	type pullSource struct {
+		PieceCid     string `db:"piece_cid"`
+		PieceRawSize int64  `db:"piece_raw_size"`
+		FetchID      int64  `db:"fetch_id"`
+		Service      string `db:"service"`
+		SourceURL    string `db:"source_url"`
+		PieceRef     *int64 `db:"parked_piece_ref"`
 	}
 
-	log.Debugw("PDPv0_PullPiece: CommP verified, piece stored in stash", "computedCid", computedCid, "stashID", stashID)
+	var sources []pullSource
+	err = t.db.Select(ctx, &sources, `
+		WITH assigned_groups AS (
+			SELECT piece_cid, piece_raw_size
+			FROM pdp_piece_pull_items
+			WHERE task_id = $1
+				AND complete = FALSE
+				AND failed = FALSE
+			GROUP BY piece_cid, piece_raw_size
+		),
+		items AS (
+			SELECT
+				fi.piece_cid,
+				fi.piece_raw_size,
+				fi.fetch_id,
+				pp.service,
+				fi.source_url,
+				fi.parked_piece_ref,
+				fi.created_at
+			FROM assigned_groups ag
+			JOIN pdp_piece_pull_items fi
+				ON fi.piece_cid = ag.piece_cid
+				AND fi.piece_raw_size = ag.piece_raw_size
+			JOIN pdp_piece_pulls pp ON pp.id = fi.fetch_id
+			WHERE fi.complete = FALSE
+				AND fi.failed = FALSE
+		)
+		SELECT piece_cid, piece_raw_size, fetch_id, service, source_url, parked_piece_ref
+		FROM items
+		ORDER BY created_at ASC, fetch_id ASC
+	`, taskID)
+	if err != nil {
+		return false, xerrors.Errorf("query pull task sources: %w", err)
+	}
+	if len(sources) == 0 {
+		return true, nil
+	}
 
-	return stashID, nil
+	group := pullPieceKey{PieceCid: sources[0].PieceCid, PieceRawSize: sources[0].PieceRawSize}
+	for _, source := range sources[1:] {
+		if source.PieceCid != group.PieceCid || source.PieceRawSize != group.PieceRawSize {
+			return false, xerrors.Errorf("expected 1 pull group for task %d", taskID)
+		}
+	}
+
+	expectedCid, err := cid.Parse(group.PieceCid)
+	if err != nil {
+		return false, xerrors.Errorf("invalid expected piece CID for pull task %d: %w", taskID, err)
+	}
+
+	log.Debugw("PDPv0_PullPiece starting", "taskID", taskID, "pieceCid", group.PieceCid, "rawSize", group.PieceRawSize)
+
+	var parkedPieceID int64
+	createdParkedPiece := false
+	var stalePullPiecesToRemove []int64
+	comm, err := t.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		var err error
+		parkedPieceID, createdParkedPiece, err = parkpiece.UpsertSkipWithInserted(tx, group.PieceCid, int64(padreader.PaddedSize(uint64(group.PieceRawSize)).Padded()), group.PieceRawSize, true, true)
+		if err != nil {
+			return false, xerrors.Errorf("upsert parked piece: %w", err)
+		}
+
+		var activeComplete bool
+		var activeTaskID sql.NullInt64
+		var activeTaskExists bool
+		var activePullOwned bool
+		cleanedPullOwnedPiece := false
+		var txRemovePieces []int64
+
+		for {
+			err = tx.QueryRow(`
+				SELECT pp.complete,
+					pp.task_id,
+					ht.id IS NOT NULL AS task_exists,
+					EXISTS (
+						SELECT 1
+						FROM pdp_piece_pull_items fi
+						WHERE fi.pull_parked_piece_id = pp.id
+							AND fi.piece_cid = $2
+							AND fi.piece_raw_size = $3
+					) AS pull_owned
+				FROM parked_pieces pp
+				LEFT JOIN harmony_task ht ON ht.id = pp.task_id
+				WHERE pp.id = $1
+			`, parkedPieceID, group.PieceCid, group.PieceRawSize).Scan(&activeComplete, &activeTaskID, &activeTaskExists, &activePullOwned)
+			if err != nil {
+				return false, xerrors.Errorf("query claimed parked piece: %w", err)
+			}
+
+			if createdParkedPiece || activeComplete || !activePullOwned {
+				break
+			}
+			if cleanedPullOwnedPiece {
+				return false, xerrors.Errorf("pull-owned parked piece still active after cleanup: %d", parkedPieceID)
+			}
+
+			removed, err := cleanupPullCreatedParkedPieceTx(tx, parkedPieceID)
+			if err != nil {
+				return false, xerrors.Errorf("cleanup stale pull-owned parked piece: %w", err)
+			}
+			if removed {
+				txRemovePieces = append(txRemovePieces, parkedPieceID)
+			}
+
+			parkedPieceID, createdParkedPiece, err = parkpiece.UpsertSkipWithInserted(tx, group.PieceCid, int64(padreader.PaddedSize(uint64(group.PieceRawSize)).Padded()), group.PieceRawSize, true, true)
+			if err != nil {
+				return false, xerrors.Errorf("upsert parked piece after cleanup: %w", err)
+			}
+			cleanedPullOwnedPiece = true
+		}
+
+		// If park_piece exhausted retries before these refs were attached, clear
+		// the stale task_id so its scheduler can pick the row again.
+		if !createdParkedPiece && activeTaskID.Valid && !activeTaskExists && !activeComplete {
+			n, err := tx.Exec(`
+				UPDATE parked_pieces
+				SET task_id = NULL
+				WHERE id = $1
+					AND task_id = $2
+					AND complete = FALSE
+			`, parkedPieceID, activeTaskID.Int64)
+			if err != nil {
+				return false, xerrors.Errorf("clear stale parked piece task: %w", err)
+			}
+			if n != 1 {
+				return false, xerrors.Errorf("expected 1 parked piece task, got %d", n)
+			}
+		}
+
+		for _, source := range sources {
+			if source.PieceRef != nil && !cleanedPullOwnedPiece {
+				continue
+			}
+
+			var pieceRef int64
+			err := tx.QueryRow(`
+				INSERT INTO parked_piece_refs (piece_id, data_url, long_term)
+				VALUES ($1, $2, TRUE)
+				RETURNING ref_id
+			`, parkedPieceID, source.SourceURL).Scan(&pieceRef)
+			if err != nil {
+				return false, xerrors.Errorf("insert parked_piece_ref for pull item: %w", err)
+			}
+
+			n, err := tx.Exec(`
+				UPDATE pdp_piece_pull_items
+				SET parked_piece_ref = $4,
+					pull_parked_piece_id = CASE WHEN $5 THEN $6 ELSE pull_parked_piece_id END
+				WHERE fetch_id = $1
+					AND piece_cid = $2
+					AND piece_raw_size = $3
+					AND source_url = $8
+					AND complete = FALSE
+					AND failed = FALSE
+					AND (parked_piece_ref IS NULL OR $7)
+			`, source.FetchID, source.PieceCid, source.PieceRawSize, pieceRef, createdParkedPiece, parkedPieceID, cleanedPullOwnedPiece, source.SourceURL)
+			if err != nil {
+				return false, xerrors.Errorf("attach parked_piece_ref to pull item: %w", err)
+			}
+			if n != 1 {
+				return false, xerrors.Errorf("expected 1 attached piece ref, got %d", n)
+			}
+		}
+
+		stalePullPiecesToRemove = txRemovePieces
+		return true, nil
+	}, harmonydb.OptionRetry())
+	if err != nil {
+		return false, err
+	}
+	if !comm {
+		return false, xerrors.Errorf("failed to commit DB transaction")
+	}
+
+	for _, pieceID := range stalePullPiecesToRemove {
+		if err := t.sc.RemovePiece(context.Background(), storiface.PieceNumber(pieceID)); err != nil {
+			log.Errorw("failed to remove stale pull-owned piece", "piece_id", pieceID, "error", err)
+		}
+	}
+
+	// If the row already existed, this task only contributes refs. ParkPiece will
+	// either keep running with refs it already loaded, or retry using the newly
+	// attached refs after the stale task_id path above.
+	if !createdParkedPiece {
+		return true, nil
+	}
+
+	ssrfPolicy := robusthttp.CurrentSSRFPolicy()
+	if pdp.PullAllowInsecure() {
+		ssrfPolicy.Disabled = true
+	}
+
+	shouldCleanup := true
+	defer func(ppid int64, taskname string) {
+		if !shouldCleanup {
+			return
+		}
+		var removed bool
+		cleanupComm, cleanupErr := t.db.BeginTransaction(context.Background(), func(tx *harmonydb.Tx) (bool, error) {
+			var err error
+			removed, err = cleanupPullCreatedParkedPieceTx(tx, ppid)
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		}, harmonydb.OptionRetry())
+		if cleanupErr != nil {
+			log.Errorw("failed to cleanup pull parked_piece_refs", "task_id", taskID, "task_type", taskname, "error", cleanupErr)
+		}
+
+		if !cleanupComm {
+			log.Errorw("failed to cleanup pull parked_piece_refs", "task_id", taskID, "task_type", taskname, "error", "failed to commit DB transaction")
+		}
+
+		if removed {
+			if err := t.sc.RemovePiece(context.Background(), storiface.PieceNumber(ppid)); err != nil {
+				log.Errorw("failed to remove piece", "task_id", taskID, "task_type", taskname, "piece_id", ppid, "error", err)
+			}
+		}
+	}(parkedPieceID, t.TypeDetails().Name)
+
+	attemptedSources := map[string]struct{}{}
+	var sourceErrors error
+	for _, source := range sources {
+		if _, ok := attemptedSources[source.SourceURL]; ok {
+			continue
+		}
+		attemptedSources[source.SourceURL] = struct{}{}
+
+		if !stillOwned() {
+			return false, nil
+		}
+
+		// Check if the source URL is good for a download
+		parsedURL, sourceErr := url.Parse(source.SourceURL)
+		if sourceErr == nil {
+			if parsedURL.Scheme != "https" && (!pdp.PullAllowInsecure() || parsedURL.Scheme != "http") {
+				sourceErr = xerrors.Errorf("source URL must use HTTPS scheme, got: %s", parsedURL.Scheme)
+			}
+		}
+		downloadPolicy := ssrfPolicy
+		downloadPolicy.ResponseHeaderTimeout = 2 * time.Minute
+		if sourceErr == nil {
+			_, sourceErr = robusthttp.ValidateClientFetchURL(source.SourceURL, nil, &downloadPolicy)
+		}
+		if sourceErr != nil {
+			log.Warnw("pull source URL rejected", "error", sourceErr, "pieceCid", group.PieceCid, "sourceURL", source.SourceURL)
+			sourceErrors = multierror.Append(sourceErrors, xerrors.Errorf("%s: %w", source.SourceURL, sourceErr))
+			continue
+		}
+
+		downloadCtx, downloadCancel := context.WithTimeout(ctx, PullAttemptTimeout)
+		client, _ := robusthttp.NewSSRFProtectedHTTPClient(&downloadPolicy, nil)
+
+		req, downloadErr := http.NewRequestWithContext(downloadCtx, http.MethodGet, source.SourceURL, nil)
+		if downloadErr == nil {
+			var resp *http.Response
+			resp, downloadErr = client.Do(req)
+			if resp != nil {
+				if downloadErr == nil && resp.StatusCode != http.StatusOK {
+					downloadErr = xerrors.Errorf("HTTP status %d from source", resp.StatusCode)
+				}
+				if downloadErr == nil && resp.ContentLength > group.PieceRawSize {
+					downloadErr = xerrors.Errorf("size mismatch: expected %d, got at least %d", group.PieceRawSize, resp.ContentLength)
+				}
+				if downloadErr == nil {
+					idleReader := &idleTimeoutReader{
+						r:      resp.Body,
+						timer:  time.AfterFunc(PullIdleReadTimeout, downloadCancel),
+						cancel: downloadCancel,
+						idle:   PullIdleReadTimeout,
+					}
+					pieceInfo, readSize, writeErr := t.sc.WriteUploadPiece(downloadCtx, storiface.PieceNumber(parkedPieceID), group.PieceRawSize, idleReader, storiface.PathStorage, true)
+					if writeErr != nil {
+						idleReader.timer.Stop()
+						downloadErr = xerrors.Errorf("write pulled piece: %w", writeErr)
+					} else {
+						if readSize != uint64(group.PieceRawSize) {
+							downloadErr = xerrors.Errorf("size mismatch: expected %d, got %d", group.PieceRawSize, readSize)
+						} else if !pieceInfo.PieceCID.Equals(expectedCid) {
+							downloadErr = xerrors.Errorf("CommP mismatch: expected %s, got %s", expectedCid, pieceInfo.PieceCID)
+						} else if pieceInfo.Size != abi.PaddedPieceSize(pdp.PadPieceSize(group.PieceRawSize)) {
+							downloadErr = xerrors.Errorf("padded size mismatch: expected %d, got %d", pdp.PadPieceSize(group.PieceRawSize), pieceInfo.Size)
+						} else {
+							var extra [1]byte
+							n, readErr := idleReader.Read(extra[:])
+							if n > 0 {
+								downloadErr = xerrors.Errorf("size mismatch: expected %d, got more", group.PieceRawSize)
+							} else if readErr != nil && readErr != io.EOF {
+								downloadErr = xerrors.Errorf("checking for oversized response: %w", readErr)
+							}
+						}
+						idleReader.timer.Stop()
+					}
+				}
+				_ = resp.Body.Close()
+			}
+		}
+		downloadCancel()
+
+		if downloadErr != nil {
+			log.Warnw("pull source URL failed", "error", downloadErr, "pieceCid", group.PieceCid, "sourceURL", source.SourceURL)
+			sourceErrors = multierror.Append(sourceErrors, xerrors.Errorf("%s: %w", source.SourceURL, downloadErr))
+			continue
+		}
+
+		comm, err := t.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+			n, err := tx.Exec(`
+				UPDATE parked_pieces
+				SET complete = TRUE
+				WHERE id = $1
+			`, parkedPieceID)
+			if err != nil {
+				return false, xerrors.Errorf("mark parked piece complete: %w", err)
+			}
+
+			if n != 1 {
+				return false, xerrors.Errorf("mark parked piece complete: expected 1, got %d", n)
+			}
+
+			// Re-read from the DB instead of using sources from task start:
+			// refs were attached after sources was loaded, and new pull items
+			// for this same piece may have arrived while the download ran.
+			// Rows that arrive after this transaction will be completed by the
+			// next completeAlreadyParkedItems pass.
+			var items []pullItemToComplete
+			err = tx.Select(&items, `
+				SELECT fi.fetch_id,
+					pp.service,
+					fi.piece_cid,
+					fi.piece_raw_size,
+					fi.source_url,
+					$3::BIGINT AS parked_piece_id,
+					fi.parked_piece_ref
+				FROM pdp_piece_pull_items fi
+				JOIN pdp_piece_pulls pp ON pp.id = fi.fetch_id
+				WHERE fi.piece_cid = $1
+					AND fi.piece_raw_size = $2
+					AND fi.complete = FALSE
+					AND fi.failed = FALSE
+				ORDER BY fi.fetch_id ASC, fi.piece_cid ASC
+			`, group.PieceCid, group.PieceRawSize, parkedPieceID)
+			if err != nil {
+				return false, xerrors.Errorf("query pull items to complete: %w", err)
+			}
+
+			for _, item := range items {
+				existingRef := int64(0)
+				if item.PieceRef != nil {
+					existingRef = *item.PieceRef
+				}
+
+				err := completePullItemWithParkedPiece(tx, item.Service, item.FetchID, item.PieceCid, uint64(item.PieceRawSize), item.SourceURL, item.ParkedPieceID, existingRef)
+				if err != nil {
+					return false, xerrors.Errorf("complete pull item %d/%s: %w", item.FetchID, item.PieceCid, err)
+				}
+			}
+
+			return true, nil
+		}, harmonydb.OptionRetry())
+		if err != nil {
+			return false, err
+		}
+
+		if !comm {
+			mainErr := xerrors.Errorf("failed to commit DB transaction")
+			return false, mainErr
+		}
+
+		log.Infow("pull piece complete", "pieceCid", group.PieceCid, "pieceID", parkedPieceID, "taskID", taskID)
+		shouldCleanup = false
+		return true, nil
+	}
+
+	if sourceErrors != nil {
+		return false, xerrors.Errorf("all pull source URLs failed: %w", sourceErrors)
+	}
+
+	return false, xerrors.Errorf("no good URL found to download the piece")
+}
+
+func cleanupPullCreatedParkedPieceTx(tx *harmonydb.Tx, parkedPieceID int64) (bool, error) {
+	var refIDs []int64
+	err := tx.Select(&refIDs, `
+		SELECT DISTINCT fi.parked_piece_ref
+		FROM pdp_piece_pull_items fi
+		JOIN parked_piece_refs pr ON pr.ref_id = fi.parked_piece_ref
+		WHERE fi.pull_parked_piece_id = $1
+			AND pr.piece_id = $1
+			AND fi.parked_piece_ref IS NOT NULL
+	`, parkedPieceID)
+	if err != nil {
+		return false, xerrors.Errorf("query pull-created parked piece refs: %w", err)
+	}
+
+	_, err = tx.Exec(`
+		UPDATE pdp_piece_pull_items
+		SET parked_piece_ref = NULL,
+			pull_parked_piece_id = NULL
+		WHERE complete = FALSE
+			AND failed = FALSE
+			AND pull_parked_piece_id = $1
+	`, parkedPieceID)
+	if err != nil {
+		return false, xerrors.Errorf("clear pull-created parked piece refs: %w", err)
+	}
+
+	if len(refIDs) > 0 {
+		_, err = tx.Exec(`
+			DELETE FROM parked_piece_refs pr
+			WHERE pr.ref_id = ANY($1::BIGINT[])
+				AND NOT EXISTS (
+					SELECT 1 FROM pdp_piecerefs ppr WHERE ppr.piece_ref = pr.ref_id
+				)
+		`, refIDs)
+		if err != nil {
+			return false, xerrors.Errorf("delete pull-created parked piece refs: %w", err)
+		}
+	}
+
+	n, err := tx.Exec(`
+		DELETE FROM parked_pieces pp
+		WHERE pp.id = $1
+			AND pp.complete = FALSE
+			AND NOT EXISTS (
+				SELECT 1 FROM parked_piece_refs ppr WHERE ppr.piece_id = pp.id
+			)
+	`, parkedPieceID)
+	if err != nil {
+		return false, xerrors.Errorf("delete pull-created parked piece: %w", err)
+	}
+	if n > 0 {
+		return true, nil
+	}
+
+	_, err = tx.Exec(`
+		UPDATE parked_pieces pp
+		SET skip = FALSE
+		WHERE pp.id = $1
+			AND pp.complete = FALSE
+			AND pp.skip = TRUE
+			AND EXISTS (
+				SELECT 1 FROM parked_piece_refs ppr WHERE ppr.piece_id = pp.id
+			)
+	`, parkedPieceID)
+	if err != nil {
+		return false, xerrors.Errorf("enable park task for remaining refs: %w", err)
+	}
+
+	return false, nil
+}
+
+func completePullItemWithParkedPiece(tx *harmonydb.Tx, service string, fetchID int64, pieceCID string, rawSize uint64, sourceURL string, parkedPieceID int64, existingPieceRef int64) error {
+	n, err := tx.Exec(`
+		UPDATE pdp_piece_pull_items
+		SET complete = TRUE,
+			failed = FALSE,
+			fail_reason = NULL,
+			task_id = NULL
+		WHERE fetch_id = $1
+			AND piece_cid = $2
+			AND piece_raw_size = $3
+			AND source_url = $4
+			AND complete = FALSE
+			AND failed = FALSE
+	`, fetchID, pieceCID, rawSize, sourceURL)
+	if err != nil {
+		return xerrors.Errorf("mark pull item complete: %w", err)
+	}
+	if n == 0 {
+		return nil
+	}
+	if n != 1 {
+		return xerrors.Errorf("mark pull item complete: expected 1, got %d", n)
+	}
+
+	pieceRef := existingPieceRef
+	if pieceRef == 0 {
+		err = tx.QueryRow(`
+			INSERT INTO parked_piece_refs (piece_id, data_url, long_term)
+			VALUES ($1, $2, TRUE)
+			RETURNING ref_id
+		`, parkedPieceID, sourceURL).Scan(&pieceRef)
+		if err != nil {
+			return xerrors.Errorf("insert parked_piece_refs: %w", err)
+		}
+
+		n, err = tx.Exec(`
+			UPDATE pdp_piece_pull_items
+			SET parked_piece_ref = $5
+			WHERE fetch_id = $1
+				AND piece_cid = $2
+				AND piece_raw_size = $3
+				AND source_url = $4
+		`, fetchID, pieceCID, rawSize, sourceURL, pieceRef)
+		if err != nil {
+			return xerrors.Errorf("attach parked_piece_ref to completed pull item: %w", err)
+		}
+		if n != 1 {
+			return xerrors.Errorf("attach parked_piece_ref to completed pull item: expected 1, got %d", n)
+		}
+	}
+
+	needsSaveCache := padreader.PaddedSize(rawSize).Padded() >= pullMinPieceSizeForCache
+	n, err = tx.Exec(`
+		INSERT INTO pdp_piecerefs (service, piece_cid, piece_ref, created_at, needs_save_cache)
+		VALUES ($1, $2, $3, NOW(), $4)
+	`, service, pieceCID, pieceRef, needsSaveCache)
+	if err != nil {
+		return xerrors.Errorf("insert pdp_piecerefs: %w", err)
+	}
+	if n != 1 {
+		return xerrors.Errorf("insert pdp_piecerefs: expected 1, got %d", n)
+	}
+
+	return nil
+}
+
+func findCompleteParkedPiece(tx *harmonydb.Tx, group pullPieceKey) (*int64, error) {
+	var id int64
+	err := tx.QueryRow(`
+		SELECT id
+		FROM parked_pieces
+		WHERE piece_cid = $1
+			AND piece_padded_size = $2
+			AND long_term = TRUE
+			AND complete = TRUE
+			AND cleanup_task_id IS NULL
+		ORDER BY created_at ASC, id ASC
+		LIMIT 1
+	`, group.PieceCid, pdp.PadPieceSize(group.PieceRawSize)).Scan(&id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, xerrors.Errorf("query complete parked piece: %w", err)
+	}
+	return &id, nil
 }
 
 func (t *PDPPullPieceTask) CanAccept(ids []harmonytask.TaskID, engine *harmonytask.TaskEngine) ([]harmonytask.TaskID, error) {
@@ -424,15 +1038,12 @@ func (t *PDPPullPieceTask) TypeDetails() harmonytask.TaskTypeDetails {
 		Name: tasknames.PDPv0_PullPiece,
 		Max:  taskhelp.Max(t.max),
 		Cost: resources.Resources{
-			Cpu: 1,
-			Gpu: 0,
-			Ram: 128 << 20, // 128 MiB for streaming + CommP computation
+			Cpu:     0,
+			Gpu:     0,
+			Ram:     128 << 20,
+			Storage: nil,
 		},
-		MaxFailures: 5,
-		RetryWait: func(retries int) time.Duration {
-			const baseWait, maxWait, factor = 10 * time.Second, 5 * time.Minute, 2.0
-			return min(time.Duration(float64(baseWait)*math.Pow(factor, float64(retries))), maxWait)
-		},
+		MaxFailures: 1,
 	}
 }
 
@@ -440,29 +1051,14 @@ func (t *PDPPullPieceTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 	t.TF.Set(taskFunc)
 }
 
-var (
-	_ harmonytask.TaskInterface = &PDPPullPieceTask{}
-	_                           = harmonytask.Reg(&PDPPullPieceTask{})
-)
+var _ harmonytask.TaskInterface = &PDPPullPieceTask{}
+var _ = harmonytask.Reg(&PDPPullPieceTask{})
 
-// idleTimeoutReader wraps an io.Reader and cancels a context if no successful
-// reads occur within the timeout. Each Read that returns n > 0 resets the
-// timer. This detects stalled HTTP transfers where the TCP connection stays
-// open but no data flows.
 type idleTimeoutReader struct {
 	r      io.Reader
 	timer  *time.Timer
 	cancel context.CancelFunc
 	idle   time.Duration
-}
-
-func newIdleTimeoutReader(r io.Reader, timeout time.Duration, cancel context.CancelFunc) *idleTimeoutReader {
-	return &idleTimeoutReader{
-		r:      r,
-		timer:  time.AfterFunc(timeout, cancel),
-		cancel: cancel,
-		idle:   timeout,
-	}
 }
 
 func (r *idleTimeoutReader) Read(p []byte) (int, error) {
@@ -471,8 +1067,4 @@ func (r *idleTimeoutReader) Read(p []byte) (int, error) {
 		r.timer.Reset(r.idle)
 	}
 	return n, err
-}
-
-func (r *idleTimeoutReader) stop() {
-	r.timer.Stop()
 }

--- a/tasks/pdpv0/task_pull_piece.go
+++ b/tasks/pdpv0/task_pull_piece.go
@@ -121,9 +121,9 @@ var (
 // extra trailing bytes, and must compute to the expected CommP.
 //
 // If no URL succeeds in a task pass, per-URL failures are recorded. Permanent
-// failures, such as bad source URLs, 410 responses, size mismatches, and CommP
-// mismatches, fail the affected pull items immediately. Transient failures,
-// including Curio-side 404s, update attempt_count and next_attempt_at; after
+// failures, such as bad source URLs, 404/410 responses, size mismatches, and CommP
+// mismatches, fail the affected pull items immediately. Transient failures
+// update attempt_count and next_attempt_at; after
 // pullItemMaxAttempts they become failed pull items instead of cycling until the
 // wall-clock budget expires.
 //
@@ -989,8 +989,8 @@ func (t *PDPPullPieceTask) tryPullSource(ctx context.Context, sourceURL string, 
 		return fail(pullSourceRequest, err)
 	}
 
-	// HTTP status gets its own stage so 404/429/5xx can be retried without
-	// string matching, while other statuses fail the matching rows.
+	// HTTP status gets its own stage so retryable statuses are classified
+	// without string matching, while other statuses fail the matching rows.
 	if resp.StatusCode != http.StatusOK {
 		return &pullSourceError{
 			sourceURL:  sourceURL,
@@ -1126,8 +1126,7 @@ func (t *PDPPullPieceTask) recordPullSourceFailures(ctx context.Context, group p
 func isTransientPullSourceError(failure pullSourceError) bool {
 	switch failure.stage {
 	case pullSourceStatus:
-		return failure.statusCode == http.StatusNotFound ||
-			failure.statusCode == http.StatusTooManyRequests ||
+		return failure.statusCode == http.StatusTooManyRequests ||
 			(failure.statusCode >= http.StatusInternalServerError && failure.statusCode <= 599)
 	case pullSourceRequest:
 		return isTransientPullRequestError(failure.err)

--- a/tasks/pdpv0/task_pull_piece.go
+++ b/tasks/pdpv0/task_pull_piece.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -30,9 +31,9 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
-const maxPullPieceTasks = 15
-
 const pullMinPieceSizeForCache = abi.PaddedPieceSize(uint64(32 * 1024 * 1024))
+
+const pullItemMaxAttempts = 3
 
 var (
 	// PullPiecePollInterval is how often to poll for new pull items.
@@ -50,6 +51,11 @@ var (
 	// duration, detecting stalled connections that hold TCP sockets open
 	// without transferring data.
 	PullIdleReadTimeout = 2 * time.Minute
+
+	// PullRetryDelayAfterFirstFailure and PullRetryDelayAfterLaterFailure bound
+	// transient source retries below the total PullItemBudget.
+	PullRetryDelayAfterFirstFailure = 30 * time.Second
+	PullRetryDelayAfterLaterFailure = 2 * time.Minute
 )
 
 // PDPPullPieceTask processes PDPv0 pull items after the handler has accepted a
@@ -78,9 +84,9 @@ var (
 //  2. expireStalePullItems: fail unscheduled items older than PullItemBudget and
 //     clean up unused pull-created refs/parked rows.
 //
-//  3. schedulePullItems: assign one Harmony task per pending piece group. A
-//     group with any active task_id is skipped so the same piece is not worked
-//     twice at the same time.
+//  3. schedulePullItems: assign one Harmony task per pending piece group whose
+//     next_attempt_at has passed. A group with any active task_id is skipped so
+//     the same piece is not worked twice at the same time.
 //
 // # Task Workflow
 //
@@ -90,10 +96,10 @@ var (
 //
 // It then claims the active long-term parked_pieces row for that piece key:
 //
-//   - If an ordinary row already exists, PullPiece attaches one parked_piece_ref
-//     per pull item and exits. ParkPiece/StorePiece continues normal processing,
-//     or a later scheduler pass marks the pull items complete if the row is
-//     already complete.
+//   - If an ordinary row from another flow (push/upload, market) already exists,
+//     PullPiece attaches one parked_piece_ref per pull item and exits.
+//     ParkPiece/StorePiece continues normal processing, or a later scheduler
+//     pass marks the pull items complete if the row is already complete.
 //
 //   - If the existing row was created by a previous PullPiece run and is still
 //     incomplete, PullPiece deletes only refs recorded on pull items for that
@@ -114,6 +120,13 @@ var (
 // succeeds. The downloaded bytes must match the declared raw size, must not have
 // extra trailing bytes, and must compute to the expected CommP.
 //
+// If no URL succeeds in a task pass, per-URL failures are recorded. Permanent
+// failures, such as bad source URLs, 410 responses, size mismatches, and CommP
+// mismatches, fail the affected pull items immediately. Transient failures,
+// including Curio-side 404s, update attempt_count and next_attempt_at; after
+// pullItemMaxAttempts they become failed pull items instead of cycling until the
+// wall-clock budget expires.
+//
 // On success, Do marks parked_pieces.complete=TRUE, re-reads active pull items
 // for the piece so refs created during the task are visible, creates pdp_piecerefs,
 // and marks those pull items complete. Rows that arrive after that completion
@@ -132,17 +145,18 @@ type PDPPullPieceTask struct {
 	max int
 }
 
-func NewPDPPullPieceTask(ctx context.Context, db *harmonydb.DB, sc *ffi2.SealCalls) *PDPPullPieceTask {
+func NewPDPPullPieceTask(ctx context.Context, db *harmonydb.DB, sc *ffi2.SealCalls, max int) *PDPPullPieceTask {
 	t := &PDPPullPieceTask{
 		db:  db,
 		sc:  sc,
-		max: maxPullPieceTasks,
+		max: max,
 	}
 
 	go t.pollPullItems(ctx)
 	return t
 }
 
+// pollPullItems runs the scheduler maintenance passes in dependency order.
 func (t *PDPPullPieceTask) pollPullItems(ctx context.Context) {
 	ticker := time.NewTicker(PullPiecePollInterval)
 	defer ticker.Stop()
@@ -166,11 +180,50 @@ func (t *PDPPullPieceTask) pollPullItems(ctx context.Context) {
 	}
 }
 
+// pullPieceKey is the scheduling key shared by all pull items for one piece.
 type pullPieceKey struct {
 	PieceCid     string `db:"piece_cid"`
 	PieceRawSize int64  `db:"piece_raw_size"`
 }
 
+// pullSource is the active pull item shape used by Do after a group is assigned.
+type pullSource struct {
+	PieceCid     string `db:"piece_cid"`
+	PieceRawSize int64  `db:"piece_raw_size"`
+	FetchID      int64  `db:"fetch_id"`
+	Service      string `db:"service"`
+	SourceURL    string `db:"source_url"`
+	PieceRef     *int64 `db:"parked_piece_ref"`
+}
+
+// pullRetryDelayForAttempt returns the backoff after a transient source failure.
+func pullRetryDelayForAttempt(attempt int) time.Duration {
+	if attempt <= 1 {
+		return PullRetryDelayAfterFirstFailure
+	}
+	return PullRetryDelayAfterLaterFailure
+}
+
+// pullSourceErrorStage records where a source attempt failed.
+type pullSourceErrorStage int
+
+const (
+	pullSourceValidate pullSourceErrorStage = iota
+	pullSourceRequest
+	pullSourceStatus
+	pullSourceWrite
+	pullSourceVerify
+)
+
+// pullSourceError keeps the original per-URL error and facts used for retry classification.
+type pullSourceError struct {
+	sourceURL  string
+	err        error
+	statusCode int
+	stage      pullSourceErrorStage
+}
+
+// pullItemToComplete is the row shape needed to finish one accepted pull item.
 type pullItemToComplete struct {
 	FetchID       int64  `db:"fetch_id"`
 	Service       string `db:"service"`
@@ -181,6 +234,7 @@ type pullItemToComplete struct {
 	PieceRef      *int64 `db:"parked_piece_ref"`
 }
 
+// completeAlreadyParkedItems completes pull items whose long-term piece already exists.
 func (t *PDPPullPieceTask) completeAlreadyParkedItems(ctx context.Context) error {
 	_, err := t.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
 		var items []pullItemToComplete
@@ -225,6 +279,7 @@ func (t *PDPPullPieceTask) completeAlreadyParkedItems(ctx context.Context) error
 	return err
 }
 
+// expireStalePullItems fails unscheduled over-budget rows and cleans pull-created refs.
 func (t *PDPPullPieceTask) expireStalePullItems(ctx context.Context) error {
 	type stalePullItem struct {
 		FetchID           int64  `db:"fetch_id"`
@@ -240,6 +295,8 @@ func (t *PDPPullPieceTask) expireStalePullItems(ctx context.Context) error {
 	}
 	comm, err := t.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
 		var staleItems []stalePullItem
+		// The wall-clock budget is enforced only between tasks. Do can still
+		// complete an item that crosses the budget while bytes are in flight.
 		err := tx.Select(&staleItems, `
 			SELECT fetch_id,
 				piece_cid,
@@ -255,21 +312,42 @@ func (t *PDPPullPieceTask) expireStalePullItems(ctx context.Context) error {
 		if err != nil {
 			return false, xerrors.Errorf("query stale pull items: %w", err)
 		}
-		if len(staleItems) == 0 {
+
+		var failedItems []stalePullItem
+		// Terminal failures can still carry pull-created refs if Curio died
+		// before deferred cleanup ran.
+		err = tx.Select(&failedItems, `
+			SELECT fetch_id,
+				piece_cid,
+				source_url,
+				parked_piece_ref,
+				pull_parked_piece_id
+			FROM pdp_piece_pull_items
+			WHERE complete = FALSE
+				AND failed = TRUE
+				AND task_id IS NULL
+				AND (parked_piece_ref IS NOT NULL OR pull_parked_piece_id IS NOT NULL)
+		`)
+		if err != nil {
+			return false, xerrors.Errorf("query failed pull items with refs: %w", err)
+		}
+		if len(staleItems) == 0 && len(failedItems) == 0 {
 			return true, nil
 		}
 
 		fetchIDs := make([]int64, 0, len(staleItems))
 		pieceCids := make([]string, 0, len(staleItems))
 		sourceURLs := make([]string, 0, len(staleItems))
+		failedFetchIDs := make([]int64, 0, len(failedItems))
+		failedPieceCids := make([]string, 0, len(failedItems))
+		failedSourceURLs := make([]string, 0, len(failedItems))
 		refIDs := make([]int64, 0, len(staleItems))
 		pieceIDs := make([]int64, 0, len(staleItems))
 		seenRefs := map[int64]struct{}{}
 		seenPieces := map[int64]struct{}{}
-		for _, item := range staleItems {
-			fetchIDs = append(fetchIDs, item.FetchID)
-			pieceCids = append(pieceCids, item.PieceCid)
-			sourceURLs = append(sourceURLs, item.SourceURL)
+		// Ref and parked-piece cleanup is shared by stale rows and rows that
+		// were already failed by source-error handling.
+		collectRefs := func(item stalePullItem) {
 			if item.PieceRef != nil {
 				if _, ok := seenRefs[*item.PieceRef]; !ok {
 					refIDs = append(refIDs, *item.PieceRef)
@@ -283,30 +361,71 @@ func (t *PDPPullPieceTask) expireStalePullItems(ctx context.Context) error {
 				}
 			}
 		}
-
-		n, err := tx.Exec(`
-			WITH stale(fetch_id, piece_cid, source_url) AS (
-				SELECT * FROM unnest($1::BIGINT[], $2::TEXT[], $3::TEXT[])
-			)
-			UPDATE pdp_piece_pull_items fi
-			SET failed = TRUE,
-				fail_reason = 'pull budget exceeded',
-				task_id = NULL,
-				parked_piece_ref = NULL,
-				pull_parked_piece_id = NULL
-			FROM stale
-			WHERE fi.fetch_id = stale.fetch_id
-				AND fi.piece_cid = stale.piece_cid
-				AND fi.source_url = stale.source_url
-				AND fi.complete = FALSE
-				AND fi.failed = FALSE
-		`, fetchIDs, pieceCids, sourceURLs)
-		if err != nil {
-			return false, xerrors.Errorf("expire stale pull items: %w", err)
+		for _, item := range staleItems {
+			fetchIDs = append(fetchIDs, item.FetchID)
+			pieceCids = append(pieceCids, item.PieceCid)
+			sourceURLs = append(sourceURLs, item.SourceURL)
+			collectRefs(item)
 		}
-		expiredCount = int64(n)
+		for _, item := range failedItems {
+			failedFetchIDs = append(failedFetchIDs, item.FetchID)
+			failedPieceCids = append(failedPieceCids, item.PieceCid)
+			failedSourceURLs = append(failedSourceURLs, item.SourceURL)
+			collectRefs(item)
+		}
+
+		if len(staleItems) > 0 {
+			// Stale open rows become terminal failures here. Already-failed
+			// rows below keep their original fail_reason.
+			n, err := tx.Exec(`
+				WITH stale(fetch_id, piece_cid, source_url) AS (
+					SELECT * FROM unnest($1::BIGINT[], $2::TEXT[], $3::TEXT[])
+				)
+				UPDATE pdp_piece_pull_items fi
+				SET failed = TRUE,
+					fail_reason = 'pull budget exceeded',
+					task_id = NULL,
+					parked_piece_ref = NULL,
+					pull_parked_piece_id = NULL
+				FROM stale
+				WHERE fi.fetch_id = stale.fetch_id
+					AND fi.piece_cid = stale.piece_cid
+					AND fi.source_url = stale.source_url
+					AND fi.complete = FALSE
+					AND fi.failed = FALSE
+			`, fetchIDs, pieceCids, sourceURLs)
+			if err != nil {
+				return false, xerrors.Errorf("expire stale pull items: %w", err)
+			}
+			expiredCount = int64(n)
+		}
+
+		if len(failedItems) > 0 {
+			// These rows are already terminal. Only detach refs so the cleanup
+			// queries can decide whether each ref or parked row is now unused.
+			_, err := tx.Exec(`
+				WITH failed_refs(fetch_id, piece_cid, source_url) AS (
+					SELECT * FROM unnest($1::BIGINT[], $2::TEXT[], $3::TEXT[])
+				)
+				UPDATE pdp_piece_pull_items fi
+				SET parked_piece_ref = NULL,
+					pull_parked_piece_id = NULL
+				FROM failed_refs
+				WHERE fi.fetch_id = failed_refs.fetch_id
+					AND fi.piece_cid = failed_refs.piece_cid
+					AND fi.source_url = failed_refs.source_url
+					AND fi.complete = FALSE
+					AND fi.failed = TRUE
+					AND fi.task_id IS NULL
+			`, failedFetchIDs, failedPieceCids, failedSourceURLs)
+			if err != nil {
+				return false, xerrors.Errorf("clear failed pull item refs: %w", err)
+			}
+		}
 
 		if len(refIDs) > 0 {
+			// Delete only refs that are not visible to PDP and are not still
+			// attached to an active pull item.
 			_, err = tx.Exec(`
 				DELETE FROM parked_piece_refs pr
 				WHERE pr.ref_id = ANY($1::BIGINT[])
@@ -327,6 +446,7 @@ func (t *PDPPullPieceTask) expireStalePullItems(ctx context.Context) error {
 		}
 
 		if len(pieceIDs) > 0 {
+			// Pull-owned skip rows are deleted only after their refs are gone.
 			err = tx.Select(&removedPieces, `
 				DELETE FROM parked_pieces pp
 				WHERE pp.id = ANY($1::BIGINT[])
@@ -341,6 +461,8 @@ func (t *PDPPullPieceTask) expireStalePullItems(ctx context.Context) error {
 				return false, xerrors.Errorf("delete expired pull parked pieces: %w", err)
 			}
 
+			// If refs remain, hand the row back to ParkPiece instead of leaving
+			// a skipped parked_pieces row with no pull task able to finish it.
 			_, err = tx.Exec(`
 				UPDATE parked_pieces pp
 				SET skip = FALSE
@@ -378,8 +500,11 @@ func (t *PDPPullPieceTask) expireStalePullItems(ctx context.Context) error {
 	return nil
 }
 
+// schedulePullItems creates one Harmony task per due piece group, up to t.max.
 func (t *PDPPullPieceTask) schedulePullItems(ctx context.Context) error {
 	var activeGroups int
+	// The cap is group-based, not row-based, because all rows for the same
+	// piece share a single download attempt.
 	err := t.db.QueryRow(ctx, `
 		SELECT COUNT(*)
 		FROM (
@@ -399,12 +524,16 @@ func (t *PDPPullPieceTask) schedulePullItems(ctx context.Context) error {
 
 	limit := t.max - activeGroups
 	var groups []pullPieceKey
+	// next_attempt_at gates whether a group is due to be scheduled. Once due,
+	// assignGroup can attach newer rows in the same group too.
 	err = t.db.Select(ctx, &groups, `
 		SELECT fi.piece_cid, fi.piece_raw_size
 		FROM pdp_piece_pull_items fi
 		WHERE fi.complete = FALSE
 			AND fi.failed = FALSE
 			AND fi.task_id IS NULL
+			AND fi.attempt_count < $3
+			AND fi.next_attempt_at <= NOW()
 			AND fi.created_at >= NOW() - ($2::BIGINT * INTERVAL '1 second')
 			AND NOT EXISTS (
 				SELECT 1
@@ -418,7 +547,7 @@ func (t *PDPPullPieceTask) schedulePullItems(ctx context.Context) error {
 		GROUP BY fi.piece_cid, fi.piece_raw_size
 		ORDER BY MIN(fi.created_at) ASC, MIN(fi.fetch_id) ASC, fi.piece_cid ASC
 		LIMIT $1
-	`, limit, int64(PullItemBudget.Seconds()))
+	`, limit, int64(PullItemBudget.Seconds()), pullItemMaxAttempts)
 	if err != nil {
 		return xerrors.Errorf("query pending pull item groups: %w", err)
 	}
@@ -438,19 +567,21 @@ func (t *PDPPullPieceTask) schedulePullItems(ctx context.Context) error {
 	return nil
 }
 
+// assignGroup attaches a task to every eligible row for the selected piece key.
 func (t *PDPPullPieceTask) assignGroup(tx *harmonydb.Tx, taskID harmonytask.TaskID, group pullPieceKey) (bool, error) {
-	// Let's double check that a complete piece does not exists
+	// If the piece completed between schedule selection and task insert, do not
+	// create another pull task. The next poll will complete the pull items.
 	completePieceID, err := findCompleteParkedPiece(tx, group)
 	if err != nil {
 		return false, err
 	}
 
-	// If it exists, we exit here
 	if completePieceID != nil {
 		return false, nil
 	}
 
-	// Schedule a single task per piece_cid and not per item
+	// Do not filter on next_attempt_at here. Once one row makes the group due,
+	// all still-eligible rows for that piece can ride on the same attempt.
 	n, err := tx.Exec(`
 		UPDATE pdp_piece_pull_items fi
 		SET task_id = $3
@@ -459,6 +590,7 @@ func (t *PDPPullPieceTask) assignGroup(tx *harmonydb.Tx, taskID harmonytask.Task
 			AND fi.complete = FALSE
 			AND fi.failed = FALSE
 			AND fi.task_id IS NULL
+			AND fi.attempt_count < $5
 			AND fi.created_at >= NOW() - ($4::BIGINT * INTERVAL '1 second')
 			AND NOT EXISTS (
 				SELECT 1
@@ -469,7 +601,7 @@ func (t *PDPPullPieceTask) assignGroup(tx *harmonydb.Tx, taskID harmonytask.Task
 					AND running.failed = FALSE
 					AND running.task_id IS NOT NULL
 			)
-	`, group.PieceCid, group.PieceRawSize, taskID, int64(PullItemBudget.Seconds()))
+	`, group.PieceCid, group.PieceRawSize, taskID, int64(PullItemBudget.Seconds()), pullItemMaxAttempts)
 	if err != nil {
 		return false, xerrors.Errorf("assign pull item task: %w", err)
 	}
@@ -480,16 +612,9 @@ func (t *PDPPullPieceTask) assignGroup(tx *harmonydb.Tx, taskID harmonytask.Task
 func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
 	ctx := context.Background()
 
-	type pullSource struct {
-		PieceCid     string `db:"piece_cid"`
-		PieceRawSize int64  `db:"piece_raw_size"`
-		FetchID      int64  `db:"fetch_id"`
-		Service      string `db:"service"`
-		SourceURL    string `db:"source_url"`
-		PieceRef     *int64 `db:"parked_piece_ref"`
-	}
-
 	var sources []pullSource
+	// Load by assigned group, then expand back to all active rows for that
+	// group. This picks up rows that arrived after the scheduler assigned task_id.
 	err = t.db.Select(ctx, &sources, `
 		WITH assigned_groups AS (
 			SELECT piece_cid, piece_raw_size
@@ -515,11 +640,12 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 			JOIN pdp_piece_pulls pp ON pp.id = fi.fetch_id
 			WHERE fi.complete = FALSE
 				AND fi.failed = FALSE
+				AND fi.attempt_count < $2
 		)
 		SELECT piece_cid, piece_raw_size, fetch_id, service, source_url, parked_piece_ref
 		FROM items
 		ORDER BY created_at ASC, fetch_id ASC
-	`, taskID)
+	`, taskID, pullItemMaxAttempts)
 	if err != nil {
 		return false, xerrors.Errorf("query pull task sources: %w", err)
 	}
@@ -546,6 +672,8 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 	var stalePullPiecesToRemove []int64
 	comm, err := t.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
 		var err error
+		// Claim or create the active long-term parked row. New pull-owned rows
+		// start as skip=TRUE so ParkPiece does not race this direct download.
 		parkedPieceID, createdParkedPiece, err = parkpiece.UpsertSkipWithInserted(tx, group.PieceCid, int64(padreader.PaddedSize(uint64(group.PieceRawSize)).Padded()), group.PieceRawSize, true, true)
 		if err != nil {
 			return false, xerrors.Errorf("upsert parked piece: %w", err)
@@ -559,6 +687,9 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		var txRemovePieces []int64
 
 		for {
+			// Existing rows split into three cases:
+			// complete rows are handled by completion logic, non-pull rows are
+			// left for their owner, and previous pull-owned rows are cleaned once.
 			err = tx.QueryRow(`
 				SELECT pp.complete,
 					pp.task_id,
@@ -585,6 +716,8 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 				return false, xerrors.Errorf("pull-owned parked piece still active after cleanup: %d", parkedPieceID)
 			}
 
+			// A previous PullPiece task created this row but did not finish it.
+			// Clear only refs recorded on pull items for that row.
 			removed, err := cleanupPullCreatedParkedPieceTx(tx, parkedPieceID)
 			if err != nil {
 				return false, xerrors.Errorf("cleanup stale pull-owned parked piece: %w", err)
@@ -600,8 +733,8 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 			cleanedPullOwnedPiece = true
 		}
 
-		// If park_piece exhausted retries before these refs were attached, clear
-		// the stale task_id so its scheduler can pick the row again.
+		// If ParkPiece's task row is gone, clear the stale task_id so its
+		// scheduler can pick this parked row again after the new refs attach.
 		if !createdParkedPiece && activeTaskID.Valid && !activeTaskExists && !activeComplete {
 			n, err := tx.Exec(`
 				UPDATE parked_pieces
@@ -619,6 +752,8 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		}
 
 		for _, source := range sources {
+			// Each accepted pull item gets its own ref. That stays true even
+			// when another URL in the group supplies the bytes.
 			if source.PieceRef != nil && !cleanedPullOwnedPiece {
 				continue
 			}
@@ -670,8 +805,9 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 	}
 
 	// If the row already existed, this task only contributes refs. ParkPiece will
-	// either keep running with refs it already loaded, or retry using the newly
-	// attached refs after the stale task_id path above.
+	// keep running, retry using newly attached refs after the stale task_id path
+	// above, or the next completion pass will finish the pull items if the row is
+	// already complete.
 	if !createdParkedPiece {
 		return true, nil
 	}
@@ -712,7 +848,10 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 
 	attemptedSources := map[string]struct{}{}
 	var sourceErrors error
+	var sourceFailures []pullSourceError
 	for _, source := range sources {
+		// Multiple pull items can carry the same URL. Try each distinct URL
+		// once; if every URL fails, failures are recorded by source_url.
 		if _, ok := attemptedSources[source.SourceURL]; ok {
 			continue
 		}
@@ -722,76 +861,11 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 			return false, nil
 		}
 
-		// Check if the source URL is good for a download
-		parsedURL, sourceErr := url.Parse(source.SourceURL)
-		if sourceErr == nil {
-			if parsedURL.Scheme != "https" && (!pdp.PullAllowInsecure() || parsedURL.Scheme != "http") {
-				sourceErr = xerrors.Errorf("source URL must use HTTPS scheme, got: %s", parsedURL.Scheme)
-			}
-		}
-		downloadPolicy := ssrfPolicy
-		downloadPolicy.ResponseHeaderTimeout = 2 * time.Minute
-		if sourceErr == nil {
-			_, sourceErr = robusthttp.ValidateClientFetchURL(source.SourceURL, nil, &downloadPolicy)
-		}
+		sourceErr := t.tryPullSource(ctx, source.SourceURL, group, expectedCid, parkedPieceID, ssrfPolicy)
 		if sourceErr != nil {
-			log.Warnw("pull source URL rejected", "error", sourceErr, "pieceCid", group.PieceCid, "sourceURL", source.SourceURL)
-			sourceErrors = multierror.Append(sourceErrors, xerrors.Errorf("%s: %w", source.SourceURL, sourceErr))
-			continue
-		}
-
-		downloadCtx, downloadCancel := context.WithTimeout(ctx, PullAttemptTimeout)
-		client, _ := robusthttp.NewSSRFProtectedHTTPClient(&downloadPolicy, nil)
-
-		req, downloadErr := http.NewRequestWithContext(downloadCtx, http.MethodGet, source.SourceURL, nil)
-		if downloadErr == nil {
-			var resp *http.Response
-			resp, downloadErr = client.Do(req)
-			if resp != nil {
-				if downloadErr == nil && resp.StatusCode != http.StatusOK {
-					downloadErr = xerrors.Errorf("HTTP status %d from source", resp.StatusCode)
-				}
-				if downloadErr == nil && resp.ContentLength > group.PieceRawSize {
-					downloadErr = xerrors.Errorf("size mismatch: expected %d, got at least %d", group.PieceRawSize, resp.ContentLength)
-				}
-				if downloadErr == nil {
-					idleReader := &idleTimeoutReader{
-						r:      resp.Body,
-						timer:  time.AfterFunc(PullIdleReadTimeout, downloadCancel),
-						cancel: downloadCancel,
-						idle:   PullIdleReadTimeout,
-					}
-					pieceInfo, readSize, writeErr := t.sc.WriteUploadPiece(downloadCtx, storiface.PieceNumber(parkedPieceID), group.PieceRawSize, idleReader, storiface.PathStorage, true)
-					if writeErr != nil {
-						idleReader.timer.Stop()
-						downloadErr = xerrors.Errorf("write pulled piece: %w", writeErr)
-					} else {
-						if readSize != uint64(group.PieceRawSize) {
-							downloadErr = xerrors.Errorf("size mismatch: expected %d, got %d", group.PieceRawSize, readSize)
-						} else if !pieceInfo.PieceCID.Equals(expectedCid) {
-							downloadErr = xerrors.Errorf("CommP mismatch: expected %s, got %s", expectedCid, pieceInfo.PieceCID)
-						} else if pieceInfo.Size != abi.PaddedPieceSize(pdp.PadPieceSize(group.PieceRawSize)) {
-							downloadErr = xerrors.Errorf("padded size mismatch: expected %d, got %d", pdp.PadPieceSize(group.PieceRawSize), pieceInfo.Size)
-						} else {
-							var extra [1]byte
-							n, readErr := idleReader.Read(extra[:])
-							if n > 0 {
-								downloadErr = xerrors.Errorf("size mismatch: expected %d, got more", group.PieceRawSize)
-							} else if readErr != nil && readErr != io.EOF {
-								downloadErr = xerrors.Errorf("checking for oversized response: %w", readErr)
-							}
-						}
-						idleReader.timer.Stop()
-					}
-				}
-				_ = resp.Body.Close()
-			}
-		}
-		downloadCancel()
-
-		if downloadErr != nil {
-			log.Warnw("pull source URL failed", "error", downloadErr, "pieceCid", group.PieceCid, "sourceURL", source.SourceURL)
-			sourceErrors = multierror.Append(sourceErrors, xerrors.Errorf("%s: %w", source.SourceURL, downloadErr))
+			log.Warnw("pull source URL failed", "error", sourceErr.err, "pieceCid", group.PieceCid, "sourceURL", source.SourceURL)
+			sourceErrors = multierror.Append(sourceErrors, xerrors.Errorf("%s: %w", source.SourceURL, sourceErr.err))
+			sourceFailures = append(sourceFailures, *sourceErr)
 			continue
 		}
 
@@ -863,15 +937,244 @@ func (t *PDPPullPieceTask) Do(taskID harmonytask.TaskID, stillOwned func() bool)
 		return true, nil
 	}
 
-	if sourceErrors != nil {
+	if len(sourceFailures) > 0 {
+		if err := t.recordPullSourceFailures(ctx, group, sourceFailures); err != nil {
+			return false, err
+		}
 		return false, xerrors.Errorf("all pull source URLs failed: %w", sourceErrors)
 	}
 
 	return false, xerrors.Errorf("no good URL found to download the piece")
 }
 
+// tryPullSource downloads one source URL into the pull-owned parked piece.
+func (t *PDPPullPieceTask) tryPullSource(ctx context.Context, sourceURL string, group pullPieceKey, expectedCid cid.Cid, parkedPieceID int64, ssrfPolicy robusthttp.SSRFPolicy) *pullSourceError {
+	fail := func(stage pullSourceErrorStage, err error) *pullSourceError {
+		return &pullSourceError{sourceURL: sourceURL, err: err, stage: stage}
+	}
+
+	// Validation-stage errors are treated as permanent because they are request
+	// shape or policy failures, not source availability failures.
+	parsedURL, err := url.Parse(sourceURL)
+	if err != nil {
+		return fail(pullSourceValidate, err)
+	}
+	if parsedURL.Scheme != "https" && (!pdp.PullAllowInsecure() || parsedURL.Scheme != "http") {
+		return fail(pullSourceValidate, xerrors.Errorf("source URL must use HTTPS scheme, got: %s", parsedURL.Scheme))
+	}
+
+	downloadPolicy := ssrfPolicy
+	downloadPolicy.ResponseHeaderTimeout = 2 * time.Minute
+	if _, err := robusthttp.ValidateClientFetchURL(sourceURL, nil, &downloadPolicy); err != nil {
+		return fail(pullSourceValidate, err)
+	}
+
+	downloadCtx, downloadCancel := context.WithTimeout(ctx, PullAttemptTimeout)
+	defer downloadCancel()
+
+	// Request failures are classified from typed network/context errors later.
+	client, _ := robusthttp.NewSSRFProtectedHTTPClient(&downloadPolicy, nil)
+	req, err := http.NewRequestWithContext(downloadCtx, http.MethodGet, sourceURL, nil)
+	if err != nil {
+		return fail(pullSourceValidate, err)
+	}
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+	}
+	if err != nil {
+		return fail(pullSourceRequest, err)
+	}
+
+	// HTTP status gets its own stage so 404/429/5xx can be retried without
+	// string matching, while other statuses fail the matching rows.
+	if resp.StatusCode != http.StatusOK {
+		return &pullSourceError{
+			sourceURL:  sourceURL,
+			err:        xerrors.Errorf("HTTP status %d from source", resp.StatusCode),
+			statusCode: resp.StatusCode,
+			stage:      pullSourceStatus,
+		}
+	}
+	if resp.ContentLength > group.PieceRawSize {
+		return fail(pullSourceVerify, xerrors.Errorf("size mismatch: expected %d, got at least %d", group.PieceRawSize, resp.ContentLength))
+	}
+
+	idleReader := &idleTimeoutReader{
+		r:      resp.Body,
+		timer:  time.AfterFunc(PullIdleReadTimeout, downloadCancel),
+		cancel: downloadCancel,
+		idle:   PullIdleReadTimeout,
+	}
+	defer idleReader.timer.Stop()
+
+	// Storage/write errors are treated as transient because they can be caused
+	// by temporary local storage pressure or IO failures.
+	pieceInfo, readSize, err := t.sc.WriteUploadPiece(downloadCtx, storiface.PieceNumber(parkedPieceID), group.PieceRawSize, idleReader, storiface.PathStorage, true)
+	if err != nil {
+		return fail(pullSourceWrite, xerrors.Errorf("write pulled piece: %w", err))
+	}
+	// Verification failures mean the source did not serve the requested piece.
+	if readSize != uint64(group.PieceRawSize) {
+		return fail(pullSourceVerify, xerrors.Errorf("size mismatch: expected %d, got %d", group.PieceRawSize, readSize))
+	}
+	if !pieceInfo.PieceCID.Equals(expectedCid) {
+		return fail(pullSourceVerify, xerrors.Errorf("CommP mismatch: expected %s, got %s", expectedCid, pieceInfo.PieceCID))
+	}
+	if pieceInfo.Size != abi.PaddedPieceSize(pdp.PadPieceSize(group.PieceRawSize)) {
+		return fail(pullSourceVerify, xerrors.Errorf("padded size mismatch: expected %d, got %d", pdp.PadPieceSize(group.PieceRawSize), pieceInfo.Size))
+	}
+
+	var extra [1]byte
+	n, err := idleReader.Read(extra[:])
+	if n > 0 {
+		return fail(pullSourceVerify, xerrors.Errorf("size mismatch: expected %d, got more", group.PieceRawSize))
+	}
+	if err != nil && err != io.EOF {
+		return fail(pullSourceRequest, xerrors.Errorf("checking for oversized response: %w", err))
+	}
+
+	return nil
+}
+
+// recordPullSourceFailures applies all per-URL failures after a full source pass.
+func (t *PDPPullPieceTask) recordPullSourceFailures(ctx context.Context, group pullPieceKey, failures []pullSourceError) error {
+	var permanentURLs, permanentReasons []string
+	var transientURLs, transientReasons []string
+	// Split only after all URLs have been tried. One good source wins the group;
+	// this function is only for the all-sources-failed path.
+	for _, failure := range failures {
+		if isTransientPullSourceError(failure) {
+			transientURLs = append(transientURLs, failure.sourceURL)
+			transientReasons = append(transientReasons, failure.err.Error())
+			continue
+		}
+		permanentURLs = append(permanentURLs, failure.sourceURL)
+		permanentReasons = append(permanentReasons, failure.err.Error())
+	}
+
+	comm, err := t.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		if len(permanentURLs) > 0 {
+			// Permanent errors fail rows that used that exact URL. Rows for
+			// other URLs in the group are handled by their own failure result.
+			_, err := tx.Exec(`
+				WITH failed_sources(source_url, reason) AS (
+					SELECT * FROM unnest($3::TEXT[], $4::TEXT[])
+				)
+				UPDATE pdp_piece_pull_items fi
+				SET failed = TRUE,
+					fail_reason = failed_sources.reason,
+					task_id = NULL
+				FROM failed_sources
+				WHERE fi.source_url = failed_sources.source_url
+					AND fi.piece_cid = $1
+					AND fi.piece_raw_size = $2
+					AND fi.complete = FALSE
+					AND fi.failed = FALSE
+			`, group.PieceCid, group.PieceRawSize, permanentURLs, permanentReasons)
+			if err != nil {
+				return false, xerrors.Errorf("mark permanent pull source failures: %w", err)
+			}
+		}
+
+		if len(transientURLs) > 0 {
+			// Transient rows get bounded retries. The final attempt records the
+			// real source error instead of leaving them to budget expiry.
+			_, err := tx.Exec(`
+				WITH transient_sources(source_url, reason) AS (
+					SELECT * FROM unnest($3::TEXT[], $4::TEXT[])
+				)
+				UPDATE pdp_piece_pull_items fi
+				SET attempt_count = fi.attempt_count + 1,
+					next_attempt_at = CASE
+						WHEN fi.attempt_count + 1 >= $5 THEN fi.next_attempt_at
+						WHEN fi.attempt_count = 0 THEN NOW() + ($6::BIGINT * INTERVAL '1 second')
+						ELSE NOW() + ($7::BIGINT * INTERVAL '1 second')
+					END,
+					failed = CASE WHEN fi.attempt_count + 1 >= $5 THEN TRUE ELSE fi.failed END,
+					fail_reason = CASE WHEN fi.attempt_count + 1 >= $5 THEN transient_sources.reason ELSE fi.fail_reason END,
+					task_id = NULL
+				FROM transient_sources
+				WHERE fi.source_url = transient_sources.source_url
+					AND fi.piece_cid = $1
+					AND fi.piece_raw_size = $2
+					AND fi.complete = FALSE
+					AND fi.failed = FALSE
+					AND fi.attempt_count < $5
+			`, group.PieceCid, group.PieceRawSize, transientURLs, transientReasons, pullItemMaxAttempts, int64(pullRetryDelayForAttempt(1).Seconds()), int64(pullRetryDelayForAttempt(2).Seconds()))
+			if err != nil {
+				return false, xerrors.Errorf("record transient pull source failures: %w", err)
+			}
+		}
+
+		return true, nil
+	}, harmonydb.OptionRetry())
+	if err != nil {
+		return err
+	}
+	if !comm {
+		return xerrors.Errorf("failed to commit DB transaction")
+	}
+
+	return nil
+}
+
+// isTransientPullSourceError decides whether a failed URL should get another pass.
+func isTransientPullSourceError(failure pullSourceError) bool {
+	switch failure.stage {
+	case pullSourceStatus:
+		return failure.statusCode == http.StatusNotFound ||
+			failure.statusCode == http.StatusTooManyRequests ||
+			(failure.statusCode >= http.StatusInternalServerError && failure.statusCode <= 599)
+	case pullSourceRequest:
+		return isTransientPullRequestError(failure.err)
+	case pullSourceWrite:
+		return true
+	default:
+		return false
+	}
+}
+
+// isTransientPullRequestError classifies network/request errors without strings.
+func isTransientPullRequestError(err error) bool {
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	var noAddrs *robusthttp.NoResolvedAddressError
+	if errors.As(err, &noAddrs) {
+		return true
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+
+	return false
+}
+
+// cleanupPullCreatedParkedPieceTx removes pull-owned refs from an incomplete parked row.
 func cleanupPullCreatedParkedPieceTx(tx *harmonydb.Tx, parkedPieceID int64) (bool, error) {
 	var refIDs []int64
+	// Only refs recorded on pull items are candidates. Refs created by other
+	// subsystems for the same parked row are left alone.
 	err := tx.Select(&refIDs, `
 		SELECT DISTINCT fi.parked_piece_ref
 		FROM pdp_piece_pull_items fi
@@ -884,12 +1187,13 @@ func cleanupPullCreatedParkedPieceTx(tx *harmonydb.Tx, parkedPieceID int64) (boo
 		return false, xerrors.Errorf("query pull-created parked piece refs: %w", err)
 	}
 
+	// Clear item pointers first so terminal rows do not keep stale pull markers
+	// if a ref cannot be deleted because it has already been promoted.
 	_, err = tx.Exec(`
 		UPDATE pdp_piece_pull_items
 		SET parked_piece_ref = NULL,
 			pull_parked_piece_id = NULL
 		WHERE complete = FALSE
-			AND failed = FALSE
 			AND pull_parked_piece_id = $1
 	`, parkedPieceID)
 	if err != nil {
@@ -897,6 +1201,7 @@ func cleanupPullCreatedParkedPieceTx(tx *harmonydb.Tx, parkedPieceID int64) (boo
 	}
 
 	if len(refIDs) > 0 {
+		// Do not delete refs already promoted into pdp_piecerefs.
 		_, err = tx.Exec(`
 			DELETE FROM parked_piece_refs pr
 			WHERE pr.ref_id = ANY($1::BIGINT[])
@@ -909,6 +1214,7 @@ func cleanupPullCreatedParkedPieceTx(tx *harmonydb.Tx, parkedPieceID int64) (boo
 		}
 	}
 
+	// Remove the pull-created parked row only when all refs are gone.
 	n, err := tx.Exec(`
 		DELETE FROM parked_pieces pp
 		WHERE pp.id = $1
@@ -924,6 +1230,7 @@ func cleanupPullCreatedParkedPieceTx(tx *harmonydb.Tx, parkedPieceID int64) (boo
 		return true, nil
 	}
 
+	// If refs remain, make the normal ParkPiece scheduler responsible for the row.
 	_, err = tx.Exec(`
 		UPDATE parked_pieces pp
 		SET skip = FALSE
@@ -941,6 +1248,7 @@ func cleanupPullCreatedParkedPieceTx(tx *harmonydb.Tx, parkedPieceID int64) (boo
 	return false, nil
 }
 
+// completePullItemWithParkedPiece creates the ref records and marks one item complete.
 func completePullItemWithParkedPiece(tx *harmonydb.Tx, service string, fetchID int64, pieceCID string, rawSize uint64, sourceURL string, parkedPieceID int64, existingPieceRef int64) error {
 	n, err := tx.Exec(`
 		UPDATE pdp_piece_pull_items
@@ -967,6 +1275,9 @@ func completePullItemWithParkedPiece(tx *harmonydb.Tx, service string, fetchID i
 
 	pieceRef := existingPieceRef
 	if pieceRef == 0 {
+		// Rows that were not attached during Do may not have a ref yet. Create
+		// one with their original URL even if another source URL downloaded
+		// the bytes.
 		err = tx.QueryRow(`
 			INSERT INTO parked_piece_refs (piece_id, data_url, long_term)
 			VALUES ($1, $2, TRUE)
@@ -1007,6 +1318,7 @@ func completePullItemWithParkedPiece(tx *harmonydb.Tx, service string, fetchID i
 	return nil
 }
 
+// findCompleteParkedPiece returns the oldest complete long-term row for a piece key.
 func findCompleteParkedPiece(tx *harmonydb.Tx, group pullPieceKey) (*int64, error) {
 	var id int64
 	err := tx.QueryRow(`
@@ -1054,6 +1366,7 @@ func (t *PDPPullPieceTask) Adder(taskFunc harmonytask.AddTaskFunc) {
 var _ harmonytask.TaskInterface = &PDPPullPieceTask{}
 var _ = harmonytask.Reg(&PDPPullPieceTask{})
 
+// idleTimeoutReader cancels its context when a response stalls between reads.
 type idleTimeoutReader struct {
 	r      io.Reader
 	timer  *time.Timer
@@ -1061,6 +1374,7 @@ type idleTimeoutReader struct {
 	idle   time.Duration
 }
 
+// Read resets the idle timer only after bytes are received.
 func (r *idleTimeoutReader) Read(p []byte) (int, error) {
 	n, err := r.r.Read(p)
 	if n > 0 {

--- a/tasks/pdpv0/task_pull_piece.go
+++ b/tasks/pdpv0/task_pull_piece.go
@@ -1126,8 +1126,7 @@ func (t *PDPPullPieceTask) recordPullSourceFailures(ctx context.Context, group p
 func isTransientPullSourceError(failure pullSourceError) bool {
 	switch failure.stage {
 	case pullSourceStatus:
-		return failure.statusCode == http.StatusTooManyRequests ||
-			(failure.statusCode >= http.StatusInternalServerError && failure.statusCode <= 599)
+		return failure.statusCode == http.StatusTooManyRequests || failure.statusCode == http.StatusInternalServerError
 	case pullSourceRequest:
 		return isTransientPullRequestError(failure.err)
 	case pullSourceWrite:

--- a/tasks/pdpv0/task_pull_piece_test.go
+++ b/tasks/pdpv0/task_pull_piece_test.go
@@ -338,9 +338,8 @@ func TestPullSourceErrorClassification(t *testing.T) {
 		transient bool
 	}{
 		{
-			name:      "404 is transient",
-			failure:   pullSourceError{stage: pullSourceStatus, statusCode: 404, err: errors.New("not found")},
-			transient: true,
+			name:    "404 is permanent",
+			failure: pullSourceError{stage: pullSourceStatus, statusCode: 404, err: errors.New("not found")},
 		},
 		{
 			name:    "410 is permanent",

--- a/tasks/pdpv0/task_pull_piece_test.go
+++ b/tasks/pdpv0/task_pull_piece_test.go
@@ -351,9 +351,14 @@ func TestPullSourceErrorClassification(t *testing.T) {
 			transient: true,
 		},
 		{
-			name:      "5xx is transient",
-			failure:   pullSourceError{stage: pullSourceStatus, statusCode: 503, err: errors.New("unavailable")},
+			name:      "500 is transient",
+			failure:   pullSourceError{stage: pullSourceStatus, statusCode: 500, err: errors.New("server internal error")},
 			transient: true,
+		},
+		{
+			name:      "5xx is permanent",
+			failure:   pullSourceError{stage: pullSourceStatus, statusCode: 503, err: errors.New("unavailable")},
+			transient: false,
 		},
 		{
 			name:    "validation is permanent",

--- a/tasks/pdpv0/task_pull_piece_test.go
+++ b/tasks/pdpv0/task_pull_piece_test.go
@@ -1,0 +1,268 @@
+package pdpv0
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/pdp"
+)
+
+func TestPullPieceCompleteAlreadyParkedItemsCompletesDuplicateSources(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	service := "pull-task-complete-duplicate-sources"
+	require.NoError(t, insertPullTaskService(ctx, db, service))
+
+	pieceCid, rawSize := testPullPieceCID(t, 1)
+	var parkedPieceID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, complete, long_term)
+		VALUES ($1, $2, $3, TRUE, TRUE)
+		RETURNING id
+	`, pieceCid, pdp.PadPieceSize(int64(rawSize)), rawSize).Scan(&parkedPieceID)
+	require.NoError(t, err)
+
+	var pullID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO pdp_piece_pulls (service, extra_data_hash, data_set_id, record_keeper, client_address)
+		VALUES ($1, $2, 1, '', '0x1')
+		RETURNING id
+	`, service, []byte("pull-task-complete")).Scan(&pullID)
+	require.NoError(t, err)
+
+	urls := []string{
+		"https://source-a.example/piece/" + pieceCid,
+		"https://source-b.example/piece/" + pieceCid,
+	}
+	for _, sourceURL := range urls {
+		_, err = db.Exec(ctx, `
+			INSERT INTO pdp_piece_pull_items (fetch_id, piece_cid, piece_raw_size, source_url)
+			VALUES ($1, $2, $3, $4)
+		`, pullID, pieceCid, rawSize, sourceURL)
+		require.NoError(t, err)
+	}
+
+	task := &PDPPullPieceTask{db: db}
+	require.NoError(t, task.completeAlreadyParkedItems(ctx))
+
+	var completeItems int
+	err = db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM pdp_piece_pull_items
+		WHERE fetch_id = $1
+			AND complete = TRUE
+			AND failed = FALSE
+			AND task_id IS NULL
+			AND parked_piece_ref IS NOT NULL
+	`, pullID).Scan(&completeItems)
+	require.NoError(t, err)
+	require.Equal(t, len(urls), completeItems)
+
+	var pieceRefs int
+	err = db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM pdp_piecerefs ppr
+		JOIN parked_piece_refs pr ON pr.ref_id = ppr.piece_ref
+		WHERE ppr.service = $1
+			AND pr.piece_id = $2
+			AND pr.data_url = ANY($3::TEXT[])
+	`, service, parkedPieceID, urls).Scan(&pieceRefs)
+	require.NoError(t, err)
+	require.Equal(t, len(urls), pieceRefs)
+}
+
+func TestCleanupPullCreatedParkedPieceOnlyDeletesPullRefsAndEnablesParkTask(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	service := "pull-task-cleanup"
+	require.NoError(t, insertPullTaskService(ctx, db, service))
+
+	pieceCid, rawSize := testPullPieceCID(t, 2)
+	var parkedPieceID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, complete, long_term, skip)
+		VALUES ($1, $2, $3, FALSE, TRUE, TRUE)
+		RETURNING id
+	`, pieceCid, pdp.PadPieceSize(int64(rawSize)), rawSize).Scan(&parkedPieceID)
+	require.NoError(t, err)
+
+	var pullRef int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO parked_piece_refs (piece_id, data_url, long_term)
+		VALUES ($1, 'https://pull.example/piece', TRUE)
+		RETURNING ref_id
+	`, parkedPieceID).Scan(&pullRef)
+	require.NoError(t, err)
+
+	var otherRef int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO parked_piece_refs (piece_id, data_url, long_term)
+		VALUES ($1, 'https://other.example/piece', TRUE)
+		RETURNING ref_id
+	`, parkedPieceID).Scan(&otherRef)
+	require.NoError(t, err)
+
+	var pullID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO pdp_piece_pulls (service, extra_data_hash, data_set_id, record_keeper, client_address)
+		VALUES ($1, $2, 1, '', '0x1')
+		RETURNING id
+	`, service, []byte("pull-task-cleanup")).Scan(&pullID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO pdp_piece_pull_items (
+			fetch_id, piece_cid, piece_raw_size, source_url, parked_piece_ref, pull_parked_piece_id
+		)
+		VALUES ($1, $2, $3, 'https://pull.example/piece', $4, $5)
+	`, pullID, pieceCid, rawSize, pullRef, parkedPieceID)
+	require.NoError(t, err)
+
+	var removed bool
+	committed, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		removed, err = cleanupPullCreatedParkedPieceTx(tx, parkedPieceID)
+		return err == nil, err
+	}, harmonydb.OptionRetry())
+	require.NoError(t, err)
+	require.True(t, committed)
+	require.False(t, removed)
+
+	var pullRefCount, otherRefCount int
+	err = db.QueryRow(ctx, `SELECT COUNT(*) FROM parked_piece_refs WHERE ref_id = $1`, pullRef).Scan(&pullRefCount)
+	require.NoError(t, err)
+	require.Zero(t, pullRefCount)
+
+	err = db.QueryRow(ctx, `SELECT COUNT(*) FROM parked_piece_refs WHERE ref_id = $1`, otherRef).Scan(&otherRefCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, otherRefCount)
+
+	var skip bool
+	err = db.QueryRow(ctx, `SELECT skip FROM parked_pieces WHERE id = $1`, parkedPieceID).Scan(&skip)
+	require.NoError(t, err)
+	require.False(t, skip)
+
+	var itemRefs int
+	err = db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM pdp_piece_pull_items
+		WHERE fetch_id = $1
+			AND parked_piece_ref IS NULL
+			AND pull_parked_piece_id IS NULL
+	`, pullID).Scan(&itemRefs)
+	require.NoError(t, err)
+	require.Equal(t, 1, itemRefs)
+}
+
+func TestExpireStalePullItemsEnablesParkTaskWhenOtherRefsRemain(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	service := "pull-task-expire"
+	require.NoError(t, insertPullTaskService(ctx, db, service))
+
+	pieceCid, rawSize := testPullPieceCID(t, 3)
+	var parkedPieceID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, complete, long_term, skip)
+		VALUES ($1, $2, $3, FALSE, TRUE, TRUE)
+		RETURNING id
+	`, pieceCid, pdp.PadPieceSize(int64(rawSize)), rawSize).Scan(&parkedPieceID)
+	require.NoError(t, err)
+
+	var pullRef int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO parked_piece_refs (piece_id, data_url, long_term)
+		VALUES ($1, 'https://pull-expire.example/piece', TRUE)
+		RETURNING ref_id
+	`, parkedPieceID).Scan(&pullRef)
+	require.NoError(t, err)
+
+	var otherRef int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO parked_piece_refs (piece_id, data_url, long_term)
+		VALUES ($1, 'https://other-expire.example/piece', TRUE)
+		RETURNING ref_id
+	`, parkedPieceID).Scan(&otherRef)
+	require.NoError(t, err)
+
+	var pullID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO pdp_piece_pulls (service, extra_data_hash, data_set_id, record_keeper, client_address)
+		VALUES ($1, $2, 1, '', '0x1')
+		RETURNING id
+	`, service, []byte("pull-task-expire")).Scan(&pullID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO pdp_piece_pull_items (
+			fetch_id, piece_cid, piece_raw_size, source_url, created_at, parked_piece_ref, pull_parked_piece_id
+		)
+		VALUES ($1, $2, $3, 'https://pull-expire.example/piece', NOW() - INTERVAL '31 minutes', $4, $5)
+	`, pullID, pieceCid, rawSize, pullRef, parkedPieceID)
+	require.NoError(t, err)
+
+	task := &PDPPullPieceTask{db: db}
+	require.NoError(t, task.expireStalePullItems(ctx))
+
+	var failedItems int
+	err = db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM pdp_piece_pull_items
+		WHERE fetch_id = $1
+			AND failed = TRUE
+			AND fail_reason = 'pull budget exceeded'
+			AND parked_piece_ref IS NULL
+			AND pull_parked_piece_id IS NULL
+	`, pullID).Scan(&failedItems)
+	require.NoError(t, err)
+	require.Equal(t, 1, failedItems)
+
+	var pullRefCount, otherRefCount int
+	err = db.QueryRow(ctx, `SELECT COUNT(*) FROM parked_piece_refs WHERE ref_id = $1`, pullRef).Scan(&pullRefCount)
+	require.NoError(t, err)
+	require.Zero(t, pullRefCount)
+
+	err = db.QueryRow(ctx, `SELECT COUNT(*) FROM parked_piece_refs WHERE ref_id = $1`, otherRef).Scan(&otherRefCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, otherRefCount)
+
+	var skip bool
+	err = db.QueryRow(ctx, `SELECT skip FROM parked_pieces WHERE id = $1`, parkedPieceID).Scan(&skip)
+	require.NoError(t, err)
+	require.False(t, skip)
+}
+
+func insertPullTaskService(ctx context.Context, db *harmonydb.DB, service string) error {
+	_, err := db.Exec(ctx, `
+		INSERT INTO pdp_services (pubkey, service_label)
+		VALUES ($1, $2)
+	`, []byte(service), service)
+	return err
+}
+
+func testPullPieceCID(t *testing.T, seed uint64) (string, uint64) {
+	t.Helper()
+
+	rawSize := uint64(127)
+	var commP [32]byte
+	binary.BigEndian.PutUint64(commP[:8], seed)
+	binary.BigEndian.PutUint64(commP[8:16], rawSize)
+	pieceCID, err := commcid.DataCommitmentToPieceCidv2(commP[:], rawSize)
+	require.NoError(t, err)
+
+	info, err := pdp.ParsePieceCidV2(pieceCID.String())
+	require.NoError(t, err)
+
+	return info.CidV1.String(), rawSize
+}

--- a/tasks/pdpv0/task_pull_piece_test.go
+++ b/tasks/pdpv0/task_pull_piece_test.go
@@ -2,14 +2,22 @@ package pdpv0
 
 import (
 	"context"
+	"database/sql"
 	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	commcid "github.com/filecoin-project/go-fil-commcid"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+	"github.com/filecoin-project/curio/lib/robusthttp"
 	"github.com/filecoin-project/curio/pdp"
 )
 
@@ -241,6 +249,292 @@ func TestExpireStalePullItemsEnablesParkTaskWhenOtherRefsRemain(t *testing.T) {
 	err = db.QueryRow(ctx, `SELECT skip FROM parked_pieces WHERE id = $1`, parkedPieceID).Scan(&skip)
 	require.NoError(t, err)
 	require.False(t, skip)
+}
+
+func TestExpireStalePullItemsCleansFailedItemRefs(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	service := "pull-task-expire-failed-refs"
+	require.NoError(t, insertPullTaskService(ctx, db, service))
+
+	pieceCid, rawSize := testPullPieceCID(t, 6)
+	var parkedPieceID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, complete, long_term, skip)
+		VALUES ($1, $2, $3, FALSE, TRUE, TRUE)
+		RETURNING id
+	`, pieceCid, pdp.PadPieceSize(int64(rawSize)), rawSize).Scan(&parkedPieceID)
+	require.NoError(t, err)
+
+	var pullRef int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO parked_piece_refs (piece_id, data_url, long_term)
+		VALUES ($1, 'https://failed-pull.example/piece', TRUE)
+		RETURNING ref_id
+	`, parkedPieceID).Scan(&pullRef)
+	require.NoError(t, err)
+
+	var otherRef int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO parked_piece_refs (piece_id, data_url, long_term)
+		VALUES ($1, 'https://other-failed-pull.example/piece', TRUE)
+		RETURNING ref_id
+	`, parkedPieceID).Scan(&otherRef)
+	require.NoError(t, err)
+
+	var pullID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO pdp_piece_pulls (service, extra_data_hash, data_set_id, record_keeper, client_address)
+		VALUES ($1, $2, 1, '', '0x1')
+		RETURNING id
+	`, service, []byte("pull-task-expire-failed-refs")).Scan(&pullID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO pdp_piece_pull_items (
+			fetch_id, piece_cid, piece_raw_size, source_url, failed, fail_reason, parked_piece_ref, pull_parked_piece_id
+		)
+		VALUES ($1, $2, $3, 'https://failed-pull.example/piece', TRUE, 'source failed', $4, $5)
+	`, pullID, pieceCid, rawSize, pullRef, parkedPieceID)
+	require.NoError(t, err)
+
+	task := &PDPPullPieceTask{db: db}
+	require.NoError(t, task.expireStalePullItems(ctx))
+
+	var failedItems int
+	err = db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM pdp_piece_pull_items
+		WHERE fetch_id = $1
+			AND failed = TRUE
+			AND fail_reason = 'source failed'
+			AND parked_piece_ref IS NULL
+			AND pull_parked_piece_id IS NULL
+	`, pullID).Scan(&failedItems)
+	require.NoError(t, err)
+	require.Equal(t, 1, failedItems)
+
+	var pullRefCount, otherRefCount int
+	err = db.QueryRow(ctx, `SELECT COUNT(*) FROM parked_piece_refs WHERE ref_id = $1`, pullRef).Scan(&pullRefCount)
+	require.NoError(t, err)
+	require.Zero(t, pullRefCount)
+
+	err = db.QueryRow(ctx, `SELECT COUNT(*) FROM parked_piece_refs WHERE ref_id = $1`, otherRef).Scan(&otherRefCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, otherRefCount)
+
+	var skip bool
+	err = db.QueryRow(ctx, `SELECT skip FROM parked_pieces WHERE id = $1`, parkedPieceID).Scan(&skip)
+	require.NoError(t, err)
+	require.False(t, skip)
+}
+
+func TestPullSourceErrorClassification(t *testing.T) {
+	tests := []struct {
+		name      string
+		failure   pullSourceError
+		transient bool
+	}{
+		{
+			name:      "404 is transient",
+			failure:   pullSourceError{stage: pullSourceStatus, statusCode: 404, err: errors.New("not found")},
+			transient: true,
+		},
+		{
+			name:    "410 is permanent",
+			failure: pullSourceError{stage: pullSourceStatus, statusCode: 410, err: errors.New("gone")},
+		},
+		{
+			name:      "429 is transient",
+			failure:   pullSourceError{stage: pullSourceStatus, statusCode: 429, err: errors.New("rate limited")},
+			transient: true,
+		},
+		{
+			name:      "5xx is transient",
+			failure:   pullSourceError{stage: pullSourceStatus, statusCode: 503, err: errors.New("unavailable")},
+			transient: true,
+		},
+		{
+			name:    "validation is permanent",
+			failure: pullSourceError{stage: pullSourceValidate, err: errors.New("bad source")},
+		},
+		{
+			name:    "verification is permanent",
+			failure: pullSourceError{stage: pullSourceVerify, err: errors.New("CommP mismatch")},
+		},
+		{
+			name:      "write is transient",
+			failure:   pullSourceError{stage: pullSourceWrite, err: errors.New("write failed")},
+			transient: true,
+		},
+		{
+			name:      "deadline is transient",
+			failure:   pullSourceError{stage: pullSourceRequest, err: context.DeadlineExceeded},
+			transient: true,
+		},
+		{
+			name:      "unexpected EOF is transient",
+			failure:   pullSourceError{stage: pullSourceRequest, err: io.ErrUnexpectedEOF},
+			transient: true,
+		},
+		{
+			name:      "DNS error is transient",
+			failure:   pullSourceError{stage: pullSourceRequest, err: &net.DNSError{Err: "lookup failed", Name: "example.test"}},
+			transient: true,
+		},
+		{
+			name:      "no resolved addresses is transient",
+			failure:   pullSourceError{stage: pullSourceRequest, err: &robusthttp.NoResolvedAddressError{Host: "example.test"}},
+			transient: true,
+		},
+		{
+			name:    "plain URL request error is permanent",
+			failure: pullSourceError{stage: pullSourceRequest, err: &url.Error{Op: "Get", URL: "https://example.test", Err: errors.New("bad redirect")}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.transient, isTransientPullSourceError(tt.failure))
+		})
+	}
+}
+
+func TestPullBackoffSourcesRetriesThenFails(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	service := "pull-task-backoff"
+	require.NoError(t, insertPullTaskService(ctx, db, service))
+
+	pieceCid, rawSize := testPullPieceCID(t, 4)
+	sourceURL := "https://source-backoff.example/piece/" + pieceCid
+
+	var pullID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO pdp_piece_pulls (service, extra_data_hash, data_set_id, record_keeper, client_address)
+		VALUES ($1, $2, 1, '', '0x1')
+		RETURNING id
+	`, service, []byte("pull-task-backoff")).Scan(&pullID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO pdp_piece_pull_items (fetch_id, piece_cid, piece_raw_size, source_url)
+		VALUES ($1, $2, $3, $4)
+	`, pullID, pieceCid, rawSize, sourceURL)
+	require.NoError(t, err)
+
+	task := &PDPPullPieceTask{db: db}
+	group := pullPieceKey{PieceCid: pieceCid, PieceRawSize: int64(rawSize)}
+	failures := []pullSourceError{{
+		sourceURL: sourceURL,
+		err:       errors.New("temporary source failure"),
+		stage:     pullSourceWrite,
+	}}
+
+	before := time.Now()
+	err = task.recordPullSourceFailures(ctx, group, failures)
+	require.NoError(t, err)
+
+	var attemptCount int
+	var failed bool
+	var taskID sql.NullInt64
+	var nextAttemptAt time.Time
+	err = db.QueryRow(ctx, `
+		SELECT attempt_count, failed, task_id, next_attempt_at
+		FROM pdp_piece_pull_items
+		WHERE fetch_id = $1 AND piece_cid = $2 AND source_url = $3
+	`, pullID, pieceCid, sourceURL).Scan(&attemptCount, &failed, &taskID, &nextAttemptAt)
+	require.NoError(t, err)
+	require.Equal(t, 1, attemptCount)
+	require.False(t, failed)
+	require.False(t, taskID.Valid)
+	require.True(t, nextAttemptAt.After(before))
+
+	_, err = db.Exec(ctx, `
+		UPDATE pdp_piece_pull_items
+		SET attempt_count = $4, next_attempt_at = NOW()
+		WHERE fetch_id = $1 AND piece_cid = $2 AND source_url = $3
+	`, pullID, pieceCid, sourceURL, pullItemMaxAttempts-1)
+	require.NoError(t, err)
+
+	err = task.recordPullSourceFailures(ctx, group, failures)
+	require.NoError(t, err)
+
+	var failReason *string
+	err = db.QueryRow(ctx, `
+		SELECT attempt_count, failed, fail_reason
+		FROM pdp_piece_pull_items
+		WHERE fetch_id = $1 AND piece_cid = $2 AND source_url = $3
+	`, pullID, pieceCid, sourceURL).Scan(&attemptCount, &failed, &failReason)
+	require.NoError(t, err)
+	require.Equal(t, pullItemMaxAttempts, attemptCount)
+	require.True(t, failed)
+	require.NotNil(t, failReason)
+	require.Equal(t, "temporary source failure", *failReason)
+}
+
+func TestAssignGroupIncludesFutureAttemptsAfterGroupSelected(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	service := "pull-task-schedule-next-attempt"
+	require.NoError(t, insertPullTaskService(ctx, db, service))
+
+	pieceCid, rawSize := testPullPieceCID(t, 5)
+	dueURL := "https://source-schedule.example/piece/" + pieceCid
+	futureURL := "https://source-schedule-later.example/piece/" + pieceCid
+
+	var pullID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO pdp_piece_pulls (service, extra_data_hash, data_set_id, record_keeper, client_address)
+		VALUES ($1, $2, 1, '', '0x1')
+		RETURNING id
+	`, service, []byte("pull-task-schedule-next-attempt")).Scan(&pullID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO pdp_piece_pull_items (fetch_id, piece_cid, piece_raw_size, source_url, next_attempt_at)
+		VALUES
+			($1, $2, $3, $4, NOW()),
+			($1, $2, $3, $5, NOW() + INTERVAL '1 minute')
+	`, pullID, pieceCid, rawSize, dueURL, futureURL)
+	require.NoError(t, err)
+
+	var taskID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO harmony_task (posted_time, added_by, name)
+		VALUES (NOW(), 1, 'test')
+		RETURNING id
+	`).Scan(&taskID)
+	require.NoError(t, err)
+
+	task := &PDPPullPieceTask{db: db}
+	group := pullPieceKey{PieceCid: pieceCid, PieceRawSize: int64(rawSize)}
+
+	var assigned bool
+	committed, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		assigned, err = task.assignGroup(tx, harmonytask.TaskID(taskID), group)
+		return err == nil, err
+	}, harmonydb.OptionRetry())
+	require.NoError(t, err)
+	require.True(t, committed)
+	require.True(t, assigned)
+
+	var assignedRows int
+	err = db.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM pdp_piece_pull_items
+		WHERE fetch_id = $1
+			AND piece_cid = $2
+			AND task_id = $3
+	`, pullID, pieceCid, taskID).Scan(&assignedRows)
+	require.NoError(t, err)
+	require.Equal(t, 2, assignedRows)
 }
 
 func insertPullTaskService(ctx context.Context, db *harmonydb.DB, service string) error {


### PR DESCRIPTION
## Summary
This refactors PDPv0 pull handling so /pdp/piece/pull only records accepted pull work, while PDPPullPieceTask owns completion, failure, ref attachment, and download execution.

### Changes:
• Adds explicit pull item state with complete, created_at, parked_piece_ref, and pull_parked_piece_id.
• Stores client_address from FWSS payer extraction for per-client pull backpressure.
• Changes pull item identity to (fetch_id, piece_cid, source_url) so one pull can supply multiple URLs for the same piece.
• Groups PullPiece work by (piece_cid, piece_raw_size) and tries all source URLs for that piece.
• Parks pulled data directly into long-term piece storage when PullPiece creates the parked row.
• Reuses existing long-term parked rows when present instead of downloading again.
• Creates one parked_piece_ref / pdp_piecerefs path per pull item, even when the data came from another URL.
• Adds stale pull expiry using a 30-minute item budget and a 10-minute per-download attempt timeout.
• Cleans only PullPiece-owned refs, and flips skip=false when non-pull refs remain on an incomplete parked row.
• Adds handler backpressure with global/per-client pending-piece limits and 429 Retry-After.
• Fixes concurrent idempotent pull creation with ON CONFLICT DO NOTHING.

### Tests:
• Handler backpressure stress test with concurrent clients and random completion.
• Pull validation for same piece with multiple source URLs.
• PullPiece task tests for already-parked completion, pull-owned cleanup, and stale-expiry handoff to normal park processing.