### PR TITLE
fix: stop PDPv0 save cache scheduler spin

### DIFF
--- a/tasks/pdpv0/task_save_cache.go
+++ b/tasks/pdpv0/task_save_cache.go
@@ -205,11 +205,9 @@ func (t *TaskPDPSaveCache) Adder(taskFunc harmonytask.AddTaskFunc) {
 }
 
 func (t *TaskPDPSaveCache) schedule(ctx context.Context, taskFunc harmonytask.AddTaskFunc) error {
-	var stop bool
-	for !stop {
+	for {
+		stop := true
 		taskFunc(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
-			stop = true // assume we're done until we find a task to schedule
-
 			var pendings []struct {
 				ID int64 `db:"id"`
 			}
@@ -239,9 +237,10 @@ func (t *TaskPDPSaveCache) schedule(ctx context.Context, taskFunc harmonytask.Ad
 			stop = false // we found a task to schedule, keep going
 			return true, nil
 		})
+		if stop {
+			return nil
+		}
 	}
-
-	return nil
 }
 
 func (t *TaskPDPSaveCache) scheduleMigrationCleanup(_ context.Context, taskFunc harmonytask.AddTaskFunc) error {

--- a/tasks/pdpv0/task_save_cache_test.go
+++ b/tasks/pdpv0/task_save_cache_test.go
@@ -1,0 +1,26 @@
+package pdpv0
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+)
+
+func TestSaveCacheScheduleStopsWhenAddTaskDoesNotRunCallback(t *testing.T) {
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		task := &TaskPDPSaveCache{}
+		_ = task.schedule(context.Background(), func(func(harmonytask.TaskID, *harmonydb.Tx) (bool, error)) {})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("schedule did not stop after AddTask declined to run its callback")
+	}
+}


### PR DESCRIPTION
`killalll curio` After that, 4 million lines of logs were generated instantly.

