### PR TITLE
chore: add alert cluster name

### DIFF
--- a/alertmanager/plugin/apprise.go
+++ b/alertmanager/plugin/apprise.go
@@ -37,7 +37,7 @@ func (p *Apprise) SendAlert(data *AlertPayload) error {
 	}
 
 	payload := map[string]any{
-		"title":  data.Summary,
+		"title":  "🚨 " + data.Summary + " [" + data.Source + "]",
 		"body":   strings.TrimSpace(body.String()),
 		"type":   "failure",
 		"format": "markdown",

--- a/alertmanager/plugin/prometheus_alertmanager.go
+++ b/alertmanager/plugin/prometheus_alertmanager.go
@@ -46,6 +46,7 @@ func (p *PrometheusAlertManager) SendAlert(data *AlertPayload) error {
 			StartsAt: data.Time,
 			Labels: map[string]string{
 				"alertName": k,
+				"cluster":   data.Source,
 				"severity":  data.Severity,
 				"instance":  data.Source,
 			},

--- a/alertmanager/plugin/slack_webhook.go
+++ b/alertmanager/plugin/slack_webhook.go
@@ -54,7 +54,7 @@ func (s *SlackWebhook) SendAlert(data *AlertPayload) error {
 				Type: "header",
 				Text: &TextBlock{
 					Type: "plain_text",
-					Text: "🚨 " + data.Summary,
+					Text: "🚨 " + data.Summary + " [" + data.Source + "]",
 				},
 			},
 			{

--- a/alertmanager/source.go
+++ b/alertmanager/source.go
@@ -1,0 +1,22 @@
+package alertmanager
+
+import (
+	"os"
+	"strings"
+)
+
+const unknownAlertSource = "unknown-host"
+
+// AlertSource returns the configured cluster identifier, falling back to the
+// hostname of the node executing the alert delivery.
+func AlertSource(clusterName string) string {
+	if name := strings.TrimSpace(clusterName); name != "" {
+		return name
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil || strings.TrimSpace(hostname) == "" {
+		return unknownAlertSource
+	}
+	return hostname
+}

--- a/alertmanager/task_alert.go
+++ b/alertmanager/task_alert.go
@@ -286,7 +286,7 @@ func (a *AlertTask) Do(taskID harmonytask.TaskID, stillOwned func() bool) (done 
 		payloadData := &plugin.AlertPayload{
 			Summary:  "Curio Alert",
 			Severity: "critical", // This can be critical, error, warning or info.
-			Source:   "Curio Cluster",
+			Source:   AlertSource(a.cfg.ClusterName),
 			Details:  details,
 			Time:     now,
 		}

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -177,6 +177,12 @@ including collateral and other operational resources.`,
 	},
 	"CurioAlertingConfig": {
 		{
+			Name: "ClusterName",
+			Type: "string",
+
+			Comment: `ClusterName identifies the Curio cluster in external alerts. When empty, the hostname of the node sending the alert is used.`,
+		},
+		{
 			Name: "MinimumWalletBalance",
 			Type: "types.FIL",
 

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -677,6 +677,9 @@ type CurioIngestConfig struct {
 }
 
 type CurioAlertingConfig struct {
+	// ClusterName identifies the Curio cluster in external alerts. When empty, the hostname of the node sending the alert is used.
+	ClusterName string
+
 	// MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
 	// alerts will be triggered for the wallet
 	// Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -1018,6 +1018,11 @@ description: The default curio configuration
 # type: CurioAlertingConfig
 [Alerting]
 
+  # ClusterName identifies the Curio cluster in external alerts. When empty, the hostname of the node sending the alert is used.
+  #
+  # type: string
+  #ClusterName = ""
+
   # MinimumWalletBalance is the minimum balance all active wallets. If the balance is below this value, an
   # alerts will be triggered for the wallet
   # Accepts a decimal string (e.g., "123.45" or "123 fil") with optional "fil" or "attofil" suffix. (Default: "5 FIL")

--- a/web/api/webrpc/alerts.go
+++ b/web/api/webrpc/alerts.go
@@ -135,7 +135,7 @@ func (a *WebRPC) AlertSendTest(ctx context.Context) error {
 		if err := p.SendAlert(&plugin.AlertPayload{
 			Summary:  "Curio Test Alert",
 			Severity: "info",
-			Source:   "Curio Web UI",
+			Source:   alertmanager.AlertSource(a.Deps.Cfg.Alerting.ClusterName),
 			Details:  map[string]any{"TestAlert": testMessage},
 			Time:     time.Now(),
 		}); err != nil {


### PR DESCRIPTION
Used to distinguish alarms from different clusters. Empty uses the hostname
<img width="665" height="270" alt="image" src="https://github.com/user-attachments/assets/da1312e1-a089-40dd-bf2c-0eddd73067c2" />
