### PR TITLE
pdp: fix PDPv0_IPNI throughput collapse under load

### DIFF
--- a/harmony/harmonydb/downgrade/20260610-pdp-ipni-hot-path-indexes.sql
+++ b/harmony/harmonydb/downgrade/20260610-pdp-ipni-hot-path-indexes.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS pdp_piecerefs_ipni_task_id;
+
+DROP INDEX IF EXISTS pdp_piecerefs_indexing_task_id;
+
+DROP INDEX IF EXISTS ipni_piece_cid_order;

--- a/harmony/harmonydb/sql/20260610-pdp-ipni-hot-path-indexes.sql
+++ b/harmony/harmonydb/sql/20260610-pdp-ipni-hot-path-indexes.sql
@@ -1,0 +1,18 @@
+-- Hot-path indexes for PDPv0 IPNI and Indexing tasks.
+--
+-- pdp_piecerefs: the per-task params queries filter WHERE <task_id_col> = $1.
+-- The existing partial pending-indexes only cover IS NULL rows, so these
+-- lookups were full table scans (measured 1.4s at 1.4M rows, paid once per
+-- task). Partial indexes over claimed rows are tiny and near-free to maintain.
+CREATE INDEX IF NOT EXISTS pdp_piecerefs_ipni_task_id
+    ON pdp_piecerefs (ipni_task_id) WHERE ipni_task_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS pdp_piecerefs_indexing_task_id
+    ON pdp_piecerefs (indexing_task_id) WHERE indexing_task_id IS NOT NULL;
+
+-- ipni: the "already published" pre-check in PDPv0_IPNI reads
+-- WHERE piece_cid = $1 ORDER BY order_number DESC LIMIT 1. With no index on
+-- piece_cid this is a table scan that grows with every advertisement
+-- published (291ms at 134k rows, seconds at millions).
+CREATE INDEX IF NOT EXISTS ipni_piece_cid_order
+    ON ipni (piece_cid, order_number DESC);

--- a/tasks/indexing/task_pdp_v0_ipni.go
+++ b/tasks/indexing/task_pdp_v0_ipni.go
@@ -95,6 +95,15 @@ func (P *PDPV0IPNITask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 	}
 
 	if exists && !isRm {
+		_, err = P.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (commit bool, err error) {
+			if err := P.recordCompletion(tx, taskID, task.ID); err != nil {
+				return false, xerrors.Errorf("recording IPNI task completion: %w", err)
+			}
+			return true, nil
+		})
+		if err != nil {
+			return false, err
+		}
 		ilog.Infow("IPNI task already published", "task_id", taskID, "piece_cid", task.PieceCID)
 		return true, nil
 	}
