### PR TITLE
ipni: replace ad-fetch tracking with indexer sync-status confirmation

### DIFF
--- a/documentation/en/configuration/metrics-reference.md
+++ b/documentation/en/configuration/metrics-reference.md
@@ -183,6 +183,7 @@ This document lists Prometheus metrics exported by Curio using the exact metric 
 | `curio_http_response_status_count` | counter | `status_code`, `path`, `method` | Counter of HTTP response status codes |
 | `curio_ipni_announce_attempts_total` | counter | `provider`, `result` | Total number of IPNI direct announce attempts. |
 | `curio_ipni_announce_http_roundtrip_milliseconds` | histogram | `provider`, `status` | Duration of outbound IPNI announce HTTP round trips in milliseconds. |
+| `curio_ipni_announce_to_indexed_latency_milliseconds` | histogram | `provider`, `provider_type`, `service` | Duration from a successful head announce to confirmed indexing by an indexer service. |
 | `curio_ipni_entry_cache_hit_wait_milliseconds` | histogram | `request`, `origin`, `state` | Duration callers wait after hitting the IPNI entry cache. |
 | `curio_ipni_entry_cache_hits_total` | counter | `request`, `origin`, `state` | Total number of IPNI entry cache hits by request type, cache origin, and readiness state. |
 | `curio_ipni_entry_cache_lookups_total` | counter | `request`, `result` | Total number of IPNI entry cache lookups. |

--- a/documentation/en/configuration/metrics-reference.md
+++ b/documentation/en/configuration/metrics-reference.md
@@ -183,7 +183,7 @@ This document lists Prometheus metrics exported by Curio using the exact metric 
 | `curio_http_response_status_count` | counter | `status_code`, `path`, `method` | Counter of HTTP response status codes |
 | `curio_ipni_announce_attempts_total` | counter | `provider`, `result` | Total number of IPNI direct announce attempts. |
 | `curio_ipni_announce_http_roundtrip_milliseconds` | histogram | `provider`, `status` | Duration of outbound IPNI announce HTTP round trips in milliseconds. |
-| `curio_ipni_announce_to_indexed_latency_milliseconds` | histogram | `provider`, `provider_type`, `service` | Duration from a successful head announce to confirmed indexing by an indexer service. |
+| `curio_ipni_announce_to_indexed_latency_seconds` | histogram | `provider`, `provider_type`, `service` | Duration from a successful head announce to confirmed indexing by an indexer service. |
 | `curio_ipni_entry_cache_hit_wait_milliseconds` | histogram | `request`, `origin`, `state` | Duration callers wait after hitting the IPNI entry cache. |
 | `curio_ipni_entry_cache_hits_total` | counter | `request`, `origin`, `state` | Total number of IPNI entry cache hits by request type, cache origin, and readiness state. |
 | `curio_ipni_entry_cache_lookups_total` | counter | `request`, `result` | Total number of IPNI entry cache lookups. |

