### PR TITLE
Fix: PDPv0 proving-period reconciliation for piece removals

### DIFF
--- a/harmony/harmonydb/sql/20260717-pdp-v0-drop-prove-backoff.sql
+++ b/harmony/harmonydb/sql/20260717-pdp-v0-drop-prove-backoff.sql
@@ -2,3 +2,10 @@
 -- Contract reverts are handled by explicit categories and Harmony task retry.
 ALTER TABLE pdp_data_sets DROP COLUMN IF EXISTS consecutive_prove_failures;
 ALTER TABLE pdp_data_sets DROP COLUMN IF EXISTS next_prove_attempt_at;
+
+ALTER TABLE pdp_data_sets
+    ADD COLUMN IF NOT EXISTS pp_reconcile_needed BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_pdp_data_sets_pp_reconcile_needed
+    ON pdp_data_sets (id)
+    WHERE pp_reconcile_needed = TRUE;

--- a/pdpnode/tasks.go
+++ b/pdpnode/tasks.go
@@ -78,6 +78,7 @@ func buildPDPTasks(ctx context.Context, d *Deps, chainSched *chainsched.CurioCha
 	pay.NewSettleWatcher(w)
 	pdpv0.NewDataSetDeleteWatcher(w)
 	pdpv0.NewCleanupPiecesWatcher(w)
+	pdpv0.NewProvingPeriodWatcher(w)
 	pdpv0.NewTerminateServiceWatcher(w)
 
 	tasks = append(tasks,

--- a/tasks/pdpv0/failure_handling.go
+++ b/tasks/pdpv0/failure_handling.go
@@ -18,7 +18,8 @@ func MarkDatasetProvingUnrecoverable(tx *harmonydb.Tx, dataSetId int64, currentH
 		SET unrecoverable_proving_failure_epoch = $2,
 			init_ready = FALSE,
 			prove_at_epoch = NULL,
-			challenge_request_msg_hash = NULL
+			challenge_request_msg_hash = NULL,
+			pp_reconcile_needed = FALSE
 		WHERE id = $1 AND unrecoverable_proving_failure_epoch IS NULL
 	`, dataSetId, currentHeight)
 	return err

--- a/tasks/pdpv0/task_next_pp.go
+++ b/tasks/pdpv0/task_next_pp.go
@@ -2,14 +2,12 @@ package pdpv0
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/samber/lo"
 	"github.com/yugabyte/pgx/v5"
 	"golang.org/x/xerrors"
 
@@ -253,117 +251,10 @@ func (n *NextProvingPeriodTask) Do(taskID harmonytask.TaskID, stillOwned func() 
 		return false, xerrors.Errorf("failed to perform database transaction: %w", err)
 	}
 
-	// For all `schedulePieceDeletions` messages relevant to this dataset, mark these pieces as removed
-	err = n.processPendingPieceDeletes(ctx, dataSetId)
-	if err != nil {
-		log.Warnf("Failed to process pending piece delete: %s", err)
-	}
-
 	// Task completed successfully
 	log.Infow("Next challenge window scheduled", "epoch", next_prove_at, "dataSetId", dataSetId)
 
 	return true, nil
-}
-
-func (n *NextProvingPeriodTask) processPendingPieceDeletes(ctx context.Context, dataSetId int64) error {
-
-	var pendingDeletes []struct {
-		PieceID   int64        `db:"piece_id"`
-		TxHash    string       `db:"rm_message_hash"`
-		TxSuccess sql.NullBool `db:"tx_success"`
-	}
-
-	err := n.db.Select(ctx, &pendingDeletes, `SELECT
-    												psp.piece_id,
-    												psp.rm_message_hash,
-													mwe.tx_success
-												FROM pdp_data_set_pieces psp
-												LEFT JOIN message_waits_eth mwe ON mwe.signed_tx_hash = psp.rm_message_hash
-												WHERE psp.rm_message_hash IS NOT NULL
-												  AND psp.data_set = $1
-												  AND psp.removed = FALSE
-												  AND mwe.tx_status = 'confirmed'`, dataSetId)
-	if err != nil {
-		return xerrors.Errorf("failed to select pending piece deletes: %w", err)
-	}
-
-	if len(pendingDeletes) == 0 {
-		return nil
-	}
-
-	pdpAddress := contract.ContractAddresses().PDPVerifier
-
-	verifier, err := contract.NewPDPVerifier(pdpAddress, n.ethClient)
-	if err != nil {
-		return xerrors.Errorf("failed to instantiate PDPVerifier contract: %w", err)
-	}
-
-	removals, err := verifier.GetScheduledRemovals(contract.EthCallOpts(ctx), big.NewInt(dataSetId))
-	if err != nil {
-		return xerrors.Errorf("failed to get scheduled removals: %w", err)
-	}
-
-	for _, piece := range pendingDeletes {
-		if !piece.TxSuccess.Valid {
-			log.Errorf("invalid message_waits_eth state for piece (%d:%d) tx %s neither successful or unsuccessful", dataSetId, piece.PieceID, piece.TxHash)
-			_, err := n.db.Exec(ctx, `UPDATE pdp_data_set_pieces SET rm_message_hash = NULL WHERE data_set = $1 AND piece_id = $2 AND rm_message_hash = $3`, dataSetId, piece.PieceID, piece.TxHash)
-			if err != nil {
-				return xerrors.Errorf("failed to clear stuck rm_message_hash %s: %w", piece.TxHash, err)
-			}
-			continue
-		}
-
-		if !piece.TxSuccess.Bool {
-			log.Errorf("failed to process pending piece delete as transaction %s failed", piece.TxHash)
-			_, err := n.db.Exec(ctx, `UPDATE pdp_data_set_pieces SET rm_message_hash = NULL WHERE data_set = $1 AND piece_id = $2 AND rm_message_hash = $3`, dataSetId, piece.PieceID, piece.TxHash)
-			if err != nil {
-				return xerrors.Errorf("failed to clear stuck rm_message_hash %s: %w", piece.TxHash, err)
-			}
-			continue
-		}
-
-		pieceID := big.NewInt(piece.PieceID)
-		contains := lo.ContainsBy(removals, func(r *big.Int) bool {
-			return r.Cmp(pieceID) == 0
-		})
-		if !contains {
-			// Check for the case where next proving period has run and piece deletions fully processed
-			live, err := verifier.PieceLive(contract.EthCallOpts(ctx), big.NewInt(dataSetId), pieceID)
-			if err != nil {
-				return xerrors.Errorf("failed to check if piece is live: %w", err)
-			}
-			if live {
-				log.Warnw("piece is live but not in scheduled removals despite successful delete tx; (possible chain reorg) clearing stale delete tracking",
-					"dataSetId", dataSetId, "pieceID", piece.PieceID, "txHash", piece.TxHash)
-				_, err := n.db.Exec(ctx, `UPDATE pdp_data_set_pieces SET rm_message_hash = NULL
-                              WHERE data_set = $1 AND piece_id = $2 AND rm_message_hash = $3`,
-					dataSetId, piece.PieceID, piece.TxHash)
-				if err != nil {
-					return xerrors.Errorf("failed to clear stale rm_message_hash: %w", err)
-				}
-				continue
-			}
-			log.Infow("piece already removed on-chain, marking as removed in DB", "dataSetId", dataSetId, "pieceID", piece.PieceID, "txHash", piece.TxHash)
-		} else {
-			log.Infow("noticed scheduled deletion, marking as removed", "dataSetId", dataSetId, "pieceID", piece.PieceID, "txHash", piece.TxHash)
-		}
-
-		m, err := n.db.Exec(ctx, `UPDATE pdp_data_set_pieces
-								SET removed = TRUE
-								WHERE data_set = $1
-								  AND piece_id = $2
-								  AND rm_message_hash = $3
-								  AND removed = FALSE`, dataSetId, piece.PieceID, piece.TxHash)
-		if err != nil {
-			return xerrors.Errorf("failed to update pdp_data_set_pieces: %w", err)
-		}
-
-		if m != 1 {
-			return xerrors.Errorf("expected to update 1 row but updated %d", m)
-		}
-	}
-
-	return nil
 }
 
 // Note: this function needs revisiting if we are ever *shrinking* proving period or challenge window values

--- a/tasks/pdpv0/task_next_pp.go
+++ b/tasks/pdpv0/task_next_pp.go
@@ -306,14 +306,13 @@ var _ = harmonytask.Reg(&NextProvingPeriodTask{})
 func resetDatasetToInitPP(ctx context.Context, db *harmonydb.DB, dataSetId int64) error {
 	log.Infow("resetting dataset to init proving period state", "dataSetId", dataSetId)
 	_, err := db.Exec(ctx, `
-             UPDATE pdp_data_sets
-             SET challenge_request_msg_hash = NULL,
-                     prove_at_epoch = NULL,
-                     init_ready = TRUE,
-                     prev_challenge_request_epoch = NULL,
-                     pp_reconcile_needed = FALSE
-             WHERE id = $1
-     `, dataSetId)
+		UPDATE pdp_data_sets
+		SET challenge_request_msg_hash = NULL,
+			prove_at_epoch = NULL,
+			init_ready = TRUE,
+			prev_challenge_request_epoch = NULL
+		WHERE id = $1
+	`, dataSetId)
 	if err != nil {
 		return xerrors.Errorf("failed to reset dataset to init state: %w", err)
 	}
@@ -330,8 +329,7 @@ func disableProvingForEmptyDataset(tx *harmonydb.Tx, dataSetId int64) error {
 		SET challenge_request_msg_hash = NULL,
 			prove_at_epoch = NULL,
 			init_ready = FALSE,
-			prev_challenge_request_epoch = NULL,
-			pp_reconcile_needed = FALSE
+			prev_challenge_request_epoch = NULL
 		WHERE id = $1
 	`, dataSetId)
 	if err != nil {
@@ -388,13 +386,12 @@ func skipCurrentOnChainProvingPeriod(ctx context.Context, tx *harmonydb.Tx, prov
 	// because the local challenge_request_msg_hash is intentionally dropped; use
 	// the reconciliation height as a marker while prove_at_epoch drives scheduling.
 	affected, err := tx.Exec(`
-			UPDATE pdp_data_sets
-				SET challenge_request_msg_hash = NULL,
-					prev_challenge_request_epoch = $2,
-					prove_at_epoch = $3,
-					pp_reconcile_needed = FALSE
-				WHERE id = $1
-			  AND unrecoverable_proving_failure_epoch IS NULL
+		UPDATE pdp_data_sets
+		SET challenge_request_msg_hash = NULL,
+			prev_challenge_request_epoch = $2,
+			prove_at_epoch = $3
+		WHERE id = $1
+		  AND unrecoverable_proving_failure_epoch IS NULL
 	`, dataSetId, currentHeight, challengeEpoch.Int64())
 	if err != nil {
 		return xerrors.Errorf("failed to skip current proving period: %w", err)

--- a/tasks/pdpv0/task_next_pp.go
+++ b/tasks/pdpv0/task_next_pp.go
@@ -226,7 +226,8 @@ func (n *NextProvingPeriodTask) Do(taskID harmonytask.TaskID, stillOwned func() 
             UPDATE pdp_data_sets
             SET challenge_request_msg_hash = $1,
                 prev_challenge_request_epoch = $2,
-				prove_at_epoch = $3
+				prove_at_epoch = $3,
+				pp_reconcile_needed = TRUE
             WHERE id = $4
         `, txHash.Hex(), ts.Height(), next_prove_at.Uint64(), dataSetId)
 		if err != nil {
@@ -309,7 +310,8 @@ func resetDatasetToInitPP(ctx context.Context, db *harmonydb.DB, dataSetId int64
              SET challenge_request_msg_hash = NULL,
                      prove_at_epoch = NULL,
                      init_ready = TRUE,
-                     prev_challenge_request_epoch = NULL
+                     prev_challenge_request_epoch = NULL,
+                     pp_reconcile_needed = FALSE
              WHERE id = $1
      `, dataSetId)
 	if err != nil {
@@ -328,7 +330,8 @@ func disableProvingForEmptyDataset(tx *harmonydb.Tx, dataSetId int64) error {
 		SET challenge_request_msg_hash = NULL,
 			prove_at_epoch = NULL,
 			init_ready = FALSE,
-			prev_challenge_request_epoch = NULL
+			prev_challenge_request_epoch = NULL,
+			pp_reconcile_needed = FALSE
 		WHERE id = $1
 	`, dataSetId)
 	if err != nil {
@@ -386,10 +389,11 @@ func skipCurrentOnChainProvingPeriod(ctx context.Context, tx *harmonydb.Tx, prov
 	// the reconciliation height as a marker while prove_at_epoch drives scheduling.
 	affected, err := tx.Exec(`
 			UPDATE pdp_data_sets
-			SET challenge_request_msg_hash = NULL,
-				prev_challenge_request_epoch = $2,
-				prove_at_epoch = $3
-			WHERE id = $1
+				SET challenge_request_msg_hash = NULL,
+					prev_challenge_request_epoch = $2,
+					prove_at_epoch = $3,
+					pp_reconcile_needed = FALSE
+				WHERE id = $1
 			  AND unrecoverable_proving_failure_epoch IS NULL
 	`, dataSetId, currentHeight, challengeEpoch.Int64())
 	if err != nil {

--- a/tasks/pdpv0/task_prove.go
+++ b/tasks/pdpv0/task_prove.go
@@ -950,7 +950,8 @@ func (p *ProveTask) disableProving(ctx context.Context, dataSetId int64) error {
 	_, err := p.db.Exec(ctx, `
 		UPDATE pdp_data_sets
 		SET challenge_request_msg_hash = NULL, prove_at_epoch = NULL, init_ready = FALSE,
-			prev_challenge_request_epoch = NULL
+			prev_challenge_request_epoch = NULL,
+			pp_reconcile_needed = FALSE
 		WHERE id = $1
 		`, dataSetId)
 	if err != nil {

--- a/tasks/pdpv0/watch_data_set_delete.go
+++ b/tasks/pdpv0/watch_data_set_delete.go
@@ -252,7 +252,7 @@ func cleanupFinalizedDataSet(ctx context.Context, db *harmonydb.DB, dataSetID in
 					pdp_data_set_piece_update (adjusts)
 				update pdp_piecerefs.data_set_refcount accordingly, so refcounts drop when pieces are removed.
 
-			pdp_pieceRefs will be cleaned up by watch_piece_delete.go process. It will also remove index entries and publish IPNI announcements.
+			pdp_pieceRefs will be cleaned up by watch_proving_period.go process. It will also remove index entries and publish IPNI announcements.
 		*/
 
 		_, err = tx.Exec(`DELETE FROM pdp_data_sets WHERE id = $1`, dataSetID)

--- a/tasks/pdpv0/watch_proving_period.go
+++ b/tasks/pdpv0/watch_proving_period.go
@@ -1,0 +1,283 @@
+package pdpv0
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/big"
+
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/curio/alertmanager/curioalerting"
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/lib/ethchain"
+	"github.com/filecoin-project/curio/pdp/contract"
+
+	chainTypes "github.com/filecoin-project/lotus/chain/types"
+)
+
+const alertNameProvingPeriod = "ProvingPeriod"
+
+// NewProvingPeriodWatcher reconciles confirmed proving-period side effects
+// before the prove watcher runs. nextProvingPeriod is what finally applies
+// scheduled piece removals and can also clear PDPVerifier's next challenge when
+// the dataset becomes empty, so both local states must be fixed before prove
+// task scheduling looks at the dataset.
+func NewProvingPeriodWatcher(w *Watcher) {
+	if err := w.AddWatcher(func(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient, al curioalerting.AlertingInterface, revert, apply *chainTypes.TipSet) {
+		if err := processEmptyProvingPeriods(ctx, db, ethClient); err != nil {
+			log.Warnf("Failed to process empty PDP proving periods: %s", err)
+			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
+				System:    alertType,
+				Subsystem: alertNameProvingPeriod,
+				Message:   fmt.Sprintf("failed to process empty PDP proving periods: %s", err),
+			})
+		}
+
+		if err := processPendingPieceDeletes(ctx, db, ethClient); err != nil {
+			log.Warnf("Failed to process pending PDP piece deletes: %s", err)
+			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
+				System:    alertType,
+				Subsystem: alertNameProvingPeriod,
+				Message:   fmt.Sprintf("failed to process pending PDP piece deletes: %s", err),
+			})
+		}
+	}, WatcherOrderCleanupPieces); err != nil {
+		panic(err)
+	}
+}
+
+type confirmedProvingPeriod struct {
+	DataSetID int64  `db:"id"`
+	TxHash    string `db:"challenge_request_msg_hash"`
+}
+
+// processEmptyProvingPeriods reconciles datasets whose confirmed initPP/nextPP
+// message left no next challenge on-chain. This happens when nextProvingPeriod
+// removes the final piece: PDPVerifier clears the challenge, but Curio may have
+// already stored the now-stale prove_at_epoch.
+//
+// Dropping that local period before piece-delete reconciliation is intentional.
+// There is no proof to submit for a zero on-chain challenge epoch. Clearing the
+// stale schedule first prevents the prove watcher from disabling proving after a
+// new add already made the dataset ready again. The current on-chain leaf count
+// then decides whether InitProvingPeriodTask should pick the dataset back up.
+func processEmptyProvingPeriods(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient) error {
+	var confirmed []confirmedProvingPeriod
+	err := db.Select(ctx, &confirmed, `
+		SELECT pds.id,
+		       pds.challenge_request_msg_hash
+		FROM pdp_data_sets pds
+		INNER JOIN message_waits_eth mwe ON mwe.signed_tx_hash = pds.challenge_request_msg_hash
+		WHERE pds.challenge_request_msg_hash IS NOT NULL
+		  AND mwe.tx_status = 'confirmed'
+		  AND mwe.tx_success = TRUE
+		  AND pds.unrecoverable_proving_failure_epoch IS NULL
+		ORDER BY pds.id
+	`)
+	if err != nil {
+		return xerrors.Errorf("failed to select confirmed proving periods: %w", err)
+	}
+	if len(confirmed) == 0 {
+		return nil
+	}
+
+	verifier, err := contract.NewPDPVerifier(contract.ContractAddresses().PDPVerifier, ethClient)
+	if err != nil {
+		return xerrors.Errorf("failed to instantiate PDPVerifier contract: %w", err)
+	}
+
+	for _, period := range confirmed {
+		dataSetID := big.NewInt(period.DataSetID)
+
+		nextChallengeEpoch, err := verifier.GetNextChallengeEpoch(contract.EthCallOpts(ctx), dataSetID)
+		if err != nil {
+			return xerrors.Errorf("failed to get next challenge epoch for data set %d: %w", period.DataSetID, err)
+		}
+		if nextChallengeEpoch.Sign() != 0 {
+			continue
+		}
+
+		leafCount, err := verifier.GetDataSetLeafCount(contract.EthCallOpts(ctx), dataSetID)
+		if err != nil {
+			return xerrors.Errorf("failed to get leaf count for data set %d: %w", period.DataSetID, err)
+		}
+		initReady := leafCount.Sign() > 0
+
+		affected, err := db.Exec(ctx, `
+			UPDATE pdp_data_sets
+			SET challenge_request_msg_hash = NULL,
+			    prove_at_epoch = NULL,
+			    prev_challenge_request_epoch = NULL,
+			    init_ready = $3
+			WHERE id = $1
+			  AND challenge_request_msg_hash = $2
+			  AND unrecoverable_proving_failure_epoch IS NULL
+		`, period.DataSetID, period.TxHash, initReady)
+		if err != nil {
+			return xerrors.Errorf("failed to reset empty proving period for data set %d: %w", period.DataSetID, err)
+		}
+		if affected > 1 {
+			return xerrors.Errorf("expected to update at most 1 proving period row, updated %d", affected)
+		}
+		if affected == 1 {
+			log.Infow("reset empty proving period",
+				"dataSetId", period.DataSetID,
+				"txHash", period.TxHash,
+				"leafCount", leafCount.String(),
+				"initReady", initReady)
+		}
+	}
+
+	return nil
+}
+
+type pendingPieceDelete struct {
+	DataSetID int64          `db:"data_set"`
+	PieceID   int64          `db:"piece_id"`
+	TxHash    string         `db:"rm_message_hash"`
+	TxStatus  sql.NullString `db:"tx_status"`
+	TxSuccess sql.NullBool   `db:"tx_success"`
+}
+
+// processPendingPieceDeletes reconciles local piece-removal rows after the
+// schedulePieceDeletions transaction is confirmed. That transaction only queues
+// removals on-chain; the piece is actually removed later by nextProvingPeriod,
+// so this function must not mark a local row removed while PDPVerifier still
+// reports the piece in GetScheduledRemovals.
+func processPendingPieceDeletes(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient) error {
+	var pendingDeletes []pendingPieceDelete
+	err := db.Select(ctx, &pendingDeletes, `
+		SELECT psp.data_set,
+		       psp.piece_id,
+		       psp.rm_message_hash,
+		       mwe.tx_status,
+		       mwe.tx_success
+		FROM pdp_data_set_pieces psp
+		LEFT JOIN message_waits_eth mwe ON mwe.signed_tx_hash = psp.rm_message_hash
+		WHERE psp.rm_message_hash IS NOT NULL
+		  AND psp.removed = FALSE
+		ORDER BY psp.data_set, psp.piece_id
+	`)
+	if err != nil {
+		return xerrors.Errorf("failed to select pending piece deletes: %w", err)
+	}
+	if len(pendingDeletes) == 0 {
+		return nil
+	}
+
+	verifier, err := contract.NewPDPVerifier(contract.ContractAddresses().PDPVerifier, ethClient)
+	if err != nil {
+		return xerrors.Errorf("failed to instantiate PDPVerifier contract: %w", err)
+	}
+
+	scheduledByDataSet := map[int64]map[int64]struct{}{}
+	for _, piece := range pendingDeletes {
+		// Wait until the schedulePieceDeletions send has a final watcher result.
+		if !piece.TxStatus.Valid || piece.TxStatus.String != "confirmed" {
+			continue
+		}
+		// A confirmed row without tx_success is malformed for our purposes; clear
+		// the local delete intent so operators can resubmit cleanly.
+		if !piece.TxSuccess.Valid {
+			log.Errorf("invalid message_waits_eth state for piece delete tx %s", piece.TxHash)
+			if err := clearPendingPieceDelete(ctx, db, piece); err != nil {
+				return err
+			}
+			continue
+		}
+		// The schedule transaction failed, so no on-chain removal is pending.
+		if !piece.TxSuccess.Bool {
+			log.Errorf("failed to process pending piece delete as transaction %s failed", piece.TxHash)
+			if err := clearPendingPieceDelete(ctx, db, piece); err != nil {
+				return err
+			}
+			continue
+		}
+
+		scheduled, ok := scheduledByDataSet[piece.DataSetID]
+		if !ok {
+			scheduled, err = getScheduledRemovalSet(ctx, verifier, piece.DataSetID)
+			if err != nil {
+				return err
+			}
+			scheduledByDataSet[piece.DataSetID] = scheduled
+		}
+		// Still scheduled means nextProvingPeriod has not processed the removal
+		// yet. Keep rm_message_hash set and leave removed=false.
+		if _, ok := scheduled[piece.PieceID]; ok {
+			continue
+		}
+
+		// Once it is no longer scheduled, PieceLive is the final authority for
+		// whether nextProvingPeriod actually removed it.
+		pieceID := big.NewInt(piece.PieceID)
+		live, err := verifier.PieceLive(contract.EthCallOpts(ctx), big.NewInt(piece.DataSetID), pieceID)
+		if err != nil {
+			return xerrors.Errorf("failed to check if piece is live: %w", err)
+		}
+		if !live {
+			if err := markPendingPieceRemoved(ctx, db, piece); err != nil {
+				return err
+			}
+			log.Infow("piece removed on-chain, marking as removed in DB", "dataSetId", piece.DataSetID, "pieceID", piece.PieceID, "txHash", piece.TxHash)
+			continue
+		}
+
+		log.Warnw("piece is live and not scheduled despite successful delete tx; clearing stale delete tracking",
+			"dataSetId", piece.DataSetID, "pieceID", piece.PieceID, "txHash", piece.TxHash)
+		if err := clearPendingPieceDelete(ctx, db, piece); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getScheduledRemovalSet(ctx context.Context, verifier *contract.PDPVerifier, dataSetID int64) (map[int64]struct{}, error) {
+	removals, err := verifier.GetScheduledRemovals(contract.EthCallOpts(ctx), big.NewInt(dataSetID))
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get scheduled removals: %w", err)
+	}
+
+	out := make(map[int64]struct{}, len(removals))
+	for _, removal := range removals {
+		if removal.IsInt64() {
+			out[removal.Int64()] = struct{}{}
+		}
+	}
+	return out, nil
+}
+
+func clearPendingPieceDelete(ctx context.Context, db *harmonydb.DB, piece pendingPieceDelete) error {
+	_, err := db.Exec(ctx, `
+		UPDATE pdp_data_set_pieces
+		SET rm_message_hash = NULL
+		WHERE data_set = $1
+		  AND piece_id = $2
+		  AND rm_message_hash = $3
+		  AND removed = FALSE
+	`, piece.DataSetID, piece.PieceID, piece.TxHash)
+	if err != nil {
+		return xerrors.Errorf("failed to clear pending piece delete %s: %w", piece.TxHash, err)
+	}
+	return nil
+}
+
+func markPendingPieceRemoved(ctx context.Context, db *harmonydb.DB, piece pendingPieceDelete) error {
+	affected, err := db.Exec(ctx, `
+		UPDATE pdp_data_set_pieces
+		SET removed = TRUE
+		WHERE data_set = $1
+		  AND piece_id = $2
+		  AND rm_message_hash = $3
+		  AND removed = FALSE
+	`, piece.DataSetID, piece.PieceID, piece.TxHash)
+	if err != nil {
+		return xerrors.Errorf("failed to mark piece removed: %w", err)
+	}
+	if affected > 1 {
+		return xerrors.Errorf("expected to update at most 1 piece delete row, updated %d", affected)
+	}
+	return nil
+}

--- a/tasks/pdpv0/watch_proving_period.go
+++ b/tasks/pdpv0/watch_proving_period.go
@@ -91,24 +91,58 @@ func NewProvingPeriodWatcher(w *Watcher) {
 }
 
 type confirmedProvingPeriod struct {
-	DataSetID int64  `db:"id"`
-	TxHash    string `db:"challenge_request_msg_hash"`
+	DataSetID int64          `db:"id"`
+	TxHash    sql.NullString `db:"challenge_request_msg_hash"`
 }
 
 func selectProvingPeriodsNeedingReconcile(ctx context.Context, db *harmonydb.DB, limit int) ([]confirmedProvingPeriod, error) {
 	var periods []confirmedProvingPeriod
+
+	// Pick datasets whose nextPP side effects can be reconciled now. The NULL
+	// hash branch is for partial progress: empty-period reconciliation already
+	// cleared the local proving schedule, but delete reconciliation or final flag
+	// clearing did not finish. The non-NULL branch requires a confirmed,
+	// successful message_waits_eth row before reconciliation runs.
+	//
+	// Keep the confirmed-message branch as LATERAL with OFFSET 0. Benchmarks on
+	// Postgres and Yugabyte showed the obvious EXISTS/join forms scan/hash
+	// message_waits_eth at million-row scale, while this shape stays bounded by
+	// the pp_reconcile_needed index and message_waits_eth primary-key lookups.
 	err := db.Select(ctx, &periods, `
-		SELECT pds.id,
-		       COALESCE(pds.challenge_request_msg_hash, '') AS challenge_request_msg_hash
-		FROM pdp_data_sets pds
-		LEFT JOIN message_waits_eth mwe ON mwe.signed_tx_hash = pds.challenge_request_msg_hash
-		WHERE pds.pp_reconcile_needed = TRUE
-		  AND pds.unrecoverable_proving_failure_epoch IS NULL
-		  AND (
-		      pds.challenge_request_msg_hash IS NULL
-		      OR (mwe.tx_status = 'confirmed' AND mwe.tx_success = TRUE)
-		  )
-		ORDER BY pds.id
+		SELECT ready.id,
+		       ready.challenge_request_msg_hash
+		FROM (
+		    (
+		        SELECT pds.id,
+		               pds.challenge_request_msg_hash
+		        FROM pdp_data_sets pds
+		        WHERE pds.pp_reconcile_needed = TRUE
+		          AND pds.unrecoverable_proving_failure_epoch IS NULL
+		          AND pds.challenge_request_msg_hash IS NULL
+		        ORDER BY pds.id
+		        LIMIT $1
+		    )
+		    UNION ALL
+		    (
+		        SELECT pds.id,
+		               pds.challenge_request_msg_hash
+		        FROM pdp_data_sets pds
+		        INNER JOIN LATERAL (
+		            SELECT 1
+		            FROM message_waits_eth mwe
+		            WHERE mwe.signed_tx_hash = pds.challenge_request_msg_hash
+		              AND mwe.tx_status = 'confirmed'
+		              AND mwe.tx_success = TRUE
+		            OFFSET 0
+		        ) mwe ON TRUE
+		        WHERE pds.pp_reconcile_needed = TRUE
+		          AND pds.unrecoverable_proving_failure_epoch IS NULL
+		          AND pds.challenge_request_msg_hash IS NOT NULL
+		        ORDER BY pds.id
+		        LIMIT $1
+		    )
+		) ready
+		ORDER BY ready.id
 		LIMIT $1
 	`, limit)
 	if err != nil {
@@ -166,7 +200,7 @@ func processEmptyProvingPeriods(ctx context.Context, db *harmonydb.DB, ethClient
 	}
 
 	for _, period := range periods {
-		if period.TxHash == "" {
+		if !period.TxHash.Valid {
 			continue
 		}
 
@@ -195,7 +229,7 @@ func processEmptyProvingPeriods(ctx context.Context, db *harmonydb.DB, ethClient
 			WHERE id = $1
 			  AND challenge_request_msg_hash = $2
 			  AND unrecoverable_proving_failure_epoch IS NULL
-		`, period.DataSetID, period.TxHash, initReady)
+		`, period.DataSetID, period.TxHash.String, initReady)
 		if err != nil {
 			return xerrors.Errorf("failed to reset empty proving period for data set %d: %w", period.DataSetID, err)
 		}
@@ -205,7 +239,7 @@ func processEmptyProvingPeriods(ctx context.Context, db *harmonydb.DB, ethClient
 		if affected == 1 {
 			log.Infow("reset empty proving period",
 				"dataSetId", period.DataSetID,
-				"txHash", period.TxHash,
+				"txHash", period.TxHash.String,
 				"leafCount", leafCount.String(),
 				"initReady", initReady)
 		}
@@ -221,7 +255,7 @@ func clearProvingPeriodReconcileNeeded(ctx context.Context, db *harmonydb.DB, pe
 			SET pp_reconcile_needed = FALSE
 			WHERE id = $1
 			  AND (challenge_request_msg_hash = $2 OR challenge_request_msg_hash IS NULL)
-		`, period.DataSetID, period.TxHash)
+		`, period.DataSetID, period.TxHash.String)
 		if err != nil {
 			return xerrors.Errorf("failed to clear proving period reconciliation flag for data set %d: %w", period.DataSetID, err)
 		}

--- a/tasks/pdpv0/watch_proving_period.go
+++ b/tasks/pdpv0/watch_proving_period.go
@@ -17,31 +17,74 @@ import (
 )
 
 const alertNameProvingPeriod = "ProvingPeriod"
+const provingPeriodReconcileBatchLimit = 128
 
 // NewProvingPeriodWatcher reconciles confirmed proving-period side effects
 // before the prove watcher runs. nextProvingPeriod is what finally applies
 // scheduled piece removals and can also clear PDPVerifier's next challenge when
 // the dataset becomes empty, so both local states must be fixed before prove
 // task scheduling looks at the dataset.
+//
+// Empty-period reconciliation runs first because there is no proof to submit for
+// a zero on-chain challenge epoch. Clearing the stale schedule before delete
+// reconciliation prevents the prove watcher from disabling proving after a new
+// add already made the dataset ready again.
 func NewProvingPeriodWatcher(w *Watcher) {
 	if err := w.AddWatcher(func(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient, al curioalerting.AlertingInterface, revert, apply *chainTypes.TipSet) {
-		if err := processEmptyProvingPeriods(ctx, db, ethClient); err != nil {
+		if err := clearFailedProvingPeriodReconciliations(ctx, db, provingPeriodReconcileBatchLimit); err != nil {
+			log.Warnf("Failed to clear failed PDP proving period reconciliation flags: %s", err)
+			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
+				System:    alertType,
+				Subsystem: alertNameProvingPeriod,
+				Message:   fmt.Sprintf("failed to clear failed PDP proving period reconciliation flags: %s", err),
+			})
+			return
+		}
+
+		readyPeriods, err := selectProvingPeriodsNeedingReconcile(ctx, db, provingPeriodReconcileBatchLimit)
+		if err != nil {
+			log.Warnf("Failed to select ready PDP proving periods: %s", err)
+			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
+				System:    alertType,
+				Subsystem: alertNameProvingPeriod,
+				Message:   fmt.Sprintf("failed to select ready PDP proving periods: %s", err),
+			})
+			return
+		}
+		if len(readyPeriods) == 0 {
+			return
+		}
+		readyDataSets := provingPeriodDataSetIDs(readyPeriods)
+
+		if err := processEmptyProvingPeriods(ctx, db, ethClient, readyPeriods); err != nil {
 			log.Warnf("Failed to process empty PDP proving periods: %s", err)
 			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
 				System:    alertType,
 				Subsystem: alertNameProvingPeriod,
 				Message:   fmt.Sprintf("failed to process empty PDP proving periods: %s", err),
 			})
+			return
 		}
 
-		if err := processPendingPieceDeletes(ctx, db, ethClient); err != nil {
+		if err := processPendingPieceDeletes(ctx, db, ethClient, readyDataSets); err != nil {
 			log.Warnf("Failed to process pending PDP piece deletes: %s", err)
 			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
 				System:    alertType,
 				Subsystem: alertNameProvingPeriod,
 				Message:   fmt.Sprintf("failed to process pending PDP piece deletes: %s", err),
 			})
+			return
 		}
+
+		if err := clearProvingPeriodReconcileNeeded(ctx, db, readyPeriods); err != nil {
+			log.Warnf("Failed to clear PDP proving period reconciliation flags: %s", err)
+			_ = al.EmitEvent(ctx, curioalerting.AlertEvent{
+				System:    alertType,
+				Subsystem: alertNameProvingPeriod,
+				Message:   fmt.Sprintf("failed to clear PDP proving period reconciliation flags: %s", err),
+			})
+		}
+
 	}, WatcherOrderCleanupPieces); err != nil {
 		panic(err)
 	}
@@ -52,33 +95,68 @@ type confirmedProvingPeriod struct {
 	TxHash    string `db:"challenge_request_msg_hash"`
 }
 
+func selectProvingPeriodsNeedingReconcile(ctx context.Context, db *harmonydb.DB, limit int) ([]confirmedProvingPeriod, error) {
+	var periods []confirmedProvingPeriod
+	err := db.Select(ctx, &periods, `
+		SELECT pds.id,
+		       COALESCE(pds.challenge_request_msg_hash, '') AS challenge_request_msg_hash
+		FROM pdp_data_sets pds
+		LEFT JOIN message_waits_eth mwe ON mwe.signed_tx_hash = pds.challenge_request_msg_hash
+		WHERE pds.pp_reconcile_needed = TRUE
+		  AND pds.unrecoverable_proving_failure_epoch IS NULL
+		  AND (
+		      pds.challenge_request_msg_hash IS NULL
+		      OR (mwe.tx_status = 'confirmed' AND mwe.tx_success = TRUE)
+		  )
+		ORDER BY pds.id
+		LIMIT $1
+	`, limit)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to select proving periods needing reconciliation: %w", err)
+	}
+
+	return periods, nil
+}
+
+func provingPeriodDataSetIDs(periods []confirmedProvingPeriod) []int64 {
+	dataSets := make([]int64, 0, len(periods))
+	for _, period := range periods {
+		dataSets = append(dataSets, period.DataSetID)
+	}
+	return dataSets
+}
+
+func clearFailedProvingPeriodReconciliations(ctx context.Context, db *harmonydb.DB, limit int) error {
+	_, err := db.Exec(ctx, `
+		WITH failed AS (
+			SELECT pds.id,
+			       pds.challenge_request_msg_hash
+			FROM pdp_data_sets pds
+			INNER JOIN message_waits_eth mwe ON mwe.signed_tx_hash = pds.challenge_request_msg_hash
+			WHERE pds.pp_reconcile_needed = TRUE
+			  AND pds.challenge_request_msg_hash IS NOT NULL
+			  AND (mwe.tx_status = 'failed' OR mwe.tx_success = FALSE)
+			ORDER BY pds.id
+			LIMIT $1
+		)
+		UPDATE pdp_data_sets pds
+		SET pp_reconcile_needed = FALSE
+		FROM failed
+		WHERE pds.id = failed.id
+		  AND pds.challenge_request_msg_hash = failed.challenge_request_msg_hash
+	`, limit)
+	if err != nil {
+		return xerrors.Errorf("failed to clear failed proving period reconciliations: %w", err)
+	}
+	return nil
+}
+
 // processEmptyProvingPeriods reconciles datasets whose confirmed initPP/nextPP
 // message left no next challenge on-chain. This happens when nextProvingPeriod
 // removes the final piece: PDPVerifier clears the challenge, but Curio may have
 // already stored the now-stale prove_at_epoch.
-//
-// Dropping that local period before piece-delete reconciliation is intentional.
-// There is no proof to submit for a zero on-chain challenge epoch. Clearing the
-// stale schedule first prevents the prove watcher from disabling proving after a
-// new add already made the dataset ready again. The current on-chain leaf count
-// then decides whether InitProvingPeriodTask should pick the dataset back up.
-func processEmptyProvingPeriods(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient) error {
-	var confirmed []confirmedProvingPeriod
-	err := db.Select(ctx, &confirmed, `
-		SELECT pds.id,
-		       pds.challenge_request_msg_hash
-		FROM pdp_data_sets pds
-		INNER JOIN message_waits_eth mwe ON mwe.signed_tx_hash = pds.challenge_request_msg_hash
-		WHERE pds.challenge_request_msg_hash IS NOT NULL
-		  AND mwe.tx_status = 'confirmed'
-		  AND mwe.tx_success = TRUE
-		  AND pds.unrecoverable_proving_failure_epoch IS NULL
-		ORDER BY pds.id
-	`)
-	if err != nil {
-		return xerrors.Errorf("failed to select confirmed proving periods: %w", err)
-	}
-	if len(confirmed) == 0 {
+func processEmptyProvingPeriods(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient, periods []confirmedProvingPeriod) error {
+	if len(periods) == 0 {
 		return nil
 	}
 
@@ -87,7 +165,11 @@ func processEmptyProvingPeriods(ctx context.Context, db *harmonydb.DB, ethClient
 		return xerrors.Errorf("failed to instantiate PDPVerifier contract: %w", err)
 	}
 
-	for _, period := range confirmed {
+	for _, period := range periods {
+		if period.TxHash == "" {
+			continue
+		}
+
 		dataSetID := big.NewInt(period.DataSetID)
 
 		nextChallengeEpoch, err := verifier.GetNextChallengeEpoch(contract.EthCallOpts(ctx), dataSetID)
@@ -132,6 +214,21 @@ func processEmptyProvingPeriods(ctx context.Context, db *harmonydb.DB, ethClient
 	return nil
 }
 
+func clearProvingPeriodReconcileNeeded(ctx context.Context, db *harmonydb.DB, periods []confirmedProvingPeriod) error {
+	for _, period := range periods {
+		_, err := db.Exec(ctx, `
+			UPDATE pdp_data_sets
+			SET pp_reconcile_needed = FALSE
+			WHERE id = $1
+			  AND (challenge_request_msg_hash = $2 OR challenge_request_msg_hash IS NULL)
+		`, period.DataSetID, period.TxHash)
+		if err != nil {
+			return xerrors.Errorf("failed to clear proving period reconciliation flag for data set %d: %w", period.DataSetID, err)
+		}
+	}
+	return nil
+}
+
 type pendingPieceDelete struct {
 	DataSetID int64          `db:"data_set"`
 	PieceID   int64          `db:"piece_id"`
@@ -140,12 +237,12 @@ type pendingPieceDelete struct {
 	TxSuccess sql.NullBool   `db:"tx_success"`
 }
 
-// processPendingPieceDeletes reconciles local piece-removal rows after the
-// schedulePieceDeletions transaction is confirmed. That transaction only queues
-// removals on-chain; the piece is actually removed later by nextProvingPeriod,
-// so this function must not mark a local row removed while PDPVerifier still
-// reports the piece in GetScheduledRemovals.
-func processPendingPieceDeletes(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient) error {
+// processPendingPieceDeletes reconciles local piece-removal rows after
+// nextProvingPeriod has applied scheduled removals on-chain. A confirmed
+// schedulePieceDeletions transaction only records delete intent; the piece
+// should not be marked removed locally while PDPVerifier still reports it as
+// scheduled or live.
+func processPendingPieceDeletes(ctx context.Context, db *harmonydb.DB, ethClient ethchain.EthClient, dataSets []int64) error {
 	var pendingDeletes []pendingPieceDelete
 	err := db.Select(ctx, &pendingDeletes, `
 		SELECT psp.data_set,
@@ -155,10 +252,11 @@ func processPendingPieceDeletes(ctx context.Context, db *harmonydb.DB, ethClient
 		       mwe.tx_success
 		FROM pdp_data_set_pieces psp
 		LEFT JOIN message_waits_eth mwe ON mwe.signed_tx_hash = psp.rm_message_hash
-		WHERE psp.rm_message_hash IS NOT NULL
+		WHERE psp.data_set = ANY($1::bigint[])
+		  AND psp.rm_message_hash IS NOT NULL
 		  AND psp.removed = FALSE
 		ORDER BY psp.data_set, psp.piece_id
-	`)
+	`, dataSets)
 	if err != nil {
 		return xerrors.Errorf("failed to select pending piece deletes: %w", err)
 	}


### PR DESCRIPTION
Built on https://github.com/filecoin-project/curio/pull/1363

## Summary
• Adds a PDPv0 proving-period watcher that reconciles confirmed proving-period effects before prove scheduling runs.
• Moves piece-delete finalization out of the immediate nextPP send path and waits for the on-chain state to reflect removal.
• Handles empty-dataset proving periods by clearing stale local proving state and re-enabling init when pieces are present