### PR TITLE
Fix: faster Piece HEAD & GET 

### DIFF
--- a/lib/cachedreader/cachedreader.go
+++ b/lib/cachedreader/cachedreader.go
@@ -528,49 +528,53 @@ func (cpr *CachedPieceReader) GetSharedPieceReader(ctx context.Context, pieceCid
 		defer close(r.ready)
 
 		reader, size, err := cpr.getPieceReaderFromPDPPark(readerCtx, pieceCid)
-		if err != nil {
+		var finalErr error
+		switch {
+		case err == nil:
+			// PDP park hit
+		case errors.Is(err, errPDPParkNotFound):
 			log.Debugw("pdp park miss, trying aggregate", "piececid", pieceCid.String(), "err", err)
+			pdpMiss := err
 
 			reader, size, err = cpr.getPieceReaderFromAggregate(readerCtx, pieceCid, retrieval)
 			if err != nil {
 				log.Debugw("failed to get piece reader from aggregate", "piececid", pieceCid.String(), "err", err)
-
-				aerr := err
+				aggErr := err
 
 				reader, size, err = cpr.getPieceReaderFromMarketPieceDeal(readerCtx, pieceCid, retrieval)
 				if err != nil {
 					log.Debugw("failed to get piece reader", "piececid", pieceCid, "err", err)
-					finalErr := fmt.Errorf("failed to get piece reader from pdp park, aggregate, sector or piece park: %w, %w", aerr, err)
-
-					// Record error metric
-					_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
-						tag.Upsert(reasonKey, "piece_not_found"),
-					}, CachedReaderMeasures.ReaderErrors.M(1))
-
-					// Cache the error in the error cache
-					cpr.pieceErrorCacheMu.Lock()
-					cpr.pieceErrorCache.Set(pieceCid, &cachedError{err: finalErr, pieceCid: pieceCid})
-					// Record error cache size
-					_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
-						tag.Upsert(cacheTypeKey, "piece_error"),
-					}, CachedReaderMeasures.CacheSize.M(int64(cpr.pieceErrorCache.Count())))
-					cpr.pieceErrorCacheMu.Unlock()
-
-					// Remove the failed reader from the main cache
-					cpr.pieceReaderCacheMu.Lock()
-					cpr.pieceReaderCache.Remove(pieceCid)
-					// Record updated cache size
-					_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
-						tag.Upsert(cacheTypeKey, "piece_reader"),
-					}, CachedReaderMeasures.CacheSize.M(int64(cpr.pieceReaderCache.Count())))
-					cpr.pieceReaderCacheMu.Unlock()
-
-					r.err = finalErr
-					readerCtxCancel()
-
-					return nil, 0, finalErr
+					finalErr = fmt.Errorf("failed to get piece reader from pdp park, aggregate, sector or piece park: %w, %w, %w", pdpMiss, aggErr, err)
 				}
 			}
+		default:
+			log.Debugw("failed to get piece reader from pdp park", "piececid", pieceCid.String(), "err", err)
+			finalErr = fmt.Errorf("failed to get piece reader from pdp park: %w", err)
+		}
+
+		if finalErr != nil {
+			_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+				tag.Upsert(reasonKey, "piece_not_found"),
+			}, CachedReaderMeasures.ReaderErrors.M(1))
+
+			cpr.pieceErrorCacheMu.Lock()
+			cpr.pieceErrorCache.Set(pieceCid, &cachedError{err: finalErr, pieceCid: pieceCid})
+			_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+				tag.Upsert(cacheTypeKey, "piece_error"),
+			}, CachedReaderMeasures.CacheSize.M(int64(cpr.pieceErrorCache.Count())))
+			cpr.pieceErrorCacheMu.Unlock()
+
+			cpr.pieceReaderCacheMu.Lock()
+			cpr.pieceReaderCache.Remove(pieceCid)
+			_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+				tag.Upsert(cacheTypeKey, "piece_reader"),
+			}, CachedReaderMeasures.CacheSize.M(int64(cpr.pieceReaderCache.Count())))
+			cpr.pieceReaderCacheMu.Unlock()
+
+			r.err = finalErr
+			readerCtxCancel()
+
+			return nil, 0, finalErr
 		}
 
 		// Record successful reader creation

