### PR TITLE
feat(pdp): enforce max pieces per batch, don't enforce extraData size

### DIFF
--- a/pdp/README.md
+++ b/pdp/README.md
@@ -700,7 +700,7 @@ When you initiate an upload with the `notify` field specified, the PDP Service w
     - `extraData`: *(Required)* Hex-encoded bytes that will be validated against the PDPVerifier contract via `eth_call`. Used for authorization and idempotency.
     - `dataSetId`: *(Optional)* The target dataset ID. If omitted or `0`, validation simulates creating a new dataset.
     - `recordKeeper`: *(Required if dataSetId is 0 or omitted)* The contract address that will receive callbacks.
-    - `pieces`: Array of pieces to pull.
+    - `pieces`: Array of pieces to pull. At most 40 entries, since the pull is validated as an `addPieces` batch (larger batches would exceed on-chain event-size limits and are rejected with `400 Bad Request`).
         - `pieceCid`: The piece CID in CommP v2 format.
         - `sourceUrl`: HTTPS URL ending in `/piece/{pieceCid}` on a public host. Localhost and private IPs are blocked for security.
 
@@ -736,7 +736,7 @@ Returns JSON with an overall status and per-piece status:
 
 #### Errors
 
-- `400 Bad Request`: Validation error, missing parameters, invalid pieceCid format, or invalid `sourceUrl`.
+- `400 Bad Request`: Validation error, missing parameters, more than 40 pieces in the batch, invalid pieceCid format, or invalid `sourceUrl`.
 - `401 Unauthorized`: Missing or invalid JWT token.
 - `403 Forbidden`: `recordKeeper` is not allowed.
 - `500 Internal Server Error`: Failed to query or store pull task.

--- a/pdp/README.md
+++ b/pdp/README.md
@@ -369,8 +369,8 @@ When you initiate an upload with the `notify` field specified, the PDP Service w
 
 - **Fields:**
     - `recordKeeper`: The Ethereum address of the record keeper (required).
-    - `pieces`: An array of piece entries (same format as `POST /pdp/data-sets/{dataSetId}/pieces`).
-    - `extraData`: *(Optional)* Hex-encoded additional data (max 8192 bytes decoded). If it contains `withIPFSIndexing` metadata, pieces will be marked for IPFS indexing.
+    - `pieces`: An array of piece entries (same format as `POST /pdp/data-sets/{dataSetId}/pieces`). At most 40 pieces per call (larger batches would exceed on-chain event-size limits and are rejected with `400 Bad Request`).
+    - `extraData`: *(Optional)* Hex-encoded additional data. If it contains `withIPFSIndexing` metadata, pieces will be marked for IPFS indexing.
 
 #### Response
 
@@ -380,7 +380,7 @@ When you initiate an upload with the `notify` field specified, the PDP Service w
 
 #### Errors
 
-- `400 Bad Request`: Invalid request body, validation errors, or size limit exceeded.
+- `400 Bad Request`: Invalid request body, validation errors, or more than 40 pieces in the batch.
 - `401 Unauthorized`: Missing or invalid JWT token.
 - `403 Forbidden`: `recordKeeper` address not allowed for this service.
 - `500 Internal Server Error`: Failed to process the request.
@@ -521,10 +521,11 @@ When you initiate an upload with the `notify` field specified, the PDP Service w
             - `subPieces`: An array of subPiece entries.
                 - Each subPiece entry contains:
                     - `subPieceCid`: The CID of the subPiece (v1 or v2). Must be previously uploaded.
-    - `extraData`: (Optional) Additional hex-encoded data for the transaction (max 8192 bytes decoded).
+    - `extraData`: (Optional) Additional hex-encoded data for the transaction.
 
 #### Constraints and Requirements
 
+- **Batch Size:** At most 40 pieces may be added per call (larger batches would exceed on-chain event-size limits and are rejected with `400 Bad Request`).
 - **SubPieces Ordering:** The `subPieces` must be provided in order **from largest to smallest size** (by padded size). This ensures correct Merkle tree computation.
 - **SubPieces Ownership:** All subPieces must belong to the service making the request and have been previously uploaded.
 - **SubPiece Sizes:** Each subPiece size must be at least 128 bytes.
@@ -539,7 +540,7 @@ When you initiate an upload with the `notify` field specified, the PDP Service w
 
 #### Errors
 
