### PR TITLE
Simpler tiny-tasks

### DIFF
--- a/alertmanager/task_alert.go
+++ b/alertmanager/task_alert.go
@@ -349,7 +349,7 @@ func (a *AlertTask) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(1),
 		Name: "AlertManager",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 			Gpu: 0,
 		},

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -284,7 +284,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 
 			sdeps.DealMarket = dm
 
-			if cfg.Subsystems.EnableCommP {
+			if cfg.Subsystems.EnableCommP || cfg.Subsystems.EnableDealMarket {
 				commpTask := storage_market.NewCommpTask(dm, db, must.One(slrLazy.Val()), full, cfg.Subsystems.CommPMaxTasks, cfg.Subsystems.BindCommPToData)
 				activeTasks = append(activeTasks, commpTask)
 			}
@@ -453,8 +453,16 @@ func addSealingTasks(
 	var slotMgr *slotmgr.SlotMgr
 	var addFinalize bool
 
+	// Auto-enable lightweight pipeline steps alongside their upstream work.
+	// Manual flags remain for cleanup-only nodes.
+	enableSendPrecommitMsg := cfg.Subsystems.EnableSendPrecommitMsg || cfg.Subsystems.EnableSealSDRTrees
+	enableSendCommitMsg := cfg.Subsystems.EnableSendCommitMsg || cfg.Subsystems.EnablePoRepProof
+	enableMoveStorage := cfg.Subsystems.EnableMoveStorage || cfg.Subsystems.EnablePoRepProof || cfg.Subsystems.EnableSendCommitMsg
+	enableUpdateSubmit := cfg.Subsystems.EnableUpdateSubmit || cfg.Subsystems.EnableUpdateProve
+	enableSnapMoveStorage := cfg.Subsystems.EnableMoveStorage || cfg.Subsystems.EnableUpdateEncode || cfg.Subsystems.EnableUpdateProve
+
 	// NOTE: Tasks with the LEAST priority are at the top
-	if cfg.Subsystems.EnableCommP {
+	if cfg.Subsystems.EnableCommP || cfg.Subsystems.EnableSealSDRTrees {
 		scrubUnsealedTask := scrub.NewCommDCheckTask(db, slr)
 		activeTasks = append(activeTasks, scrubUnsealedTask)
 	}
@@ -497,7 +505,7 @@ func addSealingTasks(
 		activeTasks = append(activeTasks, finalizeTask)
 	}
 
-	if cfg.Subsystems.EnableSendPrecommitMsg {
+	if enableSendPrecommitMsg {
 		precommitTask := seal.NewSubmitPrecommitTask(sp, db, full, sender, as, cfg)
 		activeTasks = append(activeTasks, precommitTask)
 	}
@@ -505,16 +513,15 @@ func addSealingTasks(
 		porepTask := seal.NewPoRepTask(db, full, sp, slr, asyncParams(), cfg.Subsystems.EnablePoRepProof, cfg.Subsystems.PoRepProofMaxTasks, cuzkClient)
 		activeTasks = append(activeTasks, porepTask)
 	}
-	if cfg.Subsystems.EnableMoveStorage {
+	if enableMoveStorage {
 		moveStorageTask := seal.NewMoveStorageTask(sp, slr, db, cfg.Subsystems.MoveStorageMaxTasks)
-		moveStorageSnapTask := snap.NewMoveStorageTask(slr, db, cfg.Subsystems.MoveStorageMaxTasks)
 
 		storePieceTask, err := piece2.NewStorePieceTask(db, must.One(slrLazy.Val()), stor, cfg.Subsystems.MoveStorageMaxTasks)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		activeTasks = append(activeTasks, moveStorageTask, moveStorageSnapTask, storePieceTask)
+		activeTasks = append(activeTasks, moveStorageTask, storePieceTask)
 		if !cfg.Subsystems.EnableParkPiece {
 			// add cleanup if it's not added above with park piece
 			cleanupPieceTask := piece2.NewCleanupPieceTask(db, must.One(slrLazy.Val()), 0)
@@ -526,7 +533,11 @@ func addSealingTasks(
 			activeTasks = append(activeTasks, unsealTask)
 		}
 	}
-	if cfg.Subsystems.EnableSendCommitMsg {
+	if enableSnapMoveStorage {
+		moveStorageSnapTask := snap.NewMoveStorageTask(slr, db, cfg.Subsystems.MoveStorageMaxTasks)
+		activeTasks = append(activeTasks, moveStorageSnapTask)
+	}
+	if enableSendCommitMsg {
 		commitTask := seal.NewSubmitCommitTask(sp, db, full, sender, as, cfg, prover)
 		activeTasks = append(activeTasks, commitTask)
 	}
@@ -546,7 +557,7 @@ func addSealingTasks(
 		proveTask := snap.NewProveTask(slr, db, asyncParams(), cfg.Subsystems.EnableRemoteProofs, cfg.Subsystems.UpdateProveMaxTasks, cuzkClient)
 		activeTasks = append(activeTasks, proveTask)
 	}
-	if cfg.Subsystems.EnableUpdateSubmit {
+	if enableUpdateSubmit {
 		submitTask := snap.NewSubmitTask(db, full, bstore, sender, as, cfg)
 		activeTasks = append(activeTasks, submitTask)
 	}

--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -284,7 +284,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 
 			sdeps.DealMarket = dm
 
-			if cfg.Subsystems.EnableCommP || cfg.Subsystems.EnableDealMarket {
+			if cfg.Subsystems.EnableCommP {
 				commpTask := storage_market.NewCommpTask(dm, db, must.One(slrLazy.Val()), full, cfg.Subsystems.CommPMaxTasks, cfg.Subsystems.BindCommPToData)
 				activeTasks = append(activeTasks, commpTask)
 			}
@@ -453,8 +453,8 @@ func addSealingTasks(
 	var slotMgr *slotmgr.SlotMgr
 	var addFinalize bool
 
-	// Auto-enable lightweight pipeline steps alongside their upstream work.
-	// Manual flags remain for cleanup-only nodes.
+	// Auto-enable CPU:0 pipeline steps alongside their upstream work.
+	// Manual flags remain for cleanup-only nodes and for CPU-heavy companions (CommP, StorePiece, etc.).
 	enableSendPrecommitMsg := cfg.Subsystems.EnableSendPrecommitMsg || cfg.Subsystems.EnableSealSDRTrees
 	enableSendCommitMsg := cfg.Subsystems.EnableSendCommitMsg || cfg.Subsystems.EnablePoRepProof
 	enableMoveStorage := cfg.Subsystems.EnableMoveStorage || cfg.Subsystems.EnablePoRepProof || cfg.Subsystems.EnableSendCommitMsg
@@ -462,7 +462,7 @@ func addSealingTasks(
 	enableSnapMoveStorage := cfg.Subsystems.EnableMoveStorage || cfg.Subsystems.EnableUpdateEncode || cfg.Subsystems.EnableUpdateProve
 
 	// NOTE: Tasks with the LEAST priority are at the top
-	if cfg.Subsystems.EnableCommP || cfg.Subsystems.EnableSealSDRTrees {
+	if cfg.Subsystems.EnableCommP {
 		scrubUnsealedTask := scrub.NewCommDCheckTask(db, slr)
 		activeTasks = append(activeTasks, scrubUnsealedTask)
 	}
@@ -515,13 +515,15 @@ func addSealingTasks(
 	}
 	if enableMoveStorage {
 		moveStorageTask := seal.NewMoveStorageTask(sp, slr, db, cfg.Subsystems.MoveStorageMaxTasks)
-
+		activeTasks = append(activeTasks, moveStorageTask)
+	}
+	if cfg.Subsystems.EnableMoveStorage {
 		storePieceTask, err := piece2.NewStorePieceTask(db, must.One(slrLazy.Val()), stor, cfg.Subsystems.MoveStorageMaxTasks)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		activeTasks = append(activeTasks, moveStorageTask, storePieceTask)
+		activeTasks = append(activeTasks, storePieceTask)
 		if !cfg.Subsystems.EnableParkPiece {
 			// add cleanup if it's not added above with park piece
 			cleanupPieceTask := piece2.NewCleanupPieceTask(db, must.One(slrLazy.Val()), 0)

--- a/tasks/gc/pipeline_meta_gc.go
+++ b/tasks/gc/pipeline_meta_gc.go
@@ -57,7 +57,7 @@ func (s *PipelineGC) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(1),
 		Name: "PipelineGC",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 			Gpu: 0,
 		},

--- a/tasks/gc/storage_endpoint_gc.go
+++ b/tasks/gc/storage_endpoint_gc.go
@@ -276,7 +276,7 @@ func (s *StorageEndpointGC) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(1),
 		Name: "StorageMetaGC",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 			Gpu: 0,
 		},

--- a/tasks/gc/storage_gc_mark.go
+++ b/tasks/gc/storage_gc_mark.go
@@ -486,7 +486,7 @@ func (s *StorageGCMark) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(1),
 		Name: "StorageGCMark",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 			Gpu: 0,
 		},

--- a/tasks/gc/storage_gc_sweep.go
+++ b/tasks/gc/storage_gc_sweep.go
@@ -113,7 +113,7 @@ func (s *StorageGCSweep) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(1),
 		Name: "StorageGCSweep",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 			Gpu: 0,
 		},

--- a/tasks/gc/task_cleanup_piece.go
+++ b/tasks/gc/task_cleanup_piece.go
@@ -434,7 +434,7 @@ func (p *PieceCleanupTask) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(50),
 		Name: "PieceCleanup",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 		},
 		MaxFailures: 3,

--- a/tasks/indexing/task_check_indexes.go
+++ b/tasks/indexing/task_check_indexes.go
@@ -790,7 +790,7 @@ func (c *CheckIndexesTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: "CheckIndex",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Gpu: 0,
 			Ram: 32 << 20,
 		},

--- a/tasks/indexing/task_indexing.go
+++ b/tasks/indexing/task_indexing.go
@@ -743,7 +743,7 @@ func (i *IndexingTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: "Indexing",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: uint64(i.insertBatchSize * i.insertConcurrency * 56 * 2),
 		},
 		Max:         i.max,

--- a/tasks/indexing/task_ipni.go
+++ b/tasks/indexing/task_ipni.go
@@ -438,7 +438,7 @@ func (I *IPNITask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: "IPNI",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 1 << 30,
 		},
 		MaxFailures: 3,

--- a/tasks/indexing/task_pdp_indexing.go
+++ b/tasks/indexing/task_pdp_indexing.go
@@ -297,7 +297,7 @@ func (P *PDPIndexingTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: "PDPIndexing",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: uint64(P.insertBatchSize * P.insertConcurrency * 56 * 2),
 		},
 		Max:         P.max,

--- a/tasks/indexing/task_pdp_ipni.go
+++ b/tasks/indexing/task_pdp_ipni.go
@@ -436,7 +436,7 @@ func (P *PDPIPNITask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: "PDPIpni",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 1 << 30,
 		},
 		MaxFailures: 3,

--- a/tasks/indexing/task_pdp_v0_ipni.go
+++ b/tasks/indexing/task_pdp_v0_ipni.go
@@ -303,7 +303,7 @@ func (P *PDPV0IPNITask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: "PDPv0_IPNI",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 1 << 30,
 		},
 		MaxFailures: 3,

--- a/tasks/metadata/task_sector_expirations.go
+++ b/tasks/metadata/task_sector_expirations.go
@@ -764,7 +764,7 @@ func (s *SectorMetadata) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(1),
 		Name: "SectorMetadata",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 			Gpu: 0,
 		},

--- a/tasks/pay/settle_task.go
+++ b/tasks/pay/settle_task.go
@@ -94,7 +94,7 @@ func (s *SettleTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: "Settle",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Gpu: 0,
 			Ram: 64 << 20,
 		},

--- a/tasks/pdp/notify_task.go
+++ b/tasks/pdp/notify_task.go
@@ -106,7 +106,7 @@ func (t *PDPNotifyTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: tasknames.PDPNotify,
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 128 << 20, // 128MB
 		},
 		MaxFailures: 14,

--- a/tasks/pdp/task_add_data_set.go
+++ b/tasks/pdp/task_add_data_set.go
@@ -145,7 +145,7 @@ func (p *PDPTaskAddDataSet) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(50),
 		Name: tasknames.PDPAddDataSet,
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 		},
 		MaxFailures: 3,

--- a/tasks/pdp/task_add_piece.go
+++ b/tasks/pdp/task_add_piece.go
@@ -175,7 +175,7 @@ func (p *PDPTaskAddPiece) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(50),
 		Name: tasknames.PDPAddPiece,
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 		},
 		MaxFailures: 3,

--- a/tasks/pdp/task_delete_data_set.go
+++ b/tasks/pdp/task_delete_data_set.go
@@ -153,7 +153,7 @@ func (p *PDPTaskDeleteDataSet) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(50),
 		Name: tasknames.PDPDelDataSet,
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 		},
 		MaxFailures: 3,

--- a/tasks/pdp/task_delete_piece.go
+++ b/tasks/pdp/task_delete_piece.go
@@ -151,7 +151,7 @@ func (p *PDPTaskDeletePiece) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(50),
 		Name: tasknames.PDPDeletePiece,
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 		},
 		MaxFailures: 3,

--- a/tasks/pdpv0/notify_task.go
+++ b/tasks/pdpv0/notify_task.go
@@ -197,7 +197,7 @@ func (t *PDPNotifyTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: tasknames.PDPv0_Notify,
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 128 << 20, // 128MB
 		},
 		MaxFailures: 14,

--- a/tasks/pdpv0/task_chain_sync.go
+++ b/tasks/pdpv0/task_chain_sync.go
@@ -71,7 +71,7 @@ func (t *TaskChainSync) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(1),
 		Name: tasknames.PDPv0_ChainSync,
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Gpu: 0,
 			Ram: 64 << 20,
 		},

--- a/tasks/pdpv0/task_reorg_check.go
+++ b/tasks/pdpv0/task_reorg_check.go
@@ -642,7 +642,7 @@ func (t *ReorgCheckTask) TypeDetails() harmonytask.TaskTypeDetails {
 		Name: tasknames.PDPv0_ReorgChk,
 		Max:  taskhelp.Max(1),
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 256 << 20,
 			Gpu: 0,
 		},

--- a/tasks/pdpv0/task_terminate_fwss.go
+++ b/tasks/pdpv0/task_terminate_fwss.go
@@ -133,7 +133,7 @@ func (t *TerminateFWSSTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: tasknames.PDPv0_TermFWSS,
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Gpu: 0,
 			Ram: 64 << 20,
 		},

--- a/tasks/piece/task_cleanup_piece.go
+++ b/tasks/piece/task_cleanup_piece.go
@@ -139,7 +139,7 @@ func (c *CleanupPieceTask) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(c.max),
 		Name: "DropPiece",
 		Cost: resources.Resources{
-			Cpu:     1,
+			Cpu:     0,
 			Gpu:     0,
 			Ram:     64 << 20,
 			Storage: nil,

--- a/tasks/piece/task_fix_park_piece_unique.go
+++ b/tasks/piece/task_fix_park_piece_unique.go
@@ -210,7 +210,7 @@ func (f *FixParkPieceTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: "FixParkPiece",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Gpu: 0,
 			Ram: 64 << 20,
 		},

--- a/tasks/proofshare/task_autosettle.go
+++ b/tasks/proofshare/task_autosettle.go
@@ -271,7 +271,7 @@ func (t *TaskAutosettle) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(1),
 		Name: "PSAutoSettle",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 			Gpu: 0,
 		},

--- a/tasks/proofshare/task_client_send.go
+++ b/tasks/proofshare/task_client_send.go
@@ -583,7 +583,7 @@ func (t *TaskClientSend) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: taskhelp.BackgroundTask("PSClientSend"),
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 128 << 20,
 			Gpu: 0,
 		},

--- a/tasks/proofshare/task_client_upload.go
+++ b/tasks/proofshare/task_client_upload.go
@@ -135,7 +135,7 @@ func (t *TaskClientUpload) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(t.max),
 		Name: "PSPutVanilla",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 128 << 20,
 			Gpu: 0,
 		},

--- a/tasks/proofshare/task_request.go
+++ b/tasks/proofshare/task_request.go
@@ -360,7 +360,7 @@ func (t *TaskRequestProofs) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: "bg:PShareRequest",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Gpu: 0,
 			Ram: 1 << 20,
 		},

