### PR TITLE
pdp: accept a pieceIds array in the DeletePiece endpoint for batched removals

### DIFF
--- a/pdp/README.md
+++ b/pdp/README.md
@@ -640,17 +640,21 @@ When you initiate an upload with the `notify` field specified, the PDP Service w
 - **Authentication:** Requires a valid JWT token in the `Authorization` header.
 - **URL Parameters:**
     - `dataSetId`: The ID of the data set.
-    - `pieceId`: The ID of the piece.
+    - `pieceId`: The ID of the piece. Used when no `pieceIds` array is supplied in the request body (see below).
 - **Request Body:** *(Optional)*
 
 ```json
 {
-  "extraData": "<optional-hex-encoded-extra-data>"
+  "extraData": "<optional-hex-encoded-extra-data>",
+  "pieceIds": [0, 1, 2]
 }
 ```
 
 - **Fields:**
     - `extraData`: *(Optional)* Hex-encoded additional data for the contract call (max 256 bytes decoded).
+    - `pieceIds`: *(Optional)* Array of piece IDs to delete in a single batched, on-chain `schedulePieceDeletions` call. When this array is present and non-empty, it **overrides** the `pieceId` from the URL — every ID in the array is scheduled for deletion and the URL `pieceId` is ignored. When the array is omitted or empty, only the URL `pieceId` is deleted. Duplicate IDs are removed before processing. A maximum of 500 piece IDs may be supplied per call.
+
+> **Note:** All requested pieces must belong to the data set. If any one of them is not found, the entire request fails with `404 Not Found` and no deletion is scheduled.
 
 #### Response
 
@@ -668,9 +672,9 @@ When you initiate an upload with the `notify` field specified, the PDP Service w
 
 #### Errors
 
-- `400 Bad Request`: Invalid request or `extraData` exceeds size limit.
+- `400 Bad Request`: Invalid request, `extraData` exceeds size limit, a piece ID is out of range, or `pieceIds` exceeds the maximum batch size of 500.
 - `401 Unauthorized`: Missing or invalid JWT token.
-- `404 Not Found`: Data set or piece not found.
+- `404 Not Found`: Data set not found, or one or more of the requested pieces not found ("One or more piece not found").
 - `500 Internal Server Error`: Failed to send on-chain transaction.
 
 ---
@@ -1139,6 +1143,19 @@ Authorization: Bearer <JWT-token>
 Content-Type: application/json
 
 {}
+```
+
+To delete several pieces from the data set in a single batched transaction, supply a `pieceIds` array in the body (which overrides the `pieceId` in the URL):
+
+```http
+DELETE /pdp/data-sets/{dataSetId}/pieces/{pieceId} HTTP/1.1
+Host: example.com
+Authorization: Bearer <JWT-token>
+Content-Type: application/json
+
+{
+  "pieceIds": [0, 1, 2]
+}
 ```
 
 **Response:**

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -1079,7 +1079,7 @@ func (p *PDPService) handleDeleteDataSetPiece(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if foundCount != len(pieceIDsI64) {
-		http.Error(w, "Piece not found", http.StatusNotFound)
+		http.Error(w, "One or more piece not found", http.StatusNotFound)
 		return
 	}
 

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	"net/http"
 	"strconv"
@@ -56,6 +57,8 @@ const (
 
 	// MaxDeletePieceExtraDataSize defines the limit for extraData size in DeletePiece calls (256B).
 	MaxDeletePieceExtraDataSize = 256
+
+	MaxDeletePiecesBatchSize = 500
 )
 
 // PDPService represents the service for managing data sets and pieces
@@ -953,6 +956,25 @@ func (p *PDPService) handleGetPieceAdditionStatus(w http.ResponseWriter, r *http
 	}
 }
 
+func normalizeDeletePieceIDs(ids []uint64) ([]int64, error) {
+	if len(ids) > MaxDeletePiecesBatchSize {
+		return nil, fmt.Errorf("piece count (%d) exceeds the maximum allowed per DeletePiece call (%d)", len(ids), MaxDeletePiecesBatchSize)
+	}
+	seen := make(map[uint64]struct{}, len(ids))
+	out := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if id > math.MaxInt64 {
+			return nil, fmt.Errorf("piece ID %d is out of range", id)
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, int64(id))
+	}
+	return out, nil
+}
+
 func (p *PDPService) handleDeleteDataSetPiece(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	// Step 1: Verify that the request is authorized using ECDSA JWT
@@ -1044,13 +1066,19 @@ func (p *PDPService) handleDeleteDataSetPiece(w http.ResponseWriter, r *http.Req
 		pieceIDs = payload.PieceIDs
 	}
 
+	pieceIDsI64, err := normalizeDeletePieceIDs(pieceIDs)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	var foundCount int
-	err = p.db.QueryRow(ctx, `SELECT COUNT(DISTINCT piece_id) FROM pdp_data_set_pieces WHERE data_set = $1 AND piece_id = ANY($2)`, dataSetId, pieceIDs).Scan(&foundCount)
+	err = p.db.QueryRow(ctx, `SELECT COUNT(DISTINCT piece_id) FROM pdp_data_set_pieces WHERE data_set = $1 AND piece_id = ANY($2::bigint[])`, dataSetId, pieceIDsI64).Scan(&foundCount)
 	if err != nil {
 		httpServerError(w, http.StatusInternalServerError, "Failed to query piece existence", err)
 		return
 	}
-	if foundCount != len(pieceIDs) {
+	if foundCount != len(pieceIDsI64) {
 		http.Error(w, "Piece not found", http.StatusNotFound)
 		return
 	}
@@ -1062,9 +1090,9 @@ func (p *PDPService) handleDeleteDataSetPiece(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	pieceIDArgs := make([]*big.Int, len(pieceIDs))
-	for i, id := range pieceIDs {
-		pieceIDArgs[i] = new(big.Int).SetUint64(id)
+	pieceIDArgs := make([]*big.Int, len(pieceIDsI64))
+	for i, id := range pieceIDsI64 {
+		pieceIDArgs[i] = big.NewInt(id)
 	}
 
 	// Pack the method call data
@@ -1123,13 +1151,13 @@ func (p *PDPService) handleDeleteDataSetPiece(w http.ResponseWriter, r *http.Req
 		_, err = tx.Exec(`
 			UPDATE pdp_data_set_pieces
 			SET rm_message_hash = $1
