### PR TITLE
public cors

### DIFF
--- a/cuhttp/middleware.go
+++ b/cuhttp/middleware.go
@@ -3,7 +3,6 @@ package cuhttp
 import (
 	"context"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/CAFxX/httpcompression"
@@ -11,42 +10,22 @@ import (
 	"github.com/filecoin-project/curio/deps/config"
 )
 
-// AllowedCORSOrigins returns the public API CORS allowlist.
-// DEV_CURIO_EXTERNAL_URL overrides the default https://{domainName} origin for local dev.
-func AllowedCORSOrigins(domainName string) []string {
-	if devURL := os.Getenv("DEV_CURIO_EXTERNAL_URL"); devURL != "" {
-		return []string{devURL}
-	}
-	return []string{"https://" + domainName}
-}
-
-// CORS allows cross-origin API calls from AllowedCORSOrigins (e.g. market and PDP piece uploads).
+// CORS allows any origin on the public HTTP API (market, PDP, retrieval).
+// Admin UI CORS remains restricted via HTTP.CORSOrigins on the GUI port.
 // Exposes the Location header so clients can read redirect targets after upload.
-func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
-	allowed := make(map[string]struct{}, len(allowedOrigins))
-	for _, origin := range allowedOrigins {
-		allowed[origin] = struct{}{}
-	}
+func CORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Accept, Accept-Encoding")
+		w.Header().Set("Access-Control-Expose-Headers", "Location")
 
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			origin := r.Header.Get("Origin")
-			if origin != "" {
-				if _, ok := allowed[origin]; ok {
-					w.Header().Set("Access-Control-Allow-Origin", origin)
-					w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, OPTIONS")
-					w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Accept, Accept-Encoding")
-					w.Header().Set("Access-Control-Expose-Headers", "Location")
-				}
-			}
-
-			if r.Method == http.MethodOptions {
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-			next.ServeHTTP(w, r)
-		})
-	}
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // SecureHeaders adds standard browser security headers.

--- a/cuhttp/server.go
+++ b/cuhttp/server.go
@@ -58,7 +58,7 @@ type ServiceDeps struct {
 func StartHTTPServer(ctx context.Context, d *deps.Deps, sd *ServiceDeps) error {
 	cfg := d.Cfg.HTTP
 
-	chiRouter := NewRouter(RouterConfig{CSP: cfg.CSP, DomainName: cfg.DomainName})
+	chiRouter := NewRouter(RouterConfig{CSP: cfg.CSP})
 
 	compressionMw, err := Compression(&cfg.CompressionLevels)
 	if err != nil {

--- a/cuhttp/server_common.go
+++ b/cuhttp/server_common.go
@@ -26,8 +26,6 @@ type startTime string
 type RouterConfig struct {
 	// CSP enables secure response headers when non-empty (market server only).
 	CSP string
-	// DomainName is used to derive the default allowed CORS origin (https://{DomainName}).
-	DomainName string
 }
 
 // NewRouter builds a chi router with the standard public-server middleware.
@@ -39,7 +37,7 @@ func NewRouter(cfg RouterConfig) *chi.Mux {
 	if cfg.CSP != "" {
 		r.Use(SecureHeaders(cfg.CSP))
 	}
-	r.Use(CORS(AllowedCORSOrigins(cfg.DomainName)))
+	r.Use(CORS)
 	return r
 }
 

--- a/pdpnode/http.go
+++ b/pdpnode/http.go
@@ -22,7 +22,7 @@ func StartPublic(ctx context.Context, d *Deps, sd *TaskResult) error {
 		return nil
 	}
 
-	chiRouter := cuhttp.NewRouter(cuhttp.RouterConfig{CSP: cfg.CSP, DomainName: cfg.DomainName})
+	chiRouter := cuhttp.NewRouter(cuhttp.RouterConfig{CSP: cfg.CSP})
 	cuhttp.MountStandardRoutes(chiRouter)
 
 	if err := MountPublicRoutes(ctx, chiRouter, d, &sd.ServiceDeps); err != nil {


### PR DESCRIPTION
The public endpoint should allow CORS for good web3 behavior. 
This is "common" between Curio & Curio-PDP. 

The admin endpoint remains locked-down. 