--- a/tasks/proofshare/task_submit.go
+++ b/tasks/proofshare/task_submit.go
@@ -203,7 +203,7 @@ func (t *TaskSubmit) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: "PShareSubmit",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Gpu: 0,
 			Ram: 1 << 20,
 		},

--- a/tasks/seal/task_finalize.go
+++ b/tasks/seal/task_finalize.go
@@ -219,7 +219,7 @@ func (f *FinalizeTask) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(f.max),
 		Name: tasknames.Finalize,
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Gpu: 0,
 			Ram: 100 << 20,
 		},

--- a/tasks/snap/task_movestorage.go
+++ b/tasks/snap/task_movestorage.go
@@ -123,16 +123,11 @@ func (m *MoveStorageTask) TypeDetails() harmonytask.TaskTypeDetails {
 		ssize = abi.SectorSize(2 << 20)
 	}
 
-	cpu := 1
-	if m.max > 0 {
-		cpu = 0
-	}
-
 	return harmonytask.TaskTypeDetails{
 		Max:  taskhelp.Max(m.max),
 		Name: "UpdateStore",
 		Cost: resources.Resources{
-			Cpu:     cpu,
+			Cpu:     0,
 			Ram:     128 << 20,
 			Storage: m.sc.Storage(m.taskToSector, storiface.FTNone, storiface.FTUpdate|storiface.FTUpdateCache|storiface.FTUnsealed, ssize, storiface.PathStorage, paths.MinFreeStoragePercentage),
 		},

--- a/tasks/snap/task_submit.go
+++ b/tasks/snap/task_submit.go
@@ -541,7 +541,7 @@ func (s *SubmitTask) TypeDetails() harmonytask.TaskTypeDetails {
 	return harmonytask.TaskTypeDetails{
 		Name: "UpdateBatch",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 		},
 		MaxFailures: 3,

--- a/tasks/storage-market/task_fix_rawSize.go
+++ b/tasks/storage-market/task_fix_rawSize.go
@@ -146,7 +146,7 @@ func (f *FixRawSize) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(16),
 		Name: "FixRawSize",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Gpu: 0,
 			Ram: 64 << 20,
 		},

--- a/tasks/window/recover_task.go
+++ b/tasks/window/recover_task.go
@@ -222,7 +222,7 @@ func (w *WdPostRecoverDeclareTask) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(128),
 		Name: "WdPostRecover",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Gpu: 0,
 			Ram: 128 << 20,
 		},