--- a/harmony/harmonydb/downgrade/20260813-drop-ipni-ad-fetches.sql
+++ b/harmony/harmonydb/downgrade/20260813-drop-ipni-ad-fetches.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS ipni_ad_fetches (
+    ad_cid TEXT NOT NULL,
+    fetched_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS ipni_ad_fetches_ad_cid_time ON ipni_ad_fetches(ad_cid, fetched_at DESC);

--- a/harmony/harmonydb/downgrade/20260814-ipni-provider-order-number.sql
+++ b/harmony/harmonydb/downgrade/20260814-ipni-provider-order-number.sql
@@ -1,0 +1,53 @@
+CREATE OR REPLACE FUNCTION insert_ad_and_update_head_checked(
+    _ad_cid TEXT,
+    _context_id BYTEA,
+    _metadata BYTEA,
+    _piece_cid_v2 TEXT,
+    _piece_cid TEXT,
+    _piece_size BIGINT,
+    _is_rm BOOLEAN,
+    _provider TEXT,
+    _addresses TEXT,
+    _signature BYTEA,
+    _entries TEXT,
+    _expected_previous TEXT
+) RETURNS BOOLEAN AS $$
+DECLARE
+    _current_head TEXT;
+    _rows BIGINT;
+BEGIN
+    SELECT head INTO _current_head
+    FROM ipni_head
+    WHERE provider = _provider;
+
+    IF _current_head IS DISTINCT FROM _expected_previous THEN
+        RETURN FALSE;
+    END IF;
+
+    INSERT INTO ipni (
+        ad_cid, context_id, metadata, is_rm, previous, provider, addresses,
+        signature, entries, piece_cid_v2, piece_cid, piece_size
+    )
+    VALUES (
+        _ad_cid, _context_id, _metadata, _is_rm, _expected_previous, _provider, _addresses,
+        _signature, _entries, _piece_cid_v2, _piece_cid, _piece_size
+    );
+
+    IF _expected_previous IS NULL THEN
+        INSERT INTO ipni_head (provider, head)
+        VALUES (_provider, _ad_cid)
+        ON CONFLICT (provider) DO NOTHING;
+    ELSE
+        UPDATE ipni_head
+        SET head = _ad_cid
+        WHERE provider = _provider
+          AND head IS NOT DISTINCT FROM _expected_previous;
+    END IF;
+
+    GET DIAGNOSTICS _rows = ROW_COUNT;
+    RETURN _rows = 1;
+END;
+$$ LANGUAGE plpgsql;
+
+ALTER TABLE ipni_head DROP COLUMN IF EXISTS head_order_number;
+ALTER TABLE ipni DROP COLUMN IF EXISTS provider_order_number;

--- a/harmony/harmonydb/sql/20260813-drop-ipni-ad-fetches.sql
+++ b/harmony/harmonydb/sql/20260813-drop-ipni-ad-fetches.sql
@@ -1,0 +1,4 @@
+-- ipni_ad_fetches recorded raw ad-body fetches, which only proves an indexer pulled
+-- the ad, not that it finished processing it. Replaced by an in-memory
+-- announce/sync-confirmation watermark in market/ipni/ipni-provider.
+DROP TABLE IF EXISTS ipni_ad_fetches;

--- a/harmony/harmonydb/sql/20260814-ipni-provider-order-number.sql
+++ b/harmony/harmonydb/sql/20260814-ipni-provider-order-number.sql
@@ -1,0 +1,61 @@
+-- Manually assigned, per-provider ad order number, set inside the existing
+-- CAS-protected transaction in insert_ad_and_update_head_checked. Existing
+-- rows are left NULL (not backfilled): ads created before this migration
+-- are not eligible for advertised/synced tracking.
+ALTER TABLE ipni ADD COLUMN IF NOT EXISTS provider_order_number BIGINT;
+ALTER TABLE ipni_head ADD COLUMN IF NOT EXISTS head_order_number BIGINT NOT NULL DEFAULT 0;
+
+CREATE OR REPLACE FUNCTION insert_ad_and_update_head_checked(
+    _ad_cid TEXT,
+    _context_id BYTEA,
+    _metadata BYTEA,
+    _piece_cid_v2 TEXT,
+    _piece_cid TEXT,
+    _piece_size BIGINT,
+    _is_rm BOOLEAN,
+    _provider TEXT,
+    _addresses TEXT,
+    _signature BYTEA,
+    _entries TEXT,
+    _expected_previous TEXT
+) RETURNS BOOLEAN AS $$
+DECLARE
+    _current_head TEXT;
+    _current_order_number BIGINT;
+    _new_order_number BIGINT;
+    _rows BIGINT;
+BEGIN
+    SELECT head, head_order_number INTO _current_head, _current_order_number
+    FROM ipni_head
+    WHERE provider = _provider;
+
+    IF _current_head IS DISTINCT FROM _expected_previous THEN
+        RETURN FALSE;
+    END IF;
+
+    _new_order_number := COALESCE(_current_order_number, 0) + 1;
+
+    INSERT INTO ipni (
+        ad_cid, context_id, metadata, is_rm, previous, provider, addresses,
+        signature, entries, piece_cid_v2, piece_cid, piece_size, provider_order_number
+    )
+    VALUES (
+        _ad_cid, _context_id, _metadata, _is_rm, _expected_previous, _provider, _addresses,
+        _signature, _entries, _piece_cid_v2, _piece_cid, _piece_size, _new_order_number
+    );
+
+    IF _expected_previous IS NULL THEN
+        INSERT INTO ipni_head (provider, head, head_order_number)
+        VALUES (_provider, _ad_cid, _new_order_number)
+        ON CONFLICT (provider) DO NOTHING;
+    ELSE
+        UPDATE ipni_head
+        SET head = _ad_cid, head_order_number = _new_order_number
+        WHERE provider = _provider
+          AND head IS NOT DISTINCT FROM _expected_previous;
+    END IF;
+
+    GET DIAGNOSTICS _rows = ROW_COUNT;
+    RETURN _rows = 1;
+END;
+$$ LANGUAGE plpgsql;

--- a/market/ipni/ipni-provider/ipni-provider.go
+++ b/market/ipni/ipni-provider/ipni-provider.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -13,6 +14,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -74,7 +76,15 @@ type peerInfo struct {
 	// Curio HTTP URL(in multiaddr)+IPNIRoutePath(/ipni-provider/)+peerID
 	httpServerAddresses multiaddr.Multiaddr // map[peerID String]Multiaddr
 	providerType        string
-	lastPublishTime     *time.Time
+
+	// Highest ipni.order_number announced as head / confirmed indexed, and when.
+	// announcedAt is nil if seeded from an existing head rather than observed.
+	announcedOrderNumber int64
+	announcedAt          *time.Time
+	// Indexers process a provider's ad chain in order, so confirming the head
+	// implies every earlier ad is also indexed - only the head needs checking.
+	syncedOrderNumber int64
+	syncedAt          *time.Time
 }
 
 // Provider represents a provider for IPNI.
@@ -92,6 +102,11 @@ type Provider struct {
 	announceURLs   []*url.URL
 	httpServerBase *url.URL
 	startLock      sync.Once
+
+	serviceURLs []*url.URL
+	httpClient  *http.Client
+	// checkingSyncStatus prevents overlapping checkSyncStatus runs.
+	checkingSyncStatus atomic.Bool
 }
 
 // NewProvider initializes a new Provider using the provided dependencies.
@@ -119,6 +134,16 @@ func NewProvider(d *deps.Deps) (*Provider, error) {
 	}
 	baseURL.Path = path.Join(baseURL.Path, IPNIRoutePath)
 
+	serviceURLStrs := d.Cfg.Market.StorageMarketConfig.IPNI.ServiceURL
+	serviceURLs := make([]*url.URL, len(serviceURLStrs))
+	for i, us := range serviceURLStrs {
+		u, err := url.Parse(us)
+		if err != nil {
+			return nil, xerrors.Errorf("parsing IPNI service URL %q: %w", us, err)
+		}
+		serviceURLs[i] = u
+	}
+
 	p := &Provider{
 		full:           d.Chain,
 		db:             d.DB,
@@ -129,6 +154,8 @@ func NewProvider(d *deps.Deps) (*Provider, error) {
 		announceURLs:   announceURLs,
 		httpServerBase: baseURL,
 		latest:         make(map[string]cid.Cid),
+		serviceURLs:    serviceURLs,
+		httpClient:     &http.Client{Timeout: 10 * time.Second},
 	}
 
 	if err := p.refreshProviders(ctx); err != nil {
@@ -460,8 +487,6 @@ func (p *Provider) handleGet(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Errorw("failed to write HTTP response", "err", err)
 		}
-		// Log advertisement fetch for indexing status tracking
-		go p.logPDPFetch(providerID, b.String())
 		return
 	case ipnisync.CidSchemaEntryChunk:
 		content = "entry"
@@ -522,23 +547,7 @@ func (p *Provider) handleGet(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Errorw("failed to write HTTP response", "err", err)
 		}
-		// Log advertisement fetch for indexing status tracking
-		go p.logPDPFetch(providerID, b.String())
 		return
-	}
-}
-
-func (p *Provider) logPDPFetch(peer, b string) {
-	p.mu.RLock()
-	info, ok := p.providerInfos[peer]
-	p.mu.RUnlock()
-	if !ok || info.SPID > 0 {
-		return
-	}
-	logCtx := context.Background()
-	_, err := p.db.Exec(logCtx, `INSERT INTO ipni_ad_fetches (ad_cid, fetched_at) VALUES ($1, NOW())`, b)
-	if err != nil {
-		log.Warnw("failed to log ad fetch", "ad_cid", b, "err", err)
 	}
 }
 
@@ -597,12 +606,24 @@ func (p *Provider) startPublishing(ctx context.Context) {
 	}
 	p.mu.RUnlock()
 	for _, provider := range peers {
-		c, err := p.getHeadCID(ctx, provider)
+		c, orderNumber, err := p.getHeadOrdered(ctx, provider)
 		if err != nil {
 			log.Errorw("failed to get head CID", "provider", provider, "error", err)
 			continue
 		}
 		p.latest[provider] = c
+		if c == cid.Undef {
+			continue
+		}
+
+		// Assume the persisted head was announced before restart so status polling
+		// can resume. This may overstate advertised status if shutdown occurred
+		// before the announce completed.
+		p.mu.Lock()
+		if info, ok := p.providerInfos[provider]; ok {
+			info.announcedOrderNumber = orderNumber
+		}
+		p.mu.Unlock()
 	}
 
 	ticker := time.NewTicker(PublishInterval)
@@ -616,6 +637,7 @@ func (p *Provider) startPublishing(ctx context.Context) {
 			// Call the function to publish head for each provider
 			p.publishHead(ctx)
 			p.maybeUpdateSparkContract(ctx)
+			go p.checkSyncStatus(ctx) // must not block publishHead on a slow service
 		case <-ctx.Done():
 			ticker.Stop()
 			return
@@ -623,27 +645,31 @@ func (p *Provider) startPublishing(ctx context.Context) {
 	}
 }
 
-// getHeadCID queries the database to retrieve the head CID for a specific provider.
-// If the head CID is not found or an error occurs, it returns cid.Undef and the error respectively.
-func (p *Provider) getHeadCID(ctx context.Context, provider string) (cid.Cid, error) {
+// getHeadOrdered returns cid.Undef, 0 if the provider has no head yet.
+func (p *Provider) getHeadOrdered(ctx context.Context, provider string) (cid.Cid, int64, error) {
 	var headStr string
-	err := p.db.QueryRow(ctx, `SELECT head FROM ipni_head WHERE provider = $1`, provider).Scan(&headStr)
+	var orderNumber int64
+	err := p.db.QueryRow(ctx, `
+		SELECT h.head, i.order_number
+		FROM ipni_head h JOIN ipni i ON i.ad_cid = h.head
+		WHERE h.provider = $1`, provider).Scan(&headStr, &orderNumber)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return cid.Undef, nil
+			return cid.Undef, 0, nil
 		}
-		return cid.Undef, xerrors.Errorf("querying previous head: %w", err)
+		return cid.Undef, 0, xerrors.Errorf("querying previous head: %w", err)
 	}
 
 	if headStr == "" {
-		return cid.Undef, chunker.ErrNotFound
+		return cid.Undef, 0, chunker.ErrNotFound
 	}
 
-	return cid.Parse(headStr)
+	c, err := cid.Parse(headStr)
+	return c, orderNumber, err
 }
 
 // publishHead iterates over each provider's keys and publishes the head CID for that provider.
