### PR TITLE
fix: restore eth message watcher and chain scheduler on PDP-only nodes

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -300,6 +300,7 @@ func StartTasks(ctx context.Context, dependencies *deps.Deps, shutdownChan chan 
 			if err := pdpnode.Attach(ctx, dependencies, &activeTasks, &httpSD, chainSched); err != nil {
 				return nil, err
 			}
+			senderEth = httpSD.EthSender
 		}
 
 		idxMax := taskhelp.Max(cfg.Subsystems.IndexingMaxTasks)


### PR DESCRIPTION
Fixes #1335

Since #1311 the PDP eth sender is created inside `pdpnode.Attach` and the local `senderEth` in `StartTasks` is never assigned, so PDP-only nodes (no window PoSt, no sealing) never register `MessageWatcherEth` and never start `chainSched.Run`. PDP transactions are broadcast but never observed confirming: dataset creations stay `pending` forever, `pdp_data_sets` rows are never inserted, clients time out and later fail with 404 "Data set not found". This is what has been failing the FilOzone/foc-devnet nightly frontier runs.

One-line fix: propagate the sender created by `Attach` back into `senderEth`, restoring the exact pre-#1311 gating behavior.

Verified on a local foc-devnet: with current main the create tx is confirmed on-chain while `message_waits_eth` stays `pending`; with this patch the full synapse upload and multi-copy retrieval flow passes and rows flip to `confirmed`.

Deliberately minimal — the structural issues listed in #1335 are left for a follow-up.
