### PR TITLE
fix: fix crash when a machine has no harmony_machine_details row

### DIFF
--- a/deps/config/utils.go
+++ b/deps/config/utils.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"database/sql"
 	"reflect"
 	"slices"
 	"strings"
@@ -134,7 +135,7 @@ type minerLookUpApi interface {
 func GetAddressesFromConfig(ctx context.Context, db *harmonydb.DB, api minerLookUpApi) ([]address.Address, []address.Address, error) {
 	// MachineDetails represents the structure of data received from the SQL query.
 	type machineDetail struct {
-		Layers string
+		Layers sql.NullString
 	}
 	var machineDetails []machineDetail
 
@@ -155,7 +156,7 @@ func GetAddressesFromConfig(ctx context.Context, db *harmonydb.DB, api minerLook
 	// Get unique layers in use
 	for _, machine := range machineDetails {
 		// Split the Layers field into individual layers
-		layers := strings.SplitSeq(machine.Layers, ",")
+		layers := strings.SplitSeq(machine.Layers.String, ",")
 		for layer := range layers {
 			layer = strings.TrimSpace(layer)
 			if _, exists := layerMap[layer]; !exists && layer != "" {

--- a/deps/config/utils.go
+++ b/deps/config/utils.go
@@ -155,6 +155,9 @@ func GetAddressesFromConfig(ctx context.Context, db *harmonydb.DB, api minerLook
 
 	// Get unique layers in use
 	for _, machine := range machineDetails {
+		if !machine.Layers.Valid {
+			continue
+		}
 		// Split the Layers field into individual layers
 		layers := strings.SplitSeq(machine.Layers.String, ",")
 		for layer := range layers {


### PR DESCRIPTION
> in skiff

```
{"level":"error","ts":"2026-08-07T13:17:46.041+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:345","msg":"Do() returned error","type":"AlertManager","id":"82763501","error":"getting addresses: getting config layers for all machines: scanning: scanning: doing scan: scanFn: scany: scan row into struct fields: can't scan into dest[0] (col: layers): cannot scan NULL into *string","errorVerbose":"getting addresses:\n    github.com/filecoin-project/curio/alertmanager.(*AlertTask).Do\n        /root/workspace/curio/alertmanager/task_alert.go:194\n  - getting config layers for all machines:\n    github.com/filecoin-project/curio/deps/config.GetAddressesFromConfig\n        /root/workspace/curio/deps/config/utils.go:147\n  - scanning: scanning: doing scan: scanFn: scany: scan row into struct fields: can't scan into dest[0] (col: layers): cannot scan NULL into *string"}
{"level":"info","ts":"2026-08-07T13:17:46.060+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:286","msg":"Beginning work on Task","id":82763501,"from":"poller","name":"AlertManager","sector":null}
```