### PR TITLE
fix(indexstore): add ALLOW FILTERING to GetPDPLayerIndex for Cassandra/Scylla

### DIFF
--- a/market/indexstore/indexstore.go
+++ b/market/indexstore/indexstore.go
@@ -747,7 +747,9 @@ func (i *IndexStore) AddPDPLayer(ctx context.Context, pieceCidV2 cid.Cid, layer 
 
 func (i *IndexStore) GetPDPLayerIndex(ctx context.Context, pieceCidV2 cid.Cid) (bool, int, error) {
 	var layerIdx int
-	if err := i.session.Query(`SELECT LayerIndex FROM pdp_cache_layer WHERE PieceCid = ? LIMIT 1`, pieceCidV2.Bytes()).WithContext(ctx).Scan(&layerIdx); err != nil {
+	// PieceCid is only the partition-key prefix (LayerIndex completes it), so this partial-key
+	// lookup needs ALLOW FILTERING on Cassandra/Scylla; YugabyteDB YCQL permits it implicitly.
+	if err := i.session.Query(`SELECT LayerIndex FROM pdp_cache_layer WHERE PieceCid = ? LIMIT 1 ALLOW FILTERING`, pieceCidV2.Bytes()).WithContext(ctx).Scan(&layerIdx); err != nil {
 		if errors.Is(err, gocql.ErrNotFound) {
 			return false, 0, nil
 		}


### PR DESCRIPTION
Originally came up in https://github.com/filecoin-project/curio/pull/1094 as the main piece needed for an independent CQL backend since Yugabyte accepts this but neither Cassandra or Scylla do. Now that we seem to have Postgres support back in https://github.com/filecoin-project/curio/pull/1159 I'd really like to use that an Scylla in a devnet because it's sooo much faster and they have a smaller memory footprint together.

The itests hit this path, but because Yugabyte is still in the CI image, it's talking to YCQL on port 9042. I'm not sure whether that's intentional or not, I'll leave that to you guys, I mainly just want this change.