### PR TITLE
fix: handle finalized PDP cleanup and gas retries

### DIFF
--- a/tasks/pdpv0/error_detection.go
+++ b/tasks/pdpv0/error_detection.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"strings"
 
+	"github.com/filecoin-project/curio/pdp/contract"
 	"github.com/filecoin-project/curio/pdp/contract/FWSS"
 )
 
@@ -18,6 +19,7 @@ import (
 var (
 	ErrSelectorDataSetPaymentBeyondEndEpoch    string
 	ErrSelectorDataSetPaymentAlreadyTerminated string
+	ErrSelectorPDPVerifierDataSetNotFound      string
 )
 
 func init() {
@@ -37,6 +39,17 @@ func init() {
 		panic("FWSS ABI missing DataSetPaymentAlreadyTerminated error")
 	}
 	ErrSelectorDataSetPaymentAlreadyTerminated = hex.EncodeToString(alreadyTerminated.ID[:4])
+
+	parsedPDPVerifier, err := contract.PDPVerifierMetaData.GetAbi()
+	if err != nil {
+		panic("failed to parse PDPVerifier ABI: " + err.Error())
+	}
+
+	dataSetNotFound, ok := parsedPDPVerifier.Errors["DataSetNotFound"]
+	if !ok {
+		panic("PDPVerifier ABI missing DataSetNotFound error")
+	}
+	ErrSelectorPDPVerifierDataSetNotFound = hex.EncodeToString(dataSetNotFound.ID[:4])
 }
 
 // IsUnrecoverableError returns true if the error contains a known unrecoverable
@@ -49,6 +62,16 @@ func IsUnrecoverableError(err error) bool {
 	errStr := strings.ToLower(err.Error())
 	return strings.Contains(errStr, ErrSelectorDataSetPaymentBeyondEndEpoch) ||
 		strings.Contains(errStr, ErrSelectorDataSetPaymentAlreadyTerminated)
+}
+
+// IsPDPVerifierDataSetNotFound returns true if PDPVerifier reports that a
+// data set no longer exists. In the deletion pipeline this means on-chain
+// cleanup has already finalized and local cleanup can proceed.
+func IsPDPVerifierDataSetNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), ErrSelectorPDPVerifierDataSetNotFound)
 }
 
 // IsContractRevert returns true if the error indicates a contract revert.

--- a/tasks/pdpv0/task_cleanup_pieces.go
+++ b/tasks/pdpv0/task_cleanup_pieces.go
@@ -162,7 +162,7 @@ func (t *CleanupPiecesTask) sendCleanupPieces(ctx context.Context, sender common
 			return txHash, batchSize, nil
 		}
 
-		if !strings.Contains(err.Error(), "call ran out of gas") {
+		if !isCleanupPiecesGasEstimateOutOfGas(err) {
 			return common.Hash{}, 0, err
 		}
 
@@ -297,6 +297,23 @@ func (s dataSetCleanupState) Finalized() bool {
 	return !s.Live && !s.CleanupMode && s.NextPieceID.Sign() == 0
 }
 
+func finalizedDataSetCleanupState() dataSetCleanupState {
+	return dataSetCleanupState{
+		Live:        false,
+		CleanupMode: false,
+		NextPieceID: big.NewInt(0),
+	}
+}
+
+func isCleanupPiecesGasEstimateOutOfGas(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "call ran out of gas") ||
+		strings.Contains(errStr, "out of gas (7)")
+}
+
 // readDataSetCleanupState reduces PDPVerifier state to the deletion states
 // Curio cares about: live, cleanup mode, and finalized cleanup.
 func readDataSetCleanupState(ctx context.Context, ethClient ethchain.EthClient, dataSetID int64) (dataSetCleanupState, error) {
@@ -308,11 +325,17 @@ func readDataSetCleanupState(ctx context.Context, ethClient ethchain.EthClient, 
 	setID := big.NewInt(dataSetID)
 	live, err := verifier.DataSetLive(contract.EthCallOpts(ctx), setID)
 	if err != nil {
+		if IsPDPVerifierDataSetNotFound(err) {
+			return finalizedDataSetCleanupState(), nil
+		}
 		return dataSetCleanupState{}, xerrors.Errorf("failed to check if data set %d is live: %w", dataSetID, err)
 	}
 
 	nextPieceID, err := verifier.GetNextPieceId(contract.EthCallOpts(ctx), setID)
 	if err != nil {
+		if IsPDPVerifierDataSetNotFound(err) {
+			return finalizedDataSetCleanupState(), nil
+		}
 		return dataSetCleanupState{}, xerrors.Errorf("failed to get next piece id for data set %d: %w", dataSetID, err)
 	}
 
@@ -320,6 +343,9 @@ func readDataSetCleanupState(ctx context.Context, ethClient ethchain.EthClient, 
 	if !live && nextPieceID.Sign() > 0 {
 		nextChallengeEpoch, err := verifier.GetNextChallengeEpoch(contract.EthCallOpts(ctx), setID)
 		if err != nil {
+			if IsPDPVerifierDataSetNotFound(err) {
+				return finalizedDataSetCleanupState(), nil
+			}
 			return dataSetCleanupState{}, xerrors.Errorf("failed to get next challenge epoch for data set %d: %w", dataSetID, err)
 		}
 		cleanupMode = nextChallengeEpoch.Cmp(cleanupModeSentinel) == 0


### PR DESCRIPTION
Fixes two PDPv0 cleanup failure cases observed in calib.

Errors:

```text
Failed to process pending PDP piece cleanup: failed to process PDP cleanup txs: failed to read PDP cleanup state for data set 58: failed to get next piece id for data set 58: chain: message execution failed (exit=[33], revert reason=[0x9a83803e], vm error=[message failed with backtrace:
00: f0176630 (method 3844450837) -- contract reverted at 75 (33)
01: f0176630 (method 6) -- contract reverted at 6499 (33)
 (RetCode=33)])
```

```text
error: failed to send cleanupPieces transaction: failed to estimate gas: chain: message execution failed (exit=[33], revert reason=[none], vm error=[message failed with backtrace:
00: f0176630 (method 3844450837) -- contract reverted at 75 (33)
01: f0176630 (method 6) -- out of gas (7)
 (RetCode=33)])
```

Changes:

- Treat PDPVerifier `DataSetNotFound()` as finalized cleanup state in the PDPv0 deletion pipeline.
- Retry `cleanupPieces` with a smaller batch when Lotus returns `out of gas (7)` during gas estimation.
