### PR TITLE
pdp always return Allow-Origin *

### DIFF
--- a/cuhttp/clientip/clientip.go
+++ b/cuhttp/clientip/clientip.go
@@ -9,18 +9,18 @@ import (
 	"github.com/go-chi/httprate"
 )
 
-// Middleware resolves the client IP from the TCP peer by default. A loopback
-// peer is treated as one trusted reverse-proxy hop, matching Curio's documented
-// same-host proxy setup. The proxy must overwrite or append X-Forwarded-For.
+// Middleware resolves the client IP from the TCP peer. A loopback or
+// private-network peer is trusted for one hop of X-Forwarded-For; the
+// proxy must overwrite or append that header.
 func Middleware(next http.Handler) http.Handler {
 	direct := middleware.ClientIPFromRemoteAddr(next)
-	loopbackProxy := middleware.ClientIPFromRemoteAddr(
+	trustedProxy := middleware.ClientIPFromRemoteAddr(
 		middleware.ClientIPFromXFFTrustedProxies(1)(next),
 	)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if ip, ok := remoteIP(r.RemoteAddr); ok && ip.IsLoopback() {
-			loopbackProxy.ServeHTTP(w, r)
+		if ip, ok := remoteIP(r.RemoteAddr); ok && (ip.IsLoopback() || ip.IsPrivate()) {
+			trustedProxy.ServeHTTP(w, r)
 			return
 		}
 		direct.ServeHTTP(w, r)

--- a/cuhttp/clientip/clientip_test.go
+++ b/cuhttp/clientip/clientip_test.go
@@ -33,6 +33,17 @@ func TestMiddlewareTrustModel(t *testing.T) {
 			wantIP:     "::1",
 		},
 		{
+			name:       "private-network proxy uses rightmost forwarded address",
+			remoteAddr: "10.0.0.5:1234",
+			xff:        "198.51.100.20, 192.0.2.30",
+			wantIP:     "192.0.2.30",
+		},
+		{
+			name:       "private-network proxy without header falls back to peer",
+			remoteAddr: "192.168.1.5:1234",
+			wantIP:     "192.168.1.5",
+		},
+		{
 			name:       "loopback proxy with malformed header falls back to peer",
 			remoteAddr: "127.0.0.1:1234",
 			xff:        "198.51.100.20, invalid",

--- a/cuhttp/middleware.go
+++ b/cuhttp/middleware.go
@@ -3,7 +3,6 @@ package cuhttp
 import (
 	"context"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/CAFxX/httpcompression"
@@ -11,34 +10,14 @@ import (
 	"github.com/filecoin-project/curio/deps/config"
 )
 
-// AllowedCORSOrigins returns the public API CORS allowlist.
-// DEV_CURIO_EXTERNAL_URL overrides the default https://{domainName} origin for local dev.
-func AllowedCORSOrigins(domainName string) []string {
-	if devURL := os.Getenv("DEV_CURIO_EXTERNAL_URL"); devURL != "" {
-		return []string{devURL}
-	}
-	return []string{"https://" + domainName}
-}
-
-// CORS allows cross-origin API calls from AllowedCORSOrigins (e.g. market and PDP piece uploads).
-// Exposes the Location header so clients can read redirect targets after upload.
-func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
-	allowed := make(map[string]struct{}, len(allowedOrigins))
-	for _, origin := range allowedOrigins {
-		allowed[origin] = struct{}{}
-	}
-
+// CORS allows any origin — PDP endpoints should accept requests from any source.
+func CORS() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			origin := r.Header.Get("Origin")
-			if origin != "" {
-				if _, ok := allowed[origin]; ok {
-					w.Header().Set("Access-Control-Allow-Origin", origin)
-					w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS")
-					w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Accept, Accept-Encoding")
-					w.Header().Set("Access-Control-Expose-Headers", "Location")
-				}
-			}
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Accept, Accept-Encoding")
+			w.Header().Set("Access-Control-Expose-Headers", "Location")
 
 			if r.Method == http.MethodOptions {
 				w.WriteHeader(http.StatusNoContent)

--- a/cuhttp/server.go
+++ b/cuhttp/server.go
@@ -58,7 +58,7 @@ type ServiceDeps struct {
 func StartHTTPServer(ctx context.Context, d *deps.Deps, sd *ServiceDeps) error {
 	cfg := d.Cfg.HTTP
 
-	chiRouter := NewRouter(RouterConfig{CSP: cfg.CSP, DomainName: cfg.DomainName})
+	chiRouter := NewRouter(RouterConfig{CSP: cfg.CSP})
 
 	compressionMw, err := Compression(&cfg.CompressionLevels)
 	if err != nil {

--- a/cuhttp/server_common.go
+++ b/cuhttp/server_common.go
@@ -26,8 +26,6 @@ type startTime string
 type RouterConfig struct {
 	// CSP enables secure response headers when non-empty (market server only).
 	CSP string
-	// DomainName is used to derive the default allowed CORS origin (https://{DomainName}).
-	DomainName string
 }
 
 // NewRouter builds a chi router with the standard public-server middleware.
@@ -39,7 +37,7 @@ func NewRouter(cfg RouterConfig) *chi.Mux {
 	if cfg.CSP != "" {
 		r.Use(SecureHeaders(cfg.CSP))
 	}
-	r.Use(CORS(AllowedCORSOrigins(cfg.DomainName)))
+	r.Use(CORS())
 	return r
 }
 

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -859,6 +859,15 @@ only need to be run on a single machine in the cluster. (Default: false)`,
 			Comment: `The address that should listen for Web GUI requests. It should be in form "x.x.x.x:1234" (Default: 0.0.0.0:4701)`,
 		},
 		{
+			Name: "GuiCORS",
+			Type: "[]string",
+
+			Comment: `GuiCORS specifies the allowed origins for CORS requests to the web GUI (GuiAddress). If empty, CORS is disabled.
+If not empty, only the specified origins will be allowed for CORS requests.
+This is required for third-party UI servers.
+"*" allows everyone, it's best to specify the UI servers' hostname.`,
+		},
+		{
 			Name: "UseSyntheticPoRep",
 			Type: "bool",
 
@@ -1065,15 +1074,6 @@ Time duration string (e.g., "1h2m3s") in TOML format. (Default: "30m0s")`,
 
 			Comment: `ReadHeaderTimeout is amount of time allowed to read request headers
 Time duration string (e.g., "1h2m3s") in TOML format. (Default: "0m5s")`,
-		},
-		{
-			Name: "CORSOrigins",
-			Type: "[]string",
-
-			Comment: `CORSOrigins specifies the allowed origins for CORS requests to the Curio admin UI. If empty, CORS is disabled.
-If not empty, only the specified origins will be allowed for CORS requests.
-This is required for third-party UI servers.
-"*" allows everyone, it's best to specify the UI servers' hostname.`,
 		},
 		{
 			Name: "CSP",

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -14,6 +14,7 @@ func DefaultCurioConfig() *CurioConfig {
 	return &CurioConfig{
 		Subsystems: CurioSubsystemsConfig{
 			GuiAddress:                     "0.0.0.0:4701",
+			GuiCORS:                        []string{},
 			RequireActivationSuccess:       true,
 			RequireNotificationSuccess:     true,
 			PDPPullPieceMaxTasks:           20,
@@ -141,7 +142,6 @@ func DefaultCurioConfig() *CurioConfig {
 			ReadTimeout:       time.Minute * 30,
 			IdleTimeout:       time.Minute * 30,
 			ReadHeaderTimeout: time.Second * 5,
-			CORSOrigins:       []string{},
 			CSP:               "inline",
 			CompressionLevels: CompressionConfig{
 				GzipLevel:    6,
@@ -393,6 +393,12 @@ type CurioSubsystemsConfig struct {
 
 	// The address that should listen for Web GUI requests. It should be in form "x.x.x.x:1234" (Default: 0.0.0.0:4701)
 	GuiAddress string
+
+	// GuiCORS specifies the allowed origins for CORS requests to the web GUI (GuiAddress). If empty, CORS is disabled.
+	// If not empty, only the specified origins will be allowed for CORS requests.
+	// This is required for third-party UI servers.
+	// "*" allows everyone, it's best to specify the UI servers' hostname.
+	GuiCORS []string
 
 	// UseSyntheticPoRep enables the synthetic PoRep for all new sectors. When set to true, will reduce the amount of
 	// cache data held on disk after the completion of TreeRC task to 11GiB. (Default: false)
@@ -987,11 +993,10 @@ type HTTPConfig struct {
 	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "0m5s")
 	ReadHeaderTimeout time.Duration
 
-	// CORSOrigins specifies the allowed origins for CORS requests to the Curio admin UI. If empty, CORS is disabled.
-	// If not empty, only the specified origins will be allowed for CORS requests.
-	// This is required for third-party UI servers.
-	// "*" allows everyone, it's best to specify the UI servers' hostname.
-	CORSOrigins []string
+	// CORSOrigins is DEPRECATED, moved to Subsystems.GuiCORS: this setting configures CORS for the
+	// web GUI server (Subsystems.GuiAddress), not this HTTP server, so it never belonged in this section.
+	// This HTTP server's endpoints are public/content-addressed and always send Access-Control-Allow-Origin: *.
+	CORSOrigins []string `moved:"Subsystems.GuiCORS"`
 
 	// CSP sets the Content Security Policy for content served via the /piece/ retrieval endpoint.
 	// Valid values: "off", "self", "inline" (Default: "inline")

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -993,11 +993,6 @@ type HTTPConfig struct {
 	// Time duration string (e.g., "1h2m3s") in TOML format. (Default: "0m5s")
 	ReadHeaderTimeout time.Duration
 
-	// CORSOrigins is DEPRECATED, moved to Subsystems.GuiCORS: this setting configures CORS for the
-	// web GUI server (Subsystems.GuiAddress), not this HTTP server, so it never belonged in this section.
-	// This HTTP server's endpoints are public/content-addressed and always send Access-Control-Allow-Origin: *.
-	CORSOrigins []string `moved:"Subsystems.GuiCORS"`
-
 	// CSP sets the Content Security Policy for content served via the /piece/ retrieval endpoint.
 	// Valid values: "off", "self", "inline" (Default: "inline")
 	//

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -251,6 +251,14 @@ description: The default curio configuration
   # type: string
   #GuiAddress = "0.0.0.0:4701"
 
+  # GuiCORS specifies the allowed origins for CORS requests to the web GUI (GuiAddress). If empty, CORS is disabled.
+  # If not empty, only the specified origins will be allowed for CORS requests.
+  # This is required for third-party UI servers.
+  # "*" allows everyone, it's best to specify the UI servers' hostname.
+  #
+  # type: []string
+  #GuiCORS = []
+
   # UseSyntheticPoRep enables the synthetic PoRep for all new sectors. When set to true, will reduce the amount of
   # cache data held on disk after the completion of TreeRC task to 11GiB. (Default: false)
   #
@@ -603,14 +611,6 @@ description: The default curio configuration
   #
   # type: time.Duration
   #ReadHeaderTimeout = "5s"
-
-  # CORSOrigins specifies the allowed origins for CORS requests to the Curio admin UI. If empty, CORS is disabled.
-  # If not empty, only the specified origins will be allowed for CORS requests.
-  # This is required for third-party UI servers.
-  # "*" allows everyone, it's best to specify the UI servers' hostname.
-  #
-  # type: []string
-  #CORSOrigins = []
 
   # CSP sets the Content Security Policy for content served via the /piece/ retrieval endpoint.
   # Valid values: "off", "self", "inline" (Default: "inline")

--- a/documentation/en/curio-market/curio-http-server.md
+++ b/documentation/en/curio-market/curio-http-server.md
@@ -30,7 +30,7 @@ The Curio HTTP Server is a secure, flexible, and high-performance HTTP server de
 
 * **Compression**: Utilizes the `httpcompression` package to support GZIP, Brotli, and Deflate, optimizing bandwidth usage based on configurable compression levels.
 * **Logging**: Logs every incoming request with details such as request method, path, and duration, aiding in easier debugging and monitoring.
-* **CORS Support**: Conditional CORS support based on configuration for handling cross-origin requests securely.
+* **CORS Support**: Every response sets `Access-Control-Allow-Origin: *`, allowing requests from any origin.
 
 ### 5. **WebSocket and LibP2P Support**
 
@@ -114,8 +114,6 @@ The list below is aligned with the actual `HTTPConfig` struct in `deps/config/ty
   Default: `1h`.
 * **ReadHeaderTimeout**: Max time to read headers.
   Default: `5s`.
-* **CORSOrigins**: Allowed origins; empty disables CORS.
-  Default: `[]`.
 * **CSP**: Content Security Policy mode for `/piece/` content. Values: `off`, `self`, `inline`.
   Default: `inline`.
 * **CompressionLevels**: Response compression tuning.

--- a/pdpnode/http.go
+++ b/pdpnode/http.go
@@ -22,7 +22,7 @@ func StartPublic(ctx context.Context, d *Deps, sd *TaskResult) error {
 		return nil
 	}
 
-	chiRouter := cuhttp.NewRouter(cuhttp.RouterConfig{CSP: cfg.CSP, DomainName: cfg.DomainName})
+	chiRouter := cuhttp.NewRouter(cuhttp.RouterConfig{CSP: cfg.CSP})
 	cuhttp.MountStandardRoutes(chiRouter)
 
 	if err := MountPublicRoutes(ctx, chiRouter, d, &sd.ServiceDeps); err != nil {

--- a/web/srv.go
+++ b/web/srv.go
@@ -45,7 +45,7 @@ func GetSrv(ctx context.Context, deps *deps.Deps, devMode bool) (*http.Server, e
 	// Single CORS middleware that handles all CORS logic
 	// Wrap the entire router to ensure middleware runs for all requests including unmatched routes
 	corsHandler := func(next http.Handler) http.Handler {
-		for _, ao := range deps.Cfg.HTTP.CORSOrigins {
+		for _, ao := range deps.Cfg.Subsystems.GuiCORS {
 			if ao == "*" {
 				log.Infof("This CORS configuration allows any website to call irreversable APIs on the Curio node: %s", ao)
 			}
@@ -53,13 +53,13 @@ func GetSrv(ctx context.Context, deps *deps.Deps, devMode bool) (*http.Server, e
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Handle OPTIONS preflight requests - always return 204, even if CORS not configured
 			if r.Method == http.MethodOptions {
-				if len(deps.Cfg.HTTP.CORSOrigins) > 0 {
+				if len(deps.Cfg.Subsystems.GuiCORS) > 0 {
 					origin := r.Header.Get("Origin")
 					var allowedOrigin string
 					allowed := false
 
 					// Check if origin is allowed
-					for _, ao := range deps.Cfg.HTTP.CORSOrigins {
+					for _, ao := range deps.Cfg.Subsystems.GuiCORS {
 						if ao == "*" || ao == origin {
 							allowedOrigin = ao
 							allowed = true
@@ -89,10 +89,10 @@ func GetSrv(ctx context.Context, deps *deps.Deps, devMode bool) (*http.Server, e
 			}
 
 			// Set CORS headers for non-OPTIONS requests if CORS is configured
-			if len(deps.Cfg.HTTP.CORSOrigins) > 0 {
+			if len(deps.Cfg.Subsystems.GuiCORS) > 0 {
 				origin := r.Header.Get("Origin")
 				if origin != "" {
-					for _, ao := range deps.Cfg.HTTP.CORSOrigins {
+					for _, ao := range deps.Cfg.Subsystems.GuiCORS {
 						if ao == "*" || ao == origin {
 							if ao == "*" {
 								w.Header().Set("Access-Control-Allow-Origin", "*")


### PR DESCRIPTION
1. Correct the original wrong gui cors position
2. pdp path always returns `"Access-Control-Allow-Origin", "*"`
3. Current limiting settings allow determination of LAN IP
>3 This is what I just noticed. Because the reverse proxy settings of the SP are not necessarily placed on the local machine, I modified them together here.


---
context:
https://filecoinproject.slack.com/archives/C095WFA0QK1/p1786423884375819?thread_ts=1786409312.417809&cid=C095WFA0QK1
<img width="1187" height="1033" alt="image" src="https://github.com/user-attachments/assets/51ee41d2-e086-4b58-91d6-b9f330283287" />