--- a/lib/cachedreader/cachedreader.go
+++ b/lib/cachedreader/cachedreader.go
@@ -521,9 +521,9 @@ func (cpr *CachedPieceReader) GetSharedPieceReader(ctx context.Context, pieceCid
 
 		cpr.pieceReaderCacheMu.Unlock()
 
-		// We just added a cached reader, so get its underlying piece reader.
-		// Order: PDP park (common parent / Synapse path) → aggregate (subpieces)
-		// → market deals / sector / park fallback.
+		// Cache miss: populate the slot by resolving a piece reader.
+		// Try PDP park first (Synapse/PDP parent pieces), then MK20
+		// aggregates (subpieces), then market deals (sector / piece park).
 		readerCtx, readerCtxCancel := context.WithCancel(context.Background())
 		defer close(r.ready)
 

--- a/lib/cachedreader/cachedreader.go
+++ b/lib/cachedreader/cachedreader.go
@@ -376,6 +376,71 @@ func (s SubPieceReader) ReadAt(p []byte, off int64) (n int, err error) {
 	return s.sr.ReadAt(p, off)
 }
 
+// errPDPParkNotFound means the piece is not a PDP park parent piece.
+// Callers should fall back to aggregate / market deal resolution.
+var errPDPParkNotFound = errors.New("piece not found in pdp piece park")
+
+// getPieceReaderFromPDPPark resolves parent pieces in one YSQL round-trip
+// (pdp_piecerefs ⋈ parked_piece_refs ⋈ parked_pieces). This is the common
+// Synapse / PDP retrieval path. Returns errPDPParkNotFound when absent so
+// callers can fall back to aggregate (subpieces) or market deals.
+func (cpr *CachedPieceReader) getPieceReaderFromPDPPark(ctx context.Context, piece cid.Cid) (storiface.Reader, uint64, error) {
+	pieceCidV1 := piece
+	var paddedSize abi.PaddedPieceSize
+
+	if commcidv2.IsPieceCidV2(piece) {
+		v1, rawSize, err := commcid.PieceCidV1FromV2(piece)
+		if err != nil {
+			return nil, 0, xerrors.Errorf("getting piece CID v1 from piece CID v2: %w", err)
+		}
+		pieceCidV1 = v1
+		paddedSize = padreader.PaddedSize(rawSize).Padded()
+	}
+
+	var pd []struct {
+		ID           int64  `db:"id"`
+		PieceCid     string `db:"piece_cid"`
+		PieceRawSize int64  `db:"piece_raw_size"`
+	}
+
+	// $2 = 0 means "any padded size" (PieceCID v1 without a size hint).
+	err := cpr.db.Select(ctx, &pd, `
+		SELECT
+		  pp.id,
+		  pp.piece_cid,
+		  pp.piece_raw_size
+		FROM pdp_piecerefs pr
+		JOIN parked_piece_refs pprf ON pprf.ref_id = pr.piece_ref
+		JOIN parked_pieces pp ON pp.id = pprf.piece_id
+		WHERE pr.piece_cid = $1
+		  AND ($2::bigint = 0 OR pp.piece_padded_size = $2)
+		  AND pp.complete = TRUE
+		  AND pp.long_term = TRUE
+		ORDER BY pp.piece_padded_size DESC, pp.id DESC
+		LIMIT 1`, pieceCidV1.String(), int64(paddedSize))
+	if err != nil {
+		return nil, 0, fmt.Errorf("querying pdp piece park for %s: %w", piece, err)
+	}
+	if len(pd) == 0 {
+		return nil, 0, errPDPParkNotFound
+	}
+
+	pcid, err := cid.Parse(pd[0].PieceCid)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to parse piece cid: %w", err)
+	}
+
+	reader, err := cpr.pieceParkReader.ReadPiece(ctx, storiface.PieceNumber(pd[0].ID), pd[0].PieceRawSize, pcid)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read piece from piece park: %w", err)
+	}
+	if reader == nil {
+		return nil, 0, fmt.Errorf("piece park reader returned nil for park id %d", pd[0].ID)
+	}
+
+	return reader, uint64(pd[0].PieceRawSize), nil
+}
+
 func (cpr *CachedPieceReader) getPieceReaderFromAggregate(ctx context.Context, pieceCidV2 cid.Cid, retrieval bool) (storiface.Reader, uint64, error) {
 	// Aggregate is a MK20 exclusive concept. The requesting pieceCID must be v2
 
@@ -456,50 +521,56 @@ func (cpr *CachedPieceReader) GetSharedPieceReader(ctx context.Context, pieceCid
 
 		cpr.pieceReaderCacheMu.Unlock()
 
-		// We just added a cached reader, so get its underlying piece reader
+		// We just added a cached reader, so get its underlying piece reader.
+		// Order: PDP park (common parent / Synapse path) → aggregate (subpieces)
+		// → market deals / sector / park fallback.
 		readerCtx, readerCtxCancel := context.WithCancel(context.Background())
 		defer close(r.ready)
 
-		reader, size, err := cpr.getPieceReaderFromAggregate(readerCtx, pieceCid, retrieval)
+		reader, size, err := cpr.getPieceReaderFromPDPPark(readerCtx, pieceCid)
 		if err != nil {
-			log.Debugw("failed to get piece reader from aggregate", "piececid", pieceCid.String(), "err", err)
+			log.Debugw("pdp park miss, trying aggregate", "piececid", pieceCid.String(), "err", err)
 
-			aerr := err
-
-			reader, size, err = cpr.getPieceReaderFromMarketPieceDeal(readerCtx, pieceCid, retrieval)
+			reader, size, err = cpr.getPieceReaderFromAggregate(readerCtx, pieceCid, retrieval)
 			if err != nil {
-				log.Debugw("failed to get piece reader", "piececid", pieceCid, "err", err)
-				finalErr := fmt.Errorf("failed to get piece reader from aggregate, sector or piece park: %w, %w", aerr, err)
+				log.Debugw("failed to get piece reader from aggregate", "piececid", pieceCid.String(), "err", err)
 
-				// Record error metric
-				_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
-					tag.Upsert(reasonKey, "piece_not_found"),
-				}, CachedReaderMeasures.ReaderErrors.M(1))
+				aerr := err
 
-				// Cache the error in the error cache
-				cpr.pieceErrorCacheMu.Lock()
-				cpr.pieceErrorCache.Set(pieceCid, &cachedError{err: finalErr, pieceCid: pieceCid})
-				// Record error cache size
-				_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
-					tag.Upsert(cacheTypeKey, "piece_error"),
-				}, CachedReaderMeasures.CacheSize.M(int64(cpr.pieceErrorCache.Count())))
-				cpr.pieceErrorCacheMu.Unlock()
+				reader, size, err = cpr.getPieceReaderFromMarketPieceDeal(readerCtx, pieceCid, retrieval)
+				if err != nil {
+					log.Debugw("failed to get piece reader", "piececid", pieceCid, "err", err)
+					finalErr := fmt.Errorf("failed to get piece reader from pdp park, aggregate, sector or piece park: %w, %w", aerr, err)
 
-				// Remove the failed reader from the main cache
-				cpr.pieceReaderCacheMu.Lock()
-				cpr.pieceReaderCache.Remove(pieceCid)
-				// Record updated cache size
-				_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
-					tag.Upsert(cacheTypeKey, "piece_reader"),
-				}, CachedReaderMeasures.CacheSize.M(int64(cpr.pieceReaderCache.Count())))
-				cpr.pieceReaderCacheMu.Unlock()
+					// Record error metric
+					_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+						tag.Upsert(reasonKey, "piece_not_found"),
+					}, CachedReaderMeasures.ReaderErrors.M(1))
 
