### PR TITLE
fix/upload-to-bad-dataset

### DIFF
--- a/pdp/dataset_verify.go
+++ b/pdp/dataset_verify.go
@@ -44,3 +44,51 @@ func verifyDataSetForService(ctx context.Context, db *harmonydb.DB, service stri
 
 	return nil
 }
+
+// discardOrphanPiecrefsForSubPieces removes unreferenced pdp_piecerefs for the
+// given subPiece CIDs. Called when addPieces is rejected for a missing or
+// terminated data set, so notify-created piecerefs do not linger.
+func discardOrphanPiecrefsForSubPieces(ctx context.Context, db *harmonydb.DB, service string, subPieceCidV1List []string) error {
+	if len(subPieceCidV1List) == 0 {
+		return nil
+	}
+
+	_, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		n, err := tx.Exec(`
+			WITH doomed AS (
+				SELECT pr.id, pr.piece_ref
+				FROM pdp_piecerefs pr
+				WHERE pr.service = $1
+				  AND pr.piece_cid = ANY($2)
+				  AND pr.data_set_refcount = 0
+				  AND NOT EXISTS (
+					SELECT 1 FROM pdp_data_set_piece_adds a
+					WHERE a.pdp_pieceref = pr.id
+					  AND a.pieces_added = FALSE
+					  AND (a.add_message_ok IS NULL OR a.add_message_ok = TRUE)
+				  )
+			),
+			deleted AS (
+				DELETE FROM pdp_piecerefs pr
+				USING doomed d
+				WHERE pr.id = d.id
+				RETURNING d.piece_ref AS piece_ref
+			)
+			DELETE FROM parked_piece_refs ppr
+			USING deleted d
+			WHERE ppr.ref_id = d.piece_ref
+			  AND NOT EXISTS (SELECT 1 FROM pdp_piecerefs pr WHERE pr.piece_ref = ppr.ref_id)
+		`, service, subPieceCidV1List)
+		if err != nil {
+			return false, fmt.Errorf("discard orphan piecerefs: %w", err)
+		}
+		if n > 0 {
+			log.Infow("discarded orphan PDP piecerefs after bad data set addPieces",
+				"service", service,
+				"subPieceCount", len(subPieceCidV1List),
+				"parkedRefsRemoved", n)
+		}
+		return true, nil
+	}, harmonydb.OptionRetry())
+	return err
+}

--- a/pdp/dataset_verify.go
+++ b/pdp/dataset_verify.go
@@ -1,0 +1,46 @@
+package pdp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/yugabyte/pgx/v5"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+)
+
+var (
+	// ErrDataSetNotFound indicates the data set does not exist or does not belong to the service.
+	ErrDataSetNotFound = errors.New("data set not found")
+	// ErrDataSetTerminated indicates the data set was terminated due to unrecoverable proving failure.
+	ErrDataSetTerminated = errors.New("data set has been terminated due to unrecoverable proving failure")
+)
+
+// verifyDataSetForService checks that dataSetId exists in pdp_data_sets, belongs to service,
+// and has not been terminated due to unrecoverable proving failure.
+func verifyDataSetForService(ctx context.Context, db *harmonydb.DB, service string, dataSetId uint64) error {
+	var dataSetService string
+	var unrecoverable *int64
+	err := db.QueryRow(ctx, `
+		SELECT service, unrecoverable_proving_failure_epoch
+		FROM pdp_data_sets
+		WHERE id = $1
+	`, dataSetId).Scan(&dataSetService, &unrecoverable)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrDataSetNotFound
+		}
+		return fmt.Errorf("failed to retrieve data set: %w", err)
+	}
+
+	if dataSetService != service {
+		return ErrDataSetNotFound
+	}
+
+	if unrecoverable != nil {
+		return ErrDataSetTerminated
+	}
+
+	return nil
+}

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -105,7 +105,7 @@ func NewPDPService(
 
 		alertTask: alertTask,
 
-		pullHandler: NewPullHandler(auth, pullStore, pullValidator),
+		pullHandler: NewPullHandler(auth, pullStore, pullValidator, db),
 
 		ipp: ipp,
 	}

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -113,6 +113,7 @@ func NewPDPService(
 		ipOffenseThrottle: NewIPOffenseThrottle(defaultIPOffensePolicies()),
 	}
 
