### PR TITLE
pdp: serve long-term parked pieces with no deal or pdp ref from the cached reader

### DIFF
--- a/lib/cachedreader/cachedreader.go
+++ b/lib/cachedreader/cachedreader.go
@@ -234,7 +234,11 @@ func (cpr *CachedPieceReader) getPieceReaderFromMarketPieceDeal(ctx context.Cont
 				return nil, 0, fmt.Errorf("failed to query pdp_piecerefs for piece cid %s: %w", pieceCid, err)
 			}
 			if !isPDP {
-				return nil, 0, fmt.Errorf("piece cid %s: %w", pieceCid, ErrNoDeal)
+				reader, rawSize, err := cpr.getPieceReaderFromLongTermPark(ctx, pieceCid)
+				if err != nil {
+					return nil, 0, fmt.Errorf("piece cid %s: %w", pieceCid, ErrNoDeal)
+				}
+				return reader, rawSize, nil
 			}
 		}
 		reader, rawSize, err := cpr.getPieceReaderFromPiecePark(ctx, nil, &pieceCid, &pieceSize)
@@ -348,6 +352,34 @@ func (cpr *CachedPieceReader) getPieceReaderFromPiecePark(ctx context.Context, p
 	}
 
 	reader, err := cpr.pieceParkReader.ReadPiece(ctx, storiface.PieceNumber(pd[0].ID), pd[0].PieceRawSize, pcid)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read piece from piece park: %w", err)
+	}
+
+	return reader, uint64(pd[0].PieceRawSize), nil
+}
+
+func (cpr *CachedPieceReader) getPieceReaderFromLongTermPark(ctx context.Context, pieceCid cid.Cid) (storiface.Reader, uint64, error) {
+	var pd []struct {
+		ID           int64  `db:"id"`
+		PieceCid     string `db:"piece_cid"`
+		PieceRawSize int64  `db:"piece_raw_size"`
+	}
+
+	err := cpr.db.Select(ctx, &pd, `SELECT
+										  id,
+										  piece_cid,
+										  piece_raw_size
+										FROM parked_pieces WHERE piece_cid = $1 AND long_term = TRUE AND complete = TRUE;`, pieceCid.String())
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to query parked_pieces for piece cid %s: %w", pieceCid, err)
+	}
+
+	if len(pd) == 0 {
+		return nil, 0, fmt.Errorf("failed to find long-term complete piece in parked_pieces for piece cid %s", pieceCid)
+	}
+
+	reader, err := cpr.pieceParkReader.ReadPiece(ctx, storiface.PieceNumber(pd[0].ID), pd[0].PieceRawSize, pieceCid)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to read piece from piece park: %w", err)
 	}


### PR DESCRIPTION
**Setup:** mainnet PDP SPs holding Storacha-migration first copies as long-term parked aggregates (~226k+ pieces), now sourcing second-copy replication pulls. Running v1.28.4.

Retrieving a parked piece that has neither a market deal nor a `pdp_piecerefs` row returns `ErrNoDeal`, so `/piece` requests 404 while the bytes sit complete in the piece park. Migration aggregates are parked `long_term = TRUE` by design with no pdp ref until claimed - stock Curio cannot serve them at all. Hit this on main2.ezpdpz.net on 2026-07-29 (every retrieval of a parked complete aggregate 404'd), and these pieces are exactly what the second-copy repair campaign pulls from a first-copy SP, so on stock the campaign has no source.

The fix adds a last-resort fallback in `getPieceReaderFromMarketPieceDeal`: when there is no market deal and no pdp ref, look the piece up in `parked_pieces` with `long_term = TRUE AND complete = TRUE` and serve it via the piece park reader. `ErrNoDeal` is unchanged when the fallback finds nothing.

Running in production on both my mainnet SPs since late July, carried locally across v1.28.2-rc3, v1.28.3 and v1.28.4 - currently serving the live second-copy pulls to two other SPs. Happy to adjust or add coverage if wanted.