### PR TITLE
Handle ambiguous Eth send errors with exact transaction lookup

### DIFF
--- a/tasks/message/replace_eth.go
+++ b/tasks/message/replace_eth.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -531,17 +532,41 @@ func (t *ethMessageReplacer) sendAndRecordReplacementEthMessages(ctx context.Con
 			ethCtx, cancel := context.WithTimeout(ctx, defaultEthCallTimeout)
 			sendErr := t.client.SendTransaction(ethCtx, tx)
 			cancel()
-			if isEthTransactionAlreadyKnownError(sendErr) {
-				log.Infow("eth message replacement already known", "from", replacement.Candidate.FromAddress, "nonce", replacement.Candidate.Nonce, "hash", tx.Hash().Hex())
-				sendErr = nil
+
+			sendResult := classifyEthSendError(sendErr)
+			if sendResult == ethSendUnknown {
+				time.Sleep(ethUnknownSendSettleDelay)
+
+				known, lookupErr := t.checkInTransactionPool(ctx, tx.Hash())
+				if lookupErr != nil {
+					log.Warnw("eth message replacement send state unknown; failed to look up transaction before retry",
+						"from", replacement.Candidate.FromAddress,
+						"nonce", replacement.Candidate.Nonce,
+						"hash", tx.Hash().Hex(),
+						"send_error", sendErr,
+						"lookup_error", lookupErr)
+					continue
+				}
+				if !known {
+					log.Warnw("eth message replacement send state unknown; leaving signed claim for retry",
+						"from", replacement.Candidate.FromAddress,
+						"nonce", replacement.Candidate.Nonce,
+						"hash", tx.Hash().Hex(),
+						"error", sendErr)
+					continue
+				}
+
+				log.Infow("eth message replacement found after ambiguous send error",
+					"from", replacement.Candidate.FromAddress,
+					"nonce", replacement.Candidate.Nonce,
+					"hash", tx.Hash().Hex(),
+					"error", sendErr)
+				sendResult = ethSendAccepted
 			}
-			if errors.Is(sendErr, context.Canceled) || errors.Is(sendErr, context.DeadlineExceeded) {
-				log.Warnw("eth message replacement send timed out; leaving signed claim for retry", "from", replacement.Candidate.FromAddress, "nonce", replacement.Candidate.Nonce, "hash", tx.Hash().Hex(), "error", sendErr)
-				continue
-			}
-			sendSuccess := sendErr == nil
+
+			sendSuccess := sendResult == ethSendAccepted
 			sendError := ""
-			if sendErr != nil {
+			if sendResult == ethSendDefinitiveError {
 				sendError = sendErr.Error()
 				log.Warnw("eth message replacement send failed", "from", replacement.Candidate.FromAddress, "nonce", replacement.Candidate.Nonce, "hash", tx.Hash().Hex(), "error", sendErr)
 			}
@@ -572,6 +597,27 @@ func (t *ethMessageReplacer) sendAndRecordReplacementEthMessages(ctx context.Con
 	}
 
 	return nil
+}
+
+// checkInTransactionPool returns true when Lotus can resolve the exact signed
+// tx hash, either as pending or already mined.
+func (t *ethMessageReplacer) checkInTransactionPool(ctx context.Context, hash common.Hash) (bool, error) {
+	ethCtx, cancel := context.WithTimeout(ctx, defaultEthCallTimeout)
+	defer cancel()
+
+	tx, pending, err := t.client.TransactionByHash(ethCtx, hash)
+	if err != nil {
+		if errors.Is(err, ethereum.NotFound) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if pending || tx != nil {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (t *ethMessageReplacer) deleteEthMessageReplacementClaims(ctx context.Context, candidates []ethMessageReplaceCandidate) error {
@@ -670,15 +716,4 @@ func capEthMessageGasFee(gasFeeCap, gasTipCap *big.Int, gasLimit uint64) (*big.I
 	}
 
 	return gasFeeCap, gasTipCap
-}
-
-func isEthTransactionAlreadyKnownError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "already known") ||
-		strings.Contains(msg, "already imported") ||
-		strings.Contains(msg, "already in the txpool")
 }

--- a/tasks/message/replacer_test.go
+++ b/tasks/message/replacer_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"database/sql"
+	"errors"
 	"fmt"
 	mathbig "math/big"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	gethcrypto "github.com/ethereum/go-ethereum/crypto"
@@ -603,9 +605,10 @@ func TestEthMessageReplacerReplacesFeeStuckEthMessage(t *testing.T) {
 	require.True(t, sendSuccess)
 }
 
-func TestEthMessageReplacerTreatsAlreadyKnownAsSuccess(t *testing.T) {
+func TestEthMessageReplacerAmbiguousSendSucceedsAfterExactLookup(t *testing.T) {
 	h := newEthReplaceHarness(t)
-	h.client.sendErr = fmt.Errorf("already known")
+	h.client.sendErr = errors.New(errMessageWithNonceExists)
+	h.client.lookupSentTx = true
 
 	privateKey, err := gethcrypto.GenerateKey()
 	require.NoError(t, err)
@@ -620,6 +623,8 @@ func TestEthMessageReplacerTreatsAlreadyKnownAsSuccess(t *testing.T) {
 
 	h.run(t)
 
+	require.Equal(t, 1, h.client.txCalls)
+
 	var sendSuccess bool
 	var sendError string
 	err = h.db.QueryRow(h.ctx, `
@@ -629,6 +634,41 @@ func TestEthMessageReplacerTreatsAlreadyKnownAsSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, sendSuccess)
 	require.Empty(t, sendError)
+}
+
+func TestEthMessageReplacerDoesNotTrustAmbiguousSendWithoutExactLookup(t *testing.T) {
+	h := newEthReplaceHarness(t)
+	h.client.sendErr = errors.New(errMessageWithNonceExists)
+
+	privateKey, err := gethcrypto.GenerateKey()
+	require.NoError(t, err)
+	from := gethcrypto.PubkeyToAddress(privateKey.PublicKey)
+	to := common.HexToAddress("0x1000000000000000000000000000000000000009")
+	nonce := uint64(19)
+	h.client.nonce = nonce
+	h.insertKey(t, from, gethcrypto.FromECDSA(privateKey))
+
+	original, originalData := signedDynamicTx(t, privateKey, to, nonce, 100, 10)
+	h.insertEthMessageSend(t, from, to, original, originalData, h.oldSendTime())
+
+	h.run(t)
+
+	require.Equal(t, 1, h.client.txCalls)
+
+	var signedHash sql.NullString
+	var sendSuccess sql.NullBool
+	var sendTime sql.NullTime
+	var sendError sql.NullString
+	err = h.db.QueryRow(h.ctx, `
+		SELECT signed_hash, send_success, send_time, send_error
+		FROM message_send_eth_replacements
+		WHERE from_address = $1 AND nonce = $2`, from.Hex(), nonce).Scan(&signedHash, &sendSuccess, &sendTime, &sendError)
+	require.NoError(t, err)
+	require.True(t, signedHash.Valid)
+	require.Equal(t, h.client.sentTxs[0].Hash().Hex(), signedHash.String)
+	require.False(t, sendSuccess.Valid)
+	require.False(t, sendTime.Valid)
+	require.False(t, sendError.Valid)
 }
 
 func TestEthMessageReplacerRetriesSignedClaim(t *testing.T) {
@@ -758,6 +798,7 @@ func TestEthMessageReplacerLeavesSignedClaimOnSendTimeout(t *testing.T) {
 	h.run(t)
 
 	require.Len(t, h.client.sentTxs, 1)
+	require.Equal(t, 1, h.client.txCalls)
 
 	var signedHash sql.NullString
 	var sendSuccess sql.NullBool
@@ -778,18 +819,22 @@ func TestEthMessageReplacerLeavesSignedClaimOnSendTimeout(t *testing.T) {
 type replaceEthClient struct {
 	ethchain.EthClient
 
-	nonce     uint64
-	nonceErr  error
-	header    *gethtypes.Header
-	headerErr error
-	gasTipCap *mathbig.Int
-	tipCapErr error
-	sendErr   error
+	nonce         uint64
+	nonceErr      error
+	header        *gethtypes.Header
+	headerErr     error
+	gasTipCap     *mathbig.Int
+	tipCapErr     error
+	sendErr       error
+	lookupSentTx  bool
+	lookupPending bool
+	lookupErr     error
 
 	nonceCalls  int
 	headerCalls int
 	tipCapCalls int
 	sendCalls   int
+	txCalls     int
 	sentTxs     []*gethtypes.Transaction
 }
 
@@ -821,6 +866,21 @@ func (m *replaceEthClient) SendTransaction(ctx context.Context, tx *gethtypes.Tr
 	m.sendCalls++
 	m.sentTxs = append(m.sentTxs, tx)
 	return m.sendErr
+}
+
+func (m *replaceEthClient) TransactionByHash(ctx context.Context, hash common.Hash) (*gethtypes.Transaction, bool, error) {
+	m.txCalls++
+	if m.lookupErr != nil {
+		return nil, false, m.lookupErr
+	}
+	if m.lookupSentTx {
+		for _, tx := range m.sentTxs {
+			if tx.Hash() == hash {
+				return tx, m.lookupPending, nil
+			}
+		}
+	}
+	return nil, false, ethereum.NotFound
 }
 
 func replaceTestStuckDuration() time.Duration {

--- a/tasks/message/sender_eth.go
+++ b/tasks/message/sender_eth.go
@@ -206,8 +206,7 @@ func (s *SendTaskETH) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 				"hash", signedTx.Hash().Hex(),
 				"send_error", sendErr,
 				"lookup_error", lookupErr)
-			sendResult = ethSendDefinitiveError
-			sendErr = multierr.Combine(
+			return false, multierr.Combine(
 				xerrors.Errorf("eth transaction send state unknown for %s after settle delay: %w", signedTx.Hash().Hex(), sendErr),
 				xerrors.Errorf("looking up eth transaction %s after unknown send: %w", signedTx.Hash().Hex(), lookupErr),
 			)
@@ -220,37 +219,14 @@ func (s *SendTaskETH) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 				"error", sendErr)
 			sendResult = ethSendAccepted
 		} else {
-			pendingNonce, nonceErr := s.checkPendingNonce(fromAddress)
-			if nonceErr != nil {
-				log.Warnw("eth transaction send state unknown; failed to check pending nonce after settle delay",
-					"task_id", taskID,
-					"from", dbTx.FromAddress,
-					"nonce", signedTx.Nonce(),
-					"hash", signedTx.Hash().Hex(),
-					"send_error", sendErr,
-					"nonce_error", nonceErr)
-				sendResult = ethSendDefinitiveError
-				sendErr = multierr.Combine(
-					xerrors.Errorf("eth transaction send state unknown for %s after settle delay: %w", signedTx.Hash().Hex(), sendErr),
-					xerrors.Errorf("checking pending nonce for %s after unknown send: %w", dbTx.FromAddress, nonceErr),
-				)
-			} else {
-				log.Warnw("eth transaction not found after unknown send error",
-					"task_id", taskID,
-					"from", dbTx.FromAddress,
-					"nonce", signedTx.Nonce(),
-					"pending_nonce", pendingNonce,
-					"hash", signedTx.Hash().Hex(),
-					"error", sendErr)
-				sendResult = ethSendDefinitiveError
-				if pendingNonce > signedTx.Nonce() {
-					sendErr = xerrors.Errorf("eth transaction send state unknown for %s: tx not found after %s and sender nonce advanced from %d to %d: %w",
-						signedTx.Hash().Hex(), ethUnknownSendSettleDelay, signedTx.Nonce(), pendingNonce, sendErr)
-				} else {
-					sendErr = xerrors.Errorf("eth transaction send state unknown for %s: tx not found after %s and sender nonce is %d: %w",
-						signedTx.Hash().Hex(), ethUnknownSendSettleDelay, pendingNonce, sendErr)
-				}
-			}
+			log.Warnw("eth transaction not found after unknown send error",
+				"task_id", taskID,
+				"from", dbTx.FromAddress,
+				"nonce", signedTx.Nonce(),
+				"hash", signedTx.Hash().Hex(),
+				"error", sendErr)
+			return false, xerrors.Errorf("eth transaction send state unknown for %s: tx not found after %s: %w",
+				signedTx.Hash().Hex(), ethUnknownSendSettleDelay, sendErr)
 		}
 	}
 
@@ -290,13 +266,6 @@ func (s *SendTaskETH) checkInTransactionPool(hash common.Hash) (bool, error) {
 	}
 
 	return false, nil
-}
-
-func (s *SendTaskETH) checkPendingNonce(from common.Address) (uint64, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultEthCallTimeout)
-	defer cancel()
-
-	return s.client.PendingNonceAt(ctx, from)
 }
 
 func (s *SendTaskETH) signTransaction(ctx context.Context, fromAddress common.Address, tx *types.Transaction) (*types.Transaction, error) {
@@ -548,7 +517,7 @@ const ethUnknownSendSettleDelay = 2 * time.Second
 // classifyEthSendError classifies only source-backed outcomes.
 //
 // Sources:
-//   - Lotus node/impl/eth/send.go, ethSendRawTransaction: raw tx parse, tx hash,
+//   - Lotus node/impl/eth/send.go, ethSendRawTransaction: raw tx parse, tx hash,f
 //     and Filecoin message conversion all happen before MpoolPush/MpoolPushUntrusted.
 //   - Lotus chain/messagepool/messagepool.go, MessagePool.Push/addTs/addLocked:
 //     validation happens before addLocked, while duplicate-same-message is reported

--- a/tasks/message/sender_eth.go
+++ b/tasks/message/sender_eth.go
@@ -561,6 +561,7 @@ var errMessageWithNonceExists = "message with nonce already exists"
 
 var ethSendAmbiguousErrors = []string{
 	errMessageWithNonceExists,
+	"i/o timeout",
 }
 
 var ethSendDefinitiveErrors = []string{

--- a/tasks/message/sender_eth.go
+++ b/tasks/message/sender_eth.go
@@ -199,35 +199,59 @@ func (s *SendTaskETH) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 
 		known, lookupErr := s.checkInTransactionPool(signedTx.Hash())
 		if lookupErr != nil {
-			log.Warnw("eth transaction send state unknown; failed to look up transaction before retry",
+			log.Warnw("eth transaction send state unknown; failed to look up transaction after settle delay",
 				"task_id", taskID,
 				"from", dbTx.FromAddress,
 				"nonce", signedTx.Nonce(),
 				"hash", signedTx.Hash().Hex(),
 				"send_error", sendErr,
 				"lookup_error", lookupErr)
-			return false, multierr.Combine(
-				xerrors.Errorf("eth transaction send state unknown for %s: %w", signedTx.Hash().Hex(), sendErr),
-				xerrors.Errorf("looking up eth transaction %s: %w", signedTx.Hash().Hex(), lookupErr),
+			sendResult = ethSendDefinitiveError
+			sendErr = multierr.Combine(
+				xerrors.Errorf("eth transaction send state unknown for %s after settle delay: %w", signedTx.Hash().Hex(), sendErr),
+				xerrors.Errorf("looking up eth transaction %s after unknown send: %w", signedTx.Hash().Hex(), lookupErr),
 			)
-		}
-		if !known {
-			log.Warnw("eth transaction send state unknown; leaving signed transaction for retry",
+		} else if known {
+			log.Infow("eth transaction found after unknown send error",
 				"task_id", taskID,
 				"from", dbTx.FromAddress,
 				"nonce", signedTx.Nonce(),
 				"hash", signedTx.Hash().Hex(),
 				"error", sendErr)
-			return false, xerrors.Errorf("eth transaction send state unknown for %s: %w", signedTx.Hash().Hex(), sendErr)
+			sendResult = ethSendAccepted
+		} else {
+			pendingNonce, nonceErr := s.checkPendingNonce(fromAddress)
+			if nonceErr != nil {
+				log.Warnw("eth transaction send state unknown; failed to check pending nonce after settle delay",
+					"task_id", taskID,
+					"from", dbTx.FromAddress,
+					"nonce", signedTx.Nonce(),
+					"hash", signedTx.Hash().Hex(),
+					"send_error", sendErr,
+					"nonce_error", nonceErr)
+				sendResult = ethSendDefinitiveError
+				sendErr = multierr.Combine(
+					xerrors.Errorf("eth transaction send state unknown for %s after settle delay: %w", signedTx.Hash().Hex(), sendErr),
+					xerrors.Errorf("checking pending nonce for %s after unknown send: %w", dbTx.FromAddress, nonceErr),
+				)
+			} else {
+				log.Warnw("eth transaction not found after unknown send error",
+					"task_id", taskID,
+					"from", dbTx.FromAddress,
+					"nonce", signedTx.Nonce(),
+					"pending_nonce", pendingNonce,
+					"hash", signedTx.Hash().Hex(),
+					"error", sendErr)
+				sendResult = ethSendDefinitiveError
+				if pendingNonce > signedTx.Nonce() {
+					sendErr = xerrors.Errorf("eth transaction send state unknown for %s: tx not found after %s and sender nonce advanced from %d to %d: %w",
+						signedTx.Hash().Hex(), ethUnknownSendSettleDelay, signedTx.Nonce(), pendingNonce, sendErr)
+				} else {
+					sendErr = xerrors.Errorf("eth transaction send state unknown for %s: tx not found after %s and sender nonce is %d: %w",
+						signedTx.Hash().Hex(), ethUnknownSendSettleDelay, pendingNonce, sendErr)
+				}
+			}
 		}
-
-		log.Infow("eth transaction found after ambiguous send error",
-			"task_id", taskID,
-			"from", dbTx.FromAddress,
-			"nonce", signedTx.Nonce(),
-			"hash", signedTx.Hash().Hex(),
-			"error", sendErr)
-		sendResult = ethSendAccepted
 	}
 
 	sendSuccess := sendResult == ethSendAccepted
@@ -255,7 +279,7 @@ func (s *SendTaskETH) checkInTransactionPool(hash common.Hash) (bool, error) {
 
 	tx, pending, err := s.client.TransactionByHash(ctx, hash)
 	if err != nil {
-		if errors.Is(err, ethereum.NotFound) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, ethereum.NotFound) {
 			return false, nil
 		}
 		return false, err
@@ -266,6 +290,13 @@ func (s *SendTaskETH) checkInTransactionPool(hash common.Hash) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func (s *SendTaskETH) checkPendingNonce(from common.Address) (uint64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultEthCallTimeout)
+	defer cancel()
+
+	return s.client.PendingNonceAt(ctx, from)
 }
 
 func (s *SendTaskETH) signTransaction(ctx context.Context, fromAddress common.Address, tx *types.Transaction) (*types.Transaction, error) {
@@ -318,7 +349,6 @@ func (s *SendTaskETH) TypeDetails() harmonytask.TaskTypeDetails {
 		},
 		MaxFailures: 1000,
 		Follows:     nil,
-		RetryWait:   taskhelp.RetryWaitLinear(time.Second, 2*time.Second),
 	}
 }
 

--- a/tasks/message/sender_eth.go
+++ b/tasks/message/sender_eth.go
@@ -3,8 +3,10 @@ package message
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -62,6 +64,10 @@ func (s *SendTaskETH) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 		&dbTx.FromAddress, &dbTx.ToAddress, &dbTx.UnsignedTx, &dbTx.UnsignedHash, &dbTx.Nonce, &dbTx.SignedTx, &dbTx.SendSuccess, &dbTx.SendError)
 	if err != nil {
 		return false, xerrors.Errorf("getting transaction from db: %w", err)
+	}
+
+	if dbTx.SendSuccess.Valid {
+		return true, nil
 	}
 
 	// Deserialize the unsigned transaction
@@ -186,13 +192,48 @@ func (s *SendTaskETH) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 	}
 
 	// Send the transaction
-	err = s.client.SendTransaction(ethCtx, signedTx)
+	sendErr := s.client.SendTransaction(ethCtx, signedTx)
+	sendResult := classifyEthSendError(sendErr)
+	if sendResult == ethSendUnknown {
+		time.Sleep(ethUnknownSendSettleDelay)
 
-	// Persist send result
-	var sendSuccess = err == nil
-	var sendError string
-	if err != nil {
-		sendError = err.Error()
+		known, lookupErr := s.checkInTransactionPool(signedTx.Hash())
+		if lookupErr != nil {
+			log.Warnw("eth transaction send state unknown; failed to look up transaction before retry",
+				"task_id", taskID,
+				"from", dbTx.FromAddress,
+				"nonce", signedTx.Nonce(),
+				"hash", signedTx.Hash().Hex(),
+				"send_error", sendErr,
+				"lookup_error", lookupErr)
+			return false, multierr.Combine(
+				xerrors.Errorf("eth transaction send state unknown for %s: %w", signedTx.Hash().Hex(), sendErr),
+				xerrors.Errorf("looking up eth transaction %s: %w", signedTx.Hash().Hex(), lookupErr),
+			)
+		}
+		if !known {
+			log.Warnw("eth transaction send state unknown; leaving signed transaction for retry",
+				"task_id", taskID,
+				"from", dbTx.FromAddress,
+				"nonce", signedTx.Nonce(),
+				"hash", signedTx.Hash().Hex(),
+				"error", sendErr)
+			return false, xerrors.Errorf("eth transaction send state unknown for %s: %w", signedTx.Hash().Hex(), sendErr)
+		}
+
+		log.Infow("eth transaction found after ambiguous send error",
+			"task_id", taskID,
+			"from", dbTx.FromAddress,
+			"nonce", signedTx.Nonce(),
+			"hash", signedTx.Hash().Hex(),
+			"error", sendErr)
+		sendResult = ethSendAccepted
+	}
+
+	sendSuccess := sendResult == ethSendAccepted
+	sendError := ""
+	if sendResult == ethSendDefinitiveError {
+		sendError = sendErr.Error()
 	}
 
 	_, err = s.db.Exec(ctx,
@@ -204,6 +245,27 @@ func (s *SendTaskETH) Do(taskID harmonytask.TaskID, stillOwned func() bool) (don
 	}
 
 	return true, nil
+}
+
+// checkInTransactionPool returns true when Lotus can resolve the exact signed
+// tx hash, either as pending or already mined.
+func (s *SendTaskETH) checkInTransactionPool(hash common.Hash) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultEthCallTimeout)
+	defer cancel()
+
+	tx, pending, err := s.client.TransactionByHash(ctx, hash)
+	if err != nil {
+		if errors.Is(err, ethereum.NotFound) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if pending || tx != nil {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (s *SendTaskETH) signTransaction(ctx context.Context, fromAddress common.Address, tx *types.Transaction) (*types.Transaction, error) {
@@ -256,6 +318,7 @@ func (s *SendTaskETH) TypeDetails() harmonytask.TaskTypeDetails {
 		},
 		MaxFailures: 1000,
 		Follows:     nil,
+		RetryWait:   taskhelp.RetryWaitLinear(time.Second, 2*time.Second),
 	}
 }
 
@@ -440,4 +503,140 @@ func (s *SenderETH) send(ctx context.Context, fromAddress common.Address, tx *ty
 	log.Infow("sent transaction", "hash", signedHash, "task_id", sendTaskID, "send_error", sendErr, "poll_loops", pollLoops)
 
 	return signedHash, sendErr
+}
+
+type ethSendResult int
+
+const (
+	ethSendAccepted ethSendResult = iota
+	ethSendDefinitiveError
+	ethSendUnknown
+)
+
+const ethUnknownSendSettleDelay = 2 * time.Second
+
+// classifyEthSendError classifies only source-backed outcomes.
+//
+// Sources:
+//   - Lotus node/impl/eth/send.go, ethSendRawTransaction: raw tx parse, tx hash,
+//     and Filecoin message conversion all happen before MpoolPush/MpoolPushUntrusted.
+//   - Lotus chain/messagepool/messagepool.go, MessagePool.Push/addTs/addLocked:
+//     validation happens before addLocked, while duplicate-same-message is reported
+//     from addLocked as ErrExistingNonce.
+//
+// Transport, context, JSON-RPC, storage, publish, soft-validation, and nonce-low
+// errors are left unknown unless listed below. Those errors can happen after a
+// previous send attempt may already have been accepted or landed.
+func classifyEthSendError(err error) ethSendResult {
+	if err == nil {
+		return ethSendAccepted
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ethSendUnknown
+	}
+
+	msg := strings.ToLower(err.Error())
+	if ethSendErrorContainsAny(msg, ethSendAmbiguousErrors) {
+		return ethSendUnknown
+	}
+	if ethSendErrorContainsAny(msg, ethSendDefinitiveErrors) {
+		return ethSendDefinitiveError
+	}
+
+	return ethSendUnknown
+}
+
+func ethSendErrorContainsAny(msg string, parts []string) bool {
+	for _, part := range parts {
+		if strings.Contains(msg, part) {
+			return true
+		}
+	}
+	return false
+}
+
+// Source: Lotus chain/messagepool/messagepool.go, ErrExistingNonce.
+// The same signed Filecoin message is already in the local mpool.
+var errMessageWithNonceExists = "message with nonce already exists"
+
+var ethSendAmbiguousErrors = []string{
+	errMessageWithNonceExists,
+}
+
+var ethSendDefinitiveErrors = []string{
+	// Source: Lotus chain/types/ethtypes/eth_transactions.go, ParseEthTransaction.
+	// ethSendRawTransaction returns these before calling MpoolPush.
+	"empty data",
+	"eip-2930 transaction is not supported",
+	"unsupported transaction type",
+	"failed to parse legacy transaction",
+
+	// Source: Lotus chain/types/ethtypes/eth_1559_transactions.go, parseEip1559Tx,
+	// and chain/types/ethtypes/rlp.go, DecodeRLP.
+	"invalid rlp data",
+	"not an eip-1559 transaction",
+	"access list should be an empty list",
+	"eip-1559 transactions only support 0 or 1 for v",
+	"cannot parse interface to int",
+	"cannot parse interface to ethuint64",
+	"cannot parse interface to big.int",
+	"cannot parse interface into bytes",
+	"cannot parse bytes into an ethaddress",
+
+	// Source: Lotus chain/types/ethtypes/eth_transactions.go,
+	// ToSignedFilecoinMessage. These happen before MpoolPush.
+	"failed to calculate sender",
+	"failed to convert to unsigned msg",
+	"failed to calculate signature",
+	"signature is not 65 bytes",
+
+	// Source: Lotus chain/types/ethtypes/eth_1559_transactions.go,
+	// Eth1559TxArgs.ToUnsignedFilecoinMessage, and
+	// chain/types/ethtypes/eth_types.go, EthAddress.ToFilecoinAddress.
+	"invalid chain id",
+	"failed to write input args",
+	"failed to convert ethaddress to filecoin address",
+	"cannot get filecoin address",
+	"expected a class 4 address",
+
+	// Source: Lotus chain/types/ethtypes/eth_transactions.go and
+	// eth_legacy_155_transactions.go, legacy transaction parsing.
+	"unsupported legacy transaction",
+	"not a legacy eth transaction",
+	"not a legacy transaction",
+	"legacy homestead transactions only support",
+	"failed to validate eip155 chain id",
+
+	// Source: Lotus node/impl/full/mpool.go, sanityCheckOutgoingMessage.
+	// MpoolPush/MpoolPushUntrusted run this before MessagePool.Push.
+	"delegated address but not a valid eth address",
+
+	// Source: Lotus chain/messagepool/messagepool.go, checkMessage.
+	// MessagePool.Push runs this before addTs/addLocked.
+	"message too big",
+	"mpool message too large",
+	"message not valid for block inclusion",
+	"message had invalid to address",
+	"cannot send more filecoin than will ever exist",
+	"gas fee cap too low",
+	"signature verification failed",
+	"failed to validate signature",
+
+	// Source: Lotus chain/messagepool/messagepool.go, addTs/checkBalance.
+	// These are hard rejects before addLocked inserts the message into the mpool.
+	"not enough funds (required:",
+	"not enough funds to execute transaction",
+	"is not a valid top-level sender",
+	"network version should be at least",
+
+	// Source: Lotus chain/messagepool/messagepool.go, msgSet.add.
+	// These reject the candidate instead of adding it as pending.
+	"replace by fee has too low gaspremium",
+	"too many pending messages for actor",
+	"unfulfilled nonce gap",
+
+	// Source: Lotus node/impl/eth/send.go, EthSendDisabled, and
+	// node/modules/eth.go, GatewayEthSend.
+	"ethsendrawtransactionuntrusted is not supported",
+	"module disabled",
 }

--- a/tasks/message/sender_eth_test.go
+++ b/tasks/message/sender_eth_test.go
@@ -1,0 +1,445 @@
+package message
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"database/sql"
+	"errors"
+	mathbig "math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	gethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+	"github.com/filecoin-project/curio/lib/ethchain"
+
+	"github.com/filecoin-project/lotus/build/buildconstants"
+)
+
+func TestSendTaskETHAmbiguousSendSucceedsAfterExactLookup(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	privateKey, err := gethcrypto.GenerateKey()
+	require.NoError(t, err)
+	from := gethcrypto.PubkeyToAddress(privateKey.PublicKey)
+	to := common.HexToAddress("0x2000000000000000000000000000000000000001")
+	insertSendTaskETHKey(t, ctx, db, from, gethcrypto.FromECDSA(privateKey))
+
+	taskID := harmonytask.TaskID(1)
+	insertSendTaskETHTransaction(t, ctx, db, taskID, from, to)
+
+	client := &sendTaskETHClient{
+		pendingNonce:  11,
+		sendErr:       errors.New(errMessageWithNonceExists),
+		lookupSentTx:  true,
+		lookupPending: true,
+	}
+	task := &SendTaskETH{client: client, db: db}
+
+	done, err := task.Do(taskID, func() bool { return true })
+	require.NoError(t, err)
+	require.True(t, done)
+	require.Equal(t, 1, client.sendCalls)
+	require.Equal(t, 1, client.txCalls)
+	require.Len(t, client.sentTxs, 1)
+
+	var signedHash string
+	var sendSuccess bool
+	var sendError string
+	var sendTime sql.NullTime
+	err = db.QueryRow(ctx, `
+		SELECT signed_hash, send_success, send_error, send_time
+		FROM message_sends_eth
+		WHERE send_task_id = $1`, taskID).Scan(&signedHash, &sendSuccess, &sendError, &sendTime)
+	require.NoError(t, err)
+	require.Equal(t, client.sentTxs[0].Hash().Hex(), signedHash)
+	require.True(t, sendSuccess)
+	require.Empty(t, sendError)
+	require.True(t, sendTime.Valid)
+}
+
+func TestSendTaskETHDoesNotTrustAmbiguousSendWithoutExactLookup(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	privateKey, err := gethcrypto.GenerateKey()
+	require.NoError(t, err)
+	from := gethcrypto.PubkeyToAddress(privateKey.PublicKey)
+	to := common.HexToAddress("0x2000000000000000000000000000000000000002")
+	insertSendTaskETHKey(t, ctx, db, from, gethcrypto.FromECDSA(privateKey))
+
+	taskID := harmonytask.TaskID(2)
+	insertSendTaskETHTransaction(t, ctx, db, taskID, from, to)
+
+	client := &sendTaskETHClient{
+		pendingNonce: 12,
+		sendErr:      errors.New(errMessageWithNonceExists),
+	}
+	task := &SendTaskETH{client: client, db: db}
+
+	done, err := task.Do(taskID, func() bool { return true })
+	require.Error(t, err)
+	require.False(t, done)
+	require.Equal(t, 1, client.sendCalls)
+	require.Equal(t, 1, client.txCalls)
+	require.Len(t, client.sentTxs, 1)
+
+	var signedHash sql.NullString
+	var sendSuccess sql.NullBool
+	var sendError sql.NullString
+	var sendTime sql.NullTime
+	err = db.QueryRow(ctx, `
+		SELECT signed_hash, send_success, send_error, send_time
+		FROM message_sends_eth
+		WHERE send_task_id = $1`, taskID).Scan(&signedHash, &sendSuccess, &sendError, &sendTime)
+	require.NoError(t, err)
+	require.True(t, signedHash.Valid)
+	require.Equal(t, client.sentTxs[0].Hash().Hex(), signedHash.String)
+	require.False(t, sendSuccess.Valid)
+	require.False(t, sendError.Valid)
+	require.False(t, sendTime.Valid)
+}
+
+func TestSendTaskETHFreshSendAssignsPendingNonce(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	privateKey, err := gethcrypto.GenerateKey()
+	require.NoError(t, err)
+	from := gethcrypto.PubkeyToAddress(privateKey.PublicKey)
+	to := common.HexToAddress("0x2000000000000000000000000000000000000003")
+	insertSendTaskETHKey(t, ctx, db, from, gethcrypto.FromECDSA(privateKey))
+
+	taskID := harmonytask.TaskID(3)
+	insertSendTaskETHTransaction(t, ctx, db, taskID, from, to)
+
+	client := &sendTaskETHClient{pendingNonce: 13}
+	task := &SendTaskETH{client: client, db: db}
+
+	done, err := task.Do(taskID, func() bool { return true })
+	require.NoError(t, err)
+	require.True(t, done)
+	require.Equal(t, 1, client.pendingNonceCalls)
+	require.Equal(t, 1, client.networkIDCalls)
+	require.Equal(t, 1, client.sendCalls)
+	require.Equal(t, 0, client.txCalls)
+	require.Len(t, client.sentTxs, 1)
+
+	nonce, signedHash, signedTxData, sendSuccess := loadSendTaskETHFinalState(t, ctx, db, taskID)
+	require.Equal(t, uint64(13), nonce)
+	require.Equal(t, client.sentTxs[0].Hash().Hex(), signedHash)
+	require.True(t, sendSuccess)
+
+	signedTx := unmarshalSendTaskETHSignedTx(t, signedTxData)
+	require.Equal(t, uint64(13), signedTx.Nonce())
+	require.Equal(t, client.sentTxs[0].Hash(), signedTx.Hash())
+}
+
+func TestSendTaskETHFreshSendUsesDBNonceWhenItIsAhead(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	privateKey, err := gethcrypto.GenerateKey()
+	require.NoError(t, err)
+	from := gethcrypto.PubkeyToAddress(privateKey.PublicKey)
+	to := common.HexToAddress("0x2000000000000000000000000000000000000004")
+	insertSendTaskETHKey(t, ctx, db, from, gethcrypto.FromECDSA(privateKey))
+	insertSuccessfulSendTaskETHNonce(t, ctx, db, harmonytask.TaskID(40), from, to, privateKey, 20)
+
+	taskID := harmonytask.TaskID(4)
+	insertSendTaskETHTransaction(t, ctx, db, taskID, from, to)
+
+	client := &sendTaskETHClient{pendingNonce: 13}
+	task := &SendTaskETH{client: client, db: db}
+
+	done, err := task.Do(taskID, func() bool { return true })
+	require.NoError(t, err)
+	require.True(t, done)
+	require.Equal(t, 1, client.pendingNonceCalls)
+	require.Equal(t, 1, client.networkIDCalls)
+	require.Equal(t, 1, client.sendCalls)
+	require.Len(t, client.sentTxs, 1)
+
+	nonce, signedHash, _, sendSuccess := loadSendTaskETHFinalState(t, ctx, db, taskID)
+	require.Equal(t, uint64(21), nonce)
+	require.Equal(t, client.sentTxs[0].Hash().Hex(), signedHash)
+	require.True(t, sendSuccess)
+	require.Equal(t, uint64(21), client.sentTxs[0].Nonce())
+}
+
+func TestSendTaskETHRetryUsesStoredSignedTransaction(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	privateKey, err := gethcrypto.GenerateKey()
+	require.NoError(t, err)
+	from := gethcrypto.PubkeyToAddress(privateKey.PublicKey)
+	to := common.HexToAddress("0x2000000000000000000000000000000000000005")
+	signedTx, signedTxData := signedSendTaskETHTransaction(t, privateKey, to, 15)
+	insertSignedSendTaskETHTransaction(t, ctx, db, harmonytask.TaskID(5), from, to, signedTx, signedTxData)
+
+	client := &sendTaskETHClient{pendingNonce: 99}
+	task := &SendTaskETH{client: client, db: db}
+
+	done, err := task.Do(harmonytask.TaskID(5), func() bool { return true })
+	require.NoError(t, err)
+	require.True(t, done)
+	require.Equal(t, 0, client.pendingNonceCalls)
+	require.Equal(t, 0, client.networkIDCalls)
+	require.Equal(t, 1, client.sendCalls)
+	require.Len(t, client.sentTxs, 1)
+	require.Equal(t, signedTx.Hash(), client.sentTxs[0].Hash())
+
+	nonce, signedHash, _, sendSuccess := loadSendTaskETHFinalState(t, ctx, db, harmonytask.TaskID(5))
+	require.Equal(t, uint64(15), nonce)
+	require.Equal(t, signedTx.Hash().Hex(), signedHash)
+	require.True(t, sendSuccess)
+}
+
+func TestSendTaskETHDefinitiveSendFailureFinalizesRow(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	privateKey, err := gethcrypto.GenerateKey()
+	require.NoError(t, err)
+	from := gethcrypto.PubkeyToAddress(privateKey.PublicKey)
+	to := common.HexToAddress("0x2000000000000000000000000000000000000006")
+	insertSendTaskETHKey(t, ctx, db, from, gethcrypto.FromECDSA(privateKey))
+
+	taskID := harmonytask.TaskID(6)
+	insertSendTaskETHTransaction(t, ctx, db, taskID, from, to)
+
+	client := &sendTaskETHClient{
+		pendingNonce: 16,
+		sendErr:      errors.New("gas fee cap too low"),
+	}
+	task := &SendTaskETH{client: client, db: db}
+
+	done, err := task.Do(taskID, func() bool { return true })
+	require.NoError(t, err)
+	require.True(t, done)
+	require.Equal(t, 1, client.sendCalls)
+	require.Equal(t, 0, client.txCalls)
+
+	var sendSuccess bool
+	var sendError string
+	var sendTime sql.NullTime
+	err = db.QueryRow(ctx, `
+		SELECT send_success, send_error, send_time
+		FROM message_sends_eth
+		WHERE send_task_id = $1`, taskID).Scan(&sendSuccess, &sendError, &sendTime)
+	require.NoError(t, err)
+	require.False(t, sendSuccess)
+	require.Contains(t, sendError, "gas fee cap too low")
+	require.True(t, sendTime.Valid)
+}
+
+func TestSendTaskETHAlreadyFinalizedRowIsNotResent(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	privateKey, err := gethcrypto.GenerateKey()
+	require.NoError(t, err)
+	from := gethcrypto.PubkeyToAddress(privateKey.PublicKey)
+	to := common.HexToAddress("0x2000000000000000000000000000000000000007")
+	insertSuccessfulSendTaskETHNonce(t, ctx, db, harmonytask.TaskID(7), from, to, privateKey, 17)
+
+	client := &sendTaskETHClient{pendingNonce: 17}
+	task := &SendTaskETH{client: client, db: db}
+
+	done, err := task.Do(harmonytask.TaskID(7), func() bool { return true })
+	require.NoError(t, err)
+	require.True(t, done)
+	require.Equal(t, 0, client.pendingNonceCalls)
+	require.Equal(t, 0, client.networkIDCalls)
+	require.Equal(t, 0, client.sendCalls)
+	require.Equal(t, 0, client.txCalls)
+}
+
+func insertSendTaskETHKey(t *testing.T, ctx context.Context, db *harmonydb.DB, from common.Address, privateKey []byte) {
+	t.Helper()
+
+	_, err := db.Exec(ctx, `
+		INSERT INTO eth_keys (address, private_key, role)
+		VALUES ($1, $2, 'send-task-eth-test')`, from.Hex(), privateKey)
+	require.NoError(t, err)
+}
+
+func insertSendTaskETHTransaction(t *testing.T, ctx context.Context, db *harmonydb.DB, taskID harmonytask.TaskID, from common.Address, to common.Address) {
+	t.Helper()
+
+	tx := unsignedSendTaskETHTransaction(to)
+	unsignedTx, err := tx.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO message_sends_eth (
+			from_address, to_address, send_reason, send_task_id,
+			unsigned_tx, unsigned_hash
+		)
+		VALUES ($1, $2, 'send-task-eth-test', $3, $4, $5)`,
+		from.Hex(), to.Hex(), taskID, unsignedTx, tx.Hash().Hex())
+	require.NoError(t, err)
+}
+
+func insertSignedSendTaskETHTransaction(t *testing.T, ctx context.Context, db *harmonydb.DB, taskID harmonytask.TaskID, from common.Address, to common.Address, signedTx *gethtypes.Transaction, signedTxData []byte) {
+	t.Helper()
+
+	unsignedTx := unsignedSendTaskETHTransaction(to)
+	unsignedTxData, err := unsignedTx.MarshalBinary()
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO message_sends_eth (
+			from_address, to_address, send_reason, send_task_id,
+			unsigned_tx, unsigned_hash,
+			nonce, signed_tx, signed_hash
+		)
+		VALUES ($1, $2, 'send-task-eth-test', $3, $4, $5, $6, $7, $8)`,
+		from.Hex(),
+		to.Hex(),
+		taskID,
+		unsignedTxData,
+		unsignedTx.Hash().Hex(),
+		signedTx.Nonce(),
+		signedTxData,
+		signedTx.Hash().Hex())
+	require.NoError(t, err)
+}
+
+func insertSuccessfulSendTaskETHNonce(t *testing.T, ctx context.Context, db *harmonydb.DB, taskID harmonytask.TaskID, from common.Address, to common.Address, privateKey *ecdsa.PrivateKey, nonce uint64) {
+	t.Helper()
+
+	signedTx, signedTxData := signedSendTaskETHTransaction(t, privateKey, to, nonce)
+	insertSignedSendTaskETHTransaction(t, ctx, db, taskID, from, to, signedTx, signedTxData)
+
+	_, err := db.Exec(ctx, `
+		UPDATE message_sends_eth
+		SET send_success = TRUE, send_error = '', send_time = CURRENT_TIMESTAMP
+		WHERE send_task_id = $1`, taskID)
+	require.NoError(t, err)
+}
+
+func loadSendTaskETHFinalState(t *testing.T, ctx context.Context, db *harmonydb.DB, taskID harmonytask.TaskID) (uint64, string, []byte, bool) {
+	t.Helper()
+
+	var nonce uint64
+	var signedHash string
+	var signedTx []byte
+	var sendSuccess bool
+	err := db.QueryRow(ctx, `
+		SELECT nonce, signed_hash, signed_tx, send_success
+		FROM message_sends_eth
+		WHERE send_task_id = $1`, taskID).Scan(&nonce, &signedHash, &signedTx, &sendSuccess)
+	require.NoError(t, err)
+	return nonce, signedHash, signedTx, sendSuccess
+}
+
+func signedSendTaskETHTransaction(t *testing.T, privateKey *ecdsa.PrivateKey, to common.Address, nonce uint64) (*gethtypes.Transaction, []byte) {
+	t.Helper()
+
+	chainID := mathbig.NewInt(int64(buildconstants.Eip155ChainId))
+	tx := gethtypes.NewTx(&gethtypes.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasTipCap: mathbig.NewInt(10),
+		GasFeeCap: mathbig.NewInt(100),
+		Gas:       21000,
+		To:        &to,
+		Value:     mathbig.NewInt(123),
+		Data:      []byte{1, 2, 3},
+	})
+
+	signedTx, err := gethtypes.SignTx(tx, gethtypes.LatestSignerForChainID(chainID), privateKey)
+	require.NoError(t, err)
+	signedTxData, err := signedTx.MarshalBinary()
+	require.NoError(t, err)
+
+	return signedTx, signedTxData
+}
+
+func unmarshalSendTaskETHSignedTx(t *testing.T, data []byte) *gethtypes.Transaction {
+	t.Helper()
+
+	tx := new(gethtypes.Transaction)
+	require.NoError(t, tx.UnmarshalBinary(data))
+	return tx
+}
+
+func unsignedSendTaskETHTransaction(to common.Address) *gethtypes.Transaction {
+	return gethtypes.NewTx(&gethtypes.DynamicFeeTx{
+		ChainID:   mathbig.NewInt(int64(buildconstants.Eip155ChainId)),
+		Nonce:     0,
+		GasTipCap: mathbig.NewInt(10),
+		GasFeeCap: mathbig.NewInt(100),
+		Gas:       21000,
+		To:        &to,
+		Value:     mathbig.NewInt(123),
+		Data:      []byte{1, 2, 3},
+	})
+}
+
+type sendTaskETHClient struct {
+	ethchain.EthClient
+
+	pendingNonce uint64
+	networkID    *mathbig.Int
+	sendErr      error
+
+	lookupSentTx  bool
+	lookupPending bool
+	lookupErr     error
+
+	pendingNonceCalls int
+	networkIDCalls    int
+	sendCalls         int
+	txCalls           int
+	sentTxs           []*gethtypes.Transaction
+}
+
+func (m *sendTaskETHClient) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+	m.pendingNonceCalls++
+	return m.pendingNonce, nil
+}
+
+func (m *sendTaskETHClient) NetworkID(ctx context.Context) (*mathbig.Int, error) {
+	m.networkIDCalls++
+	if m.networkID != nil {
+		return new(mathbig.Int).Set(m.networkID), nil
+	}
+	return mathbig.NewInt(int64(buildconstants.Eip155ChainId)), nil
+}
+
+func (m *sendTaskETHClient) SendTransaction(ctx context.Context, tx *gethtypes.Transaction) error {
+	m.sendCalls++
+	m.sentTxs = append(m.sentTxs, tx)
+	return m.sendErr
+}
+
+func (m *sendTaskETHClient) TransactionByHash(ctx context.Context, hash common.Hash) (*gethtypes.Transaction, bool, error) {
+	m.txCalls++
+	if m.lookupErr != nil {
+		return nil, false, m.lookupErr
+	}
+	if m.lookupSentTx {
+		for _, tx := range m.sentTxs {
+			if tx.Hash() == hash {
+				return tx, m.lookupPending, nil
+			}
+		}
+	}
+	return nil, false, ethereum.NotFound
+}

--- a/tasks/message/sender_eth_test.go
+++ b/tasks/message/sender_eth_test.go
@@ -48,6 +48,7 @@ func TestSendTaskETHAmbiguousSendSucceedsAfterExactLookup(t *testing.T) {
 	require.True(t, done)
 	require.Equal(t, 1, client.sendCalls)
 	require.Equal(t, 1, client.txCalls)
+	require.Equal(t, 1, client.pendingNonceCalls)
 	require.Len(t, client.sentTxs, 1)
 
 	var signedHash string
@@ -90,6 +91,7 @@ func TestSendTaskETHDoesNotTrustAmbiguousSendWithoutExactLookup(t *testing.T) {
 	require.False(t, done)
 	require.Equal(t, 1, client.sendCalls)
 	require.Equal(t, 1, client.txCalls)
+	require.Equal(t, 1, client.pendingNonceCalls)
 	require.Len(t, client.sentTxs, 1)
 
 	var signedHash sql.NullString


### PR DESCRIPTION
built on https://github.com/filecoin-project/curio/pull/1301

## Summary
This PR changes Eth sends to treat unclear send errors as unknown until Curio can verify the exact signed transaction hash. If the hash is visible, the send is recorded as successful. If it is not visible, the signed transaction stays pending and Harmony retries it instead of recording a false failure.
The same handling is applied to Eth replacement sends, so replacement claims are only finalized when the replacement broadcast result is known.
Tests cover the sender and replacement paths for successful lookup, missing lookup, nonce assignment, signed retry reuse, finalized-row skip, and definitive failure recording.