### PR TITLE
Be 10x more conservative on the removal queue

### DIFF
--- a/pdp/contract/ethcall.go
+++ b/pdp/contract/ethcall.go
@@ -16,6 +16,13 @@ import (
 // detected and handled within this timeout as a last resort to bound the damage.
 const EthCallTimeout = 10 * time.Second
 
+// ConservativeEnqueuedRemovalsLimit is a curio-side soft ceiling on the number of
+// scheduled piece removals we allow to be queued on-chain per data set. It sits well
+// below the on-chain MAX_ENQUEUED_REMOVALS (2000) to keep comfortable headroom: once a
+// data set's live removal queue reaches this many entries, we stop enqueuing new
+// removals for it until the next proving period flushes the queue.
+const ConservativeEnqueuedRemovalsLimit = 200
+
 // EthCallOpts returns bind.CallOpts with a timeout-bounded context derived from
 // ctx.
 // All contract calls in PDP code MUST use this instead of nil CallOpts or a raw

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -58,7 +58,7 @@ const (
 	// MaxDeletePieceExtraDataSize defines the limit for extraData size in DeletePiece calls (256B).
 	MaxDeletePieceExtraDataSize = 256
 
-	MaxDeletePiecesBatchSize = 500
+	MaxDeletePiecesBatchSize = contract.ConservativeEnqueuedRemovalsLimit
 )
 
 // PDPService represents the service for managing data sets and pieces
@@ -1079,6 +1079,24 @@ func (p *PDPService) handleDeleteDataSetPiece(w http.ResponseWriter, r *http.Req
 	}
 	if foundCount != len(pieceIDsI64) {
 		http.Error(w, "One or more piece not found", http.StatusNotFound)
+		return
+	}
+
+	// Soft gate: refuse if the data set's on-chain removal queue is already at our
+	// conservative ceiling. This keeps us well clear of the on-chain MAX_ENQUEUED_REMOVALS.
+	pdpVerifier, err := contract.NewPDPVerifier(contract.ContractAddresses().PDPVerifier, p.ethClient)
+	if err != nil {
+		httpServerError(w, http.StatusInternalServerError, "Failed to instantiate PDPVerifier", err)
+		return
+	}
+	queued, err := pdpVerifier.GetScheduledRemovals(contract.EthCallOpts(ctx), big.NewInt(int64(dataSetId)))
+	if err != nil {
+		httpServerError(w, http.StatusInternalServerError, "Failed to read scheduled removals", err)
+		return
+	}
+	if len(queued) >= contract.ConservativeEnqueuedRemovalsLimit {
+		http.Error(w, fmt.Sprintf("data set %d already has %d scheduled removals queued (limit %d); retry after the next proving period flushes the queue",
+			dataSetId, len(queued), contract.ConservativeEnqueuedRemovalsLimit), http.StatusTooManyRequests)
 		return
 	}
 

--- a/tasks/pdp/task_delete_piece.go
+++ b/tasks/pdp/task_delete_piece.go
@@ -164,32 +164,52 @@ func (p *PDPTaskDeletePiece) TypeDetails() harmonytask.TaskTypeDetails {
 func (p *PDPTaskDeletePiece) schedule(ctx context.Context, taskFunc harmonytask.AddTaskFunc) error {
 	var stop bool
 	for !stop {
+		// Pick the next pending delete and read its data set's on-chain removal queue
+		// length *before* claiming the task, so the eth_call stays out of the DB tx.
+		var did string
+		var setID int64
+		err := p.db.QueryRow(ctx, `SELECT id, set_id FROM pdp_piece_delete
+								  WHERE task_id IS NULL
+									AND tx_hash IS NULL LIMIT 1`).Scan(&did, &setID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			}
+			return xerrors.Errorf("failed to query pdp_piece_delete: %w", err)
+		}
+
+		// Soft gate: if this data set's removal queue is already at our conservative
+		// ceiling, leave the row unclaimed and stop this tick. It will be retried on the
+		// next poll once the queue drains at the next proving period. Head-of-line
+		// blocking behind an over-limit data set is acceptable here.
+		pdpVerifier, err := contract.NewPDPVerifier(contract.ContractAddresses().PDPVerifier, p.ethClient)
+		if err != nil {
+			return xerrors.Errorf("failed to instantiate PDPVerifier: %w", err)
+		}
+		queued, err := pdpVerifier.GetScheduledRemovals(contract.EthCallOpts(ctx), big.NewInt(setID))
+		if err != nil {
+			return xerrors.Errorf("failed to get scheduled removals for data set %d: %w", setID, err)
+		}
+		if len(queued) >= contract.ConservativeEnqueuedRemovalsLimit {
+			log.Infow("deferring piece delete: data set removal queue at conservative limit",
+				"set_id", setID, "queued", len(queued), "limit", contract.ConservativeEnqueuedRemovalsLimit)
+			return nil
+		}
+
+		stop = true // assume we're done until we successfully claim this row
 		taskFunc(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
-			stop = true // assume we're done until we find a task to schedule
-
-			var did string
-			err := tx.QueryRow(`SELECT id FROM pdp_piece_delete 
-								  WHERE task_id IS NULL 
-									AND tx_hash IS NULL LIMIT 1`).Scan(&did)
-			if err != nil {
-				if errors.Is(err, pgx.ErrNoRows) {
-					return false, nil
-				}
-				return false, xerrors.Errorf("failed to query pdp_piece_delete: %w", err)
-			}
-			if did == "" {
-				return false, xerrors.Errorf("no valid deal ID found for scheduling")
-			}
-
-			_, err = tx.Exec(`UPDATE pdp_piece_delete SET task_id = $1 WHERE id = $2 AND task_id IS NULL AND tx_hash IS NULL`, id, did)
+			n, err := tx.Exec(`UPDATE pdp_piece_delete SET task_id = $1 WHERE id = $2 AND task_id IS NULL AND tx_hash IS NULL`, id, did)
 			if err != nil {
 				return false, xerrors.Errorf("failed to update pdp_piece_delete: %w", err)
 			}
+			if n == 0 {
+				// Row was claimed by another scheduler between our SELECT and here; skip it.
+				return false, nil
+			}
 
-			stop = false // we found a task to schedule, keep going
+			stop = false // we claimed a task, keep going
 			return true, nil
 		})
-
 	}
 
 	return nil


### PR DESCRIPTION
This is a quick fix that should resolve @TippyFlitsUK's recent issue #1329 for practical gas values.

It simply stops submitting removal requests once the queue is up to 200 entries.  A proper solution will need to incorporate contract upgrades described in https://github.com/FilOzone/pdp/issues/283.  For now this should prevent us from getting into bad states at the cost of deletions being lower throughput.

