### PR TITLE
pdp: price eth sender fee caps with feeHistory floor and 2x baseFee headroom

### DIFF
--- a/tasks/message/sender_eth.go
+++ b/tasks/message/sender_eth.go
@@ -395,6 +395,14 @@ func (s *SenderETH) send(ctx context.Context, fromAddress common.Address, tx *ty
 			return common.Hash{}, fmt.Errorf("base fee not available; network might not support EIP-1559")
 		}
 
+		if feeHist, fhErr := s.client.FeeHistory(ctx, 120, nil, nil); fhErr == nil {
+			for _, histFee := range feeHist.BaseFee {
+				if histFee != nil && histFee.Cmp(baseFee) > 0 {
+					baseFee = histFee
+				}
+			}
+		}
+
 		// Set GasTipCap (maxPriorityFeePerGas)
 		gasTipCap, err := s.client.SuggestGasTipCap(ctx)
 		if err != nil {
@@ -402,7 +410,7 @@ func (s *SenderETH) send(ctx context.Context, fromAddress common.Address, tx *ty
 		}
 
 		// Calculate GasFeeCap (maxFeePerGas)
-		gasFeeCap := new(big.Int).Add(baseFee, gasTipCap)
+		gasFeeCap := new(big.Int).Add(new(big.Int).Mul(baseFee, big.NewInt(2)), gasTipCap)
 
 		chainID, err := s.client.NetworkID(ctx)
 		if err != nil {

--- a/tasks/message/sender_eth.go
+++ b/tasks/message/sender_eth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -32,6 +33,10 @@ type SenderETH struct {
 	sendTask *SendTaskETH
 
 	db *harmonydb.DB
+
+	feeFloorLk sync.Mutex
+	feeFloor   *big.Int
+	feeFloorAt time.Time
 }
 
 type SendTaskETH struct {
@@ -342,6 +347,40 @@ func NewSenderETH(client ethchain.EthClient, db *harmonydb.DB) (*SenderETH, *Sen
 	}, st
 }
 
+const baseFeeFloorTTL = time.Minute
+const baseFeeFloorTimeout = 5 * time.Second
+
+func (s *SenderETH) baseFeeFloor(ctx context.Context) *big.Int {
+	s.feeFloorLk.Lock()
+	defer s.feeFloorLk.Unlock()
+
+	if s.feeFloor != nil && time.Since(s.feeFloorAt) < baseFeeFloorTTL {
+		return new(big.Int).Set(s.feeFloor)
+	}
+
+	fhCtx, cancel := context.WithTimeout(ctx, baseFeeFloorTimeout)
+	defer cancel()
+
+	feeHist, err := s.client.FeeHistory(fhCtx, 120, nil, nil)
+	if err != nil {
+		if s.feeFloor == nil {
+			return nil
+		}
+		return new(big.Int).Set(s.feeFloor)
+	}
+
+	floor := new(big.Int)
+	for _, histFee := range feeHist.BaseFee {
+		if histFee != nil && histFee.Cmp(floor) > 0 {
+			floor.Set(histFee)
+		}
+	}
+
+	s.feeFloor = floor
+	s.feeFloorAt = time.Now()
+	return new(big.Int).Set(floor)
+}
+
 // Send sends an Ethereum transaction, coordinating nonce assignment, signing, and broadcasting.
 func (s *SenderETH) Send(ctx context.Context, fromAddress common.Address, tx *types.Transaction, reason string) (common.Hash, error) {
 	return s.send(ctx, fromAddress, tx, reason, 1.0)
@@ -395,13 +434,9 @@ func (s *SenderETH) send(ctx context.Context, fromAddress common.Address, tx *ty
 			return common.Hash{}, fmt.Errorf("base fee not available; network might not support EIP-1559")
 		}
 
-                 // Measure current basefee as the max over the last 120 epochs (1 hour) 
-		if feeHist, fhErr := s.client.FeeHistory(ctx, 120, nil, nil); fhErr == nil {
-			for _, histFee := range feeHist.BaseFee {
-				if histFee != nil && histFee.Cmp(baseFee) > 0 {
-					baseFee = histFee
-				}
-			}
+		// Measure current basefee as the max over the last 120 epochs (1 hour), cached
+		if floor := s.baseFeeFloor(ctx); floor != nil && floor.Cmp(baseFee) > 0 {
+			baseFee = floor
 		}
 
 		// Set GasTipCap (maxPriorityFeePerGas)

--- a/tasks/message/sender_eth.go
+++ b/tasks/message/sender_eth.go
@@ -395,6 +395,7 @@ func (s *SenderETH) send(ctx context.Context, fromAddress common.Address, tx *ty
 			return common.Hash{}, fmt.Errorf("base fee not available; network might not support EIP-1559")
 		}
 
+                 // Measure current basefee as the max over the last 120 epochs (1 hour) 
 		if feeHist, fhErr := s.client.FeeHistory(ctx, 120, nil, nil); fhErr == nil {
 			for _, histFee := range feeHist.BaseFee {
 				if histFee != nil && histFee.Cmp(baseFee) > 0 {


### PR DESCRIPTION
Send-time fee-cap pricing hardening from [#1354](https://github.com/filecoin-project/curio/issues/1354), as discussed with @ZenGround0 in #foc-wg. Two changes in `SenderETH.send`:

1. **Floor the baseFee at the max over the last 120 epochs of `eth_feeHistory`** before pricing the cap. Without this, a restart into a quiet chain prices caps at the momentary low, and they strand minutes later once load ramps baseFee back up.
2. **Price `gasFeeCap` as `2x baseFee + tip`** instead of `baseFee + tip`, so a baseFee rise between send and inclusion does not strand the message. With EIP-1559 semantics the sender still pays only `baseFee + tip` at inclusion, so the extra headroom costs nothing when unused.

Motivation: with zero headroom and no fee-bump path, any baseFee rise strands the head message, and sequential nonces then block the wallet's whole lane, including proving messages (two proving near-misses documented in #1354).

These mitigations have been running in production on two mainnet PDP SPs since 2026-07-10. During the recent congestion event ([filecoin-services#546](https://github.com/FilOzone/filecoin-services/issues/546)), the patched idle SP held 100% dealbot deal success over 12h while stock-sender SPs failed on confirmation timeouts in the same window.

Out of scope: same-nonce replacement / RBF for external spikes that outrun a fixed cap. That is [#1292](https://github.com/filecoin-project/curio/issues/1292), addressed by #1301. Per Zen this PR covers the send-time pricing leg #1301 does not.