### PR TITLE
Add Apprise alerting integration

### DIFF
--- a/alertmanager/plugin/apprise.go
+++ b/alertmanager/plugin/apprise.go
@@ -23,20 +23,6 @@ func NewApprise(cfg config.AppriseConfig) Plugin {
 	return &Apprise{cfg: cfg}
 }
 
-// appriseNotifyType maps a curio alert severity onto one of Apprise's notification types.
-func appriseNotifyType(severity string) string {
-	switch strings.ToLower(severity) {
-	case "critical", "error":
-		return "failure"
-	case "warning":
-		return "warning"
-	case "info":
-		return "info"
-	default:
-		return "warning"
-	}
-}
-
 // SendAlert posts to an Apprise API server (https://github.com/caronc/apprise-api), either its
 // stateless /notify endpoint (NotifyURLs required) or a stateful /notify/<key> endpoint (NotifyURLs
 // left empty).
@@ -53,7 +39,7 @@ func (p *Apprise) SendAlert(data *AlertPayload) error {
 	payload := map[string]any{
 		"title":  data.Summary,
 		"body":   strings.TrimSpace(body.String()),
-		"type":   appriseNotifyType(data.Severity),
+		"type":   "failure",
 		"format": "markdown",
 	}
 	if len(p.cfg.NotifyURLs) > 0 {
@@ -68,7 +54,7 @@ func (p *Apprise) SendAlert(data *AlertPayload) error {
 		return xerrors.Errorf("error marshaling JSON: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", p.cfg.APIURL, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest("POST", p.cfg.URL, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
@@ -92,7 +78,7 @@ func (p *Apprise) SendAlert(data *AlertPayload) error {
 			case http.StatusNoContent:
 				// 204 means the config key has no persisted URLs - a config error, not success.
 				time.Sleep(time.Duration(2*index) * duration) // Exponential backoff
-				return xerrors.Errorf("no Apprise configuration found for the given key (APIURL / config key is likely wrong)")
+				return xerrors.Errorf("no Apprise configuration found for the given key (URL / config key is likely wrong)")
 			default:
 				errBody, rerr := io.ReadAll(resp.Body)
 				if rerr != nil {

--- a/alertmanager/plugin/apprise.go
+++ b/alertmanager/plugin/apprise.go
@@ -1,0 +1,110 @@
+package plugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/curio/deps/config"
+)
+
+type Apprise struct {
+	cfg config.AppriseConfig
+}
+
+func NewApprise(cfg config.AppriseConfig) Plugin {
+	return &Apprise{cfg: cfg}
+}
+
+// appriseNotifyType maps a curio alert severity onto one of Apprise's notification types.
+func appriseNotifyType(severity string) string {
+	switch strings.ToLower(severity) {
+	case "critical", "error":
+		return "failure"
+	case "warning":
+		return "warning"
+	case "info":
+		return "info"
+	default:
+		return "warning"
+	}
+}
+
+// SendAlert posts to an Apprise API server (https://github.com/caronc/apprise-api), either its
+// stateless /notify endpoint (NotifyURLs required) or a stateful /notify/<key> endpoint (NotifyURLs
+// left empty).
+func (p *Apprise) SendAlert(data *AlertPayload) error {
+	if len(data.Details) == 0 {
+		return nil
+	}
+
+	var body strings.Builder
+	for key, value := range data.Details {
+		fmt.Fprintf(&body, "**%s**\n%v\n\n", key, value)
+	}
+
+	payload := map[string]any{
+		"title":  data.Summary,
+		"body":   strings.TrimSpace(body.String()),
+		"type":   appriseNotifyType(data.Severity),
+		"format": "markdown",
+	}
+	if len(p.cfg.NotifyURLs) > 0 {
+		payload["urls"] = strings.Join(p.cfg.NotifyURLs, ",")
+	}
+	if p.cfg.Tag != "" {
+		payload["tag"] = p.cfg.Tag
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return xerrors.Errorf("error marshaling JSON: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", p.cfg.APIURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		Timeout: time.Second * 15,
+	}
+	iter, _, err := lo.AttemptWithDelay(5, time.Second,
+		func(index int, duration time.Duration) error {
+			resp, err := client.Do(req)
+			if err != nil {
+				time.Sleep(time.Duration(2*index) * duration) // Exponential backoff
+				return err
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			switch resp.StatusCode {
+			case http.StatusOK:
+				return nil
+			case http.StatusNoContent:
+				// 204 means the config key has no persisted URLs - a config error, not success.
+				time.Sleep(time.Duration(2*index) * duration) // Exponential backoff
+				return xerrors.Errorf("no Apprise configuration found for the given key (APIURL / config key is likely wrong)")
+			default:
+				errBody, rerr := io.ReadAll(resp.Body)
+				if rerr != nil {
+					time.Sleep(time.Duration(2*index) * duration) // Exponential backoff
+					return rerr
+				}
+				time.Sleep(time.Duration(2*index) * duration) // Exponential backoff
+				return fmt.Errorf("unexpected HTTP response: %s: %s", resp.Status, string(errBody))
+			}
+		})
+	if err != nil {
+		return fmt.Errorf("after %d retries, last error: %w", iter, err)
+	}
+	return nil
+}

--- a/alertmanager/plugin/plugin.go
+++ b/alertmanager/plugin/plugin.go
@@ -35,6 +35,9 @@ func LoadAlertPlugins(cfg config.CurioAlertingConfig) []Plugin {
 	if cfg.SlackWebhook.Enable {
 		plugins = append(plugins, NewSlackWebhook(cfg.SlackWebhook))
 	}
+	if cfg.Apprise.Enable {
+		plugins = append(plugins, NewApprise(cfg.Apprise))
+	}
 	if len(TestPlugins) > 0 {
 		plugins = append(plugins, TestPlugins...)
 	}

--- a/alertmanager/plugin/plugin.go
+++ b/alertmanager/plugin/plugin.go
@@ -35,7 +35,7 @@ func LoadAlertPlugins(cfg config.CurioAlertingConfig) []Plugin {
 	if cfg.SlackWebhook.Enable {
 		plugins = append(plugins, NewSlackWebhook(cfg.SlackWebhook))
 	}
-	if cfg.Apprise.Enable {
+	if cfg.Apprise.URL != "" {
 		plugins = append(plugins, NewApprise(cfg.Apprise))
 	}
 	if len(TestPlugins) > 0 {

--- a/alertmanager/task_alert.go
+++ b/alertmanager/task_alert.go
@@ -299,11 +299,13 @@ func (a *AlertTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 				errs = append(errs, err)
 			}
 		}
-		if len(errs) != 0 {
-			return false, fmt.Errorf("errors sending alerts: %v", errs)
-		}
+
 		if err := a.markQueuedAlertsProcessed(ctx, now, queuedRefs.sentEventIDs, queuedRefs.sentConditions, true); err != nil {
 			return false, err
+		}
+
+		if len(errs) != 0 {
+			return false, fmt.Errorf("errors sending alerts: %v", errs)
 		}
 	} else if len(a.plugins) == 0 && len(details) > 0 {
 		log.Warnf("No alert plugins enabled, alerts recorded to DB but not sent externally")
@@ -414,12 +416,28 @@ func (a *AlertTask) markQueuedAlertsProcessed(ctx context.Context, now time.Time
 	return nil
 }
 
+const maxAlertDetailLength = 1000
+
+const alertDetailTruncatedSuffix = " ... (truncated, see alert_history for full list)"
+
 func addAlertDetail(details map[string]any, alertName string, alertMessage string) {
-	if existing, ok := details[alertName]; ok {
-		details[alertName] = fmt.Sprintf("%s. %s", existing, alertMessage)
+	existing, ok := details[alertName]
+	if !ok {
+		details[alertName] = alertMessage
 		return
 	}
-	details[alertName] = alertMessage
+
+	existingStr, _ := existing.(string)
+	if strings.HasSuffix(existingStr, alertDetailTruncatedSuffix) {
+		return
+	}
+
+	combined := fmt.Sprintf("%s. %s", existingStr, alertMessage)
+	if len(combined) > maxAlertDetailLength {
+		details[alertName] = existingStr + alertDetailTruncatedSuffix
+		return
+	}
+	details[alertName] = combined
 }
 
 func conditionAlertName(system, subsystem, condition string) string {

--- a/alertmanager/task_alert_test.go
+++ b/alertmanager/task_alert_test.go
@@ -1,6 +1,7 @@
 package alertmanager
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -141,6 +142,23 @@ func TestIsAlertMuted(t *testing.T) {
 			require.Equal(t, tt.want, isAlertMuted(tt.alertName, tt.message, tt.mutes))
 		})
 	}
+}
+
+func TestAddAlertDetail(t *testing.T) {
+	details := map[string]any{}
+
+	// A message that pushes the total past maxAlertDetailLength gets truncated
+	// instead of growing without bound.
+	addAlertDetail(details, "Test", "first message")
+	addAlertDetail(details, "Test", strings.Repeat("x", maxAlertDetailLength))
+	got := details["Test"].(string)
+	require.True(t, strings.HasSuffix(got, alertDetailTruncatedSuffix))
+	require.LessOrEqual(t, len(got), maxAlertDetailLength+len(alertDetailTruncatedSuffix))
+
+	// Once truncated, further additions in the same batch are dropped rather
+	// than repeatedly appending the truncation suffix.
+	addAlertDetail(details, "Test", "third message")
+	require.Equal(t, got, details["Test"])
 }
 
 // testPlugin is a test plugin

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -23,6 +23,35 @@ var Doc = map[string][]DocField{
 			Comment: `API auth secret for the Curio nodes to use. This value should only be set on the bade layer.`,
 		},
 	},
+	"AppriseConfig": {
+		{
+			Name: "Enable",
+			Type: "bool",
+
+			Comment: `Enable is a flag to enable or disable the Apprise integration.`,
+		},
+		{
+			Name: "APIURL",
+			Type: "string",
+
+			Comment: `APIURL is the notify endpoint of a running Apprise API server (https://github.com/caronc/apprise-api).
+Either its stateless endpoint (e.g. "http://127.0.0.1:8000/notify", use with NotifyURLs) or a
+stateful, pre-configured endpoint (e.g. "http://127.0.0.1:8000/notify/curio", leave NotifyURLs empty).`,
+		},
+		{
+			Name: "NotifyURLs",
+			Type: "[]string",
+
+			Comment: `NotifyURLs is a list of Apprise notification URLs (e.g. "tgram://bottoken/ChatID", "discord://webhook_id/webhook_token").
+Required when APIURL is a stateless /notify endpoint; leave empty for a stateful /notify/<config-key> endpoint.`,
+		},
+		{
+			Name: "Tag",
+			Type: "string",
+
+			Comment: `Tag restricts delivery to Apprise URLs carrying this tag. Only applies to stateful configs. OPTIONAL.`,
+		},
+	},
 	"BalanceManagerConfig": {
 		{
 			Name: "MK12Collateral",
@@ -177,6 +206,12 @@ Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "a
 			Type: "SlackWebhookConfig",
 
 			Comment: `SlackWebhookConfig is a configuration type for Slack webhook integration.`,
+		},
+		{
+			Name: "Apprise",
+			Type: "AppriseConfig",
+
+			Comment: `AppriseConfig is the configuration for the Apprise (https://github.com/caronc/apprise-api) integration.`,
 		},
 	},
 	"CurioBatchingConfig": {

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -25,25 +25,20 @@ var Doc = map[string][]DocField{
 	},
 	"AppriseConfig": {
 		{
-			Name: "Enable",
-			Type: "bool",
-
-			Comment: `Enable is a flag to enable or disable the Apprise integration.`,
-		},
-		{
-			Name: "APIURL",
+			Name: "URL",
 			Type: "string",
 
-			Comment: `APIURL is the notify endpoint of a running Apprise API server (https://github.com/caronc/apprise-api).
+			Comment: `URL is the notify endpoint of a running Apprise API server (https://github.com/caronc/apprise-api).
 Either its stateless endpoint (e.g. "http://127.0.0.1:8000/notify", use with NotifyURLs) or a
-stateful, pre-configured endpoint (e.g. "http://127.0.0.1:8000/notify/curio", leave NotifyURLs empty).`,
+stateful, pre-configured endpoint (e.g. "http://127.0.0.1:8000/notify/curio", leave NotifyURLs empty).
+Leave empty to disable the Apprise integration.`,
 		},
 		{
 			Name: "NotifyURLs",
 			Type: "[]string",
 
 			Comment: `NotifyURLs is a list of Apprise notification URLs (e.g. "tgram://bottoken/ChatID", "discord://webhook_id/webhook_token").
-Required when APIURL is a stateless /notify endpoint; leave empty for a stateful /notify/<config-key> endpoint.`,
+Required when URL is a stateless /notify endpoint; leave empty for a stateful /notify/<config-key> endpoint.`,
 		},
 		{
 			Name: "Tag",

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -756,16 +756,14 @@ type SlackWebhookConfig struct {
 }
 
 type AppriseConfig struct {
-	// Enable is a flag to enable or disable the Apprise integration.
-	Enable bool
-
-	// APIURL is the notify endpoint of a running Apprise API server (https://github.com/caronc/apprise-api).
+	// URL is the notify endpoint of a running Apprise API server (https://github.com/caronc/apprise-api).
 	// Either its stateless endpoint (e.g. "http://127.0.0.1:8000/notify", use with NotifyURLs) or a
 	// stateful, pre-configured endpoint (e.g. "http://127.0.0.1:8000/notify/curio", leave NotifyURLs empty).
-	APIURL string
+	// Leave empty to disable the Apprise integration.
+	URL string
 
 	// NotifyURLs is a list of Apprise notification URLs (e.g. "tgram://bottoken/ChatID", "discord://webhook_id/webhook_token").
-	// Required when APIURL is a stateless /notify endpoint; leave empty for a stateful /notify/<config-key> endpoint.
+	// Required when URL is a stateless /notify endpoint; leave empty for a stateful /notify/<config-key> endpoint.
 	NotifyURLs []string
 
 	// Tag restricts delivery to Apprise URLs carrying this tag. Only applies to stateful configs. OPTIONAL.

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -690,6 +690,9 @@ type CurioAlertingConfig struct {
 
 	// SlackWebhookConfig is a configuration type for Slack webhook integration.
 	SlackWebhook SlackWebhookConfig
+
+	// AppriseConfig is the configuration for the Apprise (https://github.com/caronc/apprise-api) integration.
+	Apprise AppriseConfig
 }
 
 type CurioSealConfig struct {
@@ -750,6 +753,23 @@ type SlackWebhookConfig struct {
 	// WebHookURL is the URL for the URL for slack Webhook.
 	// Example: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
 	WebHookURL string
+}
+
+type AppriseConfig struct {
+	// Enable is a flag to enable or disable the Apprise integration.
+	Enable bool
+
+	// APIURL is the notify endpoint of a running Apprise API server (https://github.com/caronc/apprise-api).
+	// Either its stateless endpoint (e.g. "http://127.0.0.1:8000/notify", use with NotifyURLs) or a
+	// stateful, pre-configured endpoint (e.g. "http://127.0.0.1:8000/notify/curio", leave NotifyURLs empty).
+	APIURL string
+
+	// NotifyURLs is a list of Apprise notification URLs (e.g. "tgram://bottoken/ChatID", "discord://webhook_id/webhook_token").
+	// Required when APIURL is a stateless /notify endpoint; leave empty for a stateful /notify/<config-key> endpoint.
+	NotifyURLs []string
+
+	// Tag restricts delivery to Apprise URLs carrying this tag. Only applies to stateful configs. OPTIONAL.
+	Tag string
 }
 
 type ApisConfig struct {

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -1079,6 +1079,28 @@ description: The default curio configuration
     # type: string
     #WebHookURL = ""
 
+  # AppriseConfig is the configuration for the Apprise (https://github.com/caronc/apprise-api) integration.
+  #
+  # type: AppriseConfig
+  [Alerting.Apprise]
+
+    # Enable is a flag to enable or disable the Apprise integration.
+    #
+    # type: bool
+    #Enable = false
+
+    # APIURL is the notify endpoint of a running Apprise API server (https://github.com/caronc/apprise-api).
+    # Either its stateless endpoint (e.g. "http://127.0.0.1:8000/notify", use with NotifyURLs) or a
+    # stateful, pre-configured endpoint (e.g. "http://127.0.0.1:8000/notify/curio", leave NotifyURLs empty).
+    #
+    # type: string
+    #APIURL = ""
+
+    # Tag restricts delivery to Apprise URLs carrying this tag. Only applies to stateful configs. OPTIONAL.
+    #
+    # type: string
+    #Tag = ""
+
 
 # Batching represents the batching configuration for pre-commit, commit, and update operations.
 #

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -1084,17 +1084,13 @@ description: The default curio configuration
   # type: AppriseConfig
   [Alerting.Apprise]
 
-    # Enable is a flag to enable or disable the Apprise integration.
-    #
-    # type: bool
-    #Enable = false
-
-    # APIURL is the notify endpoint of a running Apprise API server (https://github.com/caronc/apprise-api).
+    # URL is the notify endpoint of a running Apprise API server (https://github.com/caronc/apprise-api).
     # Either its stateless endpoint (e.g. "http://127.0.0.1:8000/notify", use with NotifyURLs) or a
     # stateful, pre-configured endpoint (e.g. "http://127.0.0.1:8000/notify/curio", leave NotifyURLs empty).
+    # Leave empty to disable the Apprise integration.
     #
     # type: string
-    #APIURL = ""
+    #URL = ""
 
     # Tag restricts delivery to Apprise URLs carrying this tag. Only applies to stateful configs. OPTIONAL.
     #


### PR DESCRIPTION
## Summary
- Adds a new `Apprise` alert plugin (`alertmanager/plugin/apprise.go`) alongside the existing Slack/PagerDuty/Prometheus AlertManager plugins, so a single curio config can fan alerts out to nearly any notification service (Telegram, Discord, Matrix, ntfy, email, SMS gateways, etc.) via a self-hosted [Apprise API](https://github.com/caronc/apprise-api) server.
- Supports both Apprise's stateless `/notify` endpoint (destination URLs listed in curio config via `NotifyURLs`) and its stateful `/notify/<key>` endpoint (destinations pre-configured on the Apprise server, curio just posts body/title/type).
- New config: `[Alerting.Apprise]` with `Enable`, `APIURL`, `NotifyURLs`, `Tag` — registered in `LoadAlertPlugins`.
- Regenerated `deps/config/doc_gen.go` and `documentation/en/configuration/default-curio-configuration.md` to include the new config section.

## Test plan
- [x] `go build ./alertmanager/... ./deps/config/...`
- [x] `gofmt -l` clean on touched files
- [x] Verified outgoing JSON payload (`title`/`body`/`type`/`format`/`urls`/`tag`, `Content-Type: application/json`) against the [apprise-api](https://github.com/caronc/apprise-api) API docs, including correcting a bug where HTTP 204 (no persisted config for the given key) was originally treated as a success instead of an error
- [x] End-to-end test against a running apprise-api instance with a real destination (Telegram/Discord) — in progress by reporter