### PR TITLE
pdp: scale indexes and query rewrites for large-table hot paths

### DIFF
--- a/harmony/harmonydb/downgrade/20260624-db-scale-indexes.sql
+++ b/harmony/harmonydb/downgrade/20260624-db-scale-indexes.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS idx_parked_pieces_task_id;
+DROP INDEX IF EXISTS idx_parked_pieces_cleanup_task_id;
+DROP INDEX IF EXISTS idx_sector_location_storage_id;
+DROP INDEX IF EXISTS idx_pdp_data_set_pieces_data_set_add_msg;
+DROP INDEX IF EXISTS idx_pdp_piecerefs_save_cache_pending;
+DROP INDEX IF EXISTS idx_pdp_piecerefs_save_cache_task;
+DROP INDEX IF EXISTS idx_message_sends_eth_reorg_check;
+CREATE INDEX IF NOT EXISTS idx_message_sends_eth_reorg_check
+    ON message_sends_eth (send_time, send_reason)
+    WHERE send_success = TRUE AND send_time IS NOT NULL AND signed_hash IS NOT NULL;

--- a/harmony/harmonydb/sql/20260624-db-scale-indexes.sql
+++ b/harmony/harmonydb/sql/20260624-db-scale-indexes.sql
@@ -1,0 +1,22 @@
+CREATE INDEX IF NOT EXISTS idx_parked_pieces_task_id
+    ON parked_pieces (task_id) WHERE task_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_parked_pieces_cleanup_task_id
+    ON parked_pieces (cleanup_task_id) WHERE cleanup_task_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sector_location_storage_id
+    ON sector_location (storage_id);
+
+CREATE INDEX IF NOT EXISTS idx_pdp_data_set_pieces_data_set_add_msg
+    ON pdp_data_set_pieces (data_set, add_message_hash);
+
+CREATE INDEX IF NOT EXISTS idx_pdp_piecerefs_save_cache_pending
+    ON pdp_piecerefs (created_at) WHERE save_cache_task_id IS NULL AND needs_save_cache = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_pdp_piecerefs_save_cache_task
+    ON pdp_piecerefs (save_cache_task_id) WHERE save_cache_task_id IS NOT NULL;
+
+DROP INDEX IF EXISTS idx_message_sends_eth_reorg_check;
+CREATE INDEX IF NOT EXISTS idx_message_sends_eth_reorg_check
+    ON message_sends_eth (send_reason, send_time)
+    WHERE send_success = TRUE AND send_time IS NOT NULL AND signed_hash IS NOT NULL;

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -305,9 +305,8 @@ func (p *PDPService) handleGetPieceStatus(w http.ResponseWriter, r *http.Request
 			SELECT
 				MIN(i.ad_cid) as ad_cid,
 				MIN(i.provider) as provider,
-				MIN(af.fetched_at) as fetched_at
+				MIN((SELECT MIN(af.fetched_at) FROM ipni_ad_fetches af WHERE af.ad_cid = i.ad_cid)) as fetched_at
 			FROM ipni i
-			LEFT JOIN ipni_ad_fetches af ON af.ad_cid = i.ad_cid
 			WHERE i.piece_cid = pr.piece_cid
 				AND i.provider = (SELECT peer_id FROM ipni_peerid WHERE sp_id = $3)
 				AND i.is_rm = FALSE

--- a/tasks/pdpv0/task_pull_piece.go
+++ b/tasks/pdpv0/task_pull_piece.go
@@ -249,12 +249,16 @@ func (t *PDPPullPieceTask) completeAlreadyParkedItems(ctx context.Context) error
 				fi.parked_piece_ref
 			FROM pdp_piece_pull_items fi
 			JOIN pdp_piece_pulls pp ON pp.id = fi.fetch_id
-			JOIN parked_pieces parked
-				ON parked.piece_cid = fi.piece_cid
+			CROSS JOIN LATERAL (
+				SELECT parked.id, parked.created_at
+				FROM parked_pieces parked
+				WHERE parked.piece_cid = fi.piece_cid
 				AND parked.piece_raw_size = fi.piece_raw_size
 				AND parked.long_term = TRUE
 				AND parked.complete = TRUE
 				AND parked.cleanup_task_id IS NULL
+				OFFSET 0
+			) parked
 			WHERE fi.complete = FALSE
 				AND fi.failed = FALSE
 			ORDER BY fi.fetch_id, fi.piece_cid, fi.source_url, parked.created_at ASC, parked.id ASC

--- a/tasks/pdpv0/task_save_cache.go
+++ b/tasks/pdpv0/task_save_cache.go
@@ -251,12 +251,14 @@ func (t *TaskPDPSaveCache) scheduleMigrationCleanup(_ context.Context, taskFunc 
 	// trivially will not populate the cache because they are too small
 	_, err := t.db.Exec(context.Background(), `
             UPDATE pdp_piecerefs pr SET needs_save_cache = FALSE, caching_task_completed = NOW()
-            FROM parked_piece_refs pprf
-            JOIN parked_pieces pp ON pp.id = pprf.piece_id
-            WHERE pprf.ref_id = pr.piece_ref
-            AND pr.needs_save_cache = TRUE
+            WHERE pr.needs_save_cache = TRUE
             AND pr.save_cache_task_id IS NULL
-            AND pp.piece_raw_size <= $1`, MaxRawSizeForSkip)
+            AND EXISTS (
+                SELECT 1 FROM parked_piece_refs pprf
+                JOIN parked_pieces pp ON pp.id = pprf.piece_id
+                WHERE pprf.ref_id = pr.piece_ref
+                AND pp.piece_raw_size <= $1
+            )`, MaxRawSizeForSkip)
 	if err != nil {
 		return xerrors.Errorf("bulk clearing small pieces: %w", err)
 	}


### PR DESCRIPTION
Systematic pass over hot query paths on tables that grow large at scale — piece parking, storage location, and PDP — measured on a live mainnet node via `EXPLAIN ANALYZE` (`parked_pieces` 1.87M, `sector_location` 1.85M, `pdp_data_set_pieces` 1.71M, `message_sends_eth` 1.29M, `ipni_ad_fetches` 4.65M rows).

## Indexes — `20260624-db-scale-indexes.sql`

| Index | Query | Before | After |
|---|---|---|---|
| `idx_parked_pieces_task_id` (partial) | `parked_pieces WHERE task_id = $1` (`tasks/piece/task_park_piece.go`) | 1,853 ms seq scan | 0.48 ms |
| `idx_parked_pieces_cleanup_task_id` (partial) | `parked_pieces WHERE cleanup_task_id = $1` (`tasks/piece/task_cleanup_piece.go`) | 1,859 ms seq scan | 0.57 ms |
| `idx_sector_location_storage_id` | `sector_location WHERE storage_id = $1` (`lib/paths/db_index.go`) | 1,534 ms seq scan | 0.85 ms |
| `idx_pdp_data_set_pieces_data_set_add_msg` | `pdp_data_set_pieces WHERE data_set = $1 AND add_message_hash = $2` (`pdp/handlers.go`) | 1,281 ms | 2.6 ms |
| `idx_pdp_piecerefs_save_cache_pending` + `_save_cache_task` | SaveCache `schedule()` / `Do()` | 37 s | 1.4 ms |

The two `save_cache` indexes are those identified in #1310 — `20260216-pdp-v0-save-cache.sql` added the columns and queries but no indexes.

This also corrects an existing index: `20260527` created `idx_message_sends_eth_reorg_check` as `(send_time, send_reason)`. In YugabyteDB the leading column is `HASH`, so `send_time` cannot range-scan and the reorg check rechecks the whole table. The migration drops it and recreates it as `(send_reason, send_time)`:

| `idx_message_sends_eth_reorg_check` → `(send_reason, send_time)` | reorg candidate scan (`tasks/pdpv0/task_reorg_check.go`) | 2,330 ms, 1.25M rows rechecked | 53 ms |

## Query rewrites

| Change | File | Before | After |
|---|---|---|---|
| `completeAlreadyParkedItems`: inner join → `CROSS JOIN LATERAL (… OFFSET 0)` to force a per-row probe | `tasks/pdpv0/task_pull_piece.go` | 47,000 ms | 203 ms |
| piece-status: `LEFT JOIN ipni_ad_fetches` → correlated `MIN` subquery (drops a 4.65M-row scan + 383 MB disk sort) | `pdp/handlers.go` | 25,599 ms | 8.6 ms |
| `scheduleMigrationCleanup`: `UPDATE … FROM parked_piece_refs JOIN …` → `WHERE EXISTS (…)` so it drives the SaveCache index instead of seq-scanning `parked_piece_refs` | `tasks/pdpv0/task_save_cache.go` | 23.7 s mean | index-driven semi-join |

All three are semantically equivalent to the originals (inner-join ↔ lateral; min-of-mins; `SET` uses no joined columns).

## Not included

Statistics: the node had no auto-analyze and several large tables (`pdp_piece_pull_items`, `ipni_ad_fetches`) had no statistics, which alone caused plan regressions (e.g. the piece-status query's disk sort). Operational, tracked separately.

## Issues

Closes #1310. Related, handled separately (behavioral, not index/query-shape): #1306, #1303, #1296, #1291.