### PR TITLE
Shouldtest

### DIFF
--- a/.github/shouldtest.json
+++ b/.github/shouldtest.json
@@ -1,0 +1,7 @@
+{
+  "defaultBranch": "main",
+  "alwaysRunOnPushToDefaultBranch": true,
+  "workflows": [".github/workflows/ci.yml"],
+  "walkSkipDirs": [".git", "extern", "node_modules", "vendor"],
+  "ciInvoke": "go run github.com/curiostorage/shouldtest/cmd/shouldtest"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Run actionlint
         run: actionlint -shellcheck= -pyflakes=
 
+      - name: Check shouldtest profiles are referenced in CI
+        run: go test ./shouldtest/... -run TestRepoCIRegistry -count=1
+
   build-mainnet:
     runs-on: ubuntu-latest
     needs: [ci-lint]
@@ -228,6 +231,8 @@ jobs:
     needs: [ci-lint]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Go
         uses: ./.github/actions/install-go
@@ -245,11 +250,20 @@ jobs:
           make deps
         shell: bash
 
+      - name: Decide whether to run lib/proof tests
+        id: shouldtest
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: go run github.com/curiostorage/shouldtest/cmd/shouldtest --ci --verbose ./lib/proof
+
       - name: Run lib/proof tests with coverage
+        if: steps.shouldtest.outputs.run == 'true'
         env:
           FFI_USE_OPENCL: 1
         run: |
-          mkdir -p coverage
           go test -v --tags="debug,fvm,nosupraseal" -timeout 30m -coverprofile=coverage/test-lib-proof.out -covermode=atomic ./lib/proof/...
 
       - name: Upload coverage artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,7 @@ jobs:
         env:
           FFI_USE_OPENCL: 1
         run: |
+          mkdir -p coverage
           go test -v --tags="debug,fvm,nosupraseal" -timeout 30m -coverprofile=coverage/test-lib-proof.out -covermode=atomic ./lib/proof/...
 
       - name: Upload coverage artifact

--- a/go.mod
+++ b/go.mod
@@ -383,4 +383,6 @@ require (
 	lukechampine.com/blake3 v1.4.1 // indirect
 )
 
+require github.com/curiostorage/shouldtest v0.0.0-20260522222211-a06c87260eb5
+
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/curiostorage/go-openrpc-reflect v0.0.0-20260302234910-57f4605f0e7b h1
 github.com/curiostorage/go-openrpc-reflect v0.0.0-20260302234910-57f4605f0e7b/go.mod h1:0d2D5Wu50Qf4i3NWH7OHVSblAHeup7jVsJ6cV8OdzrU=
 github.com/curiostorage/harmonyquery v1.0.2 h1:Jfk2vQaFfyB/4CC0mAufkKQ1bZXGryMNIrnNLXgFupQ=
 github.com/curiostorage/harmonyquery v1.0.2/go.mod h1:ih3N/QVNhPcps+cIWBk/s+hYRz5QEJ+9Lkc841K7xXY=
+github.com/curiostorage/shouldtest v0.0.0-20260522222211-a06c87260eb5 h1:XH67X9yFkhpa1nxv4N6pXY3vhxwG+wlCVIKtW2D6gYI=
+github.com/curiostorage/shouldtest v0.0.0-20260522222211-a06c87260eb5/go.mod h1:1f5OZeHKJFWVEI2fLbKhVi+u1bju1jZyFvbyyAICtaM=
 github.com/daaku/go.zipexe v1.0.2 h1:Zg55YLYTr7M9wjKn8SY/WcpuuEi+kR2u4E8RhvpyXmk=
 github.com/daaku/go.zipexe v1.0.2/go.mod h1:5xWogtqlYnfBXkSB1o9xysukNP9GTvaNkqzUZbt3Bw8=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/lib/proof/shouldtest.json
+++ b/lib/proof/shouldtest.json
@@ -1,0 +1,5 @@
+{
+  "buildTags": ["debug", "fvm", "nosupraseal"],
+  "extraPaths": ["lib/proof/testgolden", "extern/filecoin-ffi"],
+  "coverageFile": "test-lib-proof.out"
+}

--- a/shouldtest/integration_test.go
+++ b/shouldtest/integration_test.go
@@ -1,0 +1,114 @@
+package shouldtest_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/curiostorage/shouldtest"
+	"github.com/curiostorage/shouldtest/config"
+)
+
+func libProofDir(t *testing.T) string {
+	t.Helper()
+	root, err := config.ModuleRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(root, "lib/proof")
+}
+
+func TestDependencyDirs_libProof(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping go list integration in short mode")
+	}
+
+	moduleRoot, err := config.ModuleRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dirs, err := shouldtest.DependencyDirs([]string{"./lib/proof/..."}, []string{"debug", "fvm", "nosupraseal"}, moduleRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var foundProof, foundFFI bool
+	for _, d := range dirs {
+		if d == "lib/proof" || strings.HasPrefix(d, "lib/proof/") {
+			foundProof = true
+		}
+		if strings.HasPrefix(d, "extern/filecoin-ffi") {
+			foundFFI = true
+		}
+	}
+	if !foundProof {
+		t.Fatalf("expected lib/proof in deps, got %v", dirs)
+	}
+	if !foundFFI {
+		t.Fatalf("expected extern/filecoin-ffi in deps, got %v", dirs)
+	}
+}
+
+func TestLoadProfile_libProof(t *testing.T) {
+	p, err := shouldtest.LoadProfile(libProofDir(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.CoverageFile != "test-lib-proof.out" {
+		t.Fatalf("got %+v", p)
+	}
+}
+
+func TestRunCI_skipWritesCoverage(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "output")
+	if err := os.WriteFile(outPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_OUTPUT", outPath)
+	t.Setenv("GITHUB_EVENT_NAME", "pull_request")
+	t.Setenv("GITHUB_REF", "refs/heads/feature")
+	base, err := exec.Command("git", "merge-base", "main", "HEAD").Output()
+	if err != nil {
+		t.Skip("need git merge-base with main:", err)
+	}
+	t.Setenv("GITHUB_BASE_SHA", strings.TrimSpace(string(base)))
+	t.Setenv("GITHUB_HEAD_SHA", "HEAD")
+
+	covDir := filepath.Join(dir, "coverage")
+	repo, _, err := config.LoadFromModule()
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := shouldtest.RunCI(shouldtest.CIConfig{
+		ProfileDir:  libProofDir(t),
+		CoverageDir: covDir,
+		Repo:        repo,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Run {
+		t.Skip("workspace has matching changes; skip stub test")
+	}
+	if !res.SkippedOnCI {
+		t.Fatal("expected coverage stub")
+	}
+	data, err := os.ReadFile(filepath.Join(covDir, "test-lib-proof.out"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "mode: atomic\n" {
+		t.Fatalf("got %q", data)
+	}
+	out, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != "run=false\n" {
+		t.Fatalf("GITHUB_OUTPUT: %q", out)
+	}
+}

--- a/shouldtest/registry_test.go
+++ b/shouldtest/registry_test.go
@@ -1,0 +1,20 @@
+package shouldtest_test
+
+import (
+	"testing"
+
+	"github.com/curiostorage/shouldtest/config"
+	"github.com/curiostorage/shouldtest/registry"
+)
+
+// TestRepoCIRegistry ensures every package shouldtest.json is referenced in CI
+// per .github/shouldtest.json registry settings.
+func TestRepoCIRegistry(t *testing.T) {
+	repo, root, err := config.LoadFromModule()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Validate(root, repo.RegistryConfig()); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Use a tool that lets us quickly define that some slow tests should first be examined to see if they are likely to have changed. 

Such a tool did not exist stand-alone, so I built one that's currently Go-specific at github.com/curiostorage/shouldtest
It's configured via files in the intended folder & in .github (for "global config").