### PR TITLE
fix(message): apply 1.1x gas overestimation to eth transactions

### DIFF
--- a/lib/filecoinpayment/utils.go
+++ b/lib/filecoinpayment/utils.go
@@ -26,6 +26,11 @@ import (
 
 var log = logging.Logger("filecoin-pay")
 
+// gasOverestimation is applied on top of the eth_estimateGas result when
+// sending settleRail transactions, since it has been observed to fall short
+// at execution time and burn the whole gas limit.
+const gasOverestimation = 1.1
+
 func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient, sender *message.SenderETH, from common.Address, payees []common.Address, operators []common.Address, al curioalerting.AlertingInterface, system, subsystem string) error {
 	paymentContractAddr, err := PaymentContractAddress()
 	if err != nil {
@@ -166,7 +171,7 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 	}
 
 	for txToSend, details := range transactionsToSend {
-		txHash, err := sender.Send(ctx, from, txToSend, "settleRail")
+		txHash, err := sender.SendWithGasOverestimate(ctx, from, txToSend, "settleRail", gasOverestimation)
 		if err != nil {
 			log.Errorw("failed to send settle transaction", "railIDs", details.rail, "settleUpTo", details.upTo, "error", err)
 			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{

--- a/tasks/message/sender_eth.go
+++ b/tasks/message/sender_eth.go
@@ -20,6 +20,8 @@ import (
 	"github.com/filecoin-project/curio/harmony/taskhelp"
 	"github.com/filecoin-project/curio/lib/ethchain"
 	"github.com/filecoin-project/curio/lib/promise"
+
+	"github.com/filecoin-project/lotus/build/buildconstants"
 )
 
 type SenderETH struct {
@@ -270,6 +272,16 @@ func NewSenderETH(client ethchain.EthClient, db *harmonydb.DB) (*SenderETH, *Sen
 
 // Send sends an Ethereum transaction, coordinating nonce assignment, signing, and broadcasting.
 func (s *SenderETH) Send(ctx context.Context, fromAddress common.Address, tx *types.Transaction, reason string) (common.Hash, error) {
+	return s.send(ctx, fromAddress, tx, reason, 1.0)
+}
+
+// SendWithGasOverestimate is like Send, but multiplies the estimated gas
+// limit by overestimate before submission (capped at the block gas limit).
+func (s *SenderETH) SendWithGasOverestimate(ctx context.Context, fromAddress common.Address, tx *types.Transaction, reason string, overestimate float64) (common.Hash, error) {
+	return s.send(ctx, fromAddress, tx, reason, overestimate)
+}
+
+func (s *SenderETH) send(ctx context.Context, fromAddress common.Address, tx *types.Transaction, reason string, overestimate float64) (common.Hash, error) {
 	// Ensure the transaction has zero nonce; it will be assigned during send task
 	if tx.Nonce() != 0 {
 		return common.Hash{}, xerrors.Errorf("Send expects transaction nonce to be 0, was %d", tx.Nonce())
@@ -293,6 +305,8 @@ func (s *SenderETH) Send(ctx context.Context, fromAddress common.Address, tx *ty
 		if gasLimit == 0 {
 			return common.Hash{}, fmt.Errorf("estimated gas limit is zero")
 		}
+
+		gasLimit = min(uint64(float64(gasLimit)*overestimate), uint64(buildconstants.BlockGasLimit))
 
 		// Fetch current base fee
 		header, err := s.client.HeaderByNumber(ctx, nil)


### PR DESCRIPTION
`SenderETH.Send` uses the raw `eth_estimateGas` result as the transaction gas limit with no safety margin. The native message path gets a 1.25x buffer via lotus `GasEstimateMessageGas` (mpool default `GasLimitOverestimation`), but the ETH path has none, so state drift between estimation and inclusion can push actual usage past the limit and the transaction fails with `SysErrOutOfGas`, burning the full gas limit.

Real example (calibnet, `settleRail` for rail 12757, same class of failures discussed in #897):

- tx `0x492ec195183b9bfa96ccc98be6a6351b339ec05f50efb479f743198bf5f14b7e` was sent with gas limit 58,253,517 (the bare estimate) and failed on chain with `SysErrOutOfGas` at epoch 3864708.
- Replaying the same message on the parent tipset via `Filecoin.StateCall` with a raised gas limit succeeds with `GasUsed = 60,869,671` — about 4.5% above the estimate.

The failed settlement only surfaces as a `Settlements_FilecoinPay` alert (all tasks report success) and the rail is retried 12h later, so each occurrence wastes the full gas limit and delays settlement.

This applies the same 1.25 factor to gas limits estimated in `SenderETH.Send`, matching the native path. All FEVM transactions (settle, PDP prove, etc.) go through this path and benefit.