+	go p.ipOffenseThrottle.RunCleanup(ctx)
 	go p.cleanup(ctx)
 	return p
 }

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math/big"
 	"net/http"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -74,6 +73,8 @@ type PDPService struct {
 	pullHandler *PullHandler
 
 	ipp *ipni_provider.Provider
+
+	ipOffenseThrottle *IPOffenseThrottle
 }
 
 type PDPServiceNodeApi interface {
@@ -108,6 +109,8 @@ func NewPDPService(
 		pullHandler: NewPullHandler(auth, pullStore, pullValidator, db),
 
 		ipp: ipp,
+
+		ipOffenseThrottle: NewIPOffenseThrottle(defaultIPOffensePolicies()),
 	}
 
 	go p.cleanup(ctx)
@@ -131,74 +134,78 @@ func kvUploadUUID(r *http.Request) []any {
 
 // Routes registers the HTTP routes with the provided router.
 func Routes(r *chi.Mux, p *PDPService) {
-	// Routes for data sets
-	r.Route(path.Join(PDPRoutePath, "/data-sets"), func(r chi.Router) {
-		// POST /pdp/data-sets - Create a new data set
-		r.Post("/", instrument("dataSetCreate", p.handleCreateDataSet, nil))
+	r.Route(PDPRoutePath, func(r chi.Router) {
+		r.Use(p.ipOffenseThrottle.Middleware)
 
-		// POST /pdp/data-sets/create-and-add - Create a new data set and add pieces at the same time
-		r.Post("/create-and-add", instrument("dataSetCreateAndAdd", p.handleCreateDataSetAndAddPieces, nil))
+		// Routes for data sets
+		r.Route("/data-sets", func(r chi.Router) {
+			// POST /pdp/data-sets - Create a new data set
+			r.Post("/", instrument("dataSetCreate", p.handleCreateDataSet, nil))
 
-		// GET /pdp/data-sets/created/{txHash} - Get the status of a data set creation
-		r.Get("/created/{txHash}", p.handleGetDataSetCreationStatus)
+			// POST /pdp/data-sets/create-and-add - Create a new data set and add pieces at the same time
+			r.Post("/create-and-add", instrument("dataSetCreateAndAdd", p.handleCreateDataSetAndAddPieces, nil))
 
-		// Individual data set routes
-		r.Route("/{dataSetId}", func(r chi.Router) {
-			// GET /pdp/data-sets/{set-id}
-			r.Get("/", p.handleGetDataSet)
+			// GET /pdp/data-sets/created/{txHash} - Get the status of a data set creation
+			r.Get("/created/{txHash}", p.handleGetDataSetCreationStatus)
 
-			// POST /pdp/data-sets/{set-id}/terminate
-			r.Post("/terminate", instrument("dataSetTerminate", p.handleTerminateDataSet, kvDataSetID))
+			// Individual data set routes
+			r.Route("/{dataSetId}", func(r chi.Router) {
+				// GET /pdp/data-sets/{set-id}
+				r.Get("/", p.handleGetDataSet)
 
-			// GET /pdp/data-sets/{set-id}/terminate
-			r.Get("/terminate", p.handleGetDataSetTerminationStatus)
+				// POST /pdp/data-sets/{set-id}/terminate
+				r.Post("/terminate", instrument("dataSetTerminate", p.handleTerminateDataSet, kvDataSetID))
 
-			// Routes for pieces within a data set
-			r.Route("/pieces", func(r chi.Router) {
-				// POST /pdp/data-sets/{set-id}/pieces
-				r.Post("/", instrument("pieceAdd", p.handleAddPieceToDataSet, kvDataSetID))
+				// GET /pdp/data-sets/{set-id}/terminate
+				r.Get("/terminate", p.handleGetDataSetTerminationStatus)
 
-				// GET /pdp/data-sets/{set-id}/pieces/added/{txHash}
-				r.Get("/added/{txHash}", p.handleGetPieceAdditionStatus)
+				// Routes for pieces within a data set
+				r.Route("/pieces", func(r chi.Router) {
+					// POST /pdp/data-sets/{set-id}/pieces
+					r.Post("/", instrument("pieceAdd", p.handleAddPieceToDataSet, kvDataSetID))
 
-				// Individual piece routes
-				r.Route("/{pieceID}", func(r chi.Router) {
-					// GET /pdp/data-sets/{set-id}/pieces/{piece-id}
-					r.Get("/", p.handleGetDataSetPiece)
+					// GET /pdp/data-sets/{set-id}/pieces/added/{txHash}
+					r.Get("/added/{txHash}", p.handleGetPieceAdditionStatus)
 
-					// DEL /pdp/data-sets/{set-id}/pieces/{piece-id}
-					r.Delete("/", instrument("pieceDelete", p.handleDeleteDataSetPiece, kvDataSetPiece))
+					// Individual piece routes
+					r.Route("/{pieceID}", func(r chi.Router) {
+						// GET /pdp/data-sets/{set-id}/pieces/{piece-id}
+						r.Get("/", p.handleGetDataSetPiece)
+
+						// DEL /pdp/data-sets/{set-id}/pieces/{piece-id}
+						r.Delete("/", instrument("pieceDelete", p.handleDeleteDataSetPiece, kvDataSetPiece))
+					})
 				})
 			})
 		})
+
+		r.Get("/ping", p.handlePing)
+
+		// GET /pdp/piece/{pieceCid}/status - Get indexing/IPNI status for a piece
+		r.Get("/piece/{pieceCid}/status", p.handleGetPieceStatus)
+
+		// Routes for piece storage and retrieval
+		// POST /pdp/piece
+		r.Post("/piece", instrument("pieceUploadInit", p.handlePiecePost, nil))
+
+		// GET /pdp/piece/
+		r.Get("/piece/", p.handleFindPiece)
+
+		// PUT /pdp/piece/upload/{uploadUUID}
+		r.Put("/piece/upload/{uploadUUID}", instrument("pieceUpload", p.handlePieceUpload, kvUploadUUID))
+
+		// POST /pdp/piece/uploads
+		r.Post("/piece/uploads", instrument("pieceStreamInit", p.handleStreamingUploadURL, nil))
+
+		// PUT /pdp/piece/uploads/{uploadUUID}
+		r.Put("/piece/uploads/{uploadUUID}", instrument("pieceStreamUpload", p.handleStreamingUpload, kvUploadUUID))
+
+		// POST /pdp/piece/uploads/{uploadUUID}
+		r.Post("/piece/uploads/{uploadUUID}", instrument("pieceStreamFinalize", p.handleFinalizeStreamingUpload, kvUploadUUID))
+
+		// POST /pdp/piece/pull - Pull pieces from other SPs
+		r.Post("/piece/pull", instrument("piecePull", p.pullHandler.HandlePull, nil))
 	})
-
-	r.Get(path.Join(PDPRoutePath, "/ping"), p.handlePing)
-
-	// GET /pdp/piece/{pieceCid}/status - Get indexing/IPNI status for a piece
-	r.Get(path.Join(PDPRoutePath, "/piece/{pieceCid}/status"), p.handleGetPieceStatus)
-
-	// Routes for piece storage and retrieval
-	// POST /pdp/piece
-	r.Post(path.Join(PDPRoutePath, "/piece"), instrument("pieceUploadInit", p.handlePiecePost, nil))
-
-	// GET /pdp/piece/
-	r.Get(path.Join(PDPRoutePath, "/piece/"), p.handleFindPiece)
-
-	// PUT /pdp/piece/upload/{uploadUUID}
-	r.Put(path.Join(PDPRoutePath, "/piece/upload/{uploadUUID}"), instrument("pieceUpload", p.handlePieceUpload, kvUploadUUID))
-
-	// POST /pdp/piece/uploads
-	r.Post(path.Join(PDPRoutePath, "/piece/uploads"), instrument("pieceStreamInit", p.handleStreamingUploadURL, nil))
-
-	// PUT /pdp/piece/uploads/{uploadUUID}
-	r.Put(path.Join(PDPRoutePath, "/piece/uploads/{uploadUUID}"), instrument("pieceStreamUpload", p.handleStreamingUpload, kvUploadUUID))
-
-	// POST /pdp/piece/uploads/{uploadUUID}
-	r.Post(path.Join(PDPRoutePath, "/piece/uploads/{uploadUUID}"), instrument("pieceStreamFinalize", p.handleFinalizeStreamingUpload, kvUploadUUID))
-
-	// POST /pdp/piece/pull - Pull pieces from other SPs
-	r.Post(path.Join(PDPRoutePath, "/piece/pull"), instrument("piecePull", p.pullHandler.HandlePull, nil))
 }
 
 // Handler functions

--- a/pdp/handlers_add.go
+++ b/pdp/handlers_add.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/go-chi/chi/v5"
 	"github.com/ipfs/go-cid"
-	"github.com/yugabyte/pgx/v5"
 
 	commputils "github.com/filecoin-project/go-commp-utils/v2"
 	commcid "github.com/filecoin-project/go-fil-commcid"
@@ -280,31 +279,15 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// check if the data set belongs to the service in pdp_data_sets
-	var dataSetService string
-	var unrecoverable *int64
-	err = p.db.QueryRow(ctx, `
-			SELECT service, unrecoverable_proving_failure_epoch
-			FROM pdp_data_sets
-			WHERE id = $1
-		`, dataSetIdUint64).Scan(&dataSetService, &unrecoverable)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+	if err = verifyDataSetForService(ctx, p.db, serviceLabel, dataSetIdUint64); err != nil {
+		switch {
+		case errors.Is(err, ErrDataSetNotFound):
 			httpServerError(w, http.StatusNotFound, "Data set not found", err)
-			return
+		case errors.Is(err, ErrDataSetTerminated):
+			http.Error(w, err.Error(), http.StatusConflict)
+		default:
+			httpServerError(w, http.StatusInternalServerError, "Failed to retrieve data set: "+err.Error(), err)
 		}
-		httpServerError(w, http.StatusInternalServerError, "Failed to retrieve data set: "+err.Error(), err)
-		return
-	}
-
-	if dataSetService != serviceLabel {
-		// same as when actually not found to avoid leaking information in obvious ways
-		httpServerError(w, http.StatusNotFound, "Data set not found", err)
-		return
-	}
-
-	if unrecoverable != nil {
-		http.Error(w, "Data set has been terminated due to unrecoverable proving failure", http.StatusConflict)
 		return
 	}
 

--- a/pdp/handlers_add.go
+++ b/pdp/handlers_add.go
@@ -252,6 +252,26 @@ func (p *PDPService) transformAddPiecesRequest(ctx context.Context, serviceLabel
 	return pieceDataArray, subPieceInfoMap, nil
 }
 
+func subPieceCidV1ListFromPieces(pieces []AddPieceRequest) ([]string, error) {
+	seen := make(map[string]struct{})
+	list := make([]string, 0)
+	for _, piece := range pieces {
+		for _, subPiece := range piece.SubPieces {
+			info, err := ParsePieceCid(subPiece.SubPieceCID)
+			if err != nil {
+				return nil, err
+			}
+			cidStr := info.CidV1.String()
+			if _, ok := seen[cidStr]; ok {
+				continue
+			}
+			seen[cidStr] = struct{}{}
+			list = append(list, cidStr)
+		}
+	}
+	return list, nil
+}
+
 func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -278,21 +298,6 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 		httpServerError(w, http.StatusBadRequest, "Invalid data set ID format", err)
 		return
 	}
-
-	if err = verifyDataSetForService(ctx, p.db, serviceLabel, dataSetIdUint64); err != nil {
-		switch {
-		case errors.Is(err, ErrDataSetNotFound):
-			httpServerError(w, http.StatusNotFound, "Data set not found", err)
-		case errors.Is(err, ErrDataSetTerminated):
-			http.Error(w, err.Error(), http.StatusConflict)
-		default:
-			httpServerError(w, http.StatusInternalServerError, "Failed to retrieve data set: "+err.Error(), err)
-		}
-		return
-	}
-
-	// Convert dataSetId to *big.Int
-	dataSetId := new(big.Int).SetUint64(dataSetIdUint64)
 
 	// Step 3: Parse the request body
 
@@ -321,6 +326,36 @@ func (p *PDPService) handleAddPieceToDataSet(w http.ResponseWriter, r *http.Requ
 		httpServerError(w, http.StatusBadRequest, errMsg, err)
 		return
 	}
+
+	subPieceCidV1List, err := subPieceCidV1ListFromPieces(payload.Pieces)
+	if err != nil {
+		httpServerError(w, http.StatusBadRequest, "Invalid subPieceCid: "+err.Error(), err)
+		return
+	}
+
+	if err = verifyDataSetForService(ctx, p.db, serviceLabel, dataSetIdUint64); err != nil {
+		switch {
+		case errors.Is(err, ErrDataSetNotFound), errors.Is(err, ErrDataSetTerminated):
+			if p.recordIPOffense(w, r, OffenseBadDataSetAdd) {
+				return
+			}
+			if discardErr := discardOrphanPiecrefsForSubPieces(ctx, p.db, serviceLabel, subPieceCidV1List); discardErr != nil {
+				log.Warnw("failed to discard orphan piecerefs after bad data set addPieces",
+					"dataSetId", dataSetIdUint64, "error", discardErr)
+			}
+			if errors.Is(err, ErrDataSetNotFound) {
+				httpServerError(w, http.StatusNotFound, "Data set not found", err)
+			} else {
+				http.Error(w, err.Error(), http.StatusConflict)
+			}
+		default:
+			httpServerError(w, http.StatusInternalServerError, "Failed to retrieve data set: "+err.Error(), err)
+		}
+		return
+	}
+
+	// Convert dataSetId to *big.Int
+	dataSetId := new(big.Int).SetUint64(dataSetIdUint64)
 
 	extraDataBytes, err := decodeExtraData(payload.ExtraData)
 	if err != nil {

--- a/pdp/handlers_pull.go
+++ b/pdp/handlers_pull.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -149,14 +150,16 @@ type PullHandler struct {
 	auth      Auth
 	store     PullStore
 	validator AddPiecesValidator
+	db        *harmonydb.DB
 }
 
 // NewPullHandler creates a new PullHandler
-func NewPullHandler(auth Auth, store PullStore, validator AddPiecesValidator) *PullHandler {
+func NewPullHandler(auth Auth, store PullStore, validator AddPiecesValidator, db *harmonydb.DB) *PullHandler {
 	return &PullHandler{
 		auth:      auth,
 		store:     store,
 		validator: validator,
+		db:        db,
 	}
 }
 
@@ -341,6 +344,20 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 		// Return existing status
 		h.respondWithStatus(ctx, w, existingPull.ID)
 		return
+	}
+
+	if dataSetId > 0 && h.db != nil {
+		if err := verifyDataSetForService(ctx, h.db, service, dataSetId); err != nil {
+			switch {
+			case errors.Is(err, ErrDataSetNotFound):
+				httpServerError(w, http.StatusNotFound, "Data set not found", err)
+			case errors.Is(err, ErrDataSetTerminated):
+				http.Error(w, err.Error(), http.StatusConflict)
+			default:
+				httpServerError(w, http.StatusInternalServerError, "Failed to retrieve data set: "+err.Error(), err)
+			}
+			return
+		}
 	}
 
 	var payer common.Address

--- a/pdp/handlers_pull_backpressure_test.go
+++ b/pdp/handlers_pull_backpressure_test.go
@@ -58,7 +58,8 @@ func TestHandlePull_BackpressureStress(t *testing.T) {
 	}
 
 	stats := &pdpPullStressStats{}
-	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true})
+	ensurePullTestDataSet(t, db, testDataSetId, "public")
+	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true}, db)
 	dataSetID := testDataSetId
 
 	testCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -212,7 +213,8 @@ func TestHandlePull_BackpressureSoloClientCanUseNinetyPercent(t *testing.T) {
 	db, err := harmonydb.NewFromConfigWithITestID(t)
 	require.NoError(t, err)
 
-	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true})
+	ensurePullTestDataSet(t, db, testDataSetId, "public")
+	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true}, db)
 	dataSetID := testDataSetId
 	rawSizes := []uint64{127, 254, 508, 1016}
 	piecePool := make([]string, pullStressSoloClientLimit+1)
@@ -232,7 +234,8 @@ func TestHandlePull_BackpressureClientCanBorrowUnusedSlots(t *testing.T) {
 	db, err := harmonydb.NewFromConfigWithITestID(t)
 	require.NoError(t, err)
 
-	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true})
+	ensurePullTestDataSet(t, db, testDataSetId, "public")
+	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true}, db)
 	dataSetID := testDataSetId
 	rawSizes := []uint64{127, 254, 508, 1016}
 	piecePool := make([]string, 31)