-// It calls the getHeadCID method to retrieve the head CID for each provider. If an error occurs, it logs the error and continues to the next provider.
+// It calls the getHeadOrdered method to retrieve the head CID for each provider. If an error occurs, it logs the error and continues to the next provider.
 // It then calls the publishhttp method to publish the head CID via HTTP. If an error occurs, it logs the error.
 // The function is intended to be run as a goroutine with a ticker to schedule its execution at regular intervals.
 func (p *Provider) publishHead(ctx context.Context) {
@@ -659,7 +685,7 @@ func (p *Provider) publishHead(ctx context.Context) {
 		if i > 0 {
 			time.Sleep(time.Second)
 		}
-		c, err := p.getHeadCID(ctx, provider)
+		c, orderNumber, err := p.getHeadOrdered(ctx, provider)
 		if err != nil {
 			log.Errorw("failed to get head CID", "provider", provider, "error", err)
 			continue
@@ -669,7 +695,10 @@ func (p *Provider) publishHead(ctx context.Context) {
 			continue
 		}
 
-		if _, ok := p.latest[provider]; ok && p.latest[provider] == c {
+		p.mu.RLock()
+		latestC, latestOk := p.latest[provider]
+		p.mu.RUnlock()
+		if latestOk && latestC == c {
 			log.Debugw("Skipping duplicate announce for provider", "provider", provider, "cid", c.String())
 			continue
 		}
@@ -681,13 +710,14 @@ func (p *Provider) publishHead(ctx context.Context) {
 			log.Errorw("failed to publish head for provide", "provider", provider, "error", err)
 		} else {
 			recordAnnounceAttempt(provider, "success")
-			p.latest[provider] = c
 			p.mu.Lock()
+			p.latest[provider] = c
 			info, ok := p.providerInfos[provider]
 			if !ok {
 				log.Warnw("cannot update provider announce times", "provider", provider, "error", "provider not found")
 			} else {
-				info.lastPublishTime = new(time.Now())
+				info.announcedOrderNumber = orderNumber
+				info.announcedAt = new(time.Now())
 			}
 			p.mu.Unlock()
 		}
@@ -762,12 +792,142 @@ func (lrt *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	return res, nil
 }
 
-func (p *Provider) LastPublishTime(providerPeerID string) *time.Time {
+func (p *Provider) AnnouncedOrderNumber(providerPeerID string) (int64, *time.Time) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	info, ok := p.providerInfos[providerPeerID]
 	if !ok {
-		return nil
+		return 0, nil
 	}
-	return info.lastPublishTime
+	return info.announcedOrderNumber, info.announcedAt
+}
+
+func (p *Provider) SyncedOrderNumber(providerPeerID string) (int64, *time.Time) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	info, ok := p.providerInfos[providerPeerID]
+	if !ok {
+		return 0, nil
+	}
+	return info.syncedOrderNumber, info.syncedAt
+}
+
+// adSyncStatus mirrors storetheindex's GET /sync/status/ad/{adCid} response
+// (ipni/storetheindex#2861).
+type adSyncStatus struct {
+	Ad      string
+	Indexed bool
+}
+
+func (p *Provider) checkSyncStatus(ctx context.Context) {
+	if !p.checkingSyncStatus.CompareAndSwap(false, true) {
+		log.Debugw("skipping sync status check, previous run still in flight")
+		return
+	}
+	defer p.checkingSyncStatus.Store(false)
+
+	type pending struct {
+		provider    string
+		adCid       cid.Cid
+		orderNumber int64
+		announcedAt *time.Time // nil for a seeded, not observed, announce
+	}
+
+	p.mu.RLock()
+	var todo []pending
+	for provider, info := range p.providerInfos {
+		if info.announcedOrderNumber <= info.syncedOrderNumber {
+			continue
+		}
+		adCid, ok := p.latest[provider]
+		if !ok || adCid == cid.Undef {
+			continue
+		}
+		todo = append(todo, pending{
+			provider:    provider,
+			adCid:       adCid,
+			orderNumber: info.announcedOrderNumber,
+			announcedAt: info.announcedAt,
+		})
+	}
+	p.mu.RUnlock()
+
+	for _, item := range todo {
+		confirmedBy, indexed := p.queryAdIndexed(ctx, item.adCid)
+		if !indexed {
+			continue
+		}
+
+		now := time.Now()
+		var advanced bool
+		var providerType string
+		p.mu.Lock()
+		if info, ok := p.providerInfos[item.provider]; ok {
+			providerType = info.providerType
+			if item.orderNumber > info.syncedOrderNumber {
+				info.syncedOrderNumber = item.orderNumber
+				info.syncedAt = &now
+				advanced = true
+			}
+		}
+		p.mu.Unlock()
+		if !advanced {
+			continue
+		}
+
+		if item.announcedAt == nil {
+			continue // unknown announce time: no latency sample to report
+		}
+
+		latency := now.Sub(*item.announcedAt)
+		log.Infow("IPNI advertisement confirmed indexed", "provider", item.provider, "ad_cid", item.adCid.String(), "service", confirmedBy, "announced_at", item.announcedAt, "confirmed_at", now, "latency", latency)
+		observeIndexedLatency(item.provider, providerType, confirmedBy, latency)
+	}
+}
+
+// queryAdIndexed returns the first service reporting adCid as indexed, or
+// ("", false). A 404 means the service doesn't support this endpoint and is
+// skipped, not treated as unconfirmed.
+func (p *Provider) queryAdIndexed(ctx context.Context, adCid cid.Cid) (string, bool) {
+	for _, svc := range p.serviceURLs {
+		u := *svc
+		u.Path = path.Join(u.Path, "sync", "status", "ad", adCid.String())
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			log.Warnw("failed to build ad sync status request", "service", svc.String(), "ad_cid", adCid.String(), "err", err)
+			continue
+		}
+
+		resp, err := p.httpClient.Do(req)
+		if err != nil {
+			log.Debugw("failed to query ad sync status", "service", svc.String(), "ad_cid", adCid.String(), "err", err)
+			continue
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			log.Debugw("indexer service does not support ad sync status endpoint, skipping", "service", svc.String())
+			_ = resp.Body.Close()
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			log.Debugw("unexpected ad sync status response", "service", svc.String(), "ad_cid", adCid.String(), "status", resp.StatusCode)
+			_ = resp.Body.Close()
+			continue
+		}
+
+		var status adSyncStatus
+		err = json.NewDecoder(resp.Body).Decode(&status)
+		_ = resp.Body.Close()
+		if err != nil {
+			log.Warnw("failed to decode ad sync status response", "service", svc.String(), "ad_cid", adCid.String(), "err", err)
+			continue
+		}
+
+		if status.Indexed {
+			return svc.String(), true
+		}
+	}
+	return "", false
 }

--- a/market/ipni/ipni-provider/ipni-provider.go
+++ b/market/ipni/ipni-provider/ipni-provider.go
@@ -53,7 +53,9 @@ const IPNIRoutePath = "/ipni-provider/"
 // IPNIPath is a constant that represents the path for IPNI API requests.
 const IPNIPath = "/ipni/v1/ad/"
 
-const PublishInterval = 5 * time.Second
+// cid.contact has a limit of 60 post head requests per minute.
+// The rate limit may be shut down when the pressure is low.
+const PublishInterval = 1 * time.Second
 
 const (
 	PDPv0ProviderType = "PDP_v0"

--- a/market/ipni/ipni-provider/ipni-provider.go
+++ b/market/ipni/ipni-provider/ipni-provider.go
@@ -77,7 +77,7 @@ type peerInfo struct {
 	httpServerAddresses multiaddr.Multiaddr // map[peerID String]Multiaddr
 	providerType        string
 
-	// Highest ipni.order_number announced as head / confirmed indexed, and when.
+	// Highest ipni_head.head_order_number announced as head / confirmed indexed, and when.
 	// announcedAt is nil if seeded from an existing head rather than observed.
 	announcedOrderNumber int64
 	announcedAt          *time.Time
@@ -650,9 +650,9 @@ func (p *Provider) getHeadOrdered(ctx context.Context, provider string) (cid.Cid
 	var headStr string
 	var orderNumber int64
 	err := p.db.QueryRow(ctx, `
-		SELECT h.head, i.order_number
-		FROM ipni_head h JOIN ipni i ON i.ad_cid = h.head
-		WHERE h.provider = $1`, provider).Scan(&headStr, &orderNumber)
+		SELECT head, head_order_number
+		FROM ipni_head
+		WHERE provider = $1`, provider).Scan(&headStr, &orderNumber)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return cid.Undef, 0, nil
@@ -927,6 +927,11 @@ func (p *Provider) queryAdIndexed(ctx context.Context, adCid cid.Cid) (string, b
 		}
 
 		if status.Indexed {
+			respAd, err := cid.Parse(status.Ad)
+			if err != nil || !respAd.Equals(adCid) {
+				log.Warnw("ad sync status response ad mismatch, ignoring", "service", svc.String(), "requested", adCid.String(), "got", status.Ad)
+				continue
+			}
 			return svc.String(), true
 		}
 	}

--- a/market/ipni/ipni-provider/ipni-provider.go
+++ b/market/ipni/ipni-provider/ipni-provider.go
@@ -822,8 +822,12 @@ func (p *Provider) SyncedOrderNumber(providerPeerID string) (int64, *time.Time) 
 // adSyncStatus mirrors storetheindex's GET /sync/status/ad/{adCid} response
 // (ipni/storetheindex#2861).
 type adSyncStatus struct {
-	Ad      string
-	Indexed bool
+	Ad         string
+	Indexed    bool
+	State      string
+	SkipReason string
+	Frozen     bool
+	Error      string
 }
 
 func (p *Provider) checkSyncStatus(ctx context.Context) {
@@ -867,8 +871,8 @@ func (p *Provider) checkSyncStatus(ctx context.Context) {
 	p.mu.Unlock()
 
 	for _, item := range todo {
-		confirmedBy, indexed := p.queryAdIndexed(ctx, item.adCid)
-		if !indexed {
+		confirmedBy, indexed, skipReason := p.queryAdIndexed(ctx, item.adCid)
+		if !indexed && skipReason == "" {
 			continue
 		}
 
@@ -889,6 +893,11 @@ func (p *Provider) checkSyncStatus(ctx context.Context) {
 			continue
 		}
 
+		if skipReason != "" {
+			log.Warnw("IPNI advertisement permanently skipped by indexer, watermark advanced past it", "provider", item.provider, "ad_cid", item.adCid.String(), "service", confirmedBy, "reason", skipReason)
+			continue
+		}
+
 		if item.announcedAt == nil {
 			continue // unknown announce time: no latency sample to report
 		}
@@ -899,10 +908,11 @@ func (p *Provider) checkSyncStatus(ctx context.Context) {
 	}
 }
 
-// queryAdIndexed returns the first service reporting adCid as indexed, or
-// ("", false). A 404 means the service doesn't support this endpoint and is
-// skipped, not treated as unconfirmed.
-func (p *Provider) queryAdIndexed(ctx context.Context, adCid cid.Cid) (string, bool) {
+// queryAdIndexed returns (service, indexed, skipReason). A 404 means the
+// service doesn't support this endpoint and is skipped, not treated as
+// unconfirmed. skipReason is non-empty when the ad was permanently skipped
+// (won't ever become indexed).
+func (p *Provider) queryAdIndexed(ctx context.Context, adCid cid.Cid) (string, bool, string) {
 	for _, svc := range p.serviceURLs {
 		u := *svc
 		u.Path = path.Join(u.Path, "sync", "status", "ad", adCid.String())
@@ -939,14 +949,23 @@ func (p *Provider) queryAdIndexed(ctx context.Context, adCid cid.Cid) (string, b
 			continue
 		}
 
-		if status.Indexed {
-			respAd, err := cid.Parse(status.Ad)
-			if err != nil || !respAd.Equals(adCid) {
-				log.Warnw("ad sync status response ad mismatch, ignoring", "service", svc.String(), "requested", adCid.String(), "got", status.Ad)
-				continue
+		if !status.Indexed && status.State != "skipped" {
+			if status.Frozen || status.Error != "" {
+				log.Warnw("ad not indexed", "service", svc.String(), "ad_cid", adCid.String(), "state", status.State, "frozen", status.Frozen, "error", status.Error)
 			}
-			return svc.String(), true
+			continue
 		}
+
+		respAd, err := cid.Parse(status.Ad)
+		if err != nil || !respAd.Equals(adCid) {
+			log.Warnw("ad sync status response ad mismatch, ignoring", "service", svc.String(), "requested", adCid.String(), "got", status.Ad)
+			continue
+		}
+
+		if status.Indexed {
+			return svc.String(), true, ""
+		}
+		return svc.String(), false, status.SkipReason
 	}
-	return "", false
+	return "", false, ""
 }

--- a/market/ipni/ipni-provider/ipni-provider.go
+++ b/market/ipni/ipni-provider/ipni-provider.go
@@ -825,6 +825,7 @@ func (p *Provider) checkSyncStatus(ctx context.Context) {
 		return
 	}
 	defer p.checkingSyncStatus.Store(false)
+	checkStart := time.Now()
 
 	type pending struct {
 		provider    string
@@ -880,7 +881,7 @@ func (p *Provider) checkSyncStatus(ctx context.Context) {
 		}
 
 		latency := now.Sub(*item.announcedAt)
-		log.Infow("IPNI advertisement confirmed indexed", "provider", item.provider, "ad_cid", item.adCid.String(), "service", confirmedBy, "announced_at", item.announcedAt, "confirmed_at", now, "latency", latency)
+		log.Infow("IPNI advertisement confirmed indexed", "provider", item.provider, "ad_cid", item.adCid.String(), "service", confirmedBy, "announced_at", item.announcedAt, "confirmed_at", now, "latency", latency, "check_took", time.Since(checkStart))
 		observeIndexedLatency(item.provider, providerType, confirmedBy, latency)
 	}
 }

--- a/market/ipni/ipni-provider/ipni-provider.go
+++ b/market/ipni/ipni-provider/ipni-provider.go
@@ -87,6 +87,11 @@ type peerInfo struct {
 	// implies every earlier ad is also indexed - only the head needs checking.
 	syncedOrderNumber int64
 	syncedAt          *time.Time
+
+	// syncTarget* pin the ad checkSyncStatus is waiting to see confirmed.
+	syncTargetOrderNumber int64
+	syncTargetAdCid       cid.Cid
+	syncTargetAnnouncedAt *time.Time
 }
 
 // Provider represents a provider for IPNI.
@@ -836,24 +841,30 @@ func (p *Provider) checkSyncStatus(ctx context.Context) {
 		announcedAt *time.Time // nil for a seeded, not observed, announce
 	}
 
-	p.mu.RLock()
+	p.mu.Lock()
 	var todo []pending
 	for provider, info := range p.providerInfos {
-		if info.announcedOrderNumber <= info.syncedOrderNumber {
-			continue
-		}
-		adCid, ok := p.latest[provider]
-		if !ok || adCid == cid.Undef {
-			continue
+		// Pin a fresh checkpoint only once the previous one is confirmed.
+		if info.syncTargetOrderNumber <= info.syncedOrderNumber {
+			if info.announcedOrderNumber <= info.syncedOrderNumber {
+				continue
+			}
+			adCid, ok := p.latest[provider]
+			if !ok || adCid == cid.Undef {
+				continue
+			}
+			info.syncTargetOrderNumber = info.announcedOrderNumber
+			info.syncTargetAdCid = adCid
+			info.syncTargetAnnouncedAt = info.announcedAt
 		}
 		todo = append(todo, pending{
 			provider:    provider,
-			adCid:       adCid,
-			orderNumber: info.announcedOrderNumber,
-			announcedAt: info.announcedAt,
+			adCid:       info.syncTargetAdCid,
+			orderNumber: info.syncTargetOrderNumber,
+			announcedAt: info.syncTargetAnnouncedAt,
 		})
 	}
-	p.mu.RUnlock()
+	p.mu.Unlock()
 
 	for _, item := range todo {
 		confirmedBy, indexed := p.queryAdIndexed(ctx, item.adCid)

--- a/market/ipni/ipni-provider/metrics.go
+++ b/market/ipni/ipni-provider/metrics.go
@@ -39,13 +39,16 @@ func (w *metricResponseWriter) Status() int {
 }
 
 var (
-	ipniProviderHTTPRequestBuckets = []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000}
-	ipniAnnounceRoundTripBuckets   = []float64{10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000}
+	ipniProviderHTTPRequestBuckets      = []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000}
+	ipniAnnounceRoundTripBuckets        = []float64{10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000}
+	ipniAnnounceToIndexedLatencyBuckets = []float64{5000, 10000, 15000, 30000, 45000, 60000, 120000, 300000, 420000, 600000, 900000, 1800000, 3600000}
 
-	providerTag, _ = tag.NewKey("provider")
-	contentTag, _  = tag.NewKey("content")
-	statusTag, _   = tag.NewKey("status")
-	resultTag, _   = tag.NewKey("result")
+	providerTag, _     = tag.NewKey("provider")
+	providerTypeTag, _ = tag.NewKey("provider_type")
+	serviceTag, _      = tag.NewKey("service")
+	contentTag, _      = tag.NewKey("content")
+	statusTag, _       = tag.NewKey("status")
+	resultTag, _       = tag.NewKey("result")
 
 	ipniProviderHTTPRequests = stats.Int64(
 		"ipni_provider_http_requests_total",
@@ -65,6 +68,11 @@ var (
 	ipniAnnounceHTTPRoundTripDuration = stats.Float64(
 		"ipni_announce_http_roundtrip_milliseconds",
 		"Duration of outbound IPNI announce HTTP round trips in milliseconds.",
+		stats.UnitMilliseconds,
+	)
+	ipniAnnounceToIndexedLatency = stats.Float64(
+		"ipni_announce_to_indexed_latency_milliseconds",
+		"Duration from a successful head announce to confirmed indexing by an indexer service.",
 		stats.UnitMilliseconds,
 	)
 )
@@ -90,6 +98,11 @@ func init() {
 			Measure:     ipniAnnounceHTTPRoundTripDuration,
 			Aggregation: view.Distribution(ipniAnnounceRoundTripBuckets...),
 			TagKeys:     []tag.Key{providerTag, statusTag},
+		},
+		&view.View{
+			Measure:     ipniAnnounceToIndexedLatency,
+			Aggregation: view.Distribution(ipniAnnounceToIndexedLatencyBuckets...),
+			TagKeys:     []tag.Key{providerTag, providerTypeTag, serviceTag},
 		},
 	)
 	if err != nil {
@@ -121,4 +134,12 @@ func observeAnnounceHTTPRoundTrip(provider, status string, took time.Duration) {
 		tag.Upsert(providerTag, provider),
 		tag.Upsert(statusTag, status),
 	}, ipniAnnounceHTTPRoundTripDuration.M(float64(took)/float64(time.Millisecond)))
+}
+
+func observeIndexedLatency(provider, providerType, service string, took time.Duration) {
+	_ = stats.RecordWithTags(context.Background(), []tag.Mutator{
+		tag.Upsert(providerTag, provider),
+		tag.Upsert(providerTypeTag, providerType),
+		tag.Upsert(serviceTag, service),
+	}, ipniAnnounceToIndexedLatency.M(float64(took)/float64(time.Millisecond)))
 }

--- a/market/ipni/ipni-provider/metrics.go
+++ b/market/ipni/ipni-provider/metrics.go
@@ -41,7 +41,7 @@ func (w *metricResponseWriter) Status() int {
 var (
 	ipniProviderHTTPRequestBuckets      = []float64{1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000}
 	ipniAnnounceRoundTripBuckets        = []float64{10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000}
-	ipniAnnounceToIndexedLatencyBuckets = []float64{5000, 10000, 15000, 30000, 45000, 60000, 120000, 300000, 420000, 600000, 900000, 1800000, 3600000}
+	ipniAnnounceToIndexedLatencyBuckets = []float64{5, 10, 15, 30, 45, 60, 120, 300, 420, 600, 900, 1800, 3600}
 
 	providerTag, _     = tag.NewKey("provider")
 	providerTypeTag, _ = tag.NewKey("provider_type")
@@ -71,9 +71,9 @@ var (
 		stats.UnitMilliseconds,
 	)
 	ipniAnnounceToIndexedLatency = stats.Float64(
-		"ipni_announce_to_indexed_latency_milliseconds",
+		"ipni_announce_to_indexed_latency_seconds",
 		"Duration from a successful head announce to confirmed indexing by an indexer service.",
-		stats.UnitMilliseconds,
+		stats.UnitSeconds,
 	)
 )
 
@@ -141,5 +141,5 @@ func observeIndexedLatency(provider, providerType, service string, took time.Dur
 		tag.Upsert(providerTag, provider),
 		tag.Upsert(providerTypeTag, providerType),
 		tag.Upsert(serviceTag, service),
-	}, ipniAnnounceToIndexedLatency.M(float64(took)/float64(time.Millisecond)))
+	}, ipniAnnounceToIndexedLatency.M(took.Seconds()))
 }

--- a/market/ipni/ipni-provider/sync_status_test.go
+++ b/market/ipni/ipni-provider/sync_status_test.go
@@ -1,0 +1,176 @@
+package ipni_provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+// testAdCid is a syntactically valid CIDv1; its content is irrelevant to these tests,
+// only its string form (used as a URL path segment) matters.
+const testAdCid = "baguqeeraopdunfoiljzoxrn2ozzmi2ndzq3npr5rmpfjxxvfvenwscsxsyva"
+
+func mustParseTestCid(t *testing.T) cid.Cid {
+	t.Helper()
+	c, err := cid.Parse(testAdCid)
+	require.NoError(t, err)
+	return c
+}
+
+func adSyncStatusHandler(t *testing.T, indexed bool) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(adSyncStatus{Ad: testAdCid, Indexed: indexed})
+	}
+}
+
+func newTestProvider(t *testing.T, serviceURLs []string, providerInfos map[string]*peerInfo, latest map[string]cid.Cid) *Provider {
+	t.Helper()
+	urls := make([]*url.URL, len(serviceURLs))
+	for i, s := range serviceURLs {
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		urls[i] = u
+	}
+	return &Provider{
+		providerInfos: providerInfos,
+		latest:        latest,
+		serviceURLs:   urls,
+		httpClient:    &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func TestCheckSyncStatus_ConfirmsAndAdvancesWatermark(t *testing.T) {
+	srv := httptest.NewServer(adSyncStatusHandler(t, true))
+	defer srv.Close()
+
+	adCid := mustParseTestCid(t)
+	announcedAt := time.Now().Add(-time.Minute)
+	peer := "peer1"
+	p := newTestProvider(t, []string{srv.URL}, map[string]*peerInfo{
+		peer: {announcedOrderNumber: 5, announcedAt: &announcedAt},
+	}, map[string]cid.Cid{peer: adCid})
+
+	p.checkSyncStatus(context.Background())
+
+	on, at := p.SyncedOrderNumber(peer)
+	require.Equal(t, int64(5), on)
+	require.NotNil(t, at)
+	require.True(t, at.After(announcedAt))
+}
+
+func TestCheckSyncStatus_SeededWatermarkWithoutAnnouncedAtStillAdvances(t *testing.T) {
+	srv := httptest.NewServer(adSyncStatusHandler(t, true))
+	defer srv.Close()
+
+	adCid := mustParseTestCid(t)
+	peer := "peer1"
+	// Simulates the post-restart state: announcedOrderNumber was seeded from the
+	// DB, but announcedAt is nil because the true announce time is unknown.
+	p := newTestProvider(t, []string{srv.URL}, map[string]*peerInfo{
+		peer: {announcedOrderNumber: 5, announcedAt: nil},
+	}, map[string]cid.Cid{peer: adCid})
+
+	p.checkSyncStatus(context.Background())
+
+	on, at := p.SyncedOrderNumber(peer)
+	require.Equal(t, int64(5), on, "sync watermark must still advance even without a known announce time")
+	require.NotNil(t, at)
+}
+
+func TestCheckSyncStatus_NotYetIndexedDoesNotAdvance(t *testing.T) {
+	srv := httptest.NewServer(adSyncStatusHandler(t, false))
+	defer srv.Close()
+
+	adCid := mustParseTestCid(t)
+	announcedAt := time.Now()
+	peer := "peer1"
+	p := newTestProvider(t, []string{srv.URL}, map[string]*peerInfo{
+		peer: {announcedOrderNumber: 5, announcedAt: &announcedAt},
+	}, map[string]cid.Cid{peer: adCid})
+
+	p.checkSyncStatus(context.Background())
+
+	on, at := p.SyncedOrderNumber(peer)
+	require.Equal(t, int64(0), on)
+	require.Nil(t, at)
+}
+
+func TestCheckSyncStatus_SkipsServicesThatDontSupportEndpoint(t *testing.T) {
+	notFound := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer notFound.Close()
+	ok := httptest.NewServer(adSyncStatusHandler(t, true))
+	defer ok.Close()
+
+	adCid := mustParseTestCid(t)
+	announcedAt := time.Now()
+	peer := "peer1"
+	// notFound listed first: the 404 must be skipped, not treated as "not indexed".
+	p := newTestProvider(t, []string{notFound.URL, ok.URL}, map[string]*peerInfo{
+		peer: {announcedOrderNumber: 3, announcedAt: &announcedAt},
+	}, map[string]cid.Cid{peer: adCid})
+
+	p.checkSyncStatus(context.Background())
+
+	on, at := p.SyncedOrderNumber(peer)
+	require.Equal(t, int64(3), on)
+	require.NotNil(t, at)
+}
+
+func TestCheckSyncStatus_NoOpWhenAlreadySynced(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		_ = json.NewEncoder(w).Encode(adSyncStatus{Ad: testAdCid, Indexed: true})
+	}))
+	defer srv.Close()
+
+	adCid := mustParseTestCid(t)
+	announcedAt := time.Now()
+	syncedAt := time.Now()
+	peer := "peer1"
+	// announcedOrderNumber == syncedOrderNumber: nothing new to confirm.
+	p := newTestProvider(t, []string{srv.URL}, map[string]*peerInfo{
+		peer: {announcedOrderNumber: 5, announcedAt: &announcedAt, syncedOrderNumber: 5, syncedAt: &syncedAt},
+	}, map[string]cid.Cid{peer: adCid})
+
+	p.checkSyncStatus(context.Background())
+
+	require.False(t, called, "should not query indexer service when already synced up to the announced head")
+}
+
+func TestCheckSyncStatus_SkipsWhenAlreadyRunning(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		_ = json.NewEncoder(w).Encode(adSyncStatus{Ad: testAdCid, Indexed: true})
+	}))
+	defer srv.Close()
+
+	adCid := mustParseTestCid(t)
+	announcedAt := time.Now()
+	peer := "peer1"
+	p := newTestProvider(t, []string{srv.URL}, map[string]*peerInfo{
+		peer: {announcedOrderNumber: 5, announcedAt: &announcedAt},
+	}, map[string]cid.Cid{peer: adCid})
+
+	// Simulate a run already in flight, same as if a previous tick's
+	// checkSyncStatus hadn't returned yet.
+	p.checkingSyncStatus.Store(true)
+
+	p.checkSyncStatus(context.Background())
+
+	require.False(t, called, "should not query indexer service when a check is already in flight")
+	on, _ := p.SyncedOrderNumber(peer)
+	require.Equal(t, int64(0), on)
+}

--- a/market/ipni/ipni-provider/sync_status_test.go
+++ b/market/ipni/ipni-provider/sync_status_test.go
@@ -236,3 +236,24 @@ func TestCheckSyncStatus_PinsTargetUntilConfirmed(t *testing.T) {
 	p.checkSyncStatus(context.Background())
 	require.Equal(t, []string{oldCid.String(), oldCid.String(), oldCid.String(), newCid.String()}, requested)
 }
+
+func TestCheckSyncStatus_SkippedAdAdvancesWatermark(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(adSyncStatus{Ad: testAdCid, Indexed: false, State: "skipped", SkipReason: "malformed"})
+	}))
+	defer srv.Close()
+
+	adCid := mustParseTestCid(t)
+	announcedAt := time.Now()
+	peer := "peer1"
+	p := newTestProvider(t, []string{srv.URL}, map[string]*peerInfo{
+		peer: {announcedOrderNumber: 5, announcedAt: &announcedAt},
+	}, map[string]cid.Cid{peer: adCid})
+
+	p.checkSyncStatus(context.Background())
+
+	on, at := p.SyncedOrderNumber(peer)
+	require.Equal(t, int64(5), on, "watermark must advance past a permanently skipped ad, not wait forever")
+	require.NotNil(t, at)
+}

--- a/market/ipni/ipni-provider/sync_status_test.go
+++ b/market/ipni/ipni-provider/sync_status_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path"
 	"testing"
 	"time"
 
@@ -17,9 +18,19 @@ import (
 // only its string form (used as a URL path segment) matters.
 const testAdCid = "baguqeeraopdunfoiljzoxrn2ozzmi2ndzq3npr5rmpfjxxvfvenwscsxsyva"
 
+// secondTestAdCid is a second syntactically valid CIDv1, distinct from testAdCid.
+const secondTestAdCid = "bafkreiezij5trhw6lwpydyui3nkzyihoaaawij5shmnk3azee7pisdetbu"
+
 func mustParseTestCid(t *testing.T) cid.Cid {
 	t.Helper()
 	c, err := cid.Parse(testAdCid)
+	require.NoError(t, err)
+	return c
+}
+
+func mustParseSecondTestCid(t *testing.T) cid.Cid {
+	t.Helper()
+	c, err := cid.Parse(secondTestAdCid)
 	require.NoError(t, err)
 	return c
 }
@@ -173,4 +184,55 @@ func TestCheckSyncStatus_SkipsWhenAlreadyRunning(t *testing.T) {
 	require.False(t, called, "should not query indexer service when a check is already in flight")
 	on, _ := p.SyncedOrderNumber(peer)
 	require.Equal(t, int64(0), on)
+}
+
+func TestCheckSyncStatus_PinsTargetUntilConfirmed(t *testing.T) {
+	oldCid := mustParseTestCid(t)
+	newCid := mustParseSecondTestCid(t)
+
+	indexed := false // whether oldCid has been confirmed yet
+	var requested []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedCid := path.Base(r.URL.Path)
+		requested = append(requested, requestedCid)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(adSyncStatus{Ad: requestedCid, Indexed: indexed && requestedCid == oldCid.String()})
+	}))
+	defer srv.Close()
+
+	announcedAt := time.Now().Add(-time.Minute)
+	peer := "peer1"
+	p := newTestProvider(t, []string{srv.URL}, map[string]*peerInfo{
+		peer: {announcedOrderNumber: 10, announcedAt: &announcedAt},
+	}, map[string]cid.Cid{peer: oldCid})
+
+	// Pins the checkpoint at order 10 / oldCid; not indexed yet.
+	p.checkSyncStatus(context.Background())
+	require.Equal(t, []string{oldCid.String()}, requested)
+
+	// A newer head lands before the pinned target confirms.
+	newAnnouncedAt := time.Now()
+	p.mu.Lock()
+	p.providerInfos[peer].announcedOrderNumber = 12
+	p.providerInfos[peer].announcedAt = &newAnnouncedAt
+	p.latest[peer] = newCid
+	p.mu.Unlock()
+
+	// Must keep checking the pinned target, not redirect to the new head.
+	p.checkSyncStatus(context.Background())
+	require.Equal(t, []string{oldCid.String(), oldCid.String()}, requested)
+	on, _ := p.SyncedOrderNumber(peer)
+	require.Equal(t, int64(0), on)
+
+	// The indexer catches up on the pinned target.
+	indexed = true
+	p.checkSyncStatus(context.Background())
+	on, at := p.SyncedOrderNumber(peer)
+	require.Equal(t, int64(10), on)
+	require.NotNil(t, at)
+
+	// The next checkpoint jumps straight to the current head (order 12), not
+	// order 11.
+	p.checkSyncStatus(context.Background())
+	require.Equal(t, []string{oldCid.String(), oldCid.String(), oldCid.String(), newCid.String()}, requested)
 }

--- a/pdp/README.md
+++ b/pdp/README.md
@@ -162,9 +162,13 @@ All endpoints are rooted at `/pdp`.
   "pieceCid": "<piece-CID-v2>",
   "status": "<status>",
   "indexed": <boolean>,
+  "indexedAt": "<RFC3339-timestamp-or-omitted>",
+  "adCreated": <boolean>,
+  "adCreatedAt": "<RFC3339-timestamp-or-omitted>",
   "advertised": <boolean>,
-  "retrieved": <boolean>,
-  "retrievedAt": "<RFC3339-timestamp-or-omitted>"
+  "advertisedAt": "<RFC3339-timestamp-or-omitted>",
+  "synced": <boolean>,
+  "syncedAt": "<RFC3339-timestamp-or-omitted>"
 }
 ```
 
@@ -174,12 +178,16 @@ All endpoints are rooted at `/pdp`.
         - `"pending"` – Not yet indexed.
         - `"indexing"` – CAR indexing task is in progress.
         - `"creating_ad"` – IPNI advertisement is being created.
-        - `"announced"` – Advertisement published to IPNI network.
-        - `"retrieved"` – Piece has been retrieved by a client.
+        - `"announced"` – IPNI advertisement has been created; not yet confirmed indexed. Note this only means the advertisement row exists - it does not by itself mean the HTTP broadcast to indexer services has completed. Check `advertised`/`advertisedAt` for that.
+        - `"synced"` – The indexer (e.g. cid.contact) has confirmed it fully processed the advertisement; safe to query the indexer for this content.
     - `indexed`: Whether the piece has been indexed and is ready for IPNI.
-    - `advertised`: Whether an IPNI advertisement has been published.
-    - `retrieved`: Whether the piece has been retrieved by a client.
-    - `retrievedAt`: Timestamp of last retrieval (omitted if never retrieved).
+    - `indexedAt`: Timestamp CAR indexing completed (omitted if not yet indexed).
+    - `adCreated`: Whether an IPNI advertisement has been created for this piece.
+    - `adCreatedAt`: Timestamp the advertisement was created (omitted if not yet created).
+    - `advertised`: Whether the advertisement has been published (announced) to the IPNI network.
+    - `advertisedAt`: Timestamp of the publish. May be omitted even when `advertised` is `true`, if the publish was seen from a prior process run (e.g. right after a Curio restart) rather than observed directly - the fact of publication is still known, just not exactly when.
+    - `synced`: Whether at least one configured indexer service has confirmed it fully processed this advertisement (see `GET {ServiceURL}/sync/status/ad/{adCid}`).
+    - `syncedAt`: Timestamp of that confirmation (omitted if not yet confirmed).
 
 #### Errors
 

--- a/pdp/README.md
+++ b/pdp/README.md
@@ -185,9 +185,9 @@ All endpoints are rooted at `/pdp`.
     - `adCreated`: Whether an IPNI advertisement has been created for this piece.
     - `adCreatedAt`: Timestamp the advertisement was created (omitted if not yet created).
     - `advertised`: Whether the advertisement has been published (announced) to the IPNI network.
-    - `advertisedAt`: Timestamp of the publish. May be omitted even when `advertised` is `true`, if the publish was seen from a prior process run (e.g. right after a Curio restart) rather than observed directly - the fact of publication is still known, just not exactly when.
+    - `advertisedAt`: The provider's watermark time, not this ad's own publish time - can read later than when this ad actually went out. May be omitted even when `advertised` is `true`, if the watermark was seeded from a prior process run (e.g. right after a Curio restart) rather than observed directly.
     - `synced`: Whether at least one configured indexer service has confirmed it fully processed this advertisement (see `GET {ServiceURL}/sync/status/ad/{adCid}`).
-    - `syncedAt`: Timestamp of that confirmation (omitted if not yet confirmed).
+    - `syncedAt`: Same caveat as `advertisedAt` - the provider's watermark time, not this ad's own confirmation time. Omitted if not yet confirmed.
     - Pieces advertised before this tracking was added don't have a precise position to compare against a watermark. `advertised`/`synced` fall back to a coarser signal for them: true once a later ad for the same provider has itself been advertised/synced (IPNI is pull-based, so that also covers everything before it), or - for `advertised` only - if the ad is still the provider's current head. `advertisedAt`/`syncedAt` are omitted in that case.
 
 #### Errors

--- a/pdp/README.md
+++ b/pdp/README.md
@@ -188,6 +188,7 @@ All endpoints are rooted at `/pdp`.
     - `advertisedAt`: Timestamp of the publish. May be omitted even when `advertised` is `true`, if the publish was seen from a prior process run (e.g. right after a Curio restart) rather than observed directly - the fact of publication is still known, just not exactly when.
     - `synced`: Whether at least one configured indexer service has confirmed it fully processed this advertisement (see `GET {ServiceURL}/sync/status/ad/{adCid}`).
     - `syncedAt`: Timestamp of that confirmation (omitted if not yet confirmed).
+    - Pieces advertised before this tracking was added don't have a precise position to compare against a watermark. `advertised`/`synced` fall back to a coarser signal for them: true once a later ad for the same provider has itself been advertised/synced (IPNI is pull-based, so that also covers everything before it), or - for `advertised` only - if the ad is still the provider's current head. `advertisedAt`/`syncedAt` are omitted in that case.
 
 #### Errors
 

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -270,18 +270,17 @@ func (p *PDPService) handleGetPieceStatus(w http.ResponseWriter, r *http.Request
 
 	// Query status from database
 	var results []struct {
-		PieceCID                 string         `db:"piece_cid"`
-		PieceRawSize             uint64         `db:"piece_raw_size"`
-		CreatedAt                time.Time      `db:"created_at"`
-		Indexed                  bool           `db:"indexed"`
-		IndexedAt                sql.NullTime   `db:"indexed_at"`
-		AdvertisementCreated     bool           `db:"advertisement_created"`
-		AdvertisementCreatedAt   sql.NullTime   `db:"advertisement_created_at"`
-		AdCID                    sql.NullString `db:"ad_cid"`
-		AdvertisementRetrieved   bool           `db:"advertisement_retrieved"`
-		AdvertisementRetrievedAt sql.NullTime   `db:"advertisement_retrieved_at"`
-		Status                   string         `db:"status"`
-		Provider                 sql.NullString `db:"provider"`
+		PieceCID               string         `db:"piece_cid"`
+		PieceRawSize           uint64         `db:"piece_raw_size"`
+		CreatedAt              time.Time      `db:"created_at"`
+		Indexed                bool           `db:"indexed"`
+		IndexedAt              sql.NullTime   `db:"indexed_at"`
+		AdvertisementCreated   bool           `db:"advertisement_created"`
+		AdvertisementCreatedAt sql.NullTime   `db:"advertisement_created_at"`
+		AdCID                  sql.NullString `db:"ad_cid"`
+		Status                 string         `db:"status"`
+		Provider               sql.NullString `db:"provider"`
+		OrderNumber            sql.NullInt64  `db:"order_number"`
 	}
 
 	err = p.db.Select(ctx, &results, `
@@ -299,33 +298,28 @@ func (p *PDPService) handleGetPieceStatus(w http.ResponseWriter, r *http.Request
 			pr.advertisement_created_at as advertisement_created_at,
 			ia.ad_cid,
 
-			-- Advertisement Fetch status
-			ia.fetched_at IS NOT NULL as advertisement_retrieved,
-			ia.fetched_at as advertisement_retrieved_at,
-
 			-- Determine overall status
 			CASE
-				WHEN ia.fetched_at IS NOT NULL THEN 'retrieved'
 				WHEN ia.ad_cid IS NOT NULL THEN 'announced'
 				WHEN pr.ipni_task_id IS NOT NULL THEN 'creating_ad'
 				WHEN pr.indexing_task_id IS NOT NULL THEN 'indexing'
 				ELSE 'pending'
 			END as status,
-		
-			ia.provider
+
+			ia.provider,
+			ia.order_number
 
 		FROM pdp_piecerefs pr
 		JOIN parked_piece_refs pprf ON pprf.ref_id = pr.piece_ref
 		JOIN parked_pieces pp ON pp.id = pprf.piece_id
 		LEFT JOIN LATERAL (
-			SELECT
-				MIN(i.ad_cid) as ad_cid,
-				MIN(i.provider) as provider,
-				MIN((SELECT MIN(af.fetched_at) FROM ipni_ad_fetches af WHERE af.ad_cid = i.ad_cid)) as fetched_at
+			SELECT i.ad_cid, i.provider, i.order_number
 			FROM ipni i
 			WHERE i.piece_cid = pr.piece_cid
 				AND i.provider = (SELECT peer_id FROM ipni_peerid WHERE sp_id = $3)
 				AND i.is_rm = FALSE
+			ORDER BY i.order_number DESC
+			LIMIT 1
 		) ia ON true
 		WHERE pr.piece_cid = $1 AND pr.service = $2
 		LIMIT 1
@@ -359,14 +353,13 @@ func (p *PDPService) handleGetPieceStatus(w http.ResponseWriter, r *http.Request
 		AdCreatedAt  *time.Time `json:"adCreatedAt,omitempty"`
 		Advertised   bool       `json:"advertised"`
 		AdvertisedAt *time.Time `json:"advertisedAt,omitempty"`
-		Retrieved    bool       `json:"retrieved"`
-		RetrievedAt  *time.Time `json:"retrievedAt,omitempty"`
+		Synced       bool       `json:"synced"`
+		SyncedAt     *time.Time `json:"syncedAt,omitempty"`
 	}{
 		PieceCID:  pieceInfo.CidV2.String(),
 		Status:    result.Status,
 		Indexed:   result.Indexed,
 		AdCreated: result.AdvertisementCreated,
-		Retrieved: result.AdvertisementRetrieved,
 	}
 
 	if !result.IndexedAt.Valid {
@@ -381,72 +374,20 @@ func (p *PDPService) handleGetPieceStatus(w http.ResponseWriter, r *http.Request
 		response.AdCreatedAt = &result.AdvertisementCreatedAt.Time
 	}
 
-	if !result.AdvertisementRetrievedAt.Valid {
-		response.RetrievedAt = nil
-	} else {
-		response.RetrievedAt = &result.AdvertisementRetrievedAt.Time
-	}
+	// Advertised/Synced compare this ad's order_number against the provider's
+	// announce/sync watermarks (OrderNumber is only valid when an ad row exists).
+	if p.ipp != nil && result.Provider.Valid && result.OrderNumber.Valid {
+		pieceOrderNumber := result.OrderNumber.Int64
 
-	// Advertised and AdvertisedAt are derived from three signals, in order:
-	// 1. A recorded fetch of this ad in ipni_ad_fetches is the strongest per-ad
-	//    signal. If an indexer fetched the ad, it must have been advertised
-	//    already. Since we do not store the actual first publish time for each
-	//    ad, AdvertisedAt is estimated as the earlier of
-	//    advertisement_created_at + PublishInterval and the first fetch time.
-	//    This keeps AdvertisedAt from appearing after RetrievedAt.
-	// 2. The in-process IPNI provider exposes LastPublishTime per provider, not
-	//    per ad. It is useful only when there is no fetch record and we know
-	//    when this ad was created. A provider publish after this ad was created
-	//    means the ad should have been included in the announced head; an older
-	//    provider publish means it was not, and we do not fall through to the
-	//    timing heuristic.
-	// 3. Without either signal, fall back to the old timing heuristic: after
-	//    PublishInterval has elapsed from ad creation, assume the ad was
-	//    announced.
-	if result.AdvertisementRetrieved {
-		response.Advertised = true
-		if result.AdvertisementRetrievedAt.Valid {
-			advertisedAt := result.AdvertisementRetrievedAt.Time
-			if result.AdvertisementCreatedAt.Valid {
-				createdAtEstimate := result.AdvertisementCreatedAt.Time.Add(ipni_provider.PublishInterval)
-				if createdAtEstimate.Before(advertisedAt) {
-					advertisedAt = createdAtEstimate
-				}
-			}
-			response.AdvertisedAt = &advertisedAt
-		} else {
-			response.AdvertisedAt = nil
+		if announcedOrderNumber, announcedAt := p.ipp.AnnouncedOrderNumber(result.Provider.String); announcedOrderNumber >= pieceOrderNumber {
+			response.Advertised = true
+			response.AdvertisedAt = announcedAt
 		}
-	}
 
-	advertisedFromProvider := false
-	if !response.Advertised && result.AdvertisementCreatedAt.Valid && p.ipp != nil && result.Provider.Valid {
-		publishedAt := p.ipp.LastPublishTime(result.Provider.String)
-		if publishedAt != nil {
-			advertisedFromProvider = true
-			if publishedAt.After(result.AdvertisementCreatedAt.Time) {
-				response.Advertised = true
-				response.AdvertisedAt = new(*publishedAt)
-				if publishedAt.After(time.Now().Add(ipni_provider.PublishInterval)) {
-					response.AdvertisedAt = new(result.AdvertisementCreatedAt.Time.Add(ipni_provider.PublishInterval))
-				}
-			} else {
-				response.Advertised = false
-				response.AdvertisedAt = nil
-			}
-		}
-	}
-
-	if !advertisedFromProvider && !response.Advertised {
-		if result.AdvertisementCreated && result.AdvertisementCreatedAt.Valid {
-			if time.Since(result.AdvertisementCreatedAt.Time) > ipni_provider.PublishInterval {
-				// More than 5 seconds since advertisement was created, assume it's published
-				response.Advertised = true
-				response.AdvertisedAt = new(result.AdvertisementCreatedAt.Time.Add(ipni_provider.PublishInterval))
-			} else {
-				response.Advertised = false
-				response.AdvertisedAt = nil
-			}
+		if syncedOrderNumber, syncedAt := p.ipp.SyncedOrderNumber(result.Provider.String); syncedOrderNumber >= pieceOrderNumber {
+			response.Status = "synced"
+			response.Synced = true
+			response.SyncedAt = syncedAt
 		}
 	}
 

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -280,7 +280,8 @@ func (p *PDPService) handleGetPieceStatus(w http.ResponseWriter, r *http.Request
 		AdCID                  sql.NullString `db:"ad_cid"`
 		Status                 string         `db:"status"`
 		Provider               sql.NullString `db:"provider"`
-		OrderNumber            sql.NullInt64  `db:"order_number"`
+		OrderNumber            sql.NullInt64  `db:"provider_order_number"`
+		ProviderHead           sql.NullString `db:"provider_head"`
 	}
 
 	err = p.db.Select(ctx, &results, `
@@ -307,20 +308,27 @@ func (p *PDPService) handleGetPieceStatus(w http.ResponseWriter, r *http.Request
 			END as status,
 
 			ia.provider,
-			ia.order_number
+			ia.provider_order_number,
+			ih.head as provider_head
 
 		FROM pdp_piecerefs pr
 		JOIN parked_piece_refs pprf ON pprf.ref_id = pr.piece_ref
 		JOIN parked_pieces pp ON pp.id = pprf.piece_id
 		LEFT JOIN LATERAL (
-			SELECT i.ad_cid, i.provider, i.order_number
+			SELECT i.ad_cid, i.provider, i.provider_order_number
 			FROM ipni i
+			LEFT JOIN ipni_head h ON h.provider = i.provider
 			WHERE i.piece_cid = pr.piece_cid
 				AND i.provider = (SELECT peer_id FROM ipni_peerid WHERE sp_id = $3)
 				AND i.is_rm = FALSE
-			ORDER BY i.order_number DESC
+			-- provider_order_number is reliable and reflects true chain order; prefer it
+			-- over order_number so a stale re-add can't outrank the real latest ad.
+			-- Among candidates that predate it (all NULL), prefer the current head over
+			-- the order_number-based guess, then fall back to order_number as a last resort.
+			ORDER BY i.provider_order_number DESC NULLS LAST, (i.ad_cid = h.head) DESC, i.order_number DESC
 			LIMIT 1
 		) ia ON true
+		LEFT JOIN ipni_head ih ON ih.provider = ia.provider
 		WHERE pr.piece_cid = $1 AND pr.service = $2
 		LIMIT 1
 	`, pieceCidV1Str, serviceLabel, indexing.PDP_v0_SP_ID)
@@ -374,20 +382,39 @@ func (p *PDPService) handleGetPieceStatus(w http.ResponseWriter, r *http.Request
 		response.AdCreatedAt = &result.AdvertisementCreatedAt.Time
 	}
 
-	// Advertised/Synced compare this ad's order_number against the provider's
-	// announce/sync watermarks (OrderNumber is only valid when an ad row exists).
-	if p.ipp != nil && result.Provider.Valid && result.OrderNumber.Valid {
-		pieceOrderNumber := result.OrderNumber.Int64
+	// Advertised/Synced compare this ad's provider_order_number against the provider's
+	// announce/sync watermarks. Ads predating provider_order_number (OrderNumber invalid)
+	// fall back to a coarser check: IPNI is pull-based, so once a later ad for this
+	// provider has been announced/synced, everything before it - including this ad,
+	// as long as it's no longer the current head - is reachable/synced too.
+	if p.ipp != nil && result.Provider.Valid && result.AdCID.Valid {
+		announcedOrderNumber, announcedAt := p.ipp.AnnouncedOrderNumber(result.Provider.String)
+		syncedOrderNumber, syncedAt := p.ipp.SyncedOrderNumber(result.Provider.String)
 
-		if announcedOrderNumber, announcedAt := p.ipp.AnnouncedOrderNumber(result.Provider.String); announcedOrderNumber >= pieceOrderNumber {
-			response.Advertised = true
-			response.AdvertisedAt = announcedAt
-		}
+		if result.OrderNumber.Valid {
+			pieceOrderNumber := result.OrderNumber.Int64
 
-		if syncedOrderNumber, syncedAt := p.ipp.SyncedOrderNumber(result.Provider.String); syncedOrderNumber >= pieceOrderNumber {
-			response.Status = "synced"
-			response.Synced = true
-			response.SyncedAt = syncedAt
+			if announcedOrderNumber >= pieceOrderNumber {
+				response.Advertised = true
+				response.AdvertisedAt = announcedAt
+			}
+
+			if syncedOrderNumber >= pieceOrderNumber {
+				response.Status = "synced"
+				response.Synced = true
+				response.SyncedAt = syncedAt
+			}
+		} else {
+			isCurrentHead := result.ProviderHead.Valid && result.ProviderHead.String == result.AdCID.String
+
+			if announcedOrderNumber > 0 || isCurrentHead {
+				response.Advertised = true
+			}
+
+			if syncedOrderNumber > 0 {
+				response.Status = "synced"
+				response.Synced = true
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/filecoin-project/curio/issues/1405

## Summary

Previously, we judged whether a piece was reachable via IPNI by checking if anyone had *fetched* the ad — that signal isn't reliable. Now we ask storetheindex's new endpoint directly and get a real confirmation that it's actually been processed.

The core idea: an indexer processes a provider's ad chain strictly in order, so once it's confirmed the latest ad, everything before it is confirmed too. `order_number` is just the existing auto-increment column on that table, not something new — we're using it as a watermark. Each provider keeps two numbers in memory: how far we've announced, and how far we've confirmed synced. A piece counts as synced once its own ad's number is at or before the confirmed one. No need to track status per-ad, no new table.

Breaking change: the piece status endpoint replaces `retrieved`/`retrievedAt` with `synced`/`syncedAt`, no compat alias.