### PR TITLE
harmonytask: surface silent CanAccept resource rejection at WARN (rate-limited)

### DIFF
--- a/harmony/harmonytask/harmonytask.go
+++ b/harmony/harmonytask/harmonytask.go
@@ -399,8 +399,29 @@ func (e *TaskEngine) pollerTryAllWork(schedulable bool) bool {
 			}
 		}
 
-		if _, err := v.AssertMachineHasCapacity(); err != nil {
-			log.Debugf("skipped scheduling %s type tasks on due to %s", v.Name, err.Error())
+		if _, capErr := v.AssertMachineHasCapacity(); capErr != nil {
+			log.Debugf("skipped scheduling %s type tasks on due to %s", v.Name, capErr.Error())
+
+			// If unowned tasks are waiting on a resource rejection,
+			// surface that at WARN so operators can see the silent
+			// stuck-task condition. Without this, a task with a Cost
+			// that exceeds the machine's resource budget sits in
+			// harmony_task indefinitely with no diagnostic at INFO
+			// level. Rate-limited per task type (default 5 min)
+			// so a sustained stuck condition doesn't spam logs.
+			var waitingCount int
+			if qerr := e.db.QueryRow(e.ctx,
+				`SELECT COUNT(*) FROM harmony_task WHERE owner_id IS NULL AND name=$1`,
+				v.Name).Scan(&waitingCount); qerr == nil &&
+				waitingCount > 0 &&
+				time.Since(v.lastInsufficientWarn) > insufficientWarnInterval {
+				log.Warnw("task waiting but machine cannot accept it",
+					"task_type", v.Name,
+					"reason", capErr.Error(),
+					"waiting_count", waitingCount,
+					"hint", "check engine resource budget vs task Cost (Cpu/Ram/Gpu) or task Max limit")
+				v.lastInsufficientWarn = time.Now()
+			}
 			continue
 		}
 		type task struct {

--- a/harmony/harmonytask/task_type_handler.go
+++ b/harmony/harmonytask/task_type_handler.go
@@ -32,10 +32,24 @@ type taskTypeHandler struct {
 	TaskTypeDetails
 	TaskEngine      *TaskEngine
 	storageFailures map[TaskID]time.Time
+
+	// lastInsufficientWarn rate-limits the WARN that fires when this task
+	// type has unowned tasks waiting but the machine cannot accept them
+	// (out of CPU/RAM/GPU, or Max already reached). Single-writer:
+	// scheduler goroutine only. See harmonytask.go schedule().
+	lastInsufficientWarn time.Time
 }
 
 // Anti-hammering of storage claims.
 const STORAGE_FAILURE_TIMEOUT = 3 * time.Minute
+
+// insufficientWarnInterval is the rate limit for the WARN that fires when
+// unowned tasks are waiting but the machine cannot accept them (resource
+// rejection). Without rate-limiting, every poll cycle (~3s) re-emits the
+// same WARN. 5 minutes is short enough to surface a real misconfiguration
+// promptly, long enough to keep logs readable on a sustained stuck-task
+// condition.
+const insufficientWarnInterval = 5 * time.Minute
 
 func (h *taskTypeHandler) AddTask(extra func(TaskID, *harmonydb.Tx) (bool, error)) {
 	var tID TaskID


### PR DESCRIPTION
## Problem

When a task type has unowned tasks waiting in `harmony_task` but the machine cannot accept them (out of CPU / RAM / GPU, or `Max` already reached), the scheduler at `harmonytask.go:403` logs the rejection at DEBUG level only. Operators running with default INFO never see the message. A task with a `Cost` that exceeds the machine's resource budget sits in `harmony_task` indefinitely with no diagnostic, looking exactly the same as a task the engine simply hasn't gotten around to yet.

## Concrete case

Hit live recently in a curio-derived deployment:

- ProveTask declares `Cost.Ram = 3 GiB` (peak memory during fr32.Pad for the memtree build).
- The operator's engine `resources.Reg` declared `Ram: 1 GiB`.
- ProveTask got queued (row appeared in `harmony_task` with the right name).
- Scheduler poll cycle ran every ~3s, hit `AssertMachineHasCapacity`, got back `"Did not accept PDPv0_Prove task: out of RAM: required 3221225472 available 1073741824"`, logged it at DEBUG, and `continue`d.
- No WARN, no error, no diagnostic at INFO. Task sat 5 minutes before the operator dug into the code path.

The fix once found was trivial (bump engine `resources.Reg.Ram`). Finding it took longer than fixing it. Several other operators have likely hit silent variants of this since the per-task `Cost` is rarely tuned to match the engine's resource budget.

## Fix

Add a rate-limited WARN that fires when:
- `AssertMachineHasCapacity` returns an error (resource rejection or Max-reached condition), AND
- There are unowned tasks for that task type waiting in `harmony_task`

Rate limit is per task type, default 5 minutes. Short enough to surface a real misconfiguration promptly; long enough to keep logs readable on a sustained stuck condition.

The log line includes:
- `task_type` — the rejected task name
- `reason` — the exact error from `AssertMachineHasCapacity` (which already formats `required X available Y` numbers for the failing resource)
- `waiting_count` — how many rows of this type are stuck
- `hint` — points at the two configuration knobs (engine `resources.Reg` vs task `Cost`; task `Max`)

Sample output once a PDPv0_Prove task is stuck:

```
WARN  task waiting but machine cannot accept it
  task_type=PDPv0_Prove
  reason="Did not accept PDPv0_Prove task: out of RAM: required 3221225472 available 1073741824"
  waiting_count=1
  hint="check engine resource budget vs task Cost (Cpu/Ram/Gpu) or task Max limit"
```

## Implementation

Two files, ~37 LoC additive:

- `harmony/harmonytask/harmonytask.go` `schedule()`: after the existing `log.Debugf` inside the err branch (line 403), check if any unowned tasks exist via a lightweight `COUNT(*)` query. If yes AND the rate-limit hasn't suppressed us, emit `log.Warnw` and update `lastInsufficientWarn`. Renamed the existing `err` variable to `capErr` in the inner scope to avoid shadowing across the new `QueryRow` call.
- `harmony/harmonytask/task_type_handler.go`: add `lastInsufficientWarn time.Time` field on `taskTypeHandler` in the scheduler-goroutine-only access regime (same single-writer invariant as `storageFailures`). Add `insufficientWarnInterval = 5 * time.Minute` constant alongside `STORAGE_FAILURE_TIMEOUT`.

## Behavior

Strictly additive. The scheduling decisions are unchanged — only the diagnostic surface improves. The COUNT query runs ONLY on the err path of an existing poll cycle, so the cost is at most one COUNT per task type per ~3s during a sustained stuck condition. The rate-limit keeps the WARN bounded.

## Testing

- `go vet ./harmony/harmonytask/...`: clean
- Existing `harmony/harmonytask/` test suite passes
- Verified live: applied to a calibration deployment, no behavior change observed on healthy task types; WARN fires correctly on a deliberately-overcommitted Cost (set Cost.Ram > engine.Ram + scheduled the task + observed the WARN within ~3s, then no further WARN for 5 minutes).

## Why upstream

Lower-priority operators (single-node deployments, custom curio forks) are the population most likely to hit this since they're more likely to tune the engine budget vs upstream defaults. Making the diagnostic visible at INFO closes a real "took 5 minutes to find a trivial fix" loop.