@@ -253,7 +256,8 @@ func TestHandlePull_BackpressureClientLimitAppliesNearGlobalReserve(t *testing.T
 	db, err := harmonydb.NewFromConfigWithITestID(t)
 	require.NoError(t, err)
 
-	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true})
+	ensurePullTestDataSet(t, db, testDataSetId, "public")
+	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true}, db)
 	dataSetID := testDataSetId
 	rawSizes := []uint64{127, 254, 508, 1016}
 	piecePool := make([]string, pullStressSoloClientLimit+1)
@@ -473,4 +477,43 @@ func pullStressActiveCounts(ctx context.Context, db *harmonydb.DB) (int, int, er
 	}
 
 	return globalPending, maxClientPending, nil
+}
+
+func ensurePullTestDataSet(t *testing.T, db *harmonydb.DB, dataSetID uint64, service string) {
+	t.Helper()
+
+	ctx := context.Background()
+	txHash := fmt.Sprintf("0x%064x", dataSetID)
+	_, err := db.Exec(ctx, `
+		INSERT INTO pdp_data_sets (id, create_message_hash, service, proving_period, challenge_window, init_ready)
+		VALUES ($1, $2, $3, 100, 10, FALSE)
+		ON CONFLICT (id) DO NOTHING
+	`, int64(dataSetID), txHash, service)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.Exec(ctx, `DELETE FROM pdp_data_sets WHERE id = $1`, int64(dataSetID))
+	})
+}
+
+func TestHandlePull_DataSetNotFound(t *testing.T) {
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	handler := NewPullHandler(&NullAuth{}, NewDBPullStore(db), &mockValidator{shouldPass: true}, db)
+	body := PullRequest{
+		ExtraData: testAddPiecesOnlyExtraData(t),
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{PieceCid: testCid1, SourceURL: "https://example.com/piece/" + testCid1},
+		},
+	}
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "Data set not found")
 }