-- `400 Bad Request`: Invalid request body, missing fields, validation errors, subPieces not ordered correctly, or raw size mismatch.
+- `400 Bad Request`: Invalid request body, missing fields, validation errors, more than 40 pieces in the batch, subPieces not ordered correctly, or raw size mismatch.
 - `401 Unauthorized`: Missing or invalid JWT token.
 - `404 Not Found`: Data set not found or subPieces not found.
 - `409 Conflict`: Data set has been terminated due to unrecoverable proving failure.

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -51,8 +51,9 @@ const (
 	// MaxCreateDataSetExtraDataSize defines the limit for extraData size in CreateDataSet calls (4KB).
 	MaxCreateDataSetExtraDataSize = 4096
 
-	// MaxAddPiecesExtraDataSize defines the limit for extraData size in AddPieces calls (8KB).
-	MaxAddPiecesExtraDataSize = 8192
+	// MaxAddPiecesBatchSize caps pieces per AddPieces (or CreateDataSetAndAddPieces)
+	// call to reject early rather than revert on-chain.
+	MaxAddPiecesBatchSize = 40
 
 	// MaxDeletePieceExtraDataSize defines the limit for extraData size in DeletePiece calls (256B).
 	MaxDeletePieceExtraDataSize = 256

--- a/pdp/handlers_add.go
+++ b/pdp/handlers_add.go
@@ -333,15 +333,15 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 		httpServerError(w, http.StatusBadRequest, "At least one piece must be provided", err)
 		return
 	}
+	if len(payload.Pieces) > MaxAddPiecesBatchSize {
+		errMsg := fmt.Sprintf("piece count (%d) exceeds the maximum allowed per AddPieces call (%d)", len(payload.Pieces), MaxAddPiecesBatchSize)
+		httpServerError(w, http.StatusBadRequest, errMsg, err)
+		return
+	}
 
 	extraDataBytes, err := decodeExtraData(payload.ExtraData)
 	if err != nil {
 		httpServerError(w, http.StatusBadRequest, "Invalid extraData format (must be hex encoded): "+err.Error(), err)
-		return
-	}
-	if len(extraDataBytes) > MaxAddPiecesExtraDataSize {
-		errMsg := fmt.Sprintf("extraData size (%d bytes) exceeds the maximum allowed limit for AddPieces (%d bytes)", len(extraDataBytes), MaxAddPiecesExtraDataSize)
-		httpServerError(w, http.StatusBadRequest, errMsg, err)
 		return
 	}
 

--- a/pdp/handlers_create.go
+++ b/pdp/handlers_create.go
@@ -66,14 +66,19 @@ func (p *PDPService) handleCreateDataSetAndAddPieces(w http.ResponseWriter, r *h
 		return
 	}
 
+	if len(reqBody.Pieces) == 0 {
+		httpServerError(w, http.StatusBadRequest, "At least one piece must be provided", err)
+		return
+	}
+	if len(reqBody.Pieces) > MaxAddPiecesBatchSize {
+		errMsg := fmt.Sprintf("piece count (%d) exceeds the maximum allowed per CreateDataSetAndAddPieces call (%d)", len(reqBody.Pieces), MaxAddPiecesBatchSize)
+		httpServerError(w, http.StatusBadRequest, errMsg, err)
+		return
+	}
+
 	extraDataBytes, err := decodeExtraData(reqBody.ExtraData)
 	if err != nil {
 		httpServerError(w, http.StatusBadRequest, "Invalid extraData format (must be hex encoded)", err)
-		return
-	}
-	if len(extraDataBytes) > MaxAddPiecesExtraDataSize {
-		errMsg := fmt.Sprintf("extraData size (%d bytes) exceeds the maximum allowed limit for CreateDataSetAndAddPieces (%d bytes)", len(extraDataBytes), MaxAddPiecesExtraDataSize)
-		httpServerError(w, http.StatusBadRequest, errMsg, err)
 		return
 	}
 

--- a/pdp/handlers_pull_backpressure_test.go
+++ b/pdp/handlers_pull_backpressure_test.go
@@ -221,10 +221,9 @@ func TestHandlePull_BackpressureSoloClientCanUseNinetyPercent(t *testing.T) {
 	}
 
 	payer := common.HexToAddress("0x1111111111111111111111111111111111111111")
-	rec := submitPullStressRequest(t, handler, payer, 1, dataSetID, pullPiecesFromCIDs(piecePool[:pullStressSoloClientLimit]))
-	require.Equal(t, http.StatusOK, rec.Code)
+	nonce := submitPullStressRequestChunked(t, handler, payer, 1, dataSetID, piecePool[:pullStressSoloClientLimit])
 
-	rec = submitPullStressRequest(t, handler, payer, 2, dataSetID, pullPiecesFromCIDs(piecePool[pullStressSoloClientLimit:]))
+	rec := submitPullStressRequest(t, handler, payer, nonce, dataSetID, pullPiecesFromCIDs(piecePool[pullStressSoloClientLimit:]))
 	require.Equal(t, http.StatusTooManyRequests, rec.Code)
 	require.Equal(t, "60", rec.Header().Get("Retry-After"))
 }
