### PR TITLE
fix(pdpv0): restore sub-piece component in piece_adds primary key

### DIFF
--- a/harmony/harmonydb/downgrade/20260717-pdp-v0-piece-adds-subpiece-pk.sql
+++ b/harmony/harmonydb/downgrade/20260717-pdp-v0-piece-adds-subpiece-pk.sql
@@ -1,0 +1,19 @@
+-- Revert the piece_adds primary key to (add_message_hash, add_message_index).
+-- Note: this fails if the table holds a piece with multiple sub-pieces (rows
+-- that are only distinguished by sub_piece_offset); remove those rows first.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'pdp_data_set_piece_adds_pk'
+      AND conrelid = to_regclass('pdp_data_set_piece_adds')
+  ) THEN
+    ALTER TABLE pdp_data_set_piece_adds
+      DROP CONSTRAINT pdp_data_set_piece_adds_pk;
+  END IF;
+
+  ALTER TABLE pdp_data_set_piece_adds
+    ADD CONSTRAINT pdp_data_set_piece_adds_pk
+    PRIMARY KEY (add_message_hash, add_message_index);
+END $$;

--- a/harmony/harmonydb/sql/20260717-pdp-v0-piece-adds-subpiece-pk.sql
+++ b/harmony/harmonydb/sql/20260717-pdp-v0-piece-adds-subpiece-pk.sql
@@ -1,0 +1,28 @@
+-- pdp_data_set_piece_adds holds one row per SUB-piece, but the primary key
+-- (add_message_hash, add_message_index) only distinguishes pieces: every
+-- sub-piece row of an aggregated piece shares the piece's add_message_index,
+-- so adding a piece with two or more sub-pieces violates the PK on the second
+-- row. The handler has already broadcast the AddPieces transaction at that
+-- point, so the insert failure strands an on-chain piece with no local
+-- tracking (never proven, never indexed).
+--
+-- The pre-20251010 key (data_set, add_message_hash, sub_piece_offset) had the
+-- mirror-image flaw: single-sub-piece pieces in a multi-piece batch all sit at
+-- offset 0 and collided. Row identity needs BOTH discriminators. data_set
+-- stays out of the key: it is nullable for the create-and-add flow (20251015).
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'pdp_data_set_piece_adds_pk'
+      AND conrelid = to_regclass('pdp_data_set_piece_adds')
+  ) THEN
+    ALTER TABLE pdp_data_set_piece_adds
+      DROP CONSTRAINT pdp_data_set_piece_adds_pk;
+  END IF;
+
+  ALTER TABLE pdp_data_set_piece_adds
+    ADD CONSTRAINT pdp_data_set_piece_adds_pk
+    PRIMARY KEY (add_message_hash, add_message_index, sub_piece_offset);
+END $$;

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -907,8 +907,10 @@ func (p *PDPService) handleGetPieceAdditionStatus(w http.ResponseWriter, r *http
 		}
 	}
 
