### PR TITLE
pdp: migration-scale hardening (poller, proving task, IPNI reclaim)

### DIFF
--- a/harmony/harmonytask/harmonytask.go
+++ b/harmony/harmonytask/harmonytask.go
@@ -413,7 +413,7 @@ func (e *TaskEngine) pollerTryAllWork(schedulable bool) bool {
 		err := e.db.Select(e.ctx, &allUnownedTasks, `SELECT id, update_time, retries
 			FROM harmony_task
 			WHERE owner_id IS NULL AND name=$1
-			ORDER BY update_time`, v.Name)
+			ORDER BY update_time LIMIT 512`, v.Name)
 		if err != nil {
 			log.Error("Unable to read work ", err)
 			continue

--- a/tasks/indexing/task_pdp_v0_ipni.go
+++ b/tasks/indexing/task_pdp_v0_ipni.go
@@ -325,6 +325,12 @@ func (P *PDPV0IPNITask) TypeDetails() harmonytask.TaskTypeDetails {
 }
 
 func (P *PDPV0IPNITask) schedule(ctx context.Context, taskFunc harmonytask.AddTaskFunc) error {
+	if _, err := P.db.Exec(ctx, `UPDATE pdp_piecerefs SET ipni_task_id = NULL
+		WHERE needs_ipni = TRUE AND ipni_task_id IS NOT NULL
+		  AND NOT EXISTS (SELECT 1 FROM harmony_task t WHERE t.id = ipni_task_id)`); err != nil {
+		return xerrors.Errorf("reclaiming stranded PDP IPNI piecerefs: %w", err)
+	}
+
 	// schedule submits
 	var stop bool
 	for !stop {

--- a/tasks/indexing/task_pdp_v0_ipni.go
+++ b/tasks/indexing/task_pdp_v0_ipni.go
@@ -325,10 +325,14 @@ func (P *PDPV0IPNITask) TypeDetails() harmonytask.TaskTypeDetails {
 }
 
 func (P *PDPV0IPNITask) schedule(ctx context.Context, taskFunc harmonytask.AddTaskFunc) error {
-	if _, err := P.db.Exec(ctx, `UPDATE pdp_piecerefs SET ipni_task_id = NULL
+	n, err := P.db.Exec(ctx, `UPDATE pdp_piecerefs SET ipni_task_id = NULL
 		WHERE needs_ipni = TRUE AND ipni_task_id IS NOT NULL
-		  AND NOT EXISTS (SELECT 1 FROM harmony_task t WHERE t.id = ipni_task_id)`); err != nil {
+		  AND NOT EXISTS (SELECT 1 FROM harmony_task t WHERE t.id = ipni_task_id)`)
+	if err != nil {
 		return xerrors.Errorf("reclaiming stranded PDP IPNI piecerefs: %w", err)
+	}
+	if n > 0 {
+		ilog.Infow("reclaimed stranded PDP IPNI piecerefs", "count", n)
 	}
 
 	// schedule submits

--- a/tasks/message/sender_eth.go
+++ b/tasks/message/sender_eth.go
@@ -284,7 +284,9 @@ func (s *SenderETH) Send(ctx context.Context, fromAddress common.Address, tx *ty
 			Data:  tx.Data(),
 		}
 
-		gasLimit, err := s.client.EstimateGas(ctx, msg)
+		ethCtx, cancel := context.WithTimeout(ctx, defaultEthCallTimeout)
+		gasLimit, err := s.client.EstimateGas(ethCtx, msg)
+		cancel()
 		if err != nil {
 			return common.Hash{}, fmt.Errorf("failed to estimate gas: %w", err)
 		}

--- a/tasks/pdpv0/task_next_pp.go
+++ b/tasks/pdpv0/task_next_pp.go
@@ -418,6 +418,7 @@ func (n *NextProvingPeriodTask) TypeDetails() harmonytask.TaskTypeDetails {
 		},
 		MaxFailures: 3, // Set retry limit to 3 attempts
 		RetryWait:   taskhelp.RetryWaitExp(5*time.Second, 2),
+		Max:         taskhelp.Max(16),
 	}
 }
 

--- a/tasks/pdpv0/task_piece_gc.go
+++ b/tasks/pdpv0/task_piece_gc.go
@@ -141,7 +141,7 @@ func processIndexingAndIPNICleanup(ctx context.Context, db *harmonydb.DB, cfg *c
 										    JOIN parked_piece_refs ppr ON pr.piece_ref = ppr.ref_id
 										    JOIN parked_pieces pp ON ppr.piece_id = pp.id
 										WHERE pr.data_set_refcount = 0
-										  AND pr.created_at <= TIMEZONE('UTC', NOW()) - INTERVAL '24 hours'
+										  AND pr.created_at <= TIMEZONE('UTC', NOW()) - INTERVAL '14 days'
 										  AND NOT EXISTS (
 										      SELECT 1 FROM pdp_data_set_piece_adds a
 										      WHERE a.pdp_pieceref = pr.id
@@ -182,7 +182,8 @@ func processIndexingAndIPNICleanup(ctx context.Context, db *harmonydb.DB, cfg *c
 		}
 		pcidV2, err := commcid.PieceCidV2FromV1(pcid1, uint64(piece.RawSize))
 		if err != nil {
-			return xerrors.Errorf("failed to construct piece cid v2: %w", err)
+			log.Warnw("skipping piece with invalid commp v2; continuing GC run", "piece_cid", piece.PieceCID, "raw_size", piece.RawSize, "error", err)
+			continue
 		}
 
 		var skipLoop bool

--- a/tasks/pdpv0/task_piece_gc.go
+++ b/tasks/pdpv0/task_piece_gc.go
@@ -182,8 +182,7 @@ func processIndexingAndIPNICleanup(ctx context.Context, db *harmonydb.DB, cfg *c
 		}
 		pcidV2, err := commcid.PieceCidV2FromV1(pcid1, uint64(piece.RawSize))
 		if err != nil {
-			log.Errorw("skipping piece with invalid commp v2; continuing GC run", "piece_cid", piece.PieceCID, "raw_size", piece.RawSize, "error", err)
-			continue
+			return xerrors.Errorf("failed to construct piece cid v2: %w", err)
 		}
 
 		var skipLoop bool

--- a/tasks/pdpv0/task_piece_gc.go
+++ b/tasks/pdpv0/task_piece_gc.go
@@ -182,7 +182,7 @@ func processIndexingAndIPNICleanup(ctx context.Context, db *harmonydb.DB, cfg *c
 		}
 		pcidV2, err := commcid.PieceCidV2FromV1(pcid1, uint64(piece.RawSize))
 		if err != nil {
-			log.Warnw("skipping piece with invalid commp v2; continuing GC run", "piece_cid", piece.PieceCID, "raw_size", piece.RawSize, "error", err)
+			log.Errorw("skipping piece with invalid commp v2; continuing GC run", "piece_cid", piece.PieceCID, "raw_size", piece.RawSize, "error", err)
 			continue
 		}
 

--- a/tasks/pdpv0/task_piece_gc.go
+++ b/tasks/pdpv0/task_piece_gc.go
@@ -141,7 +141,7 @@ func processIndexingAndIPNICleanup(ctx context.Context, db *harmonydb.DB, cfg *c
 										    JOIN parked_piece_refs ppr ON pr.piece_ref = ppr.ref_id
 										    JOIN parked_pieces pp ON ppr.piece_id = pp.id
 										WHERE pr.data_set_refcount = 0
-										  AND pr.created_at <= TIMEZONE('UTC', NOW()) - INTERVAL '14 days'
+										  AND pr.created_at <= TIMEZONE('UTC', NOW()) - INTERVAL '24 hours'
 										  AND NOT EXISTS (
 										      SELECT 1 FROM pdp_data_set_piece_adds a
 										      WHERE a.pdp_pieceref = pr.id


### PR DESCRIPTION
Three small migration-scale hardening fixes.

## harmonytask poller (#1306)

`pollerTryAllWork` selected the entire unowned queue per handler per cycle with no `LIMIT`, and the engine starts one task per cycle, so drain rate degraded as queues deepened (at 47k queued tasks the scan took ~1s and task-start gaps tracked it exactly). Adds `LIMIT 512` to the fetch (~4x drain rate on a backlogged node; running locally since 10 June).

## proving task (#1296)

- `NextProvingPeriodTask` had no `Max` in `TypeDetails`. After a restart, ~600 overdue proving tasks were claimed at once, every chain call queued past `EthCallTimeout`, and `MaxFailures` + re-add kept the storm fed. Adds `Max(16)`.
- `SenderETH.Send` called `EstimateGas` with no context deadline (unlike the view calls). Tasks whose estimate response was lost could sit blocked for 30+ minutes holding a slot. The call is now bounded by `defaultEthCallTimeout`.

## IPNI stranded piecerefs (#1291)

When a `PDPv0_IPNI` task is dropped after `MaxFailures`, its pieceref keeps a non-null `ipni_task_id` pointing at the now-deleted task. `schedule()` only claims rows `WHERE ipni_task_id IS NULL`, so those pieces are never announced. `schedule()` now nulls out `ipni_task_id` for refs whose task no longer exists, so they become schedulable again. (The concurrency half of #1291 — honouring the injected limiter instead of the `Max(50)` hardcode — is already in `main`.)

Closes #1306
Closes #1296
Closes #1291