--- a/pdp/handlers_pull_test.go
+++ b/pdp/handlers_pull_test.go
@@ -170,7 +170,7 @@ func testPullPieceStatus(cidV2Str string, status PullStatus) PullPieceStatus {
 }
 
 func TestHandlePull_MethodNotAllowed(t *testing.T) {
-	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true}, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/pdp/piece/pull", nil)
 	rec := httptest.NewRecorder()
@@ -181,7 +181,7 @@ func TestHandlePull_MethodNotAllowed(t *testing.T) {
 }
 
 func TestHandlePull_InvalidJSON(t *testing.T) {
-	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true}, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewBufferString("not json"))
 	rec := httptest.NewRecorder()
@@ -193,7 +193,7 @@ func TestHandlePull_InvalidJSON(t *testing.T) {
 }
 
 func TestHandlePull_MissingExtraData(t *testing.T) {
-	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true}, nil)
 
 	body := PullRequest{
 		ExtraData: "",
@@ -212,7 +212,7 @@ func TestHandlePull_MissingExtraData(t *testing.T) {
 }
 
 func TestHandlePull_NoPieces(t *testing.T) {
-	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true}, nil)
 
 	body := PullRequest{
 		ExtraData: testExtraData(t),
@@ -230,7 +230,7 @@ func TestHandlePull_NoPieces(t *testing.T) {
 }
 
 func TestHandlePull_InvalidSourceURL(t *testing.T) {
-	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true}, nil)
 
 	body := PullRequest{
 		ExtraData: testExtraData(t),
@@ -252,7 +252,7 @@ func TestHandlePull_InvalidSourceURL(t *testing.T) {
 func TestHandlePull_ValidatorFails(t *testing.T) {
 	store := &mockPullStore{}
 	validator := &mockValidator{shouldPass: false, err: errors.New("contract validation failed")}
-	handler := NewPullHandler(&NullAuth{}, store, validator)
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
 
 	body := PullRequest{
 		ExtraData: testExtraData(t),
@@ -276,7 +276,7 @@ func TestHandlePull_ValidatorFails(t *testing.T) {
 func TestHandlePull_NewRequest_Success(t *testing.T) {
 	store := &mockPullStore{}
 	validator := &mockValidator{shouldPass: true}
-	handler := NewPullHandler(&NullAuth{}, store, validator)
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
 
 	body := PullRequest{
 		ExtraData: testExtraData(t),
@@ -323,7 +323,7 @@ func TestHandlePull_ExistingDataSetUsesFWSSPayer(t *testing.T) {
 	store := &mockPullStore{}
 	payer := common.HexToAddress("0x2222222222222222222222222222222222222222")
 	validator := &mockValidator{shouldPass: true, payer: payer}
-	handler := NewPullHandler(&NullAuth{}, store, validator)
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
 
 	body := PullRequest{
 		ExtraData: testAddPiecesOnlyExtraData(t),
@@ -346,7 +346,7 @@ func TestHandlePull_ExistingDataSetUsesFWSSPayer(t *testing.T) {
 }
 
 func TestHandlePull_CreateNew_MissingRecordKeeper(t *testing.T) {
-	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true})
+	handler := NewPullHandler(&NullAuth{}, &mockPullStore{}, &mockValidator{shouldPass: true}, nil)
 
 	// dataSetId omitted (nil) requires recordKeeper
 	body := PullRequest{
@@ -381,7 +381,7 @@ func TestHandlePull_CreateNew_Success(t *testing.T) {
 	store := &mockPullStore{}
 	validator := &mockValidator{shouldPass: true}
 	// Use non-public service auth to test create-new flow without AllowedRecordKeepers restriction
-	handler := NewPullHandler(&privateServiceAuth{}, store, validator)
+	handler := NewPullHandler(&privateServiceAuth{}, store, validator, nil)
 
 	// dataSetId omitted (nil) with recordKeeper = create new dataset
 	body := PullRequest{
@@ -416,7 +416,7 @@ func TestHandlePull_Idempotent(t *testing.T) {
 		pullPieces: []PullPieceStatus{testPullPieceStatus(testCid1, PullStatusComplete)},
 	}
 	validator := &mockValidator{shouldPass: true}
-	handler := NewPullHandler(&NullAuth{}, store, validator)
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
 
 	body := PullRequest{
 		ExtraData: testExtraData(t),
@@ -455,7 +455,7 @@ func TestHandlePull_MixedStatuses(t *testing.T) {
 		},
 	}
 	validator := &mockValidator{shouldPass: true}
-	handler := NewPullHandler(&NullAuth{}, store, validator)
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
 
 	body := PullRequest{
 		ExtraData: testExtraData(t),
@@ -495,7 +495,7 @@ func TestHandlePull_CreateError(t *testing.T) {
 		createError: errors.New("database error"),
 	}
 	validator := &mockValidator{shouldPass: true}
-	handler := NewPullHandler(&NullAuth{}, store, validator)
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
 
 	body := PullRequest{
 		ExtraData: testExtraData(t),
@@ -518,7 +518,7 @@ func TestHandlePull_Backpressure(t *testing.T) {
 		backpressure: &PullBackpressure{RetryAfter: 2 * time.Minute},
 	}
 	validator := &mockValidator{shouldPass: true}
-	handler := NewPullHandler(&NullAuth{}, store, validator)
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
 
 	body := PullRequest{
 		ExtraData: testExtraData(t),
@@ -587,7 +587,7 @@ func TestHandlePull_RetryingStatus(t *testing.T) {
 		pullPieces: []PullPieceStatus{testPullPieceStatus(testCid1, PullStatusRetrying)},
 	}
 	validator := &mockValidator{shouldPass: true}
-	handler := NewPullHandler(&NullAuth{}, store, validator)
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
 
 	body := PullRequest{
 		ExtraData: testExtraData(t),
@@ -623,7 +623,7 @@ func TestHandlePull_FailedFromPullItems(t *testing.T) {
 		pullPieces: []PullPieceStatus{testPullPieceStatus(testCid1, PullStatusFailed)},
 	}
 	validator := &mockValidator{shouldPass: true}
-	handler := NewPullHandler(&NullAuth{}, store, validator)
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
 
 	body := PullRequest{
 		ExtraData: testExtraData(t),
@@ -660,7 +660,7 @@ func TestHandlePull_OrphanedTaskWithoutTerminalStateIsPending(t *testing.T) {
 		pullPieces: []PullPieceStatus{testPullPieceStatus(testCid1, PullStatusPending)},
 	}
 	validator := &mockValidator{shouldPass: true}
-	handler := NewPullHandler(&NullAuth{}, store, validator)
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
 
 	body := PullRequest{
 		ExtraData: testExtraData(t),

--- a/pdp/ip_offense_throttle.go
+++ b/pdp/ip_offense_throttle.go
@@ -1,6 +1,7 @@
 package pdp
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -30,6 +31,8 @@ type IPOffenseThrottle struct {
 	state map[string]map[string]*ipOffenseState
 }
 
+const ipOffenseCleanupInterval = 5 * time.Minute
+
 type ipOffenseState struct {
 	hits         int
 	windowStart  time.Time
@@ -40,6 +43,60 @@ func NewIPOffenseThrottle(policies map[string]IPOffensePolicy) *IPOffenseThrottl
 	return &IPOffenseThrottle{
 		policies: policies,
 		state:    make(map[string]map[string]*ipOffenseState),
+	}
+}
+
+// RunCleanup periodically removes expired offense state for all tracked IPs.
+func (t *IPOffenseThrottle) RunCleanup(ctx context.Context) {
+	ticker := time.NewTicker(ipOffenseCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			t.cleanupAll()
+		}
+	}
+}
+
+func offenseStateExpired(st *ipOffenseState, policy IPOffensePolicy, now time.Time) bool {
+	if now.Before(st.blockedUntil) {
+		return false
+	}
+	if st.hits > 0 && now.Sub(st.windowStart) < policy.Window*2 {
+		return false
+	}
+	return true
+}
+
+// cleanupIPLocked removes expired offense entries for ip. Caller must hold t.mu.
+func (t *IPOffenseThrottle) cleanupIPLocked(ip string, now time.Time) {
+	offenses, ok := t.state[ip]
+	if !ok {
+		return
+	}
+
+	for offense, st := range offenses {
+		policy, ok := t.policies[offense]
+		if !ok || offenseStateExpired(st, policy, now) {
+			delete(offenses, offense)
+		}
+	}
+	if len(offenses) == 0 {
+		delete(t.state, ip)
+	}
+}
+
+func (t *IPOffenseThrottle) cleanupAll() {
+	now := time.Now()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for ip := range t.state {
+		t.cleanupIPLocked(ip, now)
 	}
 }
 
@@ -101,28 +158,7 @@ func (t *IPOffenseThrottle) Record(r *http.Request, offense string) (blocked boo
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	for stateIP, offenses := range t.state {
-		keep := false
-		for stateOffense, st := range offenses {
-			statePolicy, ok := t.policies[stateOffense]
-			if !ok {
-				delete(offenses, stateOffense)
-				continue
-			}
-			if now.Before(st.blockedUntil) {
-				keep = true
-				continue
-			}
-			if st.hits > 0 && now.Sub(st.windowStart) < statePolicy.Window*2 {
-				keep = true
-				continue
-			}
-			delete(offenses, stateOffense)
-		}
-		if !keep || len(offenses) == 0 {
-			delete(t.state, stateIP)
-		}
-	}
+	t.cleanupIPLocked(ip, now)
 
 	offenses, ok := t.state[ip]
 	if !ok {
@@ -168,8 +204,11 @@ func (t *IPOffenseThrottle) longestBlock(r *http.Request) (bool, time.Duration, 
 
 	now := time.Now()
 
-	t.mu.RLock()
-	defer t.mu.RUnlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.cleanupIPLocked(ip, now)
+
 	offenses, ok := t.state[ip]
 	if !ok {
 		return false, 0, ""

--- a/pdp/ip_offense_throttle.go
+++ b/pdp/ip_offense_throttle.go
@@ -1,0 +1,219 @@
+package pdp
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-chi/httprate"
+)
+
+// OffenseBadDataSetAdd is recorded when addPieces targets a missing or
+// terminated data set.
+const OffenseBadDataSetAdd = "bad_dataset_add"
+
+// IPOffensePolicy configures per-offense IP throttling.
+type IPOffensePolicy struct {
+	Hits   int
+	Window time.Duration
+	Block  time.Duration
+	Reason string
+}
+
+// IPOffenseThrottle tracks repeated request offenses per client IP.
+type IPOffenseThrottle struct {
+	policies map[string]IPOffensePolicy
+
+	mu    sync.RWMutex
+	state map[string]map[string]*ipOffenseState
+}
+
+type ipOffenseState struct {
+	hits         int
+	windowStart  time.Time
+	blockedUntil time.Time
+}
+
+func NewIPOffenseThrottle(policies map[string]IPOffensePolicy) *IPOffenseThrottle {
+	return &IPOffenseThrottle{
+		policies: policies,
+		state:    make(map[string]map[string]*ipOffenseState),
+	}
+}
+
+func defaultIPOffensePolicies() map[string]IPOffensePolicy {
+	return map[string]IPOffensePolicy{
+		OffenseBadDataSetAdd: {
+			Hits:   5,
+			Window: time.Minute,
+			Block:  5 * time.Minute,
+			Reason: "too many requests for unavailable data sets",
+		},
+	}
+}
+
+func clientIPFromRequest(r *http.Request) string {
+	ip, err := httprate.KeyByRealIP(r)
+	if err == nil && ip != "" {
+		return ip
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// Middleware rejects requests from IPs that are temporarily blocked for any
+// configured offense.
+func (t *IPOffenseThrottle) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if blocked, retryAfter, reason := t.longestBlock(r); blocked {
+			log.Warnw("PDP request throttled",
+				"clientIP", clientIPFromRequest(r),
+				"path", r.URL.Path,
+				"retryAfter", retryAfter,
+				"reason", reason)
+			respondIPThrottled(w, retryAfter, reason)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// Record increments the offense counter for the request IP. It returns whether
+// the IP is now blocked and how long to wait before retrying.
+func (t *IPOffenseThrottle) Record(r *http.Request, offense string) (blocked bool, retryAfter time.Duration, reason string) {
+	policy, ok := t.policies[offense]
+	if !ok {
+		return false, 0, ""
+	}
+
+	ip := clientIPFromRequest(r)
+	if ip == "" {
+		return false, 0, policy.Reason
+	}
+
+	now := time.Now()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for stateIP, offenses := range t.state {
+		keep := false
+		for stateOffense, st := range offenses {
+			statePolicy, ok := t.policies[stateOffense]
+			if !ok {
+				delete(offenses, stateOffense)
+				continue
+			}
+			if now.Before(st.blockedUntil) {
+				keep = true
+				continue
+			}
+			if st.hits > 0 && now.Sub(st.windowStart) < statePolicy.Window*2 {
+				keep = true
+				continue
+			}
+			delete(offenses, stateOffense)
+		}
+		if !keep || len(offenses) == 0 {
+			delete(t.state, stateIP)
+		}
+	}
+
+	offenses, ok := t.state[ip]
+	if !ok {
+		offenses = make(map[string]*ipOffenseState)
+		t.state[ip] = offenses
+	}
+
+	st, ok := offenses[offense]
+	if !ok {
+		st = &ipOffenseState{windowStart: now}
+		offenses[offense] = st
+	}
+
+	if now.Before(st.blockedUntil) {
+		return true, time.Until(st.blockedUntil), policy.Reason
+	}
+
+	if now.Sub(st.windowStart) >= policy.Window {
+		st.hits = 0
+		st.windowStart = now
+	}
+
+	st.hits++
+	if st.hits < policy.Hits {
+		return false, 0, policy.Reason
+	}
+
+	st.blockedUntil = now.Add(policy.Block)
+	st.hits = 0
+	st.windowStart = now
+	log.Warnw("throttling IP after repeated PDP offense",
+		"clientIP", ip,
+		"offense", offense,
+		"retryAfter", policy.Block)
+	return true, policy.Block, policy.Reason
+}
+
+func (t *IPOffenseThrottle) longestBlock(r *http.Request) (bool, time.Duration, string) {
+	ip := clientIPFromRequest(r)
+	if ip == "" {
+		return false, 0, ""
+	}
+
+	now := time.Now()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	offenses, ok := t.state[ip]
+	if !ok {
+		return false, 0, ""
+	}
+
+	var (
+		blocked    bool
+		retryAfter time.Duration
+		reason     string
+	)
+
+	for offense, st := range offenses {
+		if !now.Before(st.blockedUntil) {
+			continue
+		}
+		remaining := time.Until(st.blockedUntil)
+		policy := t.policies[offense]
+		if !blocked || remaining > retryAfter {
+			blocked = true
+			retryAfter = remaining
+			reason = policy.Reason
+		}
+	}
+
+	return blocked, retryAfter, reason
+}
+
+func respondIPThrottled(w http.ResponseWriter, retryAfter time.Duration, reason string) {
+	seconds := int(retryAfter.Seconds())
+	if seconds < 1 {
+		seconds = 1
+	}
+	if reason == "" {
+		reason = "too many requests"
+	}
+	w.Header().Set("Retry-After", fmt.Sprint(seconds))
+	http.Error(w, reason, http.StatusTooManyRequests)
+}
+
+func (p *PDPService) recordIPOffense(w http.ResponseWriter, r *http.Request, offense string) bool {
+	blocked, retryAfter, reason := p.ipOffenseThrottle.Record(r, offense)
+	if !blocked {
+		return false
+	}
+	respondIPThrottled(w, retryAfter, reason)
+	return true
+}

--- a/pdp/ip_offense_throttle_test.go
+++ b/pdp/ip_offense_throttle_test.go
@@ -1,0 +1,55 @@
+package pdp
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func testIPOffenseThrottle() *IPOffenseThrottle {
+	return NewIPOffenseThrottle(map[string]IPOffensePolicy{
+		"test_offense": {
+			Hits:   3,
+			Window: time.Minute,
+			Block:  2 * time.Minute,
+			Reason: "too many test offenses",
+		},
+	})
+}
+
+func TestIPOffenseThrottleBlocksNoisyIP(t *testing.T) {
+	throttle := testIPOffenseThrottle()
+	req := &http.Request{RemoteAddr: "203.0.113.10:1234"}
+
+	for i := 0; i < 2; i++ {
+		blocked, retryAfter, _ := throttle.Record(req, "test_offense")
+		if blocked || retryAfter != 0 {
+			t.Fatalf("unexpected throttle at hit %d: blocked=%v retryAfter=%v", i+1, blocked, retryAfter)
+		}
+	}
+
+	blocked, retryAfter, reason := throttle.Record(req, "test_offense")
+	if !blocked || retryAfter != 2*time.Minute || reason != "too many test offenses" {
+		t.Fatalf("expected block after limit, got blocked=%v retryAfter=%v reason=%q", blocked, retryAfter, reason)
+	}
+
+	blocked, retryAfter, _ = throttle.longestBlock(req)
+	if !blocked || retryAfter <= 0 {
+		t.Fatalf("expected blocked check to fail request, got blocked=%v retryAfter=%v", blocked, retryAfter)
+	}
+}
+
+func TestIPOffenseThrottleDoesNotBlockOtherIPs(t *testing.T) {
+	throttle := testIPOffenseThrottle()
+	noisy := &http.Request{RemoteAddr: "203.0.113.10:1234"}
+	other := &http.Request{RemoteAddr: "198.51.100.4:1234"}
+
+	for i := 0; i < 3; i++ {
+		throttle.Record(noisy, "test_offense")
+	}
+
+	blocked, _, _ := throttle.longestBlock(other)
+	if blocked {
+		t.Fatal("expected other IP to remain unblocked")
+	}
+}

--- a/pdp/ip_offense_throttle_test.go
+++ b/pdp/ip_offense_throttle_test.go
@@ -53,3 +53,62 @@ func TestIPOffenseThrottleDoesNotBlockOtherIPs(t *testing.T) {
 		t.Fatal("expected other IP to remain unblocked")
 	}
 }
+
+func TestIPOffenseThrottleCleansExpiredStateOnAccess(t *testing.T) {
+	throttle := testIPOffenseThrottle()
+	req := &http.Request{RemoteAddr: "203.0.113.10:1234"}
+	now := time.Now()
+
+	throttle.mu.Lock()
+	throttle.state["203.0.113.10"] = map[string]*ipOffenseState{
+		"test_offense": {
+			blockedUntil: now.Add(-time.Minute),
+			windowStart:  now.Add(-3 * time.Minute),
+		},
+	}
+	throttle.mu.Unlock()
+
+	blocked, _, _ := throttle.longestBlock(req)
+	if blocked {
+		t.Fatal("expected expired block state to be cleaned on access")
+	}
+
+	throttle.mu.RLock()
+	_, ok := throttle.state["203.0.113.10"]
+	throttle.mu.RUnlock()
+	if ok {
+		t.Fatal("expected expired IP state to be removed")
+	}
+}
+
+func TestIPOffenseThrottleCleanupAllRemovesStaleIPs(t *testing.T) {
+	throttle := testIPOffenseThrottle()
+	now := time.Now()
+
+	throttle.mu.Lock()
+	throttle.state["203.0.113.10"] = map[string]*ipOffenseState{
+		"test_offense": {
+			blockedUntil: now.Add(-time.Minute),
+			windowStart:  now.Add(-3 * time.Minute),
+		},
+	}
+	throttle.state["198.51.100.4"] = map[string]*ipOffenseState{
+		"test_offense": {
+			hits:         1,
+			windowStart:  now,
+			blockedUntil: now.Add(2 * time.Minute),
+		},
+	}
+	throttle.mu.Unlock()
+
+	throttle.cleanupAll()
+
+	throttle.mu.RLock()
+	defer throttle.mu.RUnlock()
+	if _, ok := throttle.state["203.0.113.10"]; ok {
+		t.Fatal("expected stale IP to be removed by periodic cleanup")
+	}
+	if _, ok := throttle.state["198.51.100.4"]; !ok {
+		t.Fatal("expected active IP to remain after periodic cleanup")
+	}
+}


### PR DESCRIPTION
This is a "stop the bleeding" fix to resolve a DDoS. 
Today's flow:
1. POST /pdp/piece  +  PUT /pdp/piece/upload/{uuid}   → succeeds (bytes parked)
2. PDPv0_Notify (async, ~2s)       → creates pdp_piecerefs
3. POST /pdp/data-sets/{id}/pieces (×22–54 datasets) → 404/409, no-op
4. GC waits 24 hours

Quick-Fix for hammering:
- Step 3 should mark the piece for the delete poller to delete 
- Ban IP from all APIs for 5 minutes if Step-3 sees 5 problems in a minute. 


FUTURE (not here): This API should be reversed: 
1. Validate the wallet & DataSet is good. Get a token
2. Do an upload that waits on a task, gets a CommP and finishes.