### PR TITLE
fix: stop PDPv0_DatasetIdx retrying terminated data sets forever

### DIFF
--- a/tasks/pdpv0/task_dataset_idx.go
+++ b/tasks/pdpv0/task_dataset_idx.go
@@ -59,6 +59,16 @@ func (t *DatasetIdxTask) Do(ctx context.Context, taskID harmonytask.TaskID, stil
 		}
 		mustIndex, err := pdp.ResolveDatasetIPFSIndexing(ctx, t.db, t.ethClient, row.ID)
 		if err != nil {
+			if IsUnrecoverableError(err) || IsPDPVerifierDataSetNotFound(err) {
+				// Data set is gone on-chain; stop retrying it, value doesn't matter.
+				if persistErr := pdp.PersistDatasetIPFSIndexing(ctx, t.db, row.ID, false); persistErr != nil {
+					log.Warnw("failed to persist IPFS indexing intent for terminated data set", "dataSetId", row.ID, "error", persistErr)
+					resolveErrs++
+				} else {
+					log.Infow("data set no longer live on-chain, resolved IPFS indexing intent to false", "dataSetId", row.ID, "error", err)
+				}
+				continue
+			}
 			log.Warnw("failed to resolve IPFS indexing intent", "dataSetId", row.ID, "error", err)
 			resolveErrs++
 			continue

--- a/tasks/pdpv0/task_dataset_idx_test.go
+++ b/tasks/pdpv0/task_dataset_idx_test.go
@@ -1,0 +1,58 @@
+package pdpv0
+
+import (
+	"context"
+	"database/sql"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+	"github.com/filecoin-project/curio/lib/ethchain"
+)
+
+type revertingEthClient struct {
+	ethchain.EthClient
+	err error
+}
+
+func (r *revertingEthClient) CallContract(context.Context, ethereum.CallMsg, *big.Int) ([]byte, error) {
+	return nil, r.err
+}
+
+func runDatasetIdxTask(ctx context.Context, db *harmonydb.DB, client ethchain.EthClient) (bool, error) {
+	task := NewDatasetIdxTask(db, client)
+	return task.Do(ctx, harmonytask.TaskID(1), func() bool { return true })
+}
+
+func TestIntegration_DatasetIdxTask_TerminalChainErrorsResolveToFalse(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"DataSetNotLive", selectorRevert(contractErrorSelector(ErrPDPVerifierDataSetNotLive))},
+		{"DataSetNotFound", selectorRevert(contractErrorSelector(ErrPDPVerifierDataSetNotFound))},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, err := harmonydb.NewFromConfigWithITestID(t)
+			require.NoError(t, err)
+
+			dataSetID := insertFailureHandlingDataSet(t, ctx, db, failureHandlingDataSetState{})
+
+			done, doErr := runDatasetIdxTask(ctx, db, &revertingEthClient{err: tc.err})
+			require.NoError(t, doErr)
+			require.True(t, done)
+
+			var ipfsIndexing sql.NullBool
+			require.NoError(t, db.QueryRow(ctx, `SELECT ipfs_indexing FROM pdp_data_sets WHERE id = $1`, dataSetID).Scan(&ipfsIndexing))
+			require.True(t, ipfsIndexing.Valid)
+			require.False(t, ipfsIndexing.Bool)
+		})
+	}
+}

--- a/tasks/pdpv0/task_dataset_idx_test.go
+++ b/tasks/pdpv0/task_dataset_idx_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
 	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/lib/ethchain"
+	"github.com/filecoin-project/curio/pdp/contract"
 )
 
 type revertingEthClient struct {
@@ -29,6 +31,10 @@ func runDatasetIdxTask(ctx context.Context, db *harmonydb.DB, client ethchain.Et
 }
 
 func TestIntegration_DatasetIdxTask_TerminalChainErrorsResolveToFalse(t *testing.T) {
+	contract.SetAddresses(contract.Addresses{
+		PDPVerifier: common.HexToAddress("0x3333333333333333333333333333333333333333"),
+	})
+
 	tests := []struct {
 		name string
 		err  error


### PR DESCRIPTION
```
{"level":"warn","ts":"2026-08-08T15:07:00.286+0800","logger":"pdpv0","caller":"pdpv0/task_dataset_idx.go:62","msg":"failed to resolve IPFS indexing intent","dataSetId":11603,"error":"GetDataSetListener(11603): chain: message execution failed (exit=[33], revert reason=[0x5d946944], vm error=[message failed with backtrace:\n00: f0176630 (method 3844450837) -- contract reverted at 75 (33)\n01: f0176630 (method 6) -- contract reverted at 6991 (33)\n (RetCode=33)])","errorVerbose":"GetDataSetListener(11603):\n    github.com/filecoin-project/curio/pdp.fetchFromChainIPFSIndexing\n        /root/workspace/curio/pdp/indexing.go:101\n  - chain: message execution failed (exit=[33], revert reason=[0x5d946944], vm error=[message failed with backtrace:\n00: f0176630 (method 3844450837) -- contract reverted at 75 (33)\n01: f0176630 (method 6) -- contract reverted at 6991 (33)\n (RetCode=33)])"}
{"level":"error","ts":"2026-08-08T15:07:00.297+0800","logger":"harmonytask","caller":"harmonytask/task_type_handler.go:345","msg":"Do() returned error","type":"PDPv0_DatasetIdx","id":"83091857","error":"failed to resolve IPFS indexing intent for 1 of 1 data sets","errorVerbose":"failed to resolve IPFS indexing intent for 1 of 1 data sets:\n    github.com/filecoin-project/curio/tasks/pdpv0.(*DatasetIdxTask).Do\n        /root/workspace/curio/tasks/pdpv0/task_dataset_idx.go:70"}
```