### PR TITLE
fix: use filozone project token secret

### DIFF
--- a/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -7,7 +7,7 @@
 # This action adds all issues and PRs with a "team/fs-wg" label to the FS project board.
 # It is used to keep the FS project board up to date with the issues and PRs.
 # It is triggered by the issue and PR events.
-# It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
+# It assumes a `FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE` secret is set in the repo.
 # This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
 name: Add issues and PRs to FS project board
 
@@ -32,5 +32,5 @@ jobs:
         continue-on-error: true # Don't fail if item already exists in project. actions/add-to-project does not currently handle this case gracefully.
         with:
           project-url: https://github.com/orgs/FilOzone/projects/14
-          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE }}
           labeled: team/fs-wg

--- a/.github/workflows/label-for-foc-wg.yml
+++ b/.github/workflows/label-for-foc-wg.yml
@@ -25,7 +25,7 @@ jobs:
           # A PAT is used instead of the default GITHUB_TOKEN because events triggered
           # by GITHUB_TOKEN do not cascade to trigger other workflows. Using a PAT allows
           # the label event emitted here to trigger add-issues-and-prs-to-fs-project-board.yml.
-          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE }}
           script: |
             const title = context.payload.issue?.title || context.payload.pull_request?.title || '';
             const body = context.payload.issue?.body || context.payload.pull_request?.body || '';


### PR DESCRIPTION
## Summary

- Update the PDP labeler workflow to read `FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE`.
- Update the FS project-board workflow token input and comment to use the same secret name.

## Why

The current workflows still reference `FILOZZY_CI_ADD_TO_PROJECT`. Recent labeler runs fail with `403 Resource not accessible by personal access token` while attempting to add `team/fs-wg`, which matches the old/incorrect secret being used after moving to the `FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE` PAT.

## Notes

PR #1332 targets `refactor/pdp-watcher`, so its `pull_request_target` workflows run from that base branch. To unblock that exact PR, this change also needs to be merged or cherry-picked into `refactor/pdp-watcher`.

## Validation

- `git diff --check -- .github/workflows/label-for-foc-wg.yml .github/workflows/add-issues-and-prs-to-fs-project-board.yml`