### PR TITLE
Revert #1333: use original FILOZZY_CI_ADD_TO_PROJECT secret name

### DIFF
--- a/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -7,7 +7,7 @@
 # This action adds all issues and PRs with a "team/fs-wg" label to the FS project board.
 # It is used to keep the FS project board up to date with the issues and PRs.
 # It is triggered by the issue and PR events.
-# It assumes a `FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE` secret is set in the repo.
+# It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
 # This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
 name: Add issues and PRs to FS project board
 
@@ -32,5 +32,5 @@ jobs:
         continue-on-error: true # Don't fail if item already exists in project. actions/add-to-project does not currently handle this case gracefully.
         with:
           project-url: https://github.com/orgs/FilOzone/projects/14
-          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE }}
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}
           labeled: team/fs-wg

--- a/.github/workflows/label-for-foc-wg.yml
+++ b/.github/workflows/label-for-foc-wg.yml
@@ -25,7 +25,7 @@ jobs:
           # A PAT is used instead of the default GITHUB_TOKEN because events triggered
           # by GITHUB_TOKEN do not cascade to trigger other workflows. Using a PAT allows
           # the label event emitted here to trigger add-issues-and-prs-to-fs-project-board.yml.
-          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE }}
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}
           script: |
             const title = context.payload.issue?.title || context.payload.pull_request?.title || '';
             const body = context.payload.issue?.body || context.payload.pull_request?.body || '';


### PR DESCRIPTION
Reverts the secret-name change from #1333 ("fix: use filozone project token secret").

## Why

#1333 renamed the Actions secret from `FILOZZY_CI_ADD_TO_PROJECT` to `FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE` in an attempt to fix the FS project-board / labeling automation. The rename wasn't the right fix.

The real problem was that `FILOZZY_CI_ADD_TO_PROJECT` was backed by a **fine-grained** PAT, which is scoped to a single org and so couldn't operate across `FilOzone` and `filecoin-project`. That secret has now been updated to use a **classic** PAT (scopes `repo` + `project`) on the FilOzzy bot account, which works across both orgs. So the original secret name works correctly; no rename was needed.

This restores the original `FILOZZY_CI_ADD_TO_PROJECT` secret name in both workflows so curio matches every other repo and uses the standard, now-working secret. The `filecoin-project` org secret `FILOZZY_CI_ADD_TO_PROJECT` is set and scoped to the relevant repos (public and selected private).

See FilOzone/github-mgmt#10 for the full write-up.

## Changes

- `.github/workflows/add-issues-and-prs-to-fs-project-board.yml`: `FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE` → `FILOZZY_CI_ADD_TO_PROJECT` (token ref + comment)
- `.github/workflows/label-for-foc-wg.yml`: `FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE` → `FILOZZY_CI_ADD_TO_PROJECT`

## Follow-up

The now-unused `FILOZZY_CI_ADD_TO_PROJECT_ALL_FILOZONE` org secret can be deleted once this merges.