@@ -181,77 +190,78 @@ func (P *PDPV0IPNITask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 		if !stillOwned() {
 			return false, nil
 		}
+
+		var prev string
+		err = P.db.QueryRow(ctx, `SELECT head FROM ipni_head WHERE provider = $1`, task.Prov).Scan(&prev)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return false, xerrors.Errorf("querying previous head: %w", err)
+		}
+
+		var privKey []byte
+		err = P.db.QueryRow(ctx, `SELECT priv_key FROM ipni_peerid WHERE sp_id = $1`, PDP_v0_SP_ID).Scan(&privKey)
+		if err != nil {
+			return false, xerrors.Errorf("failed to get private ipni-libp2p key: %w", err)
+		}
+
+		pkey, err := crypto.UnmarshalPrivateKey(privKey)
+		if err != nil {
+			return false, xerrors.Errorf("unmarshaling private key: %w", err)
+		}
+
+		adv := schema.Advertisement{
+			Provider:  task.Prov,
+			Entries:   lnk,
+			ContextID: iContext,
+			Metadata:  md,
+			IsRm:      false, // No PDP IPNI IsRms (yet)
+		}
+
+		{
+			u, err := urlhelper.GetExternalURL(&P.cfg.HTTP)
+			if err != nil {
+				return false, xerrors.Errorf("getting external URL for IPNI: %w", err)
+			}
+
+			addr, err := urlhelper.FromURLWithPort(u)
+			if err != nil {
+				return false, xerrors.Errorf("converting URL to multiaddr: %w", err)
+			}
+
+			ilog.Infow("Announcing piece to IPNI", "piece", pi.PieceCID, "provider", task.Prov, "addr", addr.String(), "task", taskID)
+
+			adv.Addresses = append(adv.Addresses, addr.String())
+		}
+
+		if prev != "" {
+			prevCID, err := cid.Parse(prev)
+			if err != nil {
+				return false, xerrors.Errorf("parsing previous CID: %w", err)
+			}
+
+			adv.PreviousID = cidlink.Link{Cid: prevCID}
+		}
+
+		err = adv.Sign(pkey)
+		if err != nil {
+			return false, xerrors.Errorf("signing the advertisement: %w", err)
+		}
+
+		err = adv.Validate()
+		if err != nil {
+			return false, xerrors.Errorf("validating the advertisement: %w", err)
+		}
+
+		adNode, err := adv.ToNode()
+		if err != nil {
+			return false, xerrors.Errorf("converting advertisement to node: %w", err)
+		}
+
+		ad, err := ipniculib.NodeToLink(adNode, schema.Linkproto)
+		if err != nil {
+			return false, xerrors.Errorf("converting advertisement to link: %w", err)
+		}
+
 		comm, err := P.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (commit bool, err error) {
-			var prev string
-			err = tx.QueryRow(`SELECT head FROM ipni_head WHERE provider = $1`, task.Prov).Scan(&prev)
-			if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-				return false, xerrors.Errorf("querying previous head: %w", err)
-			}
-
-			var privKey []byte
-			err = tx.QueryRow(`SELECT priv_key FROM ipni_peerid WHERE sp_id = $1`, PDP_v0_SP_ID).Scan(&privKey)
-			if err != nil {
-				return false, xerrors.Errorf("failed to get private ipni-libp2p key: %w", err)
-			}
-
-			pkey, err := crypto.UnmarshalPrivateKey(privKey)
-			if err != nil {
-				return false, xerrors.Errorf("unmarshaling private key: %w", err)
-			}
-
-			adv := schema.Advertisement{
-				Provider:  task.Prov,
-				Entries:   lnk,
-				ContextID: iContext,
-				Metadata:  md,
-				IsRm:      false, // No PDP IPNI IsRms (yet)
-			}
-
-			{
-				u, err := urlhelper.GetExternalURL(&P.cfg.HTTP)
-				if err != nil {
-					return false, xerrors.Errorf("getting external URL for IPNI: %w", err)
-				}
-
-				addr, err := urlhelper.FromURLWithPort(u)
-				if err != nil {
-					return false, xerrors.Errorf("converting URL to multiaddr: %w", err)
-				}
-
-				ilog.Infow("Announcing piece to IPNI", "piece", pi.PieceCID, "provider", task.Prov, "addr", addr.String(), "task", taskID)
-
-				adv.Addresses = append(adv.Addresses, addr.String())
-			}
-
-			if prev != "" {
-				prevCID, err := cid.Parse(prev)
-				if err != nil {
-					return false, xerrors.Errorf("parsing previous CID: %w", err)
-				}
-
-				adv.PreviousID = cidlink.Link{Cid: prevCID}
-			}
-
-			err = adv.Sign(pkey)
-			if err != nil {
-				return false, xerrors.Errorf("signing the advertisement: %w", err)
-			}
-
-			err = adv.Validate()
-			if err != nil {
-				return false, xerrors.Errorf("validating the advertisement: %w", err)
-			}
-
-			adNode, err := adv.ToNode()
-			if err != nil {
-				return false, xerrors.Errorf("converting advertisement to node: %w", err)
-			}
-
-			ad, err := ipniculib.NodeToLink(adNode, schema.Linkproto)
-			if err != nil {
-				return false, xerrors.Errorf("converting advertisement to link: %w", err)
-			}
-
 			var inserted bool
 			err = tx.QueryRow(`SELECT insert_ad_and_update_head_checked($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
 				ad.(cidlink.Link).Cid.String(), adv.ContextID, md, pcidV2.String(), task.PieceCID, task.Size, adv.IsRm, adv.Provider, strings.Join(adv.Addresses, "|"),
@@ -270,7 +280,7 @@ func (P *PDPV0IPNITask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (d
 
 			return true, nil
 
-		}, harmonydb.OptionRetry())
+		})
 		if err != nil {
 			return false, xerrors.Errorf("store IPNI success: %w", err)
 		}


### PR DESCRIPTION
Fixes the `PDPv0_IPNI` throughput collapse diagnosed in #1291 (see the [follow-up comment](https://github.com/filecoin-project/curio/issues/1291#issuecomment-4672460291) for the full investigation and measurements).

## Changes

**1. Shrink the `ipni_head` conflict window** (`tasks/indexing/task_pdp_v0_ipni.go`)
The write transaction previously read the head and then performed the entire Go-side ad build - key fetch, construction, URL resolution, signing, validation, serialisation - before calling `insert_ad_and_update_head_checked`. That held a read dependency on the hottest row in the DB for seconds per task, so any concurrency produced YugabyteDB `40001` serialization aborts (which burn `MaxFailures` lives and can strand piecerefs). The SQL function is already a complete CAS via `_expected_previous`, so this PR moves the head read, key read, build and signing outside the transaction; the tx is now just the CAS call plus the completion update. A lost race is the function's clean `FALSE` return and a cheap retry instead of an abort. Measured: 6.4% task failure rate → 0% at concurrency 5.

**2. Release the pieceref claim on the already-published early exit**
The exit returned success without clearing `ipni_task_id`; `schedule()` only claims rows where it is NULL, so the pieceref was stranded with `needs_ipni=TRUE` forever.

**3. Hot-path indexes** (`20260610-pdp-ipni-hot-path-indexes.sql`)
- `pdp_piecerefs(ipni_task_id)` and `(indexing_task_id)` partial over `IS NOT NULL`: the per-task params lookup was a full scan (measured 1,397ms at 1.4M rows, per task, for both `PDPv0_IPNI` and `PDPv0_Indexing`) → 64ms.
- `ipni(piece_cid, order_number DESC)`: the already-published pre-check grew linearly with published ads (291ms at 134k rows) → 36ms.
- `IF NOT EXISTS` so nodes that created these manually are unaffected.

## Measured result

Mainnet node draining a 47k announcement backlog: **~13/min → ~1,600/min, zero failures**, currently running in production on `1.28.2-rc2+mainnet+git_cc405c39`. Operator note for YugabyteDB: a running node may need `ANALYZE` on the touched tables before cached plans pick up the new indexes.

Not included (left as findings in #1291): the harmonytask poller full-queue scan - engine-wide, interacts with retry-wait scheduling, felt like your call on shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