-	if confirmedPieceIds != nil && len(confirmedPieceIds) != len(pieceAdds) {
-		msg := fmt.Sprintf("Mismatch in confirmed piece IDs count (%d) vs number of pieces added (%d) for tx %s", len(confirmedPieceIds), len(pieceAdds), txHash)
+	// pieceAdds has one row per sub-piece; compare confirmed piece IDs against
+	// the number of distinct pieces, not sub-piece rows.
+	if confirmedPieceIds != nil && len(confirmedPieceIds) != len(uniquePieceMap) {
+		msg := fmt.Sprintf("Mismatch in confirmed piece IDs count (%d) vs number of pieces added (%d) for tx %s", len(confirmedPieceIds), len(uniquePieceMap), txHash)
 		log.Error(msg)
 		http.Error(w, msg, http.StatusInternalServerError)
 		return

--- a/pdp/handlers_add_subpieces_test.go
+++ b/pdp/handlers_add_subpieces_test.go
@@ -1,0 +1,156 @@
+package pdp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+)
+
+// seedPieceRef creates the parked_pieces -> parked_piece_refs -> pdp_piecerefs
+// chain a piece-add tracking row references, returning the pdp_piecerefs.id.
+func seedPieceRef(t *testing.T, db *harmonydb.DB, service, pieceCid string, paddedSize, rawSize int64) int64 {
+	t.Helper()
+	ctx := context.Background()
+
+	var parkedID int64
+	err := db.QueryRow(ctx, `
+		INSERT INTO parked_pieces (piece_cid, piece_padded_size, piece_raw_size, complete, long_term)
+		VALUES ($1, $2, $3, TRUE, TRUE)
+		RETURNING id
+	`, pieceCid, paddedSize, rawSize).Scan(&parkedID)
+	require.NoError(t, err)
+
+	var refID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO parked_piece_refs (piece_id, long_term)
+		VALUES ($1, TRUE)
+		RETURNING ref_id
+	`, parkedID).Scan(&refID)
+	require.NoError(t, err)
+
+	var pieceRefID int64
+	err = db.QueryRow(ctx, `
+		INSERT INTO pdp_piecerefs (service, piece_cid, piece_ref)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`, service, pieceCid, refID).Scan(&pieceRefID)
+	require.NoError(t, err)
+
+	return pieceRefID
+}
+
+func seedAddPiecesFixture(t *testing.T, db *harmonydb.DB, service string, dataSetID uint64) {
+	t.Helper()
+	ctx := context.Background()
+
+	_, err := db.Exec(ctx, `
+		INSERT INTO pdp_services (pubkey, service_label)
+		VALUES ($1, $2)
+		ON CONFLICT (service_label) DO NOTHING
+	`, []byte(service), service)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO pdp_data_sets (id, create_message_hash, service, proving_period, challenge_window, init_ready)
+		VALUES ($1, $2, $3, 100, 10, FALSE)
+		ON CONFLICT (id) DO NOTHING
+	`, int64(dataSetID), fmt.Sprintf("0x%064x", dataSetID), service)
+	require.NoError(t, err)
+}
+
+func insertAddPiecesTracking(t *testing.T, db *harmonydb.DB, dataSetID *uint64, txHash string, pieces []AddPieceRequest, infoMap map[string]*SubPieceInfo) error {
+	t.Helper()
+	svc := &PDPService{}
+	_, err := db.BeginTransaction(context.Background(), func(tx *harmonydb.Tx) (bool, error) {
+		// mirror the handler: track the message, then the per-sub-piece rows
+		if _, err := tx.Exec(`
+			INSERT INTO message_waits_eth (signed_tx_hash, tx_status)
+			VALUES ($1, 'pending')
+		`, txHash); err != nil {
+			return false, err
+		}
+		if err := svc.insertPieceAdds(tx, dataSetID, txHash, pieces, infoMap); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+	return err
+}
+
+// TestInsertPieceAdds_MultiPieceBatch documents the shape that works today:
+// one AddPieces message carrying several pieces, each with exactly one
+// sub-piece. Every row gets a distinct add_message_index.
+func TestInsertPieceAdds_MultiPieceBatch(t *testing.T) {
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	const service = "subpiece-pk-test"
+	seedAddPiecesFixture(t, db, service, 424201)
+
+	txHash := fmt.Sprintf("0x%064x", 1001)
+	var pieces []AddPieceRequest
+	infoMap := map[string]*SubPieceInfo{}
+	for i := 0; i < 2; i++ {
+		sub := generatedPieceCIDV2(t, 100+i, 4096)
+		refID := seedPieceRef(t, db, service, sub, 8192, 4096)
+		pieces = append(pieces, AddPieceRequest{
+			PieceCID:   sub,
+			pieceCIDv1: sub,
+			SubPieces:  []SubPieceEntry{{SubPieceCID: sub, subPieceCIDv1: sub}},
+		})
+		infoMap[sub] = &SubPieceInfo{PaddedSize: 8192, RawSize: 4096, PDPPieceRefID: refID, SubPieceOffset: 0}
+	}
+
+	dataSetID := uint64(424201)
+	require.NoError(t, insertAddPiecesTracking(t, db, &dataSetID, txHash, pieces, infoMap))
+}
+
+// TestInsertPieceAdds_MultiSubPieceAggregate reproduces the aggregate-add
+// failure: one piece whose payload is aggregated from two sub-pieces. The
+// handler inserts one tracking row per sub-piece, and both rows carry the
+// piece's add_message_index. With a primary key that has no sub-piece
+// component the second row violates pdp_data_set_piece_adds_pk (SQLSTATE
+// 23505), the transaction rolls back, and the client gets a 500 after the
+// on-chain AddPieces message was already broadcast.
+func TestInsertPieceAdds_MultiSubPieceAggregate(t *testing.T) {
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	const service = "subpiece-pk-test"
+	seedAddPiecesFixture(t, db, service, 424202)
+
+	txHash := fmt.Sprintf("0x%064x", 1002)
+	aggregate := generatedPieceCIDV2(t, 200, 16384)
+	sub1 := generatedPieceCIDV2(t, 201, 4096)
+	sub2 := generatedPieceCIDV2(t, 202, 4096)
+	ref1 := seedPieceRef(t, db, service, sub1, 8192, 4096)
+	ref2 := seedPieceRef(t, db, service, sub2, 8192, 4096)
+
+	pieces := []AddPieceRequest{{
+		PieceCID:   aggregate,
+		pieceCIDv1: aggregate,
+		SubPieces: []SubPieceEntry{
+			{SubPieceCID: sub1, subPieceCIDv1: sub1},
+			{SubPieceCID: sub2, subPieceCIDv1: sub2},
+		},
+	}}
+	infoMap := map[string]*SubPieceInfo{
+		sub1: {PaddedSize: 8192, RawSize: 4096, PDPPieceRefID: ref1, SubPieceOffset: 0},
+		sub2: {PaddedSize: 8192, RawSize: 4096, PDPPieceRefID: ref2, SubPieceOffset: 8192},
+	}
+
+	dataSetID := uint64(424202)
+	require.NoError(t, insertAddPiecesTracking(t, db, &dataSetID, txHash, pieces, infoMap),
+		"adding one piece with two sub-pieces must insert both tracking rows")
+
+	var rows int
+	err = db.QueryRow(context.Background(), `
+		SELECT COUNT(*) FROM pdp_data_set_piece_adds WHERE add_message_hash = $1
+	`, txHash).Scan(&rows)
+	require.NoError(t, err)
+	require.Equal(t, 2, rows, "one tracking row per sub-piece")
+}


### PR DESCRIPTION
## What changed

`pdp_data_set_piece_adds` stores one row per sub-piece, but its primary key `(add_message_hash, add_message_index)` only distinguishes pieces. Any piece with 2+ sub-pieces violates the PK on its own second row (SQLSTATE 23505), after the AddPieces tx was already broadcast. The client gets a 500 and the piece lands on chain with no local tracking: never proven, never indexed. Full root-cause writeup in #1362.

- New migration restores a sub-piece component: PK `(add_message_hash, add_message_index, sub_piece_offset)`. `data_set` stays out of the key; it is nullable since 20251015 for create-and-add.
- `handleGetPieceAdditionStatus` compared confirmed piece ids (distinct pieces) against sub-piece row count, so a confirmed multi-sub-piece add would 500 on status polling once its rows can exist. Now compares distinct pieces.
- Tests: `TestInsertPieceAdds_MultiSubPieceAggregate` reproduces the collision (fails on main with the exact error from #1362), `TestInsertPieceAdds_MultiPieceBatch` locks in the batch shape that already works.

## How to verify

```
go test ./pdp/ -run TestInsertPieceAdds -v -count=1
```

On main, the aggregate test fails with `duplicate key value violates unique constraint "pdp_data_set_piece_adds_pk" (SQLSTATE 23505)`. With this branch both pass; `./pdp/` (131) and `./tasks/pdpv0/` (48) also pass.

## Notes / risks

- 20251010 replaced the original `(data_set, add_message_hash, sub_piece_offset)` key because multi-piece batches collide on it (every piece's sub-piece sits at offset 0). The new key keeps both discriminators, so both shapes insert cleanly.
- Validated on Postgres 14. Not tested on Yugabyte; the 20260414 lsm-shaped PK is dropped by the same constraint name, but a YB run would be good before merge.
- This prevents new orphans only. Pieces already stranded on chain with no local rows still need backfill or on-chain removal.