```
{"level":"info","ts":"2026-07-22T12:51:04.743+0800","logger":"curio/message","caller":"message/sender_eth.go:426","msg":"sent transaction","hash":"0x55a67b63e26ce8b9da33ac7e264f294c0e78ff5582f2bc401c9f50e5e74f3
02e","task_id":79062632,"send_error":null,"poll_loops":4}
{"level":"info","ts":"2026-07-22T12:51:04.752+0800","logger":"pdpv0","caller":"pdpv0/task_next_pp.go:290","msg":"Next challenge window scheduled","epoch":"3912536","dataSetId":11651}
{"level":"info","ts":"2026-07-22T12:51:04.995+0800","logger":"curio/message","caller":"message/sender_eth.go:426","msg":"sent transaction","hash":"0x3d2c68e3b29bfe7c315dfc8ae4aa8cb1a648c7c154629d80fc8f25ed68bfe
229","task_id":79062631,"send_error":null,"poll_loops":5}
{"level":"info","ts":"2026-07-22T12:51:04.996+0800","logger":"pdpv0","caller":"pdpv0/task_prove.go:463","msg":"PDP Prove Task: transaction sent","txHash":"0x3d2c68e3b29bfe7c315dfc8ae4aa8cb1a648c7c154629d80fc8f2
5ed68bfe229","dataSetId":12359,"taskID":79061992}
{"level":"info","ts":"2026-07-22T12:51:30.566+0800","logger":"curio/message","caller":"message/watch_eth.go:115","msg":"Assigned orphaned pending transactions","count":1,"machineID":701}
{"level":"info","ts":"2026-07-22T12:51:30.700+0800","logger":"curio/message","caller":"message/watch_eth.go:126","msg":"Processing pending transactions","count":453,"machineID":701}
{"level":"info","ts":"2026-07-22T12:51:31.208+0800","logger":"curio/message","caller":"message/watch_eth.go:126","msg":"Processing pending transactions","count":453,"machineID":701}
{"level":"info","ts":"2026-07-22T12:51:31.984+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:248","msg":"Beginning work on Task","id":79062853,"from":"poller","name":"PDPv0_Prove","sect
or":null}
{"level":"info","ts":"2026-07-22T12:51:32.315+0800","logger":"pdpv0","caller":"pdpv0/task_prove.go:413","msg":"PDP Prove Task","dataSetId":9985,"taskID":79062853,"proofCount":5,"dataLen":3620,"proofFee":"455538
0144"}
{"level":"warn","ts":"2026-07-22T12:51:34.743+0800","logger":"builder","caller":"shutdown/shutdown.go:39","msg":"received shutdown","signal":"terminated"}
{"level":"warn","ts":"2026-07-22T12:51:34.744+0800","logger":"builder","caller":"shutdown/shutdown.go:44","msg":"Shutting down..."}
{"level":"info","ts":"2026-07-22T12:51:34.744+0800","logger":"builder","caller":"shutdown/shutdown.go:52","msg":"curio shut down successfully "}
{"level":"warn","ts":"2026-07-22T12:51:34.744+0800","logger":"builder","caller":"shutdown/shutdown.go:55","msg":"Graceful shutdown successful"}
{"level":"info","ts":"2026-07-22T12:51:34.744+0800","logger":"curio-libp2p","caller":"libp2p/libp2p.go:135","msg":"Releasing libp2p claims"}
{"level":"error","ts":"2026-07-22T12:51:34.752+0800","logger":"curio-libp2p","caller":"libp2p/libp2p.go:138","msg":"Cleaning up libp2p claims context canceled"}
{"level":"warn","ts":"2026-07-22T12:51:34.744+0800","logger":"cu-http","caller":"cuhttp/server_common.go:95","msg":"Shutting down HTTP Server..."}
{"level":"warn","ts":"2026-07-22T12:51:34.744+0800","logger":"curio/rpc","caller":"rpc/rpc.go:533","msg":"Shutting down..."}
{"level":"warn","ts":"2026-07-22T12:51:34.752+0800","logger":"cu-http","caller":"cuhttp/server_common.go:99","msg":"HTTP Server graceful shutdown successful"}
{"level":"info","ts":"2026-07-22T12:51:34.752+0800","logger":"harmonytask","caller":"harmonytask/harmonytask.go:258","msg":"node shutdown deferred due to running PDPv0_Prove task"}
{"level":"warn","ts":"2026-07-22T12:51:34.752+0800","logger":"curio/rpc","caller":"rpc/rpc.go:542","msg":"Graceful shutdown successful"}
{"level":"error","ts":"2026-07-22T12:51:35.042+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:64","msg":"Could not add task. AddTasFunc failed","error":"could not insert into harmonyTask: context canceled","type":"PDPv0_SaveCache"}
{"level":"error","ts":"2026-07-22T12:51:35.042+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:64","msg":"Could not add task. AddTasFunc failed","error":"could not insert into harmonyTask: context canceled","type":"PDPv0_SaveCache"}
{"level":"error","ts":"2026-07-22T12:51:35.042+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:64","msg":"Could not add task. AddTasFunc failed","error":"could not insert into harmonyTask: context canceled","type":"PDPv0_SaveCache"}
{"level":"error","ts":"2026-07-22T12:51:35.042+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:64","msg":"Could not add task. AddTasFunc failed","error":"could not insert into harmonyTask: context canceled","type":"PDPv0_SaveCache"}
{"level":"error","ts":"2026-07-22T12:51:35.043+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:64","msg":"Could not add task. AddTasFunc failed","error":"could not insert into harmonyTask: context canceled","type":"PDPv0_SaveCache"}
{"level":"error","ts":"2026-07-22T12:51:35.043+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:64","msg":"Could not add task. AddTasFunc failed","error":"could not insert into harmonyTask: context canceled","type":"PDPv0_SaveCache"}
{"level":"error","ts":"2026-07-22T12:51:35.043+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:64","msg":"Could not add task. AddTasFunc failed","error":"could not insert into harmonyTask: context canceled","type":"PDPv0_SaveCache"}
{"level":"error","ts":"2026-07-22T12:51:35.043+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:64","msg":"Could not add task. AddTasFunc failed","error":"could not insert into harmonyTask: context canceled","type":"PDPv0_SaveCache"}
{"level":"error","ts":"2026-07-22T12:51:35.043+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:64","msg":"Could not add task. AddTasFunc failed","error":"could not insert into harmonyTas
```