@@ -264,10 +263,9 @@ func TestHandlePull_BackpressureClientLimitAppliesNearGlobalReserve(t *testing.T
 
 	firstClient := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	secondClient := common.HexToAddress("0x2222222222222222222222222222222222222222")
-	rec := submitPullStressRequest(t, handler, firstClient, 1, dataSetID, pullPiecesFromCIDs(piecePool[:pullStressSoloClientLimit-pullStressPerClientLimit]))
-	require.Equal(t, http.StatusOK, rec.Code)
+	nonce := submitPullStressRequestChunked(t, handler, firstClient, 1, dataSetID, piecePool[:pullStressSoloClientLimit-pullStressPerClientLimit])
 
-	rec = submitPullStressRequest(t, handler, secondClient, 2, dataSetID, pullPiecesFromCIDs(piecePool[pullStressSoloClientLimit-pullStressPerClientLimit:]))
+	rec := submitPullStressRequest(t, handler, secondClient, nonce, dataSetID, pullPiecesFromCIDs(piecePool[pullStressSoloClientLimit-pullStressPerClientLimit:]))
 	require.Equal(t, http.StatusTooManyRequests, rec.Code)
 	require.Equal(t, "60", rec.Header().Get("Retry-After"))
 }
@@ -407,6 +405,23 @@ func submitPullStressRequest(t *testing.T, handler *PullHandler, payer common.Ad
 	rec := httptest.NewRecorder()
 	handler.HandlePull(rec, req)
 	return rec
+}
+
+// submitPullStressRequestChunked submits cids in MaxAddPiecesBatchSize chunks
+// (each with its own nonce), requiring 200 OK for each, and returns the next
+// unused nonce. Pending state accumulates across chunks just as it would for a
+// client streaming batches at the request size limit.
+func submitPullStressRequestChunked(t *testing.T, handler *PullHandler, payer common.Address, nonce int64, dataSetID uint64, cids []string) int64 {
+	t.Helper()
+
+	for len(cids) > 0 {
+		batch := min(len(cids), MaxAddPiecesBatchSize)
+		rec := submitPullStressRequest(t, handler, payer, nonce, dataSetID, pullPiecesFromCIDs(cids[:batch]))
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+		cids = cids[batch:]
+		nonce++
+	}
+	return nonce
 }
 
 func (s *pdpPullStressStats) snapshot() pdpPullStressStats {

--- a/pdp/pull_types.go
+++ b/pdp/pull_types.go
@@ -177,6 +177,9 @@ func (r *PullRequest) Validate() error {
 	if len(r.Pieces) == 0 {
 		return fmt.Errorf("at least one piece is required")
 	}
+	if len(r.Pieces) > MaxAddPiecesBatchSize {
+		return fmt.Errorf("piece count (%d) exceeds the maximum allowed per pull (%d)", len(r.Pieces), MaxAddPiecesBatchSize)
+	}
 
 	// Validate each piece (CID format validation is done later by ParsePieceCidV2).
 	// The same piece may appear more than once with different source URLs so

--- a/pdp/pull_types_test.go
+++ b/pdp/pull_types_test.go
@@ -1,6 +1,7 @@
 package pdp
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -323,6 +324,26 @@ func TestPullRequest_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPullRequest_ValidateBatchLimit(t *testing.T) {
+	const validCid = "bafkzcibf6x7poaqtr2pqm6qki6sgetps74xutpclzrwbux5ow6rw4nsfu6tbf2zfnmnq"
+	dataSetId := uint64(1)
+
+	// Distinct source URLs so the batch-size check is isolated from the
+	// duplicate and per-piece checks that run afterwards.
+	pieces := make([]PullPieceRequest, MaxAddPiecesBatchSize+1)
+	for i := range pieces {
+		pieces[i] = PullPieceRequest{
+			PieceCid:  validCid,
+			SourceURL: fmt.Sprintf("https://sp.example.com/piece/%s?n=%d", validCid, i),
+		}
+	}
+	req := PullRequest{ExtraData: "0x1234", DataSetId: &dataSetId, Pieces: pieces}
+
+	err := req.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds the maximum allowed per pull")
 }
 
 func TestPullRetryAfter(t *testing.T) {


### PR DESCRIPTION
Ref: https://github.com/FilOzone/filecoin-services/issues/496
Ref: https://www.notion.so/filecoindev/addPieces-Batch-Limits-and-Proposed-Changes-36ddc41950c180d39f45f0da8982090c