### PR TITLE
Fix: FWSS settlement target epoch selection

### DIFF
--- a/lib/filecoinpayment/error_detection.go
+++ b/lib/filecoinpayment/error_detection.go
@@ -5,29 +5,70 @@ import (
 	"strings"
 )
 
-// ErrSelectorRailInactiveOrSettled is the hex-encoded 4-byte selector for
-// FilecoinPayV1's RailInactiveOrSettled(uint256). Reverts carrying it prove
-// the rail has been finalised and zeroed.
-var ErrSelectorRailInactiveOrSettled string
+var (
+	// ErrSelectorRailInactiveOrSettled is the hex-encoded 4-byte selector for
+	// FilecoinPayV1's RailInactiveOrSettled(uint256). Reverts carrying it prove
+	// the rail has been finalised and zeroed.
+	ErrSelectorRailInactiveOrSettled string
+
+	skippableSettleRailErrorSelectors map[string]struct{}
+)
+
+// skippableSettleRailErrorNames is intentionally Pay-only and only for
+// settleRail simulation failures. Validator-specific errors belong in the
+// validator resolver; this list is for reverts where another pass can safely
+// retry or chain state already made this settlement attempt unnecessary.
+var skippableSettleRailErrorNames = []string{
+	"CannotSettleFutureEpochs",
+	"NoProgressInSettlement",
+	"RailInactiveOrSettled",
+}
 
 func init() {
 	parsed, err := PaymentsMetaData.GetAbi()
 	if err != nil {
 		panic("failed to parse FilecoinPay Payments ABI: " + err.Error())
 	}
-	e, ok := parsed.Errors["RailInactiveOrSettled"]
-	if !ok {
-		panic("FilecoinPay Payments ABI missing RailInactiveOrSettled error")
+
+	skippableSettleRailErrorSelectors = make(map[string]struct{}, len(skippableSettleRailErrorNames))
+	for _, name := range skippableSettleRailErrorNames {
+		e, ok := parsed.Errors[name]
+		if !ok {
+			panic("FilecoinPay Payments ABI missing " + name + " error")
+		}
+
+		selector := hex.EncodeToString(e.ID[:4])
+		skippableSettleRailErrorSelectors[selector] = struct{}{}
+		if name == "RailInactiveOrSettled" {
+			ErrSelectorRailInactiveOrSettled = selector
+		}
 	}
-	ErrSelectorRailInactiveOrSettled = hex.EncodeToString(e.ID[:4])
+}
+
+func isSkippableSettleRailError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	for selector := range skippableSettleRailErrorSelectors {
+		if errorContainsSelector(err, selector) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // IsRailInactiveOrSettledError reports whether err carries the
 // RailInactiveOrSettled revert, proving the rail has been zeroed during
 // finalisation. Distinguishes finalisation from transient RPC errors.
 func IsRailInactiveOrSettledError(err error) bool {
-	if err == nil {
+	return errorContainsSelector(err, ErrSelectorRailInactiveOrSettled)
+}
+
+func errorContainsSelector(err error, selector string) bool {
+	if err == nil || selector == "" {
 		return false
 	}
-	return strings.Contains(strings.ToLower(err.Error()), "0x"+ErrSelectorRailInactiveOrSettled)
+	return strings.Contains(strings.ToLower(err.Error()), "0x"+selector)
 }

--- a/lib/filecoinpayment/error_detection_test.go
+++ b/lib/filecoinpayment/error_detection_test.go
@@ -1,9 +1,68 @@
 package filecoinpayment
 
 import (
+	"encoding/hex"
 	"errors"
 	"testing"
 )
+
+func TestIsSkippableSettleRailError(t *testing.T) {
+	insufficientFundsSelector := paymentErrorSelectorForTest(t, "InsufficientFundsForSettlement")
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "RailInactiveOrSettled selector in wrapped estimate error",
+			err:      errors.New("failed to estimate gas: chain: message execution failed revert reason=[0x" + ErrSelectorRailInactiveOrSettled + "]"),
+			expected: true,
+		},
+		{
+			name:     "InsufficientFundsForSettlement is not skippable",
+			err:      errors.New("execution reverted: 0x" + insufficientFundsSelector),
+			expected: false,
+		},
+		{
+			name:     "contract revert with unrelated selector",
+			err:      errors.New("execution reverted: 0x96ed3e73"),
+			expected: false,
+		},
+		{
+			name:     "network error",
+			err:      errors.New("connection timeout"),
+			expected: false,
+		},
+	}
+
+	for _, name := range skippableSettleRailErrorNames {
+		selector := paymentErrorSelectorForTest(t, name)
+		tests = append(tests, struct {
+			name     string
+			err      error
+			expected bool
+		}{
+			name:     name + " selector",
+			err:      errors.New("execution reverted: 0x" + selector),
+			expected: true,
+		})
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isSkippableSettleRailError(tc.err)
+			if result != tc.expected {
+				t.Errorf("isSkippableSettleRailError(%v) = %v, want %v", tc.err, result, tc.expected)
+			}
+		})
+	}
+}
 
 func TestIsRailInactiveOrSettledError(t *testing.T) {
 	tests := []struct {
@@ -41,4 +100,20 @@ func TestIsRailInactiveOrSettledError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func paymentErrorSelectorForTest(t *testing.T, name string) string {
+	t.Helper()
+
+	parsed, err := PaymentsMetaData.GetAbi()
+	if err != nil {
+		t.Fatalf("failed to parse Payments ABI: %v", err)
+	}
+
+	e, ok := parsed.Errors[name]
+	if !ok {
+		t.Fatalf("Payments ABI missing %s error", name)
+	}
+
+	return hex.EncodeToString(e.ID[:4])
 }

--- a/lib/filecoinpayment/utils.go
+++ b/lib/filecoinpayment/utils.go
@@ -133,6 +133,10 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 	for _, detail := range toSettle {
 		settleUpTo, err := calculateSettleUpTo(ctx, pabi, &paymentContractAddr, ethClient, detail.railId, from, detail.settledUpTo, detail.target)
 		if err != nil {
+			if isSkippableSettleRailError(err) {
+				log.Debugw("skipping settlement after non-actionable Pay settleRail revert", "railID", detail.railId.String(), "target", detail.target.String(), "error", err)
+				continue
+			}
 			log.Errorf("failed to gas estimate settle transaction for rail %s: %s", detail.railId.String(), err.Error())
 			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
 				System:    system,
@@ -166,6 +170,10 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 	for txToSend, details := range transactionsToSend {
 		txHash, err := sender.SendWithGasOverestimate(ctx, from, txToSend, "settleRail", gasOverestimation)
 		if err != nil {
+			if isSkippableSettleRailError(err) {
+				log.Debugw("skipping settlement send after non-actionable Pay settleRail revert", "railID", details.rail, "settleUpTo", details.upTo, "error", err)
+				continue
+			}
 			log.Errorw("failed to send settle transaction", "railIDs", details.rail, "settleUpTo", details.upTo, "error", err)
 			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
 				System:    system,

--- a/lib/filecoinpayment/utils.go
+++ b/lib/filecoinpayment/utils.go
@@ -164,11 +164,11 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 	for _, detail := range toSettle {
 		settleUpTo, err := calculateSettleUpTo(ctx, pabi, &paymentContractAddr, ethClient, detail.railId, from, detail.settledUpTo, detail.target)
 		if err != nil {
-			log.Errorf("failed to gas estimate settle transaction: %s", err)
+			log.Errorf("failed to gas estimate settle transaction for rail %s: %s", detail.railId.String(), err.Error())
 			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
 				System:    system,
 				Subsystem: subsystem,
-				Message:   fmt.Sprintf("failed to gas estimate settle transaction: %s", err.Error()),
+				Message:   fmt.Sprintf("failed to gas estimate settle transaction for rail %s: %s", detail.railId.String(), err.Error()),
 			})
 			continue
 		}
@@ -201,7 +201,7 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
 				System:    system,
 				Subsystem: subsystem,
-				Message:   fmt.Sprintf("failed to send settle transaction: %s", err.Error()),
+				Message:   fmt.Sprintf("failed to send settle transaction for railID %d: %s", details.rail, err.Error()),
 			})
 			continue
 		}

--- a/lib/filecoinpayment/utils.go
+++ b/lib/filecoinpayment/utils.go
@@ -65,12 +65,7 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 		}
 
 		for _, r := range rails.Results {
-			if !r.IsTerminated {
-				railIds = append(railIds, r.RailId)
-			}
-
-			// If rail's settlement deadline (endEpoch) passed less than 7 days ago, keep trying to settle it
-			if uint64(r.EndEpoch.Int64()) > current-(builtin.EpochsInDay*7) {
+			if shouldInspectRailForSettlement(r) {
 				railIds = append(railIds, r.RailId)
 			}
 		}
@@ -97,33 +92,7 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 			continue
 		}
 
-		shouldSettle := false
-		if view.EndEpoch.Int64() > 0 {
-			if view.SettledUpTo.Cmp(view.EndEpoch) == -1 {
-				shouldSettle = true
-			}
-		} else {
-			// could be a constant, or a config variable this is the important tunable
-			settleInterval := big.NewInt(builtin.EpochsInDay * 7)
-
-			gracedLockup := new(big.Int).Sub(view.LockupPeriod, big.NewInt(builtin.EpochsInDay))
-			if gracedLockup.Sign() <= 0 {
-				// special case, lockup period is <= 1 day so settle every run
-				// alternatively adjust the grace down from a day to something smaller
-				shouldSettle = true
-			} else if gracedLockup.Cmp(settleInterval) < 0 {
-				settleInterval = gracedLockup
-			}
-
-			if !shouldSettle {
-				nextSettle := new(big.Int).Add(view.SettledUpTo, settleInterval)
-				if nextSettle.Uint64() < current {
-					shouldSettle = true
-				}
-			}
-		}
-
-		if !shouldSettle {
+		if !railNeedsSettlement(view, current) {
 			continue
 		}
 
@@ -240,6 +209,65 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 	}
 
 	return nil
+}
+
+func shouldInspectRailForSettlement(rail PaymentsRailInfo) bool {
+	if !rail.IsTerminated {
+		return true
+	}
+
+	// Terminated rails must stay visible until Filecoin Pay finalizes them.
+	// The final settlement to endEpoch is what collects any remaining rate payment
+	// from lockup and releases the rail's fixed lockup accounting.
+	return rail.EndEpoch != nil && rail.EndEpoch.Sign() > 0
+}
+
+func railNeedsSettlement(rail PaymentsRailView, current uint64) bool {
+	// settledUpTo is non-null on any valid Pay rail view; nil only protects
+	// against malformed test data or a failed/manual construction path.
+	if rail.SettledUpTo == nil {
+		return false
+	}
+
+	if rail.EndEpoch != nil && rail.EndEpoch.Sign() > 0 {
+		// Terminated rails should be retried until settlement reaches endEpoch.
+		// Filecoin Pay finalizes the rail only after this point, so using the
+		// active-rail interval here can leave payable lockup uncollected.
+		return rail.SettledUpTo.Cmp(rail.EndEpoch) < 0
+	}
+
+	return activeRailSettlementDue(rail, current)
+}
+
+func activeRailSettlementDue(rail PaymentsRailView, current uint64) bool {
+	if rail.LockupPeriod == nil || rail.SettledUpTo == nil {
+		return false
+	}
+
+	// Active rails are settled before the lockup period becomes the only
+	// remaining guarantee. This protects the SP from a client withdrawing funds
+	// after Filecoin Pay can no longer keep enough account lockup reserved.
+	settleInterval := big.NewInt(builtin.EpochsInDay * 7)
+
+	// Keep one day of lockup as a safety buffer. Once settlement is this close to
+	// the lockup horizon, every pass should try to settle so the SP does not rely
+	// on funds the client may soon be able to withdraw.
+	gracedLockup := new(big.Int).Sub(rail.LockupPeriod, big.NewInt(builtin.EpochsInDay))
+	if gracedLockup.Sign() <= 0 {
+		return true
+	}
+
+	// Do not wait longer than the usable lockup window. The regular interval is a
+	// batching optimization; the lockup period is the actual payment guarantee.
+	if gracedLockup.Cmp(settleInterval) < 0 {
+		settleInterval = gracedLockup
+	}
+
+	// settledUpTo is the last epoch Pay has accounted for on this rail. If the next
+	// planned settlement point is behind the chain head, this rail needs a new
+	// settle attempt.
+	nextSettle := new(big.Int).Add(rail.SettledUpTo, settleInterval)
+	return nextSettle.Cmp(new(big.Int).SetUint64(current)) < 0
 }
 
 // calculateSettleUpTo starts from the resolver-provided semantic target and

