### PR TITLE
send-durability

### DIFF
--- a/harmony/harmonytask/harmonytask.go
+++ b/harmony/harmonytask/harmonytask.go
@@ -90,8 +90,19 @@ type TaskTypeDetails struct {
 	// other machines.
 	SchedulingOverrides map[string]bool
 
-	// Should block shutdown until completion..
+	// TimeSensitive tasks skip event bundling, can preempt other work when
+	// capacity is exhausted, run first in the scheduling waterfall, and block
+	// GracefullyTerminate until they finish. They are also not preemptable.
+	// Use for deadline-driven work (e.g. WindowPost/WinningPost). For tasks that
+	// must not be cancelled mid-flight but should not get that priority or
+	// preemption power, set Uninterruptible instead.
 	TimeSensitive bool
+
+	// Uninterruptible tasks are never selected as preemption victims. Unlike
+	// TimeSensitive, this does not grant scheduling priority, skip bundling,
+	// the ability to preempt others, or shutdown blocking. Use for high-Max
+	// work that must finish a critical section (e.g. chain+DB send sync).
+	Uninterruptible bool
 
 	// May Follow is a list of task names whose completion may trigger this task to be scheduled.
 	// This does not cause triggering, instead it reduces pipeline latency.

--- a/harmony/harmonytask/harmonytask.go
+++ b/harmony/harmonytask/harmonytask.go
@@ -98,10 +98,11 @@ type TaskTypeDetails struct {
 	// preemption power, set Uninterruptible instead.
 	TimeSensitive bool
 
-	// Uninterruptible tasks are never selected as preemption victims. Unlike
-	// TimeSensitive, this does not grant scheduling priority, skip bundling,
-	// the ability to preempt others, or shutdown blocking. Use for high-Max
-	// work that must finish a critical section (e.g. chain+DB send sync).
+	// Uninterruptible tasks are never selected as preemption victims and block
+	// GracefullyTerminate until they finish. Unlike TimeSensitive, this does
+	// not grant scheduling priority, skip bundling, or the ability to preempt
+	// others. Use for high-Max work that must finish a critical section
+	// (e.g. chain+DB send sync).
 	Uninterruptible bool
 
 	// May Follow is a list of task names whose completion may trigger this task to be scheduled.
@@ -408,7 +409,7 @@ func (e *TaskEngine) GracefullyTerminate() {
 	for {
 		var waited bool
 		for _, h := range e.handlers {
-			if h.TimeSensitive && h.Max.Active() > 0 {
+			if (h.TimeSensitive || h.Uninterruptible) && h.Max.Active() > 0 {
 				log.Infof("node shutdown deferred due to running %s task", h.Name)
 				time.Sleep(time.Second * 3)
 				waited = true

--- a/harmony/harmonytask/harmonytask.go
+++ b/harmony/harmonytask/harmonytask.go
@@ -99,10 +99,11 @@ type TaskTypeDetails struct {
 	TimeSensitive bool
 
 	// Uninterruptible tasks are never selected as preemption victims and block
-	// GracefullyTerminate until they finish. Unlike TimeSensitive, this does
-	// not grant scheduling priority, skip bundling, or the ability to preempt
-	// others. Use for high-Max work that must finish a critical section
-	// (e.g. chain+DB send sync).
+	// GracefullyTerminate until Active reaches zero. During drain, stillOwned()
+	// returns false so they can exit before irreversible work (e.g. before
+	// taking a send lock); once past that checkpoint they are allowed to
+	// finish. Unlike TimeSensitive, this does not grant scheduling priority,
+	// skip bundling, or the ability to preempt others.
 	Uninterruptible bool
 
 	// May Follow is a list of task names whose completion may trigger this task to be scheduled.
@@ -230,6 +231,12 @@ type taskEngineAtomics struct {
 	// Checked by pollerTryAllWork and task goroutines to skip new work or
 	// yield in-progress background tasks.
 	yieldBackground atomic.Bool
+
+	// draining is set true when GracefullyTerminate begins. Uninterruptible
+	// tasks treat stillOwned() as false so they can release before taking a
+	// send lock; tasks already past that checkpoint finish their critical
+	// section while shutdown waits on Active().
+	draining atomic.Bool
 
 	lastCleanup atomic.Value
 
@@ -399,10 +406,13 @@ func NewWithReg(
 	return e, nil
 }
 
-// GracefullyTerminate hangs until all present tasks have completed.
-// Call this to cleanly exit the process. As some processes are long-running,
-// passing a deadline will ignore those still running (to be picked-up later).
+// GracefullyTerminate hangs until time-sensitive and uninterruptible work has
+// drained, then returns so the process can exit. It cancels the engine context
+// (no new claims) and sets draining so Uninterruptible tasks fail stillOwned()
+// before their next checkpoint (e.g. send lock acquire). Tasks already past
+// that checkpoint are not cancelled; shutdown waits for their Active count.
 func (e *TaskEngine) GracefullyTerminate() {
+	e.atomics.draining.Store(true)
 	e.cfg.grace()
 	e.cfg.reg.Shutdown()
 

--- a/harmony/harmonytask/preempt.go
+++ b/harmony/harmonytask/preempt.go
@@ -24,8 +24,9 @@ type preemptionPlan struct {
 	candidates []preemptCandidate
 }
 
-// computePreemptionPlan finds the minimum-cost set of non-time-sensitive running
+// computePreemptionPlan finds the minimum-cost set of preemptable running
 // tasks to kill in order to free enough resources for `needed`.
+// TimeSensitive and Uninterruptible handlers are never candidates.
 //
 // Algorithm:
 //  1. Sort candidates youngest-first (shortest runtime = cheapest).
@@ -46,7 +47,7 @@ func (e *TaskEngine) computePreemptionPlan(needed resources.Resources) *preempti
 	var allCandidates []preemptCandidate
 	now := time.Now()
 	for _, h := range e.handlers {
-		if h.TimeSensitive {
+		if h.TimeSensitive || h.Uninterruptible {
 			continue
 		}
 		for _, entry := range h.running.Snapshot() {

--- a/harmony/harmonytask/preempt_test.go
+++ b/harmony/harmonytask/preempt_test.go
@@ -1,0 +1,93 @@
+package harmonytask
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/curio/harmony/harmonytask/internal/runregistry"
+	"github.com/filecoin-project/curio/harmony/resources"
+	"github.com/filecoin-project/curio/harmony/taskhelp"
+)
+
+func TestComputePreemptionPlanSkipsUninterruptible(t *testing.T) {
+	victimMax := taskhelp.Max(8)
+	protectedMax := taskhelp.Max(8)
+
+	victim := &taskTypeHandler{
+		TaskTypeDetails: TaskTypeDetails{
+			Name: "Victim",
+			Max:  victimMax,
+			Cost: resources.Resources{Cpu: 2, Ram: 1 << 20},
+		},
+		running: runregistry.New(),
+	}
+	protected := &taskTypeHandler{
+		TaskTypeDetails: TaskTypeDetails{
+			Name:            "SendLike",
+			Max:             protectedMax,
+			Uninterruptible: true,
+			Cost:            resources.Resources{Cpu: 2, Ram: 1 << 20},
+		},
+		running: runregistry.New(),
+	}
+
+	victim.running.Start(1, func() {})
+	victimMax.Add(1)
+	protected.running.Start(2, func() {})
+	protectedMax.Add(1)
+
+	// Total 4 CPU: both running tasks consume 2 each → available 0.
+	// Needing 2 CPU can only be satisfied by preempting Victim; SendLike is skipped.
+	e := &TaskEngine{
+		cfg: taskEngineConfig{
+			reg: &resources.Reg{
+				Resources: resources.Resources{Cpu: 4, Ram: 4 << 20},
+			},
+		},
+		handlers: []*taskTypeHandler{victim, protected},
+	}
+
+	plan := e.computePreemptionPlan(resources.Resources{Cpu: 2, Ram: 1 << 20})
+	require.NotNil(t, plan)
+	require.Len(t, plan.candidates, 1)
+	require.Equal(t, TaskID(1), plan.candidates[0].taskID)
+	require.Equal(t, "Victim", plan.candidates[0].handler.Name)
+}
+
+func TestComputePreemptionPlanSkipsTimeSensitive(t *testing.T) {
+	max := taskhelp.Max(8)
+	h := &taskTypeHandler{
+		TaskTypeDetails: TaskTypeDetails{
+			Name:          "WinPostLike",
+			Max:           max,
+			TimeSensitive: true,
+			Cost:          resources.Resources{Cpu: 2, Ram: 1 << 20},
+		},
+		running: runregistry.New(),
+	}
+	h.running.Start(7, func() {})
+	max.Add(1)
+
+	e := &TaskEngine{
+		cfg: taskEngineConfig{
+			reg: &resources.Reg{
+				Resources: resources.Resources{Cpu: 2, Ram: 4 << 20},
+			},
+		},
+		handlers: []*taskTypeHandler{h},
+	}
+
+	require.Nil(t, e.computePreemptionPlan(resources.Resources{Cpu: 2, Ram: 1 << 20}))
+}
+
+func TestComputePreemptionPlanNilWhenNoDeficit(t *testing.T) {
+	e := &TaskEngine{
+		cfg: taskEngineConfig{
+			reg: &resources.Reg{
+				Resources: resources.Resources{Cpu: 4, Ram: 8 << 20},
+			},
+		},
+	}
+	require.Nil(t, e.computePreemptionPlan(resources.Resources{Cpu: 1, Ram: 1 << 20}))
+}

--- a/harmony/harmonytask/task_type_handler.go
+++ b/harmony/harmonytask/task_type_handler.go
@@ -331,6 +331,15 @@ func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter e
 						return false
 					}
 				}
+				// Uninterruptible work (e.g. Send*) calls stillOwned before
+				// taking a per-sender lock. During shutdown drain, fail that
+				// check so hundreds of waiters can exit without starting a new
+				// critical section; in-flight holders do not call stillOwned
+				// and are waited on via Active() in GracefullyTerminate.
+				if h.Uninterruptible && h.TaskEngine.atomics.draining.Load() {
+					log.Infow("yielding uninterruptible task during shutdown drain", "name", h.Name, "id", tID)
+					return false
+				}
 
 				var owner int
 				err := h.TaskEngine.cfg.db.QueryRow(taskCtx,

--- a/tasks/message/send_lock.go
+++ b/tasks/message/send_lock.go
@@ -1,0 +1,122 @@
+package message
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+	"github.com/filecoin-project/curio/harmony/resources"
+)
+
+const sendLockReleaseTimeout = 15 * time.Second
+
+// SendLockStaleTTL is how old a lock must be before it may be stolen from a
+// holder whose harmony_task row still exists but has no live owning machine.
+// Missing harmony_task rows may be stolen immediately. Overridable in tests.
+var SendLockStaleTTL = 2 * time.Minute
+
+func releaseLockCtx() (context.Context, context.CancelFunc) {
+	// Must not use the task ctx: preemption/cancel would make DELETE fail and
+	// leave an orphan lock that wedges all subsequent sends for the address.
+	return context.WithTimeout(context.Background(), sendLockReleaseTimeout)
+}
+
+func releaseMessageSendLock(db *harmonydb.DB, fromKey string, taskID harmonytask.TaskID) error {
+	ctx, cancel := releaseLockCtx()
+	defer cancel()
+	_, err := db.Exec(ctx, `
+		DELETE FROM message_send_locks WHERE from_key = $1 AND task_id = $2`, fromKey, taskID)
+	return err
+}
+
+func releaseEthSendLock(db *harmonydb.DB, fromAddress string, taskID harmonytask.TaskID) error {
+	ctx, cancel := releaseLockCtx()
+	defer cancel()
+	_, err := db.Exec(ctx, `
+		DELETE FROM message_send_eth_locks WHERE from_address = $1 AND task_id = $2`, fromAddress, taskID)
+	return err
+}
+
+// tryAcquireMessageSendLock claims message_send_locks for fromKey.
+// Succeeds when
+// - the row is free,
+// - already held by taskID,
+// - the holding task is gone from harmony_task, or
+// - it's after SendLockStaleTTL & the holder's harmony_machines TTL expired.
+func tryAcquireMessageSendLock(ctx context.Context, db *harmonydb.DB, fromKey string, taskID harmonytask.TaskID) (bool, error) {
+	var prevTask sql.NullInt64
+	_ = db.QueryRow(ctx, `SELECT task_id FROM message_send_locks WHERE from_key = $1`, fromKey).Scan(&prevTask)
+
+	cn, err := db.Exec(ctx, `
+		INSERT INTO message_send_locks (from_key, task_id, claimed_at)
+		VALUES ($1, $2, CURRENT_TIMESTAMP)
+		ON CONFLICT (from_key) DO UPDATE
+		SET task_id = EXCLUDED.task_id, claimed_at = CURRENT_TIMESTAMP
+		WHERE message_send_locks.task_id = $2
+		   OR NOT EXISTS (
+		        SELECT 1 FROM harmony_task ht WHERE ht.id = message_send_locks.task_id
+		   )
+		   OR (
+		        message_send_locks.claimed_at < CURRENT_TIMESTAMP - ($3::bigint * INTERVAL '1 millisecond')
+		        AND NOT EXISTS (
+		            SELECT 1
+		            FROM harmony_task ht
+		            JOIN harmony_machines hm ON hm.id = ht.owner_id
+		            WHERE ht.id = message_send_locks.task_id
+		              AND hm.last_contact > CURRENT_TIMESTAMP - ($4::bigint * INTERVAL '1 millisecond')
+		        )
+		   )`,
+		fromKey, taskID, SendLockStaleTTL.Milliseconds(), resources.LOOKS_DEAD_TIMEOUT.Milliseconds())
+	if err != nil {
+		return false, err
+	}
+	if cn == 1 {
+		if prevTask.Valid && prevTask.Int64 != int64(taskID) {
+			log.Infow("stole stale message send lock",
+				"from", fromKey, "old_task", prevTask.Int64, "new_task", taskID)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// tryAcquireEthSendLock claims message_send_eth_locks for fromAddress.
+// See tryAcquireMessageSendLock for steal conditions.
+func tryAcquireEthSendLock(ctx context.Context, db *harmonydb.DB, fromAddress string, taskID harmonytask.TaskID) (bool, error) {
+	var prevTask sql.NullInt64
+	_ = db.QueryRow(ctx, `SELECT task_id FROM message_send_eth_locks WHERE from_address = $1`, fromAddress).Scan(&prevTask)
+
+	cn, err := db.Exec(ctx, `
+		INSERT INTO message_send_eth_locks (from_address, task_id, claimed_at)
+		VALUES ($1, $2, CURRENT_TIMESTAMP)
+		ON CONFLICT (from_address) DO UPDATE
+		SET task_id = EXCLUDED.task_id, claimed_at = CURRENT_TIMESTAMP
+		WHERE message_send_eth_locks.task_id = $2
+		   OR NOT EXISTS (
+		        SELECT 1 FROM harmony_task ht WHERE ht.id = message_send_eth_locks.task_id
+		   )
+		   OR (
+		        message_send_eth_locks.claimed_at < CURRENT_TIMESTAMP - ($3::bigint * INTERVAL '1 millisecond')
+		        AND NOT EXISTS (
+		            SELECT 1
+		            FROM harmony_task ht
+		            JOIN harmony_machines hm ON hm.id = ht.owner_id
+		            WHERE ht.id = message_send_eth_locks.task_id
+		              AND hm.last_contact > CURRENT_TIMESTAMP - ($4::bigint * INTERVAL '1 millisecond')
+		        )
+		   )`,
+		fromAddress, taskID, SendLockStaleTTL.Milliseconds(), resources.LOOKS_DEAD_TIMEOUT.Milliseconds())
+	if err != nil {
+		return false, err
+	}
+	if cn == 1 {
+		if prevTask.Valid && prevTask.Int64 != int64(taskID) {
+			log.Infow("stole stale eth send lock",
+				"from", fromAddress, "old_task", prevTask.Int64, "new_task", taskID)
+		}
+		return true, nil
+	}
+	return false, nil
+}

--- a/tasks/message/send_lock_test.go
+++ b/tasks/message/send_lock_test.go
@@ -1,0 +1,236 @@
+package message
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+	"github.com/filecoin-project/curio/harmony/resources"
+)
+
+func TestReleaseSendLockIgnoresCanceledTaskContext(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	from := "0xlock-release-cancel"
+	taskID := harmonytask.TaskID(9001)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO message_send_eth_locks (from_address, task_id, claimed_at)
+		VALUES ($1, $2, CURRENT_TIMESTAMP)`, from, taskID)
+	require.NoError(t, err)
+
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+
+	// Bug we fixed: release must not use the canceled task ctx.
+	_, err = db.Exec(canceled,
+		`DELETE FROM message_send_eth_locks WHERE from_address = $1 AND task_id = $2`, from, taskID)
+	require.Error(t, err)
+
+	require.NoError(t, releaseEthSendLock(db, from, taskID))
+
+	var n int
+	require.NoError(t, db.QueryRow(ctx,
+		`SELECT count(*) FROM message_send_eth_locks WHERE from_address = $1`, from).Scan(&n))
+	require.Equal(t, 0, n)
+}
+
+func TestEthSendLockStealMissingTask(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	from := "0xlock-steal-missing"
+	holder := harmonytask.TaskID(9101)
+	waiter := harmonytask.TaskID(9102)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO message_send_eth_locks (from_address, task_id, claimed_at)
+		VALUES ($1, $2, CURRENT_TIMESTAMP)`, from, holder)
+	require.NoError(t, err)
+
+	got, err := tryAcquireEthSendLock(ctx, db, from, waiter)
+	require.NoError(t, err)
+	require.True(t, got, "missing harmony_task row should allow immediate steal")
+
+	var holding int64
+	require.NoError(t, db.QueryRow(ctx,
+		`SELECT task_id FROM message_send_eth_locks WHERE from_address = $1`, from).Scan(&holding))
+	require.Equal(t, int64(waiter), holding)
+}
+
+func TestEthSendLockNoStealLiveOwner(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	oldTTL := SendLockStaleTTL
+	SendLockStaleTTL = time.Millisecond
+	t.Cleanup(func() { SendLockStaleTTL = oldTTL })
+
+	from := "0xlock-no-steal-live"
+	machineID := insertLiveMachine(t, ctx, db, "lock-live-owner")
+	holder := insertOwnedHarmonyTask(t, ctx, db, "SendTransaction", machineID)
+	waiter := harmonytask.TaskID(9202)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO message_send_eth_locks (from_address, task_id, claimed_at)
+		VALUES ($1, $2, CURRENT_TIMESTAMP - INTERVAL '1 hour')`, from, holder)
+	require.NoError(t, err)
+
+	got, err := tryAcquireEthSendLock(ctx, db, from, waiter)
+	require.NoError(t, err)
+	require.False(t, got, "must not steal from a live owning machine")
+}
+
+func TestEthSendLockStealDeadOwnerAfterTTL(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	oldTTL := SendLockStaleTTL
+	oldDead := resources.LOOKS_DEAD_TIMEOUT
+	SendLockStaleTTL = time.Millisecond
+	resources.LOOKS_DEAD_TIMEOUT = time.Minute
+	t.Cleanup(func() {
+		SendLockStaleTTL = oldTTL
+		resources.LOOKS_DEAD_TIMEOUT = oldDead
+	})
+
+	from := "0xlock-steal-dead"
+	machineID := insertStaleMachine(t, ctx, db, "lock-dead-owner", 2*time.Hour)
+	holder := insertOwnedHarmonyTask(t, ctx, db, "SendTransaction", machineID)
+	waiter := harmonytask.TaskID(9302)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO message_send_eth_locks (from_address, task_id, claimed_at)
+		VALUES ($1, $2, CURRENT_TIMESTAMP - INTERVAL '1 hour')`, from, holder)
+	require.NoError(t, err)
+
+	got, err := tryAcquireEthSendLock(ctx, db, from, waiter)
+	require.NoError(t, err)
+	require.True(t, got, "TTL + dead harmony_machines owner should allow steal")
+
+	var holding int64
+	require.NoError(t, db.QueryRow(ctx,
+		`SELECT task_id FROM message_send_eth_locks WHERE from_address = $1`, from).Scan(&holding))
+	require.Equal(t, int64(waiter), holding)
+}
+
+func TestEthSendLockStealNullOwnerAfterTTL(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	oldTTL := SendLockStaleTTL
+	SendLockStaleTTL = time.Millisecond
+	t.Cleanup(func() { SendLockStaleTTL = oldTTL })
+
+	from := "0xlock-steal-null-owner"
+	machineID := insertLiveMachine(t, ctx, db, "lock-null-owner-machine")
+	holder := insertOwnedHarmonyTask(t, ctx, db, "SendTransaction", machineID)
+	_, err = db.Exec(ctx, `UPDATE harmony_task SET owner_id = NULL WHERE id = $1`, holder)
+	require.NoError(t, err)
+	waiter := harmonytask.TaskID(9352)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO message_send_eth_locks (from_address, task_id, claimed_at)
+		VALUES ($1, $2, CURRENT_TIMESTAMP - INTERVAL '1 hour')`, from, holder)
+	require.NoError(t, err)
+
+	got, err := tryAcquireEthSendLock(ctx, db, from, waiter)
+	require.NoError(t, err)
+	require.True(t, got, "TTL + disowned harmony_task should allow steal")
+}
+
+func TestEthSendLockNoStealDeadOwnerBeforeTTL(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	oldTTL := SendLockStaleTTL
+	oldDead := resources.LOOKS_DEAD_TIMEOUT
+	SendLockStaleTTL = time.Hour
+	resources.LOOKS_DEAD_TIMEOUT = time.Minute
+	t.Cleanup(func() {
+		SendLockStaleTTL = oldTTL
+		resources.LOOKS_DEAD_TIMEOUT = oldDead
+	})
+
+	from := "0xlock-no-steal-young"
+	machineID := insertStaleMachine(t, ctx, db, "lock-dead-young", 2*time.Hour)
+	holder := insertOwnedHarmonyTask(t, ctx, db, "SendTransaction", machineID)
+	waiter := harmonytask.TaskID(9402)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO message_send_eth_locks (from_address, task_id, claimed_at)
+		VALUES ($1, $2, CURRENT_TIMESTAMP)`, from, holder)
+	require.NoError(t, err)
+
+	got, err := tryAcquireEthSendLock(ctx, db, from, waiter)
+	require.NoError(t, err)
+	require.False(t, got, "dead owner alone is not enough before SendLockStaleTTL")
+}
+
+func TestMessageSendLockStealMissingTask(t *testing.T) {
+	ctx := t.Context()
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	from := "f1lockstealmissing"
+	holder := harmonytask.TaskID(9501)
+	waiter := harmonytask.TaskID(9502)
+
+	_, err = db.Exec(ctx, `
+		INSERT INTO message_send_locks (from_key, task_id, claimed_at)
+		VALUES ($1, $2, CURRENT_TIMESTAMP)`, from, holder)
+	require.NoError(t, err)
+
+	got, err := tryAcquireMessageSendLock(ctx, db, from, waiter)
+	require.NoError(t, err)
+	require.True(t, got)
+
+	var holding int64
+	require.NoError(t, db.QueryRow(ctx,
+		`SELECT task_id FROM message_send_locks WHERE from_key = $1`, from).Scan(&holding))
+	require.Equal(t, int64(waiter), holding)
+}
+
+func insertLiveMachine(t *testing.T, ctx context.Context, db *harmonydb.DB, host string) int64 {
+	t.Helper()
+	var id int64
+	err := db.QueryRow(ctx, `
+		INSERT INTO harmony_machines (host_and_port, cpu, ram, gpu, last_contact)
+		VALUES ($1, 1, 1, 0, CURRENT_TIMESTAMP)
+		RETURNING id`, host).Scan(&id)
+	require.NoError(t, err)
+	return id
+}
+
+func insertStaleMachine(t *testing.T, ctx context.Context, db *harmonydb.DB, host string, age time.Duration) int64 {
+	t.Helper()
+	var id int64
+	err := db.QueryRow(ctx, `
+		INSERT INTO harmony_machines (host_and_port, cpu, ram, gpu, last_contact)
+		VALUES ($1, 1, 1, 0, CURRENT_TIMESTAMP - ($2::bigint * INTERVAL '1 millisecond'))
+		RETURNING id`, host, age.Milliseconds()).Scan(&id)
+	require.NoError(t, err)
+	return id
+}
+
+func insertOwnedHarmonyTask(t *testing.T, ctx context.Context, db *harmonydb.DB, name string, ownerID int64) harmonytask.TaskID {
+	t.Helper()
+	var id int64
+	err := db.QueryRow(ctx, `
+		INSERT INTO harmony_task (posted_time, owner_id, added_by, name)
+		VALUES (CURRENT_TIMESTAMP, $1, $1, $2)
+		RETURNING id`, ownerID, name).Scan(&id)
+	require.NoError(t, err)
+	return harmonytask.TaskID(id)
+}

--- a/tasks/message/sender.go
+++ b/tasks/message/sender.go
@@ -121,18 +121,11 @@ func (s *SendTask) Do(ctx context.Context, taskID harmonytask.TaskID, stillOwned
 			return false, xerrors.Errorf("lost ownership of task")
 		}
 
-		// try to acquire lock
-		cn, err := s.db.Exec(ctx, `
-			INSERT INTO message_send_locks (from_key, task_id, claimed_at) 
-			VALUES ($1, $2, CURRENT_TIMESTAMP) ON CONFLICT (from_key) DO UPDATE 
-			SET task_id = EXCLUDED.task_id, claimed_at = CURRENT_TIMESTAMP 
-			WHERE message_send_locks.task_id = $2;`, dbMsg.FromKey, taskID)
+		got, err := tryAcquireMessageSendLock(ctx, s.db, dbMsg.FromKey, taskID)
 		if err != nil {
 			return false, xerrors.Errorf("acquiring send lock: %w", err)
 		}
-
-		if cn == 1 {
-			// we got the lock
+		if got {
 			break
 		}
 
@@ -143,8 +136,7 @@ func (s *SendTask) Do(ctx context.Context, taskID harmonytask.TaskID, stillOwned
 
 	// defer release db send lock
 	defer func() {
-		_, err2 := s.db.Exec(ctx, `
-			DELETE from message_send_locks WHERE from_key = $1 AND task_id = $2`, dbMsg.FromKey, taskID)
+		err2 := releaseMessageSendLock(s.db, dbMsg.FromKey, taskID)
 		if err2 != nil {
 			log.Errorw("releasing send lock", "task_id", taskID, "from", dbMsg.FromKey, "error", err2)
 
@@ -264,7 +256,8 @@ func (s *SendTask) TypeDetails() harmonytask.TaskTypeDetails {
 			Gpu: 0,
 			Ram: 1 << 20,
 		},
-		MaxFailures: 1000,
+		Uninterruptible: true,
+		MaxFailures:     1000,
 		RetryWait: func(retries int) time.Duration {
 			return min(time.Second*time.Duration(retries), time.Second*10)
 		},

--- a/tasks/message/sender_eth.go
+++ b/tasks/message/sender_eth.go
@@ -90,19 +90,11 @@ func (s *SendTaskETH) Do(ctx context.Context, taskID harmonytask.TaskID, stillOw
 			return false, xerrors.Errorf("lost ownership of task")
 		}
 
-		// Try to acquire lock
-		cn, err := s.db.Exec(ctx,
-			`INSERT INTO message_send_eth_locks (from_address, task_id, claimed_at)
-             VALUES ($1, $2, CURRENT_TIMESTAMP)
-             ON CONFLICT (from_address) DO UPDATE
-             SET task_id = EXCLUDED.task_id, claimed_at = CURRENT_TIMESTAMP
-             WHERE message_send_eth_locks.task_id = $2`, dbTx.FromAddress, taskID)
+		got, err := tryAcquireEthSendLock(ctx, s.db, dbTx.FromAddress, taskID)
 		if err != nil {
 			return false, xerrors.Errorf("acquiring send lock: %w", err)
 		}
-
-		if cn == 1 {
-			// Acquired the lock
+		if got {
 			break
 		}
 
@@ -113,8 +105,7 @@ func (s *SendTaskETH) Do(ctx context.Context, taskID harmonytask.TaskID, stillOw
 
 	// Defer release of the lock
 	defer func() {
-		_, err2 := s.db.Exec(ctx,
-			`DELETE FROM message_send_eth_locks WHERE from_address = $1 AND task_id = $2`, dbTx.FromAddress, taskID)
+		err2 := releaseEthSendLock(s.db, dbTx.FromAddress, taskID)
 		if err2 != nil {
 			log.Errorw("releasing send lock", "task_id", taskID, "from", dbTx.FromAddress, "error", err2)
 
@@ -321,7 +312,8 @@ func (s *SendTaskETH) TypeDetails() harmonytask.TaskTypeDetails {
 			Gpu: 0,
 			Ram: 1 << 20,
 		},
-		MaxFailures: 1000,
+		Uninterruptible: true,
+		MaxFailures:     1000,
 	}
 }
 


### PR DESCRIPTION
 Fixes Case 1 of #1413

**Portion 1:  Task design**
- Introduces an "uninterruptible" harmony_task flag to prevent preemption for send_task & send_task_eth
(This is basically "TimeSensitive" without the pre-emption line-jumping. 

**Portion 2:  Unlock exceptions**
- Unlock via TTL+harmony_machine liveness gone
- Unlock irrespective of the CTX (so unlock on shutdown). 
- Unlock for self task_id (in a restart case). 
- Unlock when holder task_id is not running. 