-			WHERE data_set = $2 AND piece_id = ANY($3)`,
-			txHashLower, dataSetId, pieceIDs)
+			WHERE data_set = $2 AND piece_id = ANY($3::bigint[])`,
+			txHashLower, dataSetId, pieceIDsI64)
 		if err != nil {
-			log.Errorw("Failed to update rm_message_hash in pdp_data_set_pieces", "dataSetId", dataSetId, "pieceID", pieceID, "error", err)
+			log.Errorw("Failed to update rm_message_hash in pdp_data_set_pieces", "dataSetId", dataSetId, "pieceIDs", pieceIDsI64, "error", err)
 			return false, err
 		}
-		log.Infow("scheduled user requested deletion", "dataSetId", dataSetId, "pieceID", pieceID, "txHash", txHashLower)
+		log.Infow("scheduled user requested deletion", "dataSetId", dataSetId, "pieceIDs", pieceIDsI64, "txHash", txHashLower)
 
 		return true, nil
 	}, harmonydb.OptionRetry())

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -1008,7 +1008,8 @@ func (p *PDPService) handleDeleteDataSetPiece(w http.ResponseWriter, r *http.Req
 		return
 	}
 	type DeletePiecePayload struct {
-		ExtraData *string `json:"extraData"`
+		ExtraData *string  `json:"extraData"`
+		PieceIDs  []uint64 `json:"pieceIds"`
 	}
 	var payload DeletePiecePayload
 	err = json.NewDecoder(r.Body).Decode(&payload)
@@ -1038,14 +1039,18 @@ func (p *PDPService) handleDeleteDataSetPiece(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	// Check if we have this piece or not
-	var found bool
-	err = p.db.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM pdp_data_set_pieces WHERE data_set = $1 AND piece_id = $2)`, dataSetId, pieceID).Scan(&found)
+	pieceIDs := []uint64{pieceID}
+	if len(payload.PieceIDs) > 0 {
+		pieceIDs = payload.PieceIDs
+	}
+
+	var foundCount int
+	err = p.db.QueryRow(ctx, `SELECT COUNT(DISTINCT piece_id) FROM pdp_data_set_pieces WHERE data_set = $1 AND piece_id = ANY($2)`, dataSetId, pieceIDs).Scan(&foundCount)
 	if err != nil {
 		httpServerError(w, http.StatusInternalServerError, "Failed to query piece existence", err)
 		return
 	}
-	if !found {
+	if foundCount != len(pieceIDs) {
 		http.Error(w, "Piece not found", http.StatusNotFound)
 		return
 	}
@@ -1057,10 +1062,15 @@ func (p *PDPService) handleDeleteDataSetPiece(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	pieceIDArgs := make([]*big.Int, len(pieceIDs))
+	for i, id := range pieceIDs {
+		pieceIDArgs[i] = new(big.Int).SetUint64(id)
+	}
+
 	// Pack the method call data
 	data, err := abiData.Pack("schedulePieceDeletions",
 		big.NewInt(int64(dataSetId)),
-		[]*big.Int{big.NewInt(int64(pieceID))},
+		pieceIDArgs,
 		[]byte(extraDataBytes),
 	)
 	if err != nil {
@@ -1113,8 +1123,8 @@ func (p *PDPService) handleDeleteDataSetPiece(w http.ResponseWriter, r *http.Req
 		_, err = tx.Exec(`
 			UPDATE pdp_data_set_pieces
 			SET rm_message_hash = $1