-				r.err = finalErr
-				readerCtxCancel()
+					// Cache the error in the error cache
+					cpr.pieceErrorCacheMu.Lock()
+					cpr.pieceErrorCache.Set(pieceCid, &cachedError{err: finalErr, pieceCid: pieceCid})
+					// Record error cache size
+					_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+						tag.Upsert(cacheTypeKey, "piece_error"),
+					}, CachedReaderMeasures.CacheSize.M(int64(cpr.pieceErrorCache.Count())))
+					cpr.pieceErrorCacheMu.Unlock()
 
-				return nil, 0, finalErr
+					// Remove the failed reader from the main cache
+					cpr.pieceReaderCacheMu.Lock()
+					cpr.pieceReaderCache.Remove(pieceCid)
+					// Record updated cache size
+					_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+						tag.Upsert(cacheTypeKey, "piece_reader"),
+					}, CachedReaderMeasures.CacheSize.M(int64(cpr.pieceReaderCache.Count())))
+					cpr.pieceReaderCacheMu.Unlock()
+
+					r.err = finalErr
+					readerCtxCancel()
+
+					return nil, 0, finalErr
+				}
 			}
-
 		}
 
 		// Record successful reader creation

--- a/lib/paths/local.go
+++ b/lib/paths/local.go
@@ -112,7 +112,9 @@ type path struct {
 	Reserved     int64
 	Reservations map[string]int64
 
-	CanSeal bool
+	CanSeal    bool
+	AllowTypes []string
+	DenyTypes  []string
 
 	lastSinfoTime time.Time
 	lastSinfo     *storiface.StorageInfo
@@ -244,6 +246,31 @@ func (p *path) sectorPath(sid abi.SectorID, fileType storiface.SectorFileType) s
 	return filepath.Join(p.Local, fileType.String(), storiface.SectorName(sid))
 }
 
+// ExistingLocalFile returns a local filesystem path for sid/ft if the file
+// exists under any registered local storage path that allows ft. It does not
+// consult the sector index (no DB round-trip). Callers should fall back to
+// AcquireSector / StorageFindSector when this returns false.
+//
+// When multiple local roots are registered, Stats run sequentially on each path.
+// The random order should tend toward less disk activity then purely-parallel searching.
+func (st *Local) ExistingLocalFile(sid abi.SectorID, ft storiface.SectorFileType) (string, bool) {
+	candidates := make([]string, 0, len(st.paths))
+	st.localLk.RLock()
+	for _, p := range st.paths {
+		if p.Local == "" || !ft.Allowed(p.AllowTypes, p.DenyTypes) {
+			continue
+		}
+		candidates = append(candidates, p.sectorPath(sid, ft))
+	}
+	st.localLk.RUnlock()
+	for _, spath := range candidates {
+		if fi, err := os.Stat(spath); err == nil && !fi.IsDir() {
+			return spath, true
+		}
+	}
+	return "", false
+}
+
 type URLs []string
 
 func UrlsFromString(in string) URLs {
@@ -321,6 +348,8 @@ func (st *Local) openPath(ctx context.Context, p string, declare bool) (storifac
 		Reserved:     0,
 		Reservations: map[string]int64{},
 		CanSeal:      meta.CanSeal,
+		AllowTypes:   meta.AllowTypes,
+		DenyTypes:    meta.DenyTypes,
 	}
 
 	// Remove all stashes on startup

--- a/lib/paths/local.go
+++ b/lib/paths/local.go
@@ -261,9 +261,13 @@ func (st *Local) ExistingLocalFile(sid abi.SectorID, ft storiface.SectorFileType
 			continue
 		}
 		candidates = append(candidates, p.sectorPath(sid, ft))
+		if len(candidates) >= 5 {
+			return "", false // this is no fast path, return false
+		}
 	}
 	st.localLk.RUnlock()
 	for _, spath := range candidates {
+		// Worst= O(Log(dirLength)) which should be very fast for most cases.
 		if fi, err := os.Stat(spath); err == nil && !fi.IsDir() {
 			return spath, true
 		}

--- a/lib/paths/local.go
+++ b/lib/paths/local.go
@@ -252,7 +252,7 @@ func (p *path) sectorPath(sid abi.SectorID, fileType storiface.SectorFileType) s
 // AcquireSector / StorageFindSector when this returns false.
 //
 // When multiple local roots are registered, Stats run sequentially on each path.
-// The random order should tend toward less disk activity then purely-parallel searching.
+// The random order should tend toward less disk activity than purely-parallel searching.
 func (st *Local) ExistingLocalFile(sid abi.SectorID, ft storiface.SectorFileType) (string, bool) {
 	candidates := make([]string, 0, len(st.paths))
 	st.localLk.RLock()

--- a/lib/paths/local_test.go
+++ b/lib/paths/local_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-state-types/abi"
+
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/lib/storiface"
 
@@ -97,4 +99,36 @@ func TestLocalStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	// TODO: put more things here
+}
+
+func TestExistingLocalFile(t *testing.T) {
+	root := t.TempDir()
+	sid := abi.SectorID{Miner: 0, Number: 42}
+
+	pieceDir := filepath.Join(root, storiface.FTPiece.String())
+	require.NoError(t, os.MkdirAll(pieceDir, 0755))
+	fpath := filepath.Join(pieceDir, storiface.SectorName(sid))
+	require.NoError(t, os.WriteFile(fpath, []byte("piece-bytes"), 0644))
+
+	emptyRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(emptyRoot, storiface.FTPiece.String()), 0755))
+
+	st := &Local{
+		paths: map[storiface.ID]*path{
+			"local-1": {Local: root},
+			"local-2": {Local: emptyRoot},
+		},
+	}
+
+	got, ok := st.ExistingLocalFile(sid, storiface.FTPiece)
+	require.True(t, ok)
+	require.Equal(t, fpath, got)
+
+	_, ok = st.ExistingLocalFile(abi.SectorID{Miner: 0, Number: 99}, storiface.FTPiece)
+	require.False(t, ok)
+
+	// Path that denies FTPiece should be skipped even if the file exists.
+	st.paths["local-1"].DenyTypes = []string{storiface.FTPiece.String()}
+	_, ok = st.ExistingLocalFile(sid, storiface.FTPiece)
+	require.False(t, ok)
 }