--- a/lib/filecoinpayment/utils.go
+++ b/lib/filecoinpayment/utils.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-state-types/builtin"
@@ -26,12 +25,17 @@ import (
 
 var log = logging.Logger("filecoin-pay")
 
+// SettleTargetResolver returns the highest epoch a rail should settle to.
+// ok=false means the rail is valid but should not be settled in this pass.
+// Implementation must ensure that PaymentsRailView is not mutated
+type SettleTargetResolver func(ctx context.Context, railID *big.Int, rail PaymentsRailView, currentEpoch *big.Int) (target *big.Int, ok bool, err error)
+
 // gasOverestimation is applied on top of the eth_estimateGas result when
 // sending settleRail transactions, since it has been observed to fall short
 // at execution time and burn the whole gas limit.
 const gasOverestimation = 1.1
 
-func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient, sender *message.SenderETH, from common.Address, payees []common.Address, operators []common.Address, al curioalerting.AlertingInterface, system, subsystem string) error {
+func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient, sender *message.SenderETH, from common.Address, payees []common.Address, resolvers map[common.Address]SettleTargetResolver, al curioalerting.AlertingInterface, system, subsystem string) error {
 	paymentContractAddr, err := PaymentContractAddress()
 	if err != nil {
 		return fmt.Errorf("failed to get payment contract address: %w", err)
@@ -76,27 +80,27 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 	type toSettleRail struct {
 		railId      *big.Int
 		settledUpTo *big.Int
+		target      *big.Int
 	}
 
 	var toSettle []toSettleRail
+	currentEpoch := new(big.Int).SetUint64(current)
 	for _, rail := range railIds {
+		railID := new(big.Int).Set(rail)
 		view, err := payment.GetRail(&bind.CallOpts{Context: ctx}, rail)
 		if err != nil {
 			return xerrors.Errorf("failed to get rail: %w", err)
 		}
 
-		// Let's only settle rail if it's our operator i.e., PDP related operator
-		if !lo.Contains(operators, view.Operator) {
+		resolver, ok := resolvers[view.Operator]
+		if !ok {
 			continue
 		}
 
-		// If rail is terminated but not settled yet, settle it
+		shouldSettle := false
 		if view.EndEpoch.Int64() > 0 {
 			if view.SettledUpTo.Cmp(view.EndEpoch) == -1 {
-				toSettle = append(toSettle, toSettleRail{
-					railId:      rail,
-					settledUpTo: view.SettledUpTo,
-				})
+				shouldSettle = true
 			}
 		} else {
 			// could be a constant, or a config variable this is the important tunable
@@ -106,22 +110,42 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 			if gracedLockup.Sign() <= 0 {
 				// special case, lockup period is <= 1 day so settle every run
 				// alternatively adjust the grace down from a day to something smaller
-				toSettle = append(toSettle, toSettleRail{
-					railId:      rail,
-					settledUpTo: view.SettledUpTo,
-				})
-				continue
+				shouldSettle = true
 			} else if gracedLockup.Cmp(settleInterval) < 0 {
 				settleInterval = gracedLockup
 			}
 
-			nextSettle := new(big.Int).Add(view.SettledUpTo, settleInterval)
-			if nextSettle.Uint64() < current {
-				toSettle = append(toSettle, toSettleRail{
-					settledUpTo: view.SettledUpTo,
-					railId:      rail})
+			if !shouldSettle {
+				nextSettle := new(big.Int).Add(view.SettledUpTo, settleInterval)
+				if nextSettle.Uint64() < current {
+					shouldSettle = true
+				}
 			}
 		}
+
+		if !shouldSettle {
+			continue
+		}
+
+		target, ok, err := resolver(ctx, railID, view, new(big.Int).Set(currentEpoch))
+		if err != nil {
+			log.Errorw("failed to resolve settle target", "railID", railID.String(), "operator", view.Operator, "error", err)
+			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
+				System:    system,
+				Subsystem: subsystem,
+				Message:   fmt.Sprintf("failed to resolve settle target for rail %s: %s", railID.String(), err.Error()),
+			})
+			continue
+		}
+		if !ok || target == nil || target.Cmp(view.SettledUpTo) <= 0 {
+			continue
+		}
+
+		toSettle = append(toSettle, toSettleRail{
+			railId:      railID,
+			settledUpTo: new(big.Int).Set(view.SettledUpTo),
+			target:      new(big.Int).Set(target),
+		})
 	}
 
 	log.Debugw("Total number of rails to be settled", "total", len(railIds), "rails", railIds)
@@ -138,7 +162,7 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 
 	transactionsToSend := make(map[*types.Transaction]settleRailTx)
 	for _, detail := range toSettle {
-		settleUpTo, err := calculateSettleUpTo(ctx, pabi, &paymentContractAddr, ethClient, detail.railId, from, detail.settledUpTo, big.NewInt(int64(current)))
+		settleUpTo, err := calculateSettleUpTo(ctx, pabi, &paymentContractAddr, ethClient, detail.railId, from, detail.settledUpTo, detail.target)
 		if err != nil {
 			log.Errorf("failed to gas estimate settle transaction: %s", err)
 			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
@@ -218,8 +242,10 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 	return nil
 }
 
-func calculateSettleUpTo(ctx context.Context, pabi *abi.ABI, paymentContractAddr *common.Address, ethClient ethchain.EthClient, id *big.Int, from common.Address, settledUpTo, currentEpoch *big.Int) (int64, error) {
-	next := currentEpoch
+// calculateSettleUpTo starts from the resolver-provided semantic target and
+// only lowers it when gas estimation shows the settlement would run out of gas.
+func calculateSettleUpTo(ctx context.Context, pabi *abi.ABI, paymentContractAddr *common.Address, ethClient ethchain.EthClient, id *big.Int, from common.Address, settledUpTo, targetEpoch *big.Int) (int64, error) {
+	next := new(big.Int).Set(targetEpoch)
 	for {
 		data, err := pabi.Pack("settleRail", id, next)
 		if err != nil {

--- a/lib/filecoinpayment/utils.go
+++ b/lib/filecoinpayment/utils.go
@@ -106,7 +106,10 @@ func SettleLockupPeriod(ctx context.Context, db *harmonydb.DB, ethClient ethchai
 			})
 			continue
 		}
-		if !ok || target == nil || target.Cmp(view.SettledUpTo) <= 0 {
+		if !ok || target == nil {
+			continue
+		}
+		if target.Cmp(view.SettledUpTo) <= 0 && !IsTerminatedRailFinalizationTarget(view, target) {
 			continue
 		}
 
@@ -238,13 +241,27 @@ func railNeedsSettlement(rail PaymentsRailView, current uint64) bool {
 	}
 
 	if rail.EndEpoch != nil && rail.EndEpoch.Sign() > 0 {
-		// Terminated rails should be retried until settlement reaches endEpoch.
-		// Filecoin Pay finalizes the rail only after this point, so using the
-		// active-rail interval here can leave payable lockup uncollected.
-		return rail.SettledUpTo.Cmp(rail.EndEpoch) < 0
+		// The equality case can still need one final settleRail call to zero the
+		// rail. Once finalized, getRail stops returning the rail.
+		return rail.SettledUpTo.Cmp(rail.EndEpoch) <= 0
 	}
 
 	return activeRailSettlementDue(rail, current)
+}
+
+// IsTerminatedRailFinalizationTarget reports whether settling to target can be
+// useful even without advancing settledUpTo. Filecoin Pay finalizes terminated
+// rails in a final settleRail call; until GetRail returns RailInactiveOrSettled,
+// a rail at settledUpTo == endEpoch may still need that call.
+func IsTerminatedRailFinalizationTarget(rail PaymentsRailView, target *big.Int) bool {
+	if rail.SettledUpTo == nil || rail.EndEpoch == nil || target == nil {
+		return false
+	}
+	if rail.EndEpoch.Sign() <= 0 {
+		return false
+	}
+
+	return rail.SettledUpTo.Cmp(rail.EndEpoch) == 0 && target.Cmp(rail.EndEpoch) == 0
 }
 
 func activeRailSettlementDue(rail PaymentsRailView, current uint64) bool {

--- a/lib/filecoinpayment/utils_test.go
+++ b/lib/filecoinpayment/utils_test.go
@@ -1,0 +1,99 @@
+package filecoinpayment
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/filecoin-project/go-state-types/builtin"
+)
+
+func TestShouldInspectRailForSettlement(t *testing.T) {
+	tests := []struct {
+		name string
+		rail PaymentsRailInfo
+		want bool
+	}{
+		{
+			name: "active rail",
+			rail: PaymentsRailInfo{RailId: big.NewInt(1)},
+			want: true,
+		},
+		{
+			name: "terminated rail with end epoch",
+			rail: PaymentsRailInfo{RailId: big.NewInt(1), IsTerminated: true, EndEpoch: big.NewInt(100)},
+			want: true,
+		},
+		{
+			name: "terminated rail without end epoch",
+			rail: PaymentsRailInfo{RailId: big.NewInt(1), IsTerminated: true, EndEpoch: big.NewInt(0)},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldInspectRailForSettlement(tt.rail); got != tt.want {
+				t.Fatalf("shouldInspectRailForSettlement = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRailNeedsSettlement(t *testing.T) {
+	current := uint64(1_000_000)
+
+	tests := []struct {
+		name string
+		rail PaymentsRailView
+		want bool
+	}{
+		{
+			name: "terminated rail retries until final settlement reaches end epoch",
+			rail: PaymentsRailView{
+				SettledUpTo: big.NewInt(100),
+				EndEpoch:    big.NewInt(200),
+			},
+			want: true,
+		},
+		{
+			name: "fully settled terminated rail does not need work",
+			rail: PaymentsRailView{
+				SettledUpTo: big.NewInt(200),
+				EndEpoch:    big.NewInt(200),
+			},
+			want: false,
+		},
+		{
+			name: "active rail due after settlement interval",
+			rail: PaymentsRailView{
+				SettledUpTo:  new(big.Int).SetUint64(current - uint64(builtin.EpochsInDay*8)),
+				LockupPeriod: big.NewInt(builtin.EpochsInDay * 30),
+			},
+			want: true,
+		},
+		{
+			name: "active rail not due before settlement interval",
+			rail: PaymentsRailView{
+				SettledUpTo:  new(big.Int).SetUint64(current - uint64(builtin.EpochsInDay)),
+				LockupPeriod: big.NewInt(builtin.EpochsInDay * 30),
+			},
+			want: false,
+		},
+		{
+			name: "short lockup period settles every pass",
+			rail: PaymentsRailView{
+				SettledUpTo:  big.NewInt(100),
+				LockupPeriod: big.NewInt(builtin.EpochsInDay),
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := railNeedsSettlement(tt.rail, current); got != tt.want {
+				t.Fatalf("railNeedsSettlement = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/lib/filecoinpayment/utils_test.go
+++ b/lib/filecoinpayment/utils_test.go
@@ -56,12 +56,12 @@ func TestRailNeedsSettlement(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "fully settled terminated rail does not need work",
+			name: "terminated rail at end epoch still needs finalization",
 			rail: PaymentsRailView{
 				SettledUpTo: big.NewInt(200),
 				EndEpoch:    big.NewInt(200),
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "active rail due after settlement interval",
@@ -93,6 +93,59 @@ func TestRailNeedsSettlement(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := railNeedsSettlement(tt.rail, current); got != tt.want {
 				t.Fatalf("railNeedsSettlement = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTerminatedRailFinalizationTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		rail   PaymentsRailView
+		target *big.Int
+		want   bool
+	}{
+		{
+			name: "terminated rail at end epoch",
+			rail: PaymentsRailView{
+				SettledUpTo: big.NewInt(200),
+				EndEpoch:    big.NewInt(200),
+			},
+			target: big.NewInt(200),
+			want:   true,
+		},
+		{
+			name: "terminated rail before end epoch",
+			rail: PaymentsRailView{
+				SettledUpTo: big.NewInt(100),
+				EndEpoch:    big.NewInt(200),
+			},
+			target: big.NewInt(200),
+			want:   false,
+		},
+		{
+			name: "active rail at target",
+			rail: PaymentsRailView{
+				SettledUpTo: big.NewInt(200),
+			},
+			target: big.NewInt(200),
+			want:   false,
+		},
+		{
+			name: "terminated rail with non-end target",
+			rail: PaymentsRailView{
+				SettledUpTo: big.NewInt(200),
+				EndEpoch:    big.NewInt(200),
+			},
+			target: big.NewInt(199),
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTerminatedRailFinalizationTarget(tt.rail, tt.target); got != tt.want {
+				t.Fatalf("IsTerminatedRailFinalizationTarget = %t, want %t", got, tt.want)
 			}
 		})
 	}

--- a/pdp/contract/FWSS/settle_resolver.go
+++ b/pdp/contract/FWSS/settle_resolver.go
@@ -88,7 +88,7 @@ func standardSettleTarget(rail filecoinpayment.PaymentsRailView, currentEpoch *b
 	if rail.EndEpoch != nil && rail.EndEpoch.Sign() > 0 && rail.EndEpoch.Cmp(target) < 0 {
 		target.Set(rail.EndEpoch)
 	}
-	if target.Cmp(rail.SettledUpTo) <= 0 {
+	if target.Cmp(rail.SettledUpTo) <= 0 && !filecoinpayment.IsTerminatedRailFinalizationTarget(rail, target) {
 		return nil, false
 	}
 
@@ -140,7 +140,7 @@ func pdpSettleTarget(rail filecoinpayment.PaymentsRailView, currentEpoch, activa
 		}
 	}
 
-	if target.Cmp(rail.SettledUpTo) <= 0 {
+	if target.Cmp(rail.SettledUpTo) <= 0 && !filecoinpayment.IsTerminatedRailFinalizationTarget(rail, target) {
 		return nil, false
 	}
 

--- a/pdp/contract/FWSS/settle_resolver.go
+++ b/pdp/contract/FWSS/settle_resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/curio/lib/ethchain"
@@ -12,9 +13,9 @@ import (
 )
 
 // SettleTargetResolver builds a Filecoin Pay settlement target resolver for
-// FWSS rails. It keeps FWSS-specific validator boundaries outside the common
-// payment package by resolving the rail's dataset and proving state through the
-// FWSS view contract.
+// FWSS rails. FWSS uses multiple rail types: PDP validator rails must respect
+// proving-period boundaries, while non-validator rails can use the normal
+// Filecoin Pay settlement target.
 func SettleTargetResolver(ctx context.Context, ethClient ethchain.EthClient) (filecoinpayment.SettleTargetResolver, error) {
 	serviceAddr := contract.ContractAddresses().AllowedPublicRecordKeepers.FWSService
 
@@ -38,8 +39,15 @@ func SettleTargetResolver(ctx context.Context, ethClient ethchain.EthClient) (fi
 	}
 
 	return func(ctx context.Context, railID *big.Int, rail filecoinpayment.PaymentsRailView, currentEpoch *big.Int) (*big.Int, bool, error) {
+		if rail.Validator == (common.Address{}) {
+			// CDN/cache rails use immediate one-time payments and no FWSS
+			// validator, but terminated rails still need settlement so
+			// Filecoin Pay can finalize and release fixed lockup accounting.
+			target, ok := standardSettleTarget(rail, currentEpoch)
+			return target, ok, nil
+		}
 		if rail.Validator != serviceAddr {
-			return nil, false, nil
+			return nil, false, xerrors.Errorf("FWSS rail %s uses unexpected validator %s", railID.String(), rail.Validator.Hex())
 		}
 
 		dataSet, err := fwssv.RailToDataSet(contract.EthCallOpts(ctx), new(big.Int).Set(railID))
@@ -50,21 +58,28 @@ func SettleTargetResolver(ctx context.Context, ethClient ethchain.EthClient) (fi
 			return nil, false, xerrors.Errorf("FWSS rail %s has no associated data set", railID.String())
 		}
 
+		dataSetInfo, err := fwssv.GetDataSet(contract.EthCallOpts(ctx), new(big.Int).Set(dataSet))
+		if err != nil {
+			return nil, false, xerrors.Errorf("failed to get FWSS data set %s for rail %s: %w", dataSet.String(), railID.String(), err)
+		}
+		if dataSetInfo.PdpRailId == nil || dataSetInfo.PdpRailId.Cmp(railID) != 0 {
+			return nil, false, xerrors.Errorf("FWSS validator rail %s is not the PDP rail for data set %s", railID.String(), dataSet.String())
+		}
+
 		activationEpoch, err := fwssv.ProvingActivationEpoch(contract.EthCallOpts(ctx), new(big.Int).Set(dataSet))
 		if err != nil {
 			return nil, false, xerrors.Errorf("failed to get FWSS proving activation epoch for data set %s: %w", dataSet.String(), err)
 		}
 
-		target, ok := settleTarget(rail, currentEpoch, activationEpoch, maxProvingPeriod)
+		target, ok := pdpSettleTarget(rail, currentEpoch, activationEpoch, maxProvingPeriod)
 		return target, ok, nil
 	}, nil
 }
 
-// settleTarget returns the largest epoch FWSS can safely ask Filecoin Pay
-// to settle. For activated datasets, FWSS validation only accepts epochs up to
-// the last proving-period deadline that is strictly before the current chain
-// epoch; open periods must be left unsettled because they can still be proven.
-func settleTarget(rail filecoinpayment.PaymentsRailView, currentEpoch, activationEpoch, maxProvingPeriod *big.Int) (*big.Int, bool) {
+// standardSettleTarget returns the normal Filecoin Pay target for FWSS rails
+// that are not validated by FWSS proving state. This is used for CDN/cache
+// rails where settlement is about Pay lockup/finalization, not PDP proofs.
+func standardSettleTarget(rail filecoinpayment.PaymentsRailView, currentEpoch *big.Int) (*big.Int, bool) {
 	if currentEpoch == nil || rail.SettledUpTo == nil {
 		return nil, false
 	}
@@ -72,6 +87,22 @@ func settleTarget(rail filecoinpayment.PaymentsRailView, currentEpoch, activatio
 	target := new(big.Int).Set(currentEpoch)
 	if rail.EndEpoch != nil && rail.EndEpoch.Sign() > 0 && rail.EndEpoch.Cmp(target) < 0 {
 		target.Set(rail.EndEpoch)
+	}
+	if target.Cmp(rail.SettledUpTo) <= 0 {
+		return nil, false
+	}
+
+	return target, true
+}
+
+// pdpSettleTarget returns the largest epoch FWSS can safely ask Filecoin Pay
+// to settle. For activated datasets, FWSS validation only accepts epochs up to
+// the last proving-period deadline that is strictly before the current chain
+// epoch; open periods must be left unsettled because they can still be proven.
+func pdpSettleTarget(rail filecoinpayment.PaymentsRailView, currentEpoch, activationEpoch, maxProvingPeriod *big.Int) (*big.Int, bool) {
+	target, ok := standardSettleTarget(rail, currentEpoch)
+	if !ok {
+		return nil, false
 	}
 
 	if activationEpoch != nil && activationEpoch.Sign() > 0 {
@@ -95,6 +126,12 @@ func settleTarget(rail filecoinpayment.PaymentsRailView, currentEpoch, activatio
 			target.Set(closedTarget)
 		}
 		if target.Cmp(activationEpoch) < 0 {
+			// A terminated PDP rail can have endEpoch before proving activation.
+			// FWSS cannot validate that range today, but skipping it would hide a
+			// rail that still needs final settlement/finalization from lockup.
+			if rail.EndEpoch != nil && rail.EndEpoch.Sign() > 0 {
+				return target, true
+			}
 			return nil, false
 		}
 	}

--- a/pdp/contract/FWSS/settle_resolver.go
+++ b/pdp/contract/FWSS/settle_resolver.go
@@ -1,0 +1,107 @@
+package FWSS
+
+import (
+	"context"
+	"math/big"
+
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/curio/lib/ethchain"
+	"github.com/filecoin-project/curio/lib/filecoinpayment"
+	"github.com/filecoin-project/curio/pdp/contract"
+)
+
+// SettleTargetResolver builds a Filecoin Pay settlement target resolver for
+// FWSS rails. It keeps FWSS-specific validator boundaries outside the common
+// payment package by resolving the rail's dataset and proving state through the
+// FWSS view contract.
+func SettleTargetResolver(ctx context.Context, ethClient ethchain.EthClient) (filecoinpayment.SettleTargetResolver, error) {
+	serviceAddr := contract.ContractAddresses().AllowedPublicRecordKeepers.FWSService
+
+	viewAddr, err := contract.ResolveViewAddress(ctx, serviceAddr, ethClient)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get FWSS view address: %w", err)
+	}
+
+	fwssv, err := NewFilecoinWarmStorageServiceStateView(viewAddr, ethClient)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create FWSS view: %w", err)
+	}
+
+	config, err := fwssv.GetPDPConfig(contract.EthCallOpts(ctx))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get FWSS PDP config: %w", err)
+	}
+	maxProvingPeriod := new(big.Int).SetUint64(config.MaxProvingPeriod)
+	if maxProvingPeriod.Sign() <= 0 {
+		return nil, xerrors.Errorf("FWSS max proving period is zero")
+	}
+
+	return func(ctx context.Context, railID *big.Int, rail filecoinpayment.PaymentsRailView, currentEpoch *big.Int) (*big.Int, bool, error) {
+		if rail.Validator != serviceAddr {
+			return nil, false, nil
+		}
+
+		dataSet, err := fwssv.RailToDataSet(contract.EthCallOpts(ctx), new(big.Int).Set(railID))
+		if err != nil {
+			return nil, false, xerrors.Errorf("failed to get FWSS data set for rail %s: %w", railID.String(), err)
+		}
+		if dataSet.Sign() == 0 {
+			return nil, false, xerrors.Errorf("FWSS rail %s has no associated data set", railID.String())
+		}
+
+		activationEpoch, err := fwssv.ProvingActivationEpoch(contract.EthCallOpts(ctx), new(big.Int).Set(dataSet))
+		if err != nil {
+			return nil, false, xerrors.Errorf("failed to get FWSS proving activation epoch for data set %s: %w", dataSet.String(), err)
+		}
+
+		target, ok := settleTarget(rail, currentEpoch, activationEpoch, maxProvingPeriod)
+		return target, ok, nil
+	}, nil
+}
+
+// settleTarget returns the largest epoch FWSS can safely ask Filecoin Pay
+// to settle. For activated datasets, FWSS validation only accepts epochs up to
+// the last proving-period deadline that is strictly before the current chain
+// epoch; open periods must be left unsettled because they can still be proven.
+func settleTarget(rail filecoinpayment.PaymentsRailView, currentEpoch, activationEpoch, maxProvingPeriod *big.Int) (*big.Int, bool) {
+	if currentEpoch == nil || rail.SettledUpTo == nil {
+		return nil, false
+	}
+
+	target := new(big.Int).Set(currentEpoch)
+	if rail.EndEpoch != nil && rail.EndEpoch.Sign() > 0 && rail.EndEpoch.Cmp(target) < 0 {
+		target.Set(rail.EndEpoch)
+	}
+
+	if activationEpoch != nil && activationEpoch.Sign() > 0 {
+		if maxProvingPeriod == nil || maxProvingPeriod.Sign() <= 0 {
+			return nil, false
+		}
+		if currentEpoch.Cmp(activationEpoch) < 0 {
+			return nil, false
+		}
+
+		closedTarget := new(big.Int).Set(activationEpoch)
+		if currentEpoch.Cmp(activationEpoch) > 0 {
+			delta := new(big.Int).Sub(new(big.Int).Set(currentEpoch), activationEpoch)
+			delta.Sub(delta, big.NewInt(1))
+			closedPeriods := new(big.Int).Div(delta, maxProvingPeriod)
+			closedOffset := new(big.Int).Mul(closedPeriods, maxProvingPeriod)
+			closedTarget.Add(closedTarget, closedOffset)
+		}
+
+		if target.Cmp(closedTarget) > 0 {
+			target.Set(closedTarget)
+		}
+		if target.Cmp(activationEpoch) < 0 {
+			return nil, false
+		}
+	}
+
+	if target.Cmp(rail.SettledUpTo) <= 0 {
+		return nil, false
+	}
+
+	return target, true
+}

--- a/pdp/contract/FWSS/settle_resolver.go
+++ b/pdp/contract/FWSS/settle_resolver.go
@@ -105,6 +105,10 @@ func pdpSettleTarget(rail filecoinpayment.PaymentsRailView, currentEpoch, activa
 		return nil, false
 	}
 
+	if shouldSkipFWSSActivationTerminationBoundary(rail, activationEpoch) {
+		return nil, false
+	}
+
 	if activationEpoch != nil && activationEpoch.Sign() > 0 {
 		if maxProvingPeriod == nil || maxProvingPeriod.Sign() <= 0 {
 			return nil, false
@@ -141,4 +145,24 @@ func pdpSettleTarget(rail filecoinpayment.PaymentsRailView, currentEpoch, activa
 	}
 
 	return target, true
+}
+
+// shouldSkipFWSSActivationTerminationBoundary is a temporary FWSS contract
+// workaround. When a terminated PDP rail ends exactly at proving activation,
+// FWSS accepts toEpoch == activationEpoch in its outer range check but then
+// treats the same epoch as an invalid proving period internally. Lower targets
+// are also invalid for that rail, so Curio has no settlement epoch to submit
+// until the contract edge case is fixed.
+func shouldSkipFWSSActivationTerminationBoundary(rail filecoinpayment.PaymentsRailView, activationEpoch *big.Int) bool {
+	if activationEpoch == nil || activationEpoch.Sign() <= 0 {
+		return false
+	}
+	if rail.SettledUpTo == nil || rail.EndEpoch == nil || rail.EndEpoch.Sign() <= 0 {
+		return false
+	}
+	if rail.EndEpoch.Cmp(activationEpoch) != 0 {
+		return false
+	}
+
+	return rail.SettledUpTo.Cmp(rail.EndEpoch) < 0
 }

--- a/pdp/contract/FWSS/settle_resolver_test.go
+++ b/pdp/contract/FWSS/settle_resolver_test.go
@@ -32,6 +32,14 @@ func TestFWSSStandardSettleTarget(t *testing.T) {
 			wantResolvable: true,
 		},
 		{
+			name:           "terminated rail at end epoch can finalize",
+			settledUpTo:    150,
+			endEpoch:       150,
+			currentEpoch:   200,
+			wantTarget:     150,
+			wantResolvable: true,
+		},
+		{
 			name:           "no progress skips settlement",
 			settledUpTo:    200,
 			currentEpoch:   200,
@@ -116,6 +124,16 @@ func TestFWSSPDPSettleTarget(t *testing.T) {
 			wantResolvable: true,
 		},
 		{
+			name:           "terminated rail at end epoch can finalize",
+			settledUpTo:    5000,
+			endEpoch:       5000,
+			currentEpoch:   7000,
+			activation:     1000,
+			provingPeriod:  2880,
+			wantTarget:     5000,
+			wantResolvable: true,
+		},
+		{
 			name:           "terminated rail before activation surfaces invalid contract range",
 			settledUpTo:    800,
 			endEpoch:       900,
@@ -123,6 +141,16 @@ func TestFWSSPDPSettleTarget(t *testing.T) {
 			activation:     1000,
 			provingPeriod:  2880,
 			wantTarget:     900,
+			wantResolvable: true,
+		},
+		{
+			name:           "terminated rail ending at activation can finalize after reaching end epoch",
+			settledUpTo:    1000,
+			endEpoch:       1000,
+			currentEpoch:   7000,
+			activation:     1000,
+			provingPeriod:  2880,
+			wantTarget:     1000,
 			wantResolvable: true,
 		},
 		{

--- a/pdp/contract/FWSS/settle_resolver_test.go
+++ b/pdp/contract/FWSS/settle_resolver_test.go
@@ -1,0 +1,142 @@
+package FWSS
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/filecoin-project/curio/lib/filecoinpayment"
+)
+
+func TestFWSSSettleTarget(t *testing.T) {
+	tests := []struct {
+		name           string
+		settledUpTo    int64
+		endEpoch       int64
+		currentEpoch   int64
+		activation     int64
+		provingPeriod  int64
+		wantTarget     int64
+		wantResolvable bool
+	}{
+		{
+			name:           "unactivated dataset can settle to current epoch",
+			settledUpTo:    100,
+			currentEpoch:   200,
+			provingPeriod:  2880,
+			wantTarget:     200,
+			wantResolvable: true,
+		},
+		{
+			name:           "deadline epoch itself is still open",
+			settledUpTo:    900,
+			currentEpoch:   3880,
+			activation:     1000,
+			provingPeriod:  2880,
+			wantTarget:     1000,
+			wantResolvable: true,
+		},
+		{
+			name:           "first period closes after deadline",
+			settledUpTo:    1000,
+			currentEpoch:   3881,
+			activation:     1000,
+			provingPeriod:  2880,
+			wantTarget:     3880,
+			wantResolvable: true,
+		},
+		{
+			name:           "multiple closed periods",
+			settledUpTo:    3880,
+			currentEpoch:   7000,
+			activation:     1000,
+			provingPeriod:  2880,
+			wantTarget:     6760,
+			wantResolvable: true,
+		},
+		{
+			name:           "terminated rail caps target to end epoch",
+			settledUpTo:    3880,
+			endEpoch:       5000,
+			currentEpoch:   7000,
+			activation:     1000,
+			provingPeriod:  2880,
+			wantTarget:     5000,
+			wantResolvable: true,
+		},
+		{
+			name:           "terminated rail before activation has no valid target",
+			settledUpTo:    800,
+			endEpoch:       900,
+			currentEpoch:   7000,
+			activation:     1000,
+			provingPeriod:  2880,
+			wantResolvable: false,
+		},
+		{
+			name:           "no progress skips settlement",
+			settledUpTo:    6760,
+			currentEpoch:   7000,
+			activation:     1000,
+			provingPeriod:  2880,
+			wantResolvable: false,
+		},
+		{
+			name:           "current before activation has no valid target",
+			settledUpTo:    900,
+			currentEpoch:   999,
+			activation:     1000,
+			provingPeriod:  2880,
+			wantResolvable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rail := filecoinpayment.PaymentsRailView{
+				SettledUpTo: big.NewInt(tt.settledUpTo),
+				EndEpoch:    big.NewInt(tt.endEpoch),
+			}
+			target, ok := settleTarget(rail, big.NewInt(tt.currentEpoch), big.NewInt(tt.activation), big.NewInt(tt.provingPeriod))
+			if ok != tt.wantResolvable {
+				t.Fatalf("resolvable = %t, want %t", ok, tt.wantResolvable)
+			}
+			if !ok {
+				return
+			}
+			if target.Int64() != tt.wantTarget {
+				t.Fatalf("target = %d, want %d", target.Int64(), tt.wantTarget)
+			}
+		})
+	}
+}
+
+func TestFWSSSettleTargetDoesNotMutateInputs(t *testing.T) {
+	settledUpTo := big.NewInt(3880)
+	endEpoch := big.NewInt(5000)
+	currentEpoch := big.NewInt(7000)
+	activation := big.NewInt(1000)
+	provingPeriod := big.NewInt(2880)
+
+	rail := filecoinpayment.PaymentsRailView{
+		SettledUpTo: settledUpTo,
+		EndEpoch:    endEpoch,
+	}
+	target, ok := settleTarget(rail, currentEpoch, activation, provingPeriod)
+	if !ok {
+		t.Fatal("expected target")
+	}
+	target.SetInt64(1)
+
+	assertBigInt(t, "settledUpTo", settledUpTo, 3880)
+	assertBigInt(t, "endEpoch", endEpoch, 5000)
+	assertBigInt(t, "currentEpoch", currentEpoch, 7000)
+	assertBigInt(t, "activation", activation, 1000)
+	assertBigInt(t, "provingPeriod", provingPeriod, 2880)
+}
+
+func assertBigInt(t *testing.T, name string, got *big.Int, want int64) {
+	t.Helper()
+	if got.Int64() != want {
+		t.Fatalf("%s = %d, want %d", name, got.Int64(), want)
+	}
+}

--- a/pdp/contract/FWSS/settle_resolver_test.go
+++ b/pdp/contract/FWSS/settle_resolver_test.go
@@ -126,6 +126,15 @@ func TestFWSSPDPSettleTarget(t *testing.T) {
 			wantResolvable: true,
 		},
 		{
+			name:           "terminated rail ending at activation is skipped for FWSS contract bug",
+			settledUpTo:    997,
+			endEpoch:       1000,
+			currentEpoch:   7000,
+			activation:     1000,
+			provingPeriod:  2880,
+			wantResolvable: false,
+		},
+		{
 			name:           "no progress skips settlement",
 			settledUpTo:    6760,
 			currentEpoch:   7000,

--- a/pdp/contract/FWSS/settle_resolver_test.go
+++ b/pdp/contract/FWSS/settle_resolver_test.go
@@ -7,7 +7,59 @@ import (
 	"github.com/filecoin-project/curio/lib/filecoinpayment"
 )
 
-func TestFWSSSettleTarget(t *testing.T) {
+func TestFWSSStandardSettleTarget(t *testing.T) {
+	tests := []struct {
+		name           string
+		settledUpTo    int64
+		endEpoch       int64
+		currentEpoch   int64
+		wantTarget     int64
+		wantResolvable bool
+	}{
+		{
+			name:           "settles to current epoch",
+			settledUpTo:    100,
+			currentEpoch:   200,
+			wantTarget:     200,
+			wantResolvable: true,
+		},
+		{
+			name:           "terminated rail caps target to end epoch",
+			settledUpTo:    100,
+			endEpoch:       150,
+			currentEpoch:   200,
+			wantTarget:     150,
+			wantResolvable: true,
+		},
+		{
+			name:           "no progress skips settlement",
+			settledUpTo:    200,
+			currentEpoch:   200,
+			wantResolvable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rail := filecoinpayment.PaymentsRailView{
+				SettledUpTo: big.NewInt(tt.settledUpTo),
+				EndEpoch:    big.NewInt(tt.endEpoch),
+			}
+			target, ok := standardSettleTarget(rail, big.NewInt(tt.currentEpoch))
+			if ok != tt.wantResolvable {
+				t.Fatalf("resolvable = %t, want %t", ok, tt.wantResolvable)
+			}
+			if !ok {
+				return
+			}
+			if target.Int64() != tt.wantTarget {
+				t.Fatalf("target = %d, want %d", target.Int64(), tt.wantTarget)
+			}
+		})
+	}
+}
+
+func TestFWSSPDPSettleTarget(t *testing.T) {
 	tests := []struct {
 		name           string
 		settledUpTo    int64
@@ -64,13 +116,14 @@ func TestFWSSSettleTarget(t *testing.T) {
 			wantResolvable: true,
 		},
 		{
-			name:           "terminated rail before activation has no valid target",
+			name:           "terminated rail before activation surfaces invalid contract range",
 			settledUpTo:    800,
 			endEpoch:       900,
 			currentEpoch:   7000,
 			activation:     1000,
 			provingPeriod:  2880,
-			wantResolvable: false,
+			wantTarget:     900,
+			wantResolvable: true,
 		},
 		{
 			name:           "no progress skips settlement",
@@ -96,7 +149,7 @@ func TestFWSSSettleTarget(t *testing.T) {
 				SettledUpTo: big.NewInt(tt.settledUpTo),
 				EndEpoch:    big.NewInt(tt.endEpoch),
 			}
-			target, ok := settleTarget(rail, big.NewInt(tt.currentEpoch), big.NewInt(tt.activation), big.NewInt(tt.provingPeriod))
+			target, ok := pdpSettleTarget(rail, big.NewInt(tt.currentEpoch), big.NewInt(tt.activation), big.NewInt(tt.provingPeriod))
 			if ok != tt.wantResolvable {
 				t.Fatalf("resolvable = %t, want %t", ok, tt.wantResolvable)
 			}
@@ -121,7 +174,7 @@ func TestFWSSSettleTargetDoesNotMutateInputs(t *testing.T) {
 		SettledUpTo: settledUpTo,
 		EndEpoch:    endEpoch,
 	}
-	target, ok := settleTarget(rail, currentEpoch, activation, provingPeriod)
+	target, ok := pdpSettleTarget(rail, currentEpoch, activation, provingPeriod)
 	if !ok {
 		t.Fatal("expected target")
 	}

--- a/tasks/pay/settle_task.go
+++ b/tasks/pay/settle_task.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/curio/lib/ethchain"
 	"github.com/filecoin-project/curio/lib/filecoinpayment"
 	"github.com/filecoin-project/curio/pdp/contract"
+	"github.com/filecoin-project/curio/pdp/contract/FWSS"
 	"github.com/filecoin-project/curio/tasks/message"
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
@@ -82,8 +83,14 @@ func (s *SettleTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done
 	payee := provider.Info.Payee
 
 	serviceAddr := contract.ContractAddresses().AllowedPublicRecordKeepers.FWSService
+	resolver, err := FWSS.SettleTargetResolver(ctx, s.ethClient)
+	if err != nil {
+		return false, fmt.Errorf("failed to create FWSS settle target resolver: %w", err)
+	}
 
-	err = filecoinpayment.SettleLockupPeriod(ctx, s.db, s.ethClient, s.sender, opAddr, []common.Address{payee}, []common.Address{serviceAddr}, s.al, alertType, alertName)
+	err = filecoinpayment.SettleLockupPeriod(ctx, s.db, s.ethClient, s.sender, opAddr, []common.Address{payee}, map[common.Address]filecoinpayment.SettleTargetResolver{
+		serviceAddr: resolver,
+	}, s.al, alertType, alertName)
 	if err != nil {
 		return false, fmt.Errorf("failed to settle lockup period: %w", err)
 	}


### PR DESCRIPTION
## Problem
FWSS settlement currently asks Filecoin Pay to settle up to the current chain epoch. That is not always a valid target for FWSS rails because the FWSS validator only accepts settlement through closed proving-period boundaries. When the target falls inside an open proving period or outside the validator’s accepted range, gas estimation can fail with InvalidEpochRange even though the rail still needs settlement.

## Summary:
• Add operator-keyed settlement target resolvers to Filecoin Pay settlement.
• Keep common payment settlement FWSS-agnostic while letting FWSS provide validator-specific settle bounds.
• Cap FWSS settlement targets to the last closed proving-period deadline before gas estimation.
• Add tests

## ~Blocker~
- [x] Fix InvalidEpochRange