### PR TITLE
fix/make testing easier - lang err to stderr

### DIFF
--- a/cmd/curio/internal/translations/translations.go
+++ b/cmd/curio/internal/translations/translations.go
@@ -63,7 +63,11 @@ func SetupLanguage() (func(key message.Reference, a ...any) string, func(style l
 	if err != nil {
 		lang = language.English
 		problem = true
-		os.Stderr.WriteString("Error parsing language\n")
+		_, err = os.Stderr.WriteString("Error parsing language\n")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing to stderr: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	langs := message.DefaultCatalog.Languages()

--- a/cmd/curio/internal/translations/translations.go
+++ b/cmd/curio/internal/translations/translations.go
@@ -63,7 +63,7 @@ func SetupLanguage() (func(key message.Reference, a ...any) string, func(style l
 	if err != nil {
 		lang = language.English
 		problem = true
-		fmt.Println("Error parsing language")
+		os.Stderr.WriteString("Error parsing language\n")
 	}
 
 	langs := message.DefaultCatalog.Languages()


### PR DESCRIPTION
"Error parsing language" breaks a number of tests. Instead of working around it in many places, move it to stderr. 