--- a/lib/paths/remote.go
+++ b/lib/paths/remote.go
@@ -802,6 +802,14 @@ func (r *Remote) Reader(ctx context.Context, s storiface.SectorRef, offset, size
 //
 //	Hopefully when PartialFile is removed, this method will be used instead of Reader.
 func (r *Remote) ReaderPiece(ctx context.Context, s storiface.SectorRef, ft storiface.SectorFileType, offset, size int64) (func(startOffset, endOffset int64) (io.ReadCloser, error), error) {
+	// Fast path: probe local disks before any sector-index DB lookup.
+	if path, ok := r.existingLocalFile(s.ID, ft); ok {
+		log.Debugw("returning piece reader from local disk probe", "sector", s.ID, "path", path, "offset", offset, "size", size)
+		return localPieceFileGetter(path, offset), nil
+	}
+
+	ctx = context.WithValue(ctx, FindSectorCacheKey, r.findSectorCache)
+
 	// check if we have the unsealed sector file locally
 	paths, _, err := r.local.AcquireSector(ctx, s, ft, storiface.FTNone, storiface.PathStorage, storiface.AcquireMove)
 	if err != nil {
@@ -812,82 +820,7 @@ func (r *Remote) ReaderPiece(ctx context.Context, s storiface.SectorRef, ft stor
 
 	if path != "" {
 		log.Debugw("returning piece reader for local unsealed piece sector=%+v, (offset=%d, size=%d)", s.ID, offset, size)
-
-		// refs keep track of the currently opened pf
-		// if they drop to 0 for longer than LocalReaderTimeout, pf will be closed
-		var refsLk sync.Mutex
-		refs := 0
-
-		var f *os.File
-
-		cleanupIdle := func() {
-			lastRefs := 1
-
-			ticker := time.NewTicker(LocalReaderTimeout)
-			defer ticker.Stop()
-
-			for range ticker.C {
-				refsLk.Lock()
-				if refs == 0 && lastRefs == 0 && f != nil {
-					log.Debugw("closing idle partial file", "path", path)
-					err := f.Close()
-					if err != nil {
-						log.Errorw("closing idle partial file", "path", path, "error", err)
-					}
-
-					f = nil
-					refsLk.Unlock()
-					return
-				}
-				lastRefs = refs
-				refsLk.Unlock()
-			}
-		}
-
-		getFile := func() (*os.File, func() error, error) {
-			refsLk.Lock()
-			defer refsLk.Unlock()
-
-			if f == nil {
-				// got closed in the meantime, reopen
-
-				var err error
-				f, err = os.Open(path)
-				if err != nil {
-					return nil, nil, xerrors.Errorf("reopening file: %w", err)
-				}
-				log.Debugf("local file reopened %s (+%d,%d)", path, offset, size)
-
-				go cleanupIdle()
-			}
-
-			refs++
-
-			return f, func() error {
-				refsLk.Lock()
-				defer refsLk.Unlock()
-
-				refs--
-				return nil
-			}, nil
-		}
-
-		return func(startOffset, endOffset int64) (io.ReadCloser, error) {
-			f, done, err := getFile()
-			if err != nil {
-				return nil, xerrors.Errorf("getting partialfile handle: %w", err)
-			}
-
-			r := io.NewSectionReader(f, offset+startOffset, endOffset-startOffset)
-
-			return struct {
-				io.Reader
-				io.Closer
-			}{
-				Reader: r,
-				Closer: funcCloser(done),
-			}, nil
-		}, nil
+		return localPieceFileGetter(path, offset), nil
 	}
 
 	// --- We don't have the piece file locally
@@ -930,6 +863,89 @@ func (r *Remote) ReaderPiece(ctx context.Context, s storiface.SectorRef, ft stor
 	// we couldn't find a unsealed file with the unsealed piece, will return a nil reader.
 	log.Debugf("returning nil reader, did not find unsealed piece for %+v (+%d,%d), last error=%s", s, offset, size, lastErr)
 	return nil, nil
+}
+
+func (r *Remote) existingLocalFile(sid abi.SectorID, ft storiface.SectorFileType) (string, bool) {
+	local, ok := r.local.(*Local)
+	if !ok {
+		return "", false
+	}
+	return local.ExistingLocalFile(sid, ft)
+}
+
+func localPieceFileGetter(path string, offset int64) func(startOffset, endOffset int64) (io.ReadCloser, error) {
+	var refsLk sync.Mutex
+	refs := 0
+	var f *os.File
+
+	cleanupIdle := func() {
+		lastRefs := 1
+
+		ticker := time.NewTicker(LocalReaderTimeout)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			refsLk.Lock()
+			if refs == 0 && lastRefs == 0 && f != nil {
+				log.Debugw("closing idle partial file", "path", path)
+				err := f.Close()
+				if err != nil {
+					log.Errorw("closing idle partial file", "path", path, "error", err)
+				}
+
+				f = nil
+				refsLk.Unlock()
+				return
+			}
+			lastRefs = refs
+			refsLk.Unlock()
+		}
+	}
+
+	getFile := func() (*os.File, func() error, error) {
+		refsLk.Lock()
+		defer refsLk.Unlock()
+
+		if f == nil {
+			// got closed in the meantime, reopen
+
+			var err error
+			f, err = os.Open(path)
+			if err != nil {
+				return nil, nil, xerrors.Errorf("reopening file: %w", err)
+			}
+			log.Debugf("local file reopened %s (+%d)", path, offset)
+
+			go cleanupIdle()
+		}
+
+		refs++
+
+		return f, func() error {
+			refsLk.Lock()
+			defer refsLk.Unlock()
+
+			refs--
+			return nil
+		}, nil
+	}
+
+	return func(startOffset, endOffset int64) (io.ReadCloser, error) {
+		f, done, err := getFile()
+		if err != nil {
+			return nil, xerrors.Errorf("getting partialfile handle: %w", err)
+		}
+
+		sr := io.NewSectionReader(f, offset+startOffset, endOffset-startOffset)
+
+		return struct {
+			io.Reader
+			io.Closer
+		}{
+			Reader: sr,
+			Closer: funcCloser(done),
+		}, nil
+	}
 }
 
 // ReaderSeq creates a simple sequential reader for a file. Does not work for

--- a/lib/pieceprovider/cached_piecereader.go
+++ b/lib/pieceprovider/cached_piecereader.go
@@ -265,7 +265,10 @@ func (p *pieceReader) ReadAt(b []byte, off int64) (n int, err error) {
 		}
 		_ = stats.RecordWithTags(p.atMCtx, []tag.Mutator{tag.Insert(metrics.PRReadSize, sizeTag)}, metrics.DagStorePRAtReadBytes.M(int64(bn)), metrics.DagStorePRAtReadCount.M(1))
 	} else {
-		// Streaming-sized ReadAt: modest read-ahead into remReads.
+		// Read-ahead into remReads; never allocate more than MinRandomReadSize (1MiB).
+		if fetchSize > MinRandomReadSize {
+			fetchSize = MinRandomReadSize
+		}
 		readBuf := make([]byte, fetchSize)
 		bn, err := p.readInto(readBuf, readOff)
 		if err != nil && err != io.EOF {
@@ -293,14 +296,14 @@ func (p *pieceReader) ReadAt(b []byte, off int64) (n int, err error) {
 }
 
 // storageReadSize chooses how many bytes to fetch for a ReadAt of the given size.
-// MIME-sniff peeks stay exact; mid-size streaming reads may read-ahead up to ReadBuf
-// (not a flat 1MiB) so HEAD/content-type checks do not over-fetch.
+// MIME-sniff peeks stay exact; mid-size streaming may read-ahead up to ReadBuf.
+// The read-ahead path never returns more than MinRandomReadSize (1MiB).
 func storageReadSize(requested int64) int64 {
 	if requested <= ExactReadAtMax {
 		return requested
 	}
 	if requested >= MinRandomReadSize {
-		return requested
+		return requested // exact into caller buffer (no extra alloc)
 	}
 	ahead := int64(ReadBuf)
 	if ahead < requested {

--- a/lib/pieceprovider/cached_piecereader.go
+++ b/lib/pieceprovider/cached_piecereader.go
@@ -32,6 +32,7 @@ var MinRandomReadSize = int64(1 << 20)
 
 // ExactReadAtMax is the largest ReadAt satisfied without read-ahead.
 // Matches net/http MIME sniff length so HEAD/content-type peeks do not pull MinRandomReadSize.
+// market/retrieval.MIME_SNIFF_BYTES aliases this constant.
 const ExactReadAtMax int64 = 512
 
 type pieceGetter func(offset, size uint64) (io.ReadCloser, error)

--- a/lib/pieceprovider/cached_piecereader.go
+++ b/lib/pieceprovider/cached_piecereader.go
@@ -26,7 +26,13 @@ var _ storiface.Reader = &pieceReader{}
 var MaxPieceReaderBurnBytes int64 = 1 << 20 // 1M
 var ReadBuf = 128 * (127 * 8)               // unpadded(128k)
 
+// MinRandomReadSize is the read-ahead cap for streaming ReadAt calls.
+// Requests at or below ExactReadAtMax are fetched exactly (no amplification).
 var MinRandomReadSize = int64(1 << 20)
+
+// ExactReadAtMax is the largest ReadAt satisfied without read-ahead.
+// Matches net/http MIME sniff length so HEAD/content-type peeks do not pull MinRandomReadSize.
+const ExactReadAtMax int64 = 512
 
 type pieceGetter func(offset, size uint64) (io.ReadCloser, error)
 
@@ -243,12 +249,24 @@ func (p *pieceReader) ReadAt(b []byte, off int64) (n int, err error) {
 
 	readOff := off + filled
 	readSize := int64(len(b)) - filled
+	fetchSize := storageReadSize(readSize)
 
-	smallRead := readSize < MinRandomReadSize
+	if fetchSize == readSize {
+		// Exact fetch: peeks (incl. MIME sniff) and large reads go straight into the caller buffer.
+		bn, err := p.readInto(b[filled:], readOff)
+		if err != nil && err != io.EOF {
+			return int(filled), err
+		}
+		filled += int64(bn)
 
-	if smallRead {
-		// read into small read buf
-		readBuf := make([]byte, MinRandomReadSize)
+		sizeTag := "big"
+		if readSize <= ExactReadAtMax {
+			sizeTag = "exact"
+		}
+		_ = stats.RecordWithTags(p.atMCtx, []tag.Mutator{tag.Insert(metrics.PRReadSize, sizeTag)}, metrics.DagStorePRAtReadBytes.M(int64(bn)), metrics.DagStorePRAtReadCount.M(1))
+	} else {
+		// Streaming-sized ReadAt: modest read-ahead into remReads.
+		readBuf := make([]byte, fetchSize)
 		bn, err := p.readInto(readBuf, readOff)
 		if err != nil && err != io.EOF {
 			return int(filled), err
@@ -256,27 +274,15 @@ func (p *pieceReader) ReadAt(b []byte, off int64) (n int, err error) {
 
 		_ = stats.RecordWithTags(p.atMCtx, []tag.Mutator{tag.Insert(metrics.PRReadSize, "small")}, metrics.DagStorePRAtReadBytes.M(int64(bn)), metrics.DagStorePRAtReadCount.M(1))
 
-		// reslice so that the slice is the data
 		readBuf = readBuf[:bn]
 
-		// fill user data
-		used := copy(b[filled:], readBuf[:])
+		used := copy(b[filled:], readBuf)
 		filled += int64(used)
 		readBuf = readBuf[used:]
 
-		// cache the rest
 		if len(readBuf) > 0 {
 			p.remReads.Add(readOff+int64(used), readBuf)
 		}
-	} else {
-		// read into user buf
-		bn, err := p.readInto(b[filled:], readOff)
-		if err != nil {
-			return int(filled), err
-		}
-		filled += int64(bn)
-
-		_ = stats.RecordWithTags(p.atMCtx, []tag.Mutator{tag.Insert(metrics.PRReadSize, "big")}, metrics.DagStorePRAtReadBytes.M(int64(bn)), metrics.DagStorePRAtReadCount.M(1))
 	}
 
 	if filled < int64(len(b)) {
@@ -284,6 +290,26 @@ func (p *pieceReader) ReadAt(b []byte, off int64) (n int, err error) {
 	}
 
 	return int(filled), nil
+}
+
+// storageReadSize chooses how many bytes to fetch for a ReadAt of the given size.
+// MIME-sniff peeks stay exact; mid-size streaming reads may read-ahead up to ReadBuf
+// (not a flat 1MiB) so HEAD/content-type checks do not over-fetch.
+func storageReadSize(requested int64) int64 {
+	if requested <= ExactReadAtMax {
+		return requested
+	}
+	if requested >= MinRandomReadSize {
+		return requested
+	}
+	ahead := int64(ReadBuf)
+	if ahead < requested {
+		return requested
+	}
+	if ahead > MinRandomReadSize {
+		return MinRandomReadSize
+	}
+	return ahead
 }
 
 func (p *pieceReader) readInto(b []byte, off int64) (n int, err error) {

--- a/lib/pieceprovider/cached_piecereader_test.go
+++ b/lib/pieceprovider/cached_piecereader_test.go
@@ -1207,6 +1207,14 @@ func TestStorageReadSize(t *testing.T) {
 	assert.Equal(t, int64(ReadBuf)+1, storageReadSize(int64(ReadBuf)+1))
 	assert.Equal(t, MinRandomReadSize, storageReadSize(MinRandomReadSize))
 	assert.Equal(t, MinRandomReadSize*2, storageReadSize(MinRandomReadSize*2))
+
+	// Read-ahead sizes (the only path that allocates internally) stay ≤ 1MiB.
+	for _, req := range []int64{ExactReadAtMax + 1, int64(ReadBuf) - 1, int64(ReadBuf)} {
+		got := storageReadSize(req)
+		if got != req { // amplified
+			assert.LessOrEqual(t, got, MinRandomReadSize)
+		}
+	}
 }
 
 // TestPieceReader_ReadInto tests the readInto internal function

--- a/lib/pieceprovider/cached_piecereader_test.go
+++ b/lib/pieceprovider/cached_piecereader_test.go
@@ -534,11 +534,7 @@ func TestPieceReader_ReadAt(t *testing.T) {
 
 // TestPieceReader_ReadAtCaching tests the LRU cache behavior in ReadAt
 func TestPieceReader_ReadAtCaching(t *testing.T) {
-	// We need to use data larger than MinRandomReadSize to test caching behavior
-	// MinRandomReadSize is 1MB, so we'll test with smaller reads that trigger caching
-
-	t.Run("small reads are cached", func(t *testing.T) {
-		// Create data larger than MinRandomReadSize for meaningful testing
+	t.Run("streaming reads are cached via read-ahead", func(t *testing.T) {
 		dataSize := MinRandomReadSize + 1024
 		data := make([]byte, dataSize)
 		for i := range data {
@@ -549,48 +545,45 @@ func TestPieceReader_ReadAtCaching(t *testing.T) {
 			_ = pr.Close()
 		}()
 
-		// First small read (smaller than MinRandomReadSize)
-		buf := make([]byte, 100)
+		reqSize := ExactReadAtMax + 1
+		buf := make([]byte, reqSize)
 		n, err := pr.ReadAt(buf, 0)
 		require.NoError(t, err)
-		assert.Equal(t, 100, n)
+		assert.Equal(t, len(buf), n)
 
-		// Check that we made calls (initial + ReadAt call)
 		calls := tracker.getCalls()
-		assert.GreaterOrEqual(t, len(calls), 1)
+		require.GreaterOrEqual(t, len(calls), 2) // init + ReadAt
+		assert.Equal(t, uint64(ReadBuf), calls[len(calls)-1].Size)
 
-		// Second read at same offset should hit cache (if data was cached)
+		// Remainder after the caller buffer should be served from remReads.
+		before := len(tracker.getCalls())
 		buf2 := make([]byte, 50)
-		_, err = pr.ReadAt(buf2, 0)
+		_, err = pr.ReadAt(buf2, int64(reqSize))
 		require.NoError(t, err)
-
-		// Verify the first part matches
-		assert.Equal(t, buf[:50], buf2)
+		assert.Equal(t, before, len(tracker.getCalls()))
+		assert.Equal(t, data[reqSize:reqSize+50], buf2)
 	})
 
-	t.Run("cache stores read-ahead data", func(t *testing.T) {
-		// Create deterministic test data
+	t.Run("mime sniff peeks fetch exactly ExactReadAtMax", func(t *testing.T) {
 		dataSize := MinRandomReadSize * 2
 		data := make([]byte, dataSize)
 		for i := range data {
 			data[i] = byte(i % 256)
 		}
-		pr, _ := createTestPieceReader(t, data)
+		pr, tracker := createTestPieceReader(t, data)
 		defer func() {
 			_ = pr.Close()
 		}()
 
-		// Small read at offset 0
-		buf1 := make([]byte, 100)
-		_, err := pr.ReadAt(buf1, 0)
+		initialCalls := len(tracker.getCalls())
+		buf := make([]byte, ExactReadAtMax)
+		n, err := pr.ReadAt(buf, 0)
 		require.NoError(t, err)
+		assert.Equal(t, int(ExactReadAtMax), n)
 
-		// Verify data correctness
-		expected := make([]byte, 100)
-		for i := range expected {
-			expected[i] = byte(i % 256)
-		}
-		assert.Equal(t, expected, buf1)
+		calls := tracker.getCalls()
+		require.Greater(t, len(calls), initialCalls)
+		assert.Equal(t, uint64(ExactReadAtMax), calls[len(calls)-1].Size)
 	})
 }
 
@@ -1104,27 +1097,52 @@ func TestPieceReader_GetReaderErrors(t *testing.T) {
 
 // TestPieceReader_SmallVsLargeReads tests the behavior difference between small and large reads in ReadAt
 func TestPieceReader_SmallVsLargeReads(t *testing.T) {
-	t.Run("small read triggers caching behavior", func(t *testing.T) {
+	t.Run("mid-size read under ReadBuf triggers read-ahead", func(t *testing.T) {
 		dataSize := int(MinRandomReadSize * 2)
 		data := make([]byte, dataSize)
 		for i := range data {
 			data[i] = byte(i % 256)
 		}
-		pr, _ := createTestPieceReader(t, data)
+		pr, tracker := createTestPieceReader(t, data)
 		defer func() {
 			_ = pr.Close()
 		}()
 
-		// Small read (less than MinRandomReadSize)
-		smallBuf := make([]byte, MinRandomReadSize/2)
+		reqSize := int(ExactReadAtMax + 1)
+		smallBuf := make([]byte, reqSize)
 		n, err := pr.ReadAt(smallBuf, 0)
 		require.NoError(t, err)
-		assert.Equal(t, int(MinRandomReadSize/2), n)
+		assert.Equal(t, reqSize, n)
 
-		// Verify data
+		calls := tracker.getCalls()
+		require.NotEmpty(t, calls)
+		assert.Equal(t, uint64(ReadBuf), calls[len(calls)-1].Size)
+
 		for i := range smallBuf {
 			assert.Equal(t, byte(i%256), smallBuf[i], "mismatch at position %d", i)
 		}
+	})
+
+	t.Run("read larger than ReadBuf fetches exactly the request", func(t *testing.T) {
+		dataSize := int(MinRandomReadSize * 2)
+		data := make([]byte, dataSize)
+		for i := range data {
+			data[i] = byte(i % 256)
+		}
+		pr, tracker := createTestPieceReader(t, data)
+		defer func() {
+			_ = pr.Close()
+		}()
+
+		reqSize := int64(ReadBuf) + 1024
+		buf := make([]byte, reqSize)
+		n, err := pr.ReadAt(buf, 0)
+		require.NoError(t, err)
+		assert.Equal(t, int(reqSize), n)
+
+		calls := tracker.getCalls()
+		require.NotEmpty(t, calls)
+		assert.Equal(t, uint64(reqSize), calls[len(calls)-1].Size)
 	})
 
 	t.Run("large read goes directly to user buffer", func(t *testing.T) {
@@ -1133,52 +1151,62 @@ func TestPieceReader_SmallVsLargeReads(t *testing.T) {
 		for i := range data {
 			data[i] = byte(i % 256)
 		}
-		pr, _ := createTestPieceReader(t, data)
+		pr, tracker := createTestPieceReader(t, data)
 		defer func() {
 			_ = pr.Close()
 		}()
 
-		// Large read (greater than MinRandomReadSize)
 		largeBuf := make([]byte, MinRandomReadSize*2)
 		n, err := pr.ReadAt(largeBuf, 0)
 		require.NoError(t, err)
 		assert.Equal(t, int(MinRandomReadSize*2), n)
 
-		// Verify data
+		calls := tracker.getCalls()
+		require.NotEmpty(t, calls)
+		assert.Equal(t, uint64(MinRandomReadSize*2), calls[len(calls)-1].Size)
+
 		for i := range largeBuf {
 			assert.Equal(t, byte(i%256), largeBuf[i], "mismatch at position %d", i)
 		}
 	})
 }
 
-// TestPieceReader_HeaderCaching tests that offset 0 data is specially cached
+// TestPieceReader_HeaderCaching tests that read-ahead remainders are cached
 func TestPieceReader_HeaderCaching(t *testing.T) {
-	t.Run("header data kept in cache", func(t *testing.T) {
+	t.Run("read-ahead remainder served from remReads", func(t *testing.T) {
 		dataSize := int(MinRandomReadSize * 2)
 		data := make([]byte, dataSize)
 		for i := range data {
 			data[i] = byte(i % 256)
 		}
-		pr, _ := createTestPieceReader(t, data)
+		pr, tracker := createTestPieceReader(t, data)
 		defer func() {
 			_ = pr.Close()
 		}()
 
-		// Read header (offset 0)
-		headerBuf := make([]byte, 100)
+		reqSize := int(ExactReadAtMax + 1)
+		headerBuf := make([]byte, reqSize)
 		n, err := pr.ReadAt(headerBuf, 0)
 		require.NoError(t, err)
-		assert.Equal(t, 100, n)
+		assert.Equal(t, reqSize, n)
 
-		// Read header again - should use cache
-		headerBuf2 := make([]byte, 50)
-		n, err = pr.ReadAt(headerBuf2, 0)
+		before := len(tracker.getCalls())
+		next := make([]byte, 50)
+		n, err = pr.ReadAt(next, int64(reqSize))
 		require.NoError(t, err)
 		assert.Equal(t, 50, n)
-
-		// Data should match
-		assert.Equal(t, headerBuf[:50], headerBuf2)
+		assert.Equal(t, before, len(tracker.getCalls()))
+		assert.Equal(t, data[reqSize:reqSize+50], next)
 	})
+}
+
+func TestStorageReadSize(t *testing.T) {
+	assert.Equal(t, int64(512), storageReadSize(512))
+	assert.Equal(t, int64(100), storageReadSize(100))
+	assert.Equal(t, int64(ReadBuf), storageReadSize(ExactReadAtMax+1))
+	assert.Equal(t, int64(ReadBuf)+1, storageReadSize(int64(ReadBuf)+1))
+	assert.Equal(t, MinRandomReadSize, storageReadSize(MinRandomReadSize))
+	assert.Equal(t, MinRandomReadSize*2, storageReadSize(MinRandomReadSize*2))
 }
 
 // TestPieceReader_ReadInto tests the readInto internal function

--- a/market/retrieval/piecehandler.go
+++ b/market/retrieval/piecehandler.go
@@ -21,6 +21,11 @@ import (
 // non-zero last modified time.
 var lastModified = time.UnixMilli(1)
 
+// MIME_SNIFF_BYTES is the net/http / WHATWG sniff window. Tied to
+// pieceprovider.ExactReadAtMax so peeks are not amplified on ReadAt.
+// It's also the same size buff
+const MIME_SNIFF_BYTES = 512
+
 func (rp *Provider) handleByPieceCid(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	startTime := time.Now()
@@ -62,14 +67,11 @@ func (rp *Provider) handleByPieceCid(w http.ResponseWriter, r *http.Request) {
 		_ = reader.Close()
 	}()
 
-	buf := make([]byte, 512)
-	n, _ := reader.Read(buf)
-	contentType := http.DetectContentType(buf[:n])
-
-	// rewind reader before sending
-	_, err = reader.Seek(0, io.SeekStart)
+	// Exact MIME_SNIFF_BYTES ReadAt (no Seek). HEAD still sniffs for Content-Type;
+	// ServeContent below writes no body for HEAD.
+	contentType, err := sniffContentType(reader)
 	if err != nil {
-		log.Errorf("error rewinding reader for piece CID %s: %s", pieceCid, err)
+		log.Errorf("error sniffing content type for piece CID %s: %s", pieceCid, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		stats.Record(ctx, remoteblockstore.HttpPieceByCid500ResponseCount.M(1))
 		return
@@ -87,6 +89,15 @@ func (rp *Provider) handleByPieceCid(w http.ResponseWriter, r *http.Request) {
 	stats.Record(ctx, remoteblockstore.HttpPieceByCid200ResponseCount.M(1))
 	stats.Record(ctx, remoteblockstore.HttpPieceByCidRequestDuration.M(float64(time.Since(startTime).Milliseconds())))
 
+}
+
+func sniffContentType(r io.ReaderAt) (string, error) {
+	buf := make([]byte, MIME_SNIFF_BYTES)
+	n, err := r.ReadAt(buf, 0)
+	if n == 0 && err != nil && err != io.EOF {
+		return "", err
+	}
+	return http.DetectContentType(buf[:n]), nil
 }
 
 func setHeaders(w http.ResponseWriter, pieceCid cid.Cid, contentType string) {

--- a/market/retrieval/piecehandler.go
+++ b/market/retrieval/piecehandler.go
@@ -13,6 +13,7 @@ import (
 	"go.opencensus.io/stats"
 
 	"github.com/filecoin-project/curio/lib/cachedreader"
+	"github.com/filecoin-project/curio/lib/pieceprovider"
 	"github.com/filecoin-project/curio/market/retrieval/remoteblockstore"
 )
 
@@ -21,10 +22,9 @@ import (
 // non-zero last modified time.
 var lastModified = time.UnixMilli(1)
 
-// MIME_SNIFF_BYTES is the net/http / WHATWG sniff window. Tied to
+// MIME_SNIFF_BYTES is the net/http / WHATWG sniff window. Aliased to
 // pieceprovider.ExactReadAtMax so peeks are not amplified on ReadAt.
-// It's also the same size buff
-const MIME_SNIFF_BYTES = 512
+const MIME_SNIFF_BYTES = pieceprovider.ExactReadAtMax
 
 func (rp *Provider) handleByPieceCid(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/market/retrieval/piecehandler_test.go
+++ b/market/retrieval/piecehandler_test.go
@@ -11,6 +11,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type sniffReaderAt struct {
+	data      []byte
+	lastSize  int
+	readCount int
+}
+
+func (s *sniffReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	s.readCount++
+	s.lastSize = len(p)
+	if off >= int64(len(s.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, s.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func TestSniffContentTypeReadsExactWindow(t *testing.T) {
+	payload := append([]byte("%PDF-1.4"), bytes.Repeat([]byte("x"), 4096)...)
+	r := &sniffReaderAt{data: payload}
+
+	ct, err := sniffContentType(r)
+	require.NoError(t, err)
+	require.Equal(t, "application/pdf", ct)
+	require.Equal(t, 1, r.readCount)
+	require.Equal(t, int(MIME_SNIFF_BYTES), r.lastSize)
+}
+
+func TestSniffContentTypeShortPiece(t *testing.T) {
+	r := &sniffReaderAt{data: []byte("hello")}
+	ct, err := sniffContentType(r)
+	require.NoError(t, err)
+	require.Equal(t, "text/plain; charset=utf-8", ct)
+	require.Equal(t, int(MIME_SNIFF_BYTES), r.lastSize)
+}
+
 func TestServeContentHeadRequest(t *testing.T) {
 	req := httptest.NewRequest(http.MethodHead, "/piece/test", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
Our common-case TTFB is leaving lots of performance on the table. 

### THIS PR
**Disk improvements**
- Head reads just 512b (was 512 B + 1 MB)
- GET too, then no seek
- ReadAhead never supercedes range (start or end) nor 1MB

Bets with fallbacks:
 -  they gave a Parent CID
 -  the sector is on this machine

SQL Optimizations:
- The triple SQL RT of [deal, exists, parked_pieces] gets unified. 

Left Unoptimized:
- HEAD could avoid reads by serving 'application/octet-stream': browsers don't mind. Concern here: do we have custom clients that care?
- avoid rereading that 512b a second time for serving (it's likely in OS cache)
- a streaming form of the mime sniffer could read less, but the savings is below 1 disk sector read

### New Flow
1 YSQL for [deal+exists+parked_pieces]
\--> not_found then tries with YCQL to find parent & go again (1% non-PDP case)
Try-local (Disk)
\--> not_found does YSQL for find-sector (1x, not 2 because of try-local-first on other node).
open
sniff(512b) (return here for HEAD)
read only what's requested for RANGE, max 1MB.

### Previous Flow
Aggregate → (YCQL)
market_piece_deal (miss) → (YSQL)
pdp_piecerefs → (YSQL)
parked_pieces → (YSQL)
find-sector → (YSQL). (done 2x if remote)
open → (DISK/HTTP)
sniff → (DISK/HTTP) 
SEEK(0)
ReadAt for 1MB
first body byte.