### PR TITLE
Bump extradata size limits to accommodate richer auth (programmable-acls)

### DIFF
--- a/cmd/pdptool/main.go
+++ b/cmd/pdptool/main.go
@@ -45,8 +45,9 @@ func validateExtraData(extraDataHexStr string) error {
 	if err != nil {
 		return fmt.Errorf("failed to decode hex in extra-data: %w", err)
 	}
-	if len(decoded) > 2048 {
-		return fmt.Errorf("decoded extra-data exceeds maximum size of 2048 bytes (decoded length: %d)", len(decoded))
+	// 8192 bytes is the size of the largest extradata (for addPieces). Individual smaller limits are checked later
+	if len(decoded) > 8192 {
+		return fmt.Errorf("decoded extra-data exceeds maximum size of 8192 bytes (decoded length: %d)", len(decoded))
 	}
 	return nil
 }

--- a/market/mk20/pdp_v1.go
+++ b/market/mk20/pdp_v1.go
@@ -18,7 +18,7 @@ const (
 	MaxAddPiecesExtraDataSize = 8192
 
 	// MaxDeletePieceExtraDataSize defines the limit for extraData size in DeletePiece calls (256B).
-	MaxDeletePieceExtraDataSize = 256
+	MaxDeletePieceExtraDataSize = 1024
 
 	// MaxPieceLimit defines the maximum number of pieces that can be added in a sinle deal
 	MaxPieceLimit = 1024

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -58,8 +58,8 @@ const (
 	// call to reject early rather than revert on-chain.
 	MaxAddPiecesBatchSize = 40
 
-	// MaxDeletePieceExtraDataSize defines the limit for extraData size in DeletePiece calls (256B).
-	MaxDeletePieceExtraDataSize = 256
+	// MaxDeletePieceExtraDataSize defines the limit for extraData size in DeletePiece calls (1KiB).
+	MaxDeletePieceExtraDataSize = 1024
 
 	MaxDeletePiecesBatchSize = contract.ConservativeEnqueuedRemovalsLimit
 )


### PR DESCRIPTION
Bump extradata size limits to accommodate richer auth

ONLY NEEDED IF https://github.com/FilOzone/filecoin-services/pull/536 MERGES!

Rationale: we already know that passkeys and WebAuthn are targets for identified service users. WebAuthn envelope with P256 on its own is around 700 bytes so rounding up to a KiB gives space for usable payload without going overboard.

For TerminateService and SchedulePieceRemovals we just set the limit to 1KiB as the only thing that was in there before was a legacy signature, and we make it either/or. For AddPieces we increase by 1KiB so as not to reduce the total capacity for the metadata that's also carried in there. I guess in principle we could take 160b off this to remove the previous SKR entry but I'm not sure how worthwhile that is with an already large structure.

Note that there's a small inconsistency here: Curio has addPieces max as 8192, and I've stayed faithful to that here, but the contracts have it currently at 4096 and the ACL proposal only bumps to 5120. Worth fixing?