### PR TITLE
fix: make StorePiece min free storage percent configurable

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -520,7 +520,7 @@ func addSealingTasks(
 		activeTasks = append(activeTasks, moveStorageTask)
 	}
 	if cfg.Subsystems.EnableMoveStorage {
-		storePieceTask, err := piece2.NewStorePieceTask(db, must.One(slrLazy.Val()), stor, cfg.Subsystems.MoveStorageMaxTasks)
+		storePieceTask, err := piece2.NewStorePieceTask(db, must.One(slrLazy.Val()), stor, cfg.Subsystems.MoveStorageMaxTasks, cfg.Subsystems.ParkPieceMinFreeStoragePercent)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/tasks/piece/task_park_piece.go
+++ b/tasks/piece/task_park_piece.go
@@ -51,8 +51,8 @@ func NewParkPieceTask(db *harmonydb.DB, sc *ffi2.SealCalls, remote *paths.Remote
 	return newPieceTask(db, sc, remote, max, maxInPark, false, p2Active, minFreeStoragePercent)
 }
 
-func NewStorePieceTask(db *harmonydb.DB, sc *ffi2.SealCalls, remote *paths.Remote, max int) (*ParkPieceTask, error) {
-	return newPieceTask(db, sc, remote, max, 0, true, nil, 10)
+func NewStorePieceTask(db *harmonydb.DB, sc *ffi2.SealCalls, remote *paths.Remote, max int, minFreeStoragePercent float64) (*ParkPieceTask, error) {
+	return newPieceTask(db, sc, remote, max, 0, true, nil, minFreeStoragePercent)
 }
 
 func newPieceTask(db *harmonydb.DB, sc *ffi2.SealCalls, remote *paths.Remote, max int, maxInPark int, longTerm bool, p2Active func() bool, minFreeStoragePercent float64) (*ParkPieceTask, error) {


### PR DESCRIPTION
StorePiece task used a hardcoded 10% min free storage requirement, so it stops scheduling once storage is over 90% full.

Use `ParkPieceMinFreeStoragePercent` (default 5, settable to 0) instead, same as ParkPiece.