### PR TITLE
fix(market): use MK20 DDO duration for deal schedule

### DIFF
--- a/market/mk20/mk20.go
+++ b/market/mk20/mk20.go
@@ -478,14 +478,14 @@ func (m *MK20) sanitizeDDODeal(ctx context.Context, deal *Deal) (*ProviderDealRe
 		if alloc.TermMin > deal.Products.DDOV1.Duration {
 			return &ProviderDealRejectionInfo{
 				HTTPCode: ErrBadProposal,
-				Reason:   "Allocation term min is less than deal duration",
+				Reason:   "Allocation term min is greater than deal duration",
 			}, nil
 		}
 
-		if alloc.TermMax > deal.Products.DDOV1.Duration {
+		if alloc.TermMax < deal.Products.DDOV1.Duration {
 			return &ProviderDealRejectionInfo{
 				HTTPCode: ErrBadProposal,
-				Reason:   "Allocation term max is greater than deal duration",
+				Reason:   "Allocation term max is less than deal duration",
 			}, nil
 		}
 

--- a/tasks/storage-market/mk20.go
+++ b/tasks/storage-market/mk20.go
@@ -1070,7 +1070,14 @@ func (d *CurioStorageDealMarket) processMK20DealIngestion(ctx context.Context) {
 				log.Errorw("allocation expired", "deal", deal.ID, "error", err)
 				continue
 			}
-			end = start + alloc.TermMin
+			if abi.ChainEpoch(deal.Duration) < alloc.TermMin || abi.ChainEpoch(deal.Duration) > alloc.TermMax {
+				log.Errorw("deal duration outside allocation bounds",
+					"deal", deal.ID,
+					"duration", deal.Duration,
+					"term_min", alloc.TermMin,
+					"term_max", alloc.TermMax)
+				continue
+			}
 			vak = &miner.VerifiedAllocationKey{
 				Client: abi.ActorID(allocClientID),
 				ID:     verifreg13.AllocationId(*mk20Deal.Products.DDOV1.AllocationId),


### PR DESCRIPTION
## Problem

MK20 DDO ingestion was not preserving the duration requested by the DDO.

The code computes the deal end epoch from the DDO duration, but then replaces it with `start + alloc.TermMin` when building the piece activation manifest for an allocation-backed DDO.

In practice this makes the sector deal schedule use the allocation minimum term instead of the DDO duration. For example, a DDO with a 5 year duration and an allocation with a 180 day `TermMin` is inserted as a 180 day deal schedule.

## Root Cause

The allocation `TermMin` was being used as the deal duration.

For MK20 DDO, the DDO duration should be the requested deal duration. The allocation terms should only be used to validate that the requested duration is allowed.

## Fix

Keep the DDO duration as the deal schedule duration.

When an allocation is present, validate that the requested duration is within the allocation bounds:

`TermMin <= duration <= TermMax`

This also fixes the MK20 DDO sanity check so invalid durations are rejected before ingestion instead of reaching this path.

## Testing

- `go test ./tasks/storage-market ./market/storageingest`
  - `github.com/filecoin-project/curio/tasks/storage-market` [no test files]
  - `github.com/filecoin-project/curio/market/storageingest` [no test files]