-			WHERE data_set = $2 AND piece_id = $3`,
-			txHashLower, dataSetId, pieceID)
+			WHERE data_set = $2 AND piece_id = ANY($3)`,
+			txHashLower, dataSetId, pieceIDs)
 		if err != nil {
 			log.Errorw("Failed to update rm_message_hash in pdp_data_set_pieces", "dataSetId", dataSetId, "pieceID", pieceID, "error", err)
 			return false, err

--- a/pdp/handlers_delete_test.go
+++ b/pdp/handlers_delete_test.go
@@ -1,0 +1,81 @@
+package pdp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+)
+
+func TestNormalizeDeletePieceIDs(t *testing.T) {
+	t.Run("single id passes through", func(t *testing.T) {
+		out, err := normalizeDeletePieceIDs([]uint64{5})
+		require.NoError(t, err)
+		require.Equal(t, []int64{5}, out)
+	})
+
+	t.Run("duplicates collapse preserving first-seen order", func(t *testing.T) {
+		out, err := normalizeDeletePieceIDs([]uint64{3, 1, 3, 2, 1})
+		require.NoError(t, err)
+		require.Equal(t, []int64{3, 1, 2}, out)
+	})
+
+	t.Run("batch at the cap is accepted", func(t *testing.T) {
+		ids := make([]uint64, MaxDeletePiecesBatchSize)
+		for i := range ids {
+			ids[i] = uint64(i)
+		}
+		out, err := normalizeDeletePieceIDs(ids)
+		require.NoError(t, err)
+		require.Len(t, out, MaxDeletePiecesBatchSize)
+	})
+
+	t.Run("batch over the cap is rejected", func(t *testing.T) {
+		ids := make([]uint64, MaxDeletePiecesBatchSize+1)
+		_, err := normalizeDeletePieceIDs(ids)
+		require.Error(t, err)
+	})
+
+	t.Run("max int64 is accepted", func(t *testing.T) {
+		out, err := normalizeDeletePieceIDs([]uint64{math.MaxInt64})
+		require.NoError(t, err)
+		require.Equal(t, []int64{math.MaxInt64}, out)
+	})
+
+	t.Run("id beyond int64 range is rejected", func(t *testing.T) {
+		_, err := normalizeDeletePieceIDs([]uint64{uint64(math.MaxInt64) + 1})
+		require.Error(t, err)
+	})
+}
+
+func TestHandleDeleteDataSetPiece_MissingPiece404(t *testing.T) {
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	ensurePullTestDataSet(t, db, testDataSetId, "public")
+	p := &PDPService{Auth: &NullAuth{}, db: db}
+
+	body, err := json.Marshal(map[string]any{"pieceIds": []uint64{999001, 999002}})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodDelete, "/", bytes.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("dataSetId", strconv.FormatUint(testDataSetId, 10))
+	rctx.URLParams.Add("pieceID", "999001")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rec := httptest.NewRecorder()
+	p.handleDeleteDataSetPiece(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "Piece not found")
+}

--- a/pdp/handlers_delete_test.go
+++ b/pdp/handlers_delete_test.go
@@ -77,5 +77,5 @@ func TestHandleDeleteDataSetPiece_MissingPiece404(t *testing.T) {
 	p.handleDeleteDataSetPiece(rec, req)
 
 	require.Equal(t, http.StatusNotFound, rec.Code)
-	require.Contains(t, rec.Body.String(), "Piece not found")
+	require.Contains(t, rec.Body.String(), "One or more piece not found")
 }


### PR DESCRIPTION
`schedulePieceDeletions` on PDPVerifier takes a `uint256[]`, but the DELETE `/pdp/data-sets/{set}/pieces/{pieceId}` handler hardcodes a single-element array — so bulk removals cost one transaction per piece.

This change adds an optional `pieceIds` field to the request body. When present, the handler validates all ids exist in the data set, packs them into one `schedulePieceDeletions` call, and records `rm_message_hash` for every id. When absent, behaviour is unchanged (the path id is used, as today).

Context: while removing ~19,800 duplicate pieces from one data set (a client-tool re-commit bug, details in BravoNatalie/migration-support-scripts#9 and fixed in BravoNatalie/migration-support-scripts#12), per-piece removal would have been 19,800 transactions; with this change it is 40 (500 ids per call, each estimating ~2.5B gas — well within block limits). The client-side authorization already supports arrays (`signSchedulePieceRemovals` signs the id list), so only the handler needed the change.

Running in production on my mainnet node.