--- a/tasks/winning/inclusion_check_task.go
+++ b/tasks/winning/inclusion_check_task.go
@@ -108,7 +108,7 @@ func (i *InclusionCheckTask) TypeDetails() harmonytask.TaskTypeDetails {
 		Max:  taskhelp.Max(1),
 		Name: "WinInclCheck",
 		Cost: resources.Resources{
-			Cpu: 1,
+			Cpu: 0,
 			Ram: 64 << 20,
 			Gpu: 0,
 		},


### PR DESCRIPTION
Lets make tiny tasks less of an SP/Support hassle.

https://github.com/filecoin-project/curio/issues/1257

isTiny: Something that makes a small number of SQL / chain calls & does minimal processing on the result.

Switch to 0 CPU
Category | Tasks
-- | --
PoSt (non-prove) | WdPostRecover, WinInclCheck
Sealing pipeline (light) | Finalize, UpdateStore, UpdateBatch
ProofShare (non-snark) | bg:PShareRequest, PShareSubmit, PSAutoSettle, PSPutVanilla, PSClientSend
GC / metadata | PipelineGC, StorageMetaGC, StorageGCMark, StorageGCSweep, SectorMetadata, AlertManager
Indexing / IPNI | CheckIndex, Indexing, IPNI, PDPIndexing, PDPIpni, PDPv0_IPNI
Market / piece cleanup | FixRawSize, DropPiece, FixParkPiece, PieceCleanup
PDP admin | PDPNotify, PDPv0_Notify, PDPAddPiece, PDPAddDataSet, PDPDeletePiece, PDPDelDataSet, PDPv0_TermFWSS, PDPv0_ChainSync, PDPv0_ReorgChk, Settle

Add auto-start to avoid the "why did this not work?" support questions:

Enable Task | When
-- | --
PreCommitBatch | EnableSealSDRTrees
CommitBatch | EnablePoRepProof
MoveStorage | EnablePoRepProof or EnableSendCommitMsg
UpdateStore | EnableUpdateEncode or EnableUpdateProve
UpdateBatch | EnableUpdateProve

