### PR TITLE
Dynamics in gui

### DIFF
--- a/cmd/curio/config.go
+++ b/cmd/curio/config.go
@@ -203,6 +203,7 @@ var configRmCmd = &cli.Command{
 		return nil
 	},
 }
+
 var configViewCmd = &cli.Command{
 	Name:      "interpret",
 	Aliases:   []string{"view", "stacked", "stack"},

--- a/deps/config/dynamic_test.go
+++ b/deps/config/dynamic_test.go
@@ -177,6 +177,8 @@ func TestDefaultCurioConfigMarshal(t *testing.T) {
 	data, err := TransparentMarshal(cfg)
 	assert.NoError(t, err, "Should be able to marshal DefaultCurioConfig to TOML")
 	assert.NotEmpty(t, data)
+	assert.Contains(t, string(data), "PDPUnclaimedUploadKeepHours = 2")
+	assert.NotContains(t, string(data), "[Subsystems.PDPUnclaimedUploadKeepHours]")
 	t.Logf("Successfully marshaled config to %d bytes of TOML", len(data))
 }
 

--- a/deps/config/dynamic_toml.go
+++ b/deps/config/dynamic_toml.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"reflect"
 	"strings"
 
@@ -30,6 +31,11 @@ func TransparentUnmarshal(data []byte, v any) error {
 // with default values (e.g., types.MustParseFIL("0")) before calling this function.
 // NOTE: FixTOML should be called BEFORE this function to ensure proper slice lengths and FIL initialization.
 func TransparentDecode(data string, v any) (toml.MetaData, error) {
+	data, err := StripEmptyDynamicTables(data, v)
+	if err != nil {
+		return toml.MetaData{}, err
+	}
+
 	// Create a shadow struct to decode into
 	shadow := createShadowStruct(v)
 
@@ -331,6 +337,110 @@ func wrapDynamics(shadow, target any) error {
 	return nil
 }
 
+// StripEmptyDynamicTables drops empty tables left by raw toml.Encode of Dynamic[T].
+func StripEmptyDynamicTables(text string, sample any) (string, error) {
+	if strings.TrimSpace(text) == "" || sample == nil {
+		return text, nil
+	}
+
+	var raw map[string]any
+	if err := toml.Unmarshal([]byte(text), &raw); err != nil {
+		return text, nil
+	}
+
+	changed := false
+	for _, path := range collectDynamicTOMLPaths(reflect.TypeOf(sample), nil) {
+		if deleteEmptyMapAtPath(raw, path) {
+			changed = true
+		}
+	}
+	if !changed {
+		return text, nil
+	}
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(raw); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func collectDynamicTOMLPaths(t reflect.Type, prefix []string) [][]string {
+	if t == nil {
+		return nil
+	}
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+
+	var out [][]string
+	for field := range t.Fields() {
+		if !field.IsExported() {
+			continue
+		}
+		name := tomlFieldName(field)
+		if name == "-" {
+			continue
+		}
+		path := append(append([]string{}, prefix...), name)
+		if isDynamicTypeForMarshal(field.Type) {
+			out = append(out, path)
+			continue
+		}
+		out = append(out, collectDynamicTOMLPaths(field.Type, path)...)
+	}
+	return out
+}
+
+func tomlFieldName(f reflect.StructField) string {
+	tag := f.Tag.Get("toml")
+	if tag == "" {
+		return f.Name
+	}
+	name, _, _ := strings.Cut(tag, ",")
+	if name == "" {
+		return f.Name
+	}
+	return name
+}
+
+func deleteEmptyMapAtPath(m map[string]any, path []string) bool {
+	if len(path) == 0 || m == nil {
+		return false
+	}
+	key, val, ok := mapLookupCI(m, path[0])
+	if !ok {
+		return false
+	}
+	child, isMap := val.(map[string]any)
+	if !isMap {
+		return false
+	}
+	if len(path) > 1 {
+		return deleteEmptyMapAtPath(child, path[1:])
+	}
+	if len(child) > 0 {
+		return false
+	}
+	delete(m, key)
+	return true
+}
+
+func mapLookupCI(m map[string]any, key string) (string, any, bool) {
+	if v, ok := m[key]; ok {
+		return key, v, true
+	}
+	for k, v := range m {
+		if strings.EqualFold(k, key) {
+			return k, v, true
+		}
+	}
+	return "", nil, false
+}
+
 // isDynamicTypeForMarshal checks if a type is Dynamic[T]
 // (renamed to avoid conflict with isDynamicType in dynamic.go)
 func isDynamicTypeForMarshal(t reflect.Type) bool {
@@ -397,6 +507,14 @@ func extractDynamicValue(v reflect.Value) reflect.Value {
 	}
 
 	return results[0]
+}
+
+// DynamicInnerType returns T from Dynamic[T] or *Dynamic[T].
+func DynamicInnerType(t reflect.Type) (reflect.Type, bool) {
+	if !isDynamicTypeForMarshal(t) {
+		return nil, false
+	}
+	return extractDynamicInnerType(t), true
 }
 
 // extractDynamicInnerType gets the T from Dynamic[T]

--- a/deps/config/dynamic_toml.go
+++ b/deps/config/dynamic_toml.go
@@ -338,31 +338,91 @@ func wrapDynamics(shadow, target any) error {
 }
 
 // StripEmptyDynamicTables drops empty tables left by raw toml.Encode of Dynamic[T].
+// Prefer this for in-memory decode paths; use RepairEmptyDynamicTablesText when
+// persisting a cleaned layer so comments and surrounding formatting are kept.
 func StripEmptyDynamicTables(text string, sample any) (string, error) {
+	fixed, _, err := RepairEmptyDynamicTablesText(text, sample)
+	return fixed, err
+}
+
+// RepairEmptyDynamicTablesText removes empty Dynamic[T] wrapper tables from TOML
+// while preserving comments and non-corrupt content. changed is true when any
+// empty wrapper table header was dropped.
+func RepairEmptyDynamicTablesText(text string, sample any) (string, bool, error) {
 	if strings.TrimSpace(text) == "" || sample == nil {
-		return text, nil
+		return text, false, nil
 	}
 
 	var raw map[string]any
 	if err := toml.Unmarshal([]byte(text), &raw); err != nil {
-		return text, nil
+		// Leave unloadable TOML alone for callers that handle decode errors.
+		return text, false, nil
 	}
 
-	changed := false
+	var empty [][]string
 	for _, path := range collectDynamicTOMLPaths(reflect.TypeOf(sample), nil) {
-		if deleteEmptyMapAtPath(raw, path) {
-			changed = true
+		if emptyMapAtPath(raw, path) {
+			empty = append(empty, path)
 		}
 	}
-	if !changed {
-		return text, nil
+	if len(empty) == 0 {
+		return text, false, nil
 	}
 
-	var buf bytes.Buffer
-	if err := toml.NewEncoder(&buf).Encode(raw); err != nil {
-		return "", err
+	fixed := removeTOMLTableHeaders(text, empty)
+	if fixed == text {
+		// Header lines were not found (unusual encoding); fall back to re-encode.
+		for _, path := range empty {
+			_ = deleteEmptyMapAtPath(raw, path)
+		}
+		var buf bytes.Buffer
+		if err := toml.NewEncoder(&buf).Encode(raw); err != nil {
+			return "", false, err
+		}
+		return buf.String(), true, nil
 	}
-	return buf.String(), nil
+	return fixed, true, nil
+}
+
+func emptyMapAtPath(m map[string]any, path []string) bool {
+	if len(path) == 0 || m == nil {
+		return false
+	}
+	_, val, ok := mapLookupCI(m, path[0])
+	if !ok {
+		return false
+	}
+	child, isMap := val.(map[string]any)
+	if !isMap {
+		return false
+	}
+	if len(path) > 1 {
+		return emptyMapAtPath(child, path[1:])
+	}
+	return len(child) == 0
+}
+
+// removeTOMLTableHeaders drops plain table header lines whose dotted names match
+// paths (case-insensitive). Array tables ([[...]]) are left untouched.
+func removeTOMLTableHeaders(text string, paths [][]string) string {
+	want := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		want[strings.ToLower(strings.Join(path, "."))] = struct{}{}
+	}
+
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") && !strings.HasPrefix(trimmed, "[[") {
+			inner := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+			if _, ok := want[strings.ToLower(inner)]; ok {
+				continue
+			}
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
 }
 
 func collectDynamicTOMLPaths(t reflect.Type, prefix []string) [][]string {

--- a/deps/config/dynamic_toml_strip_test.go
+++ b/deps/config/dynamic_toml_strip_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripEmptyDynamicTables(t *testing.T) {
+	const broken = `
+[Subsystems]
+EnablePDP = true
+
+[Subsystems.PDPUnclaimedUploadKeepHours]
+
+[Ingest]
+MaxQueueDownload = 16
+
+[Ingest.MaxMarketRunningPipelines]
+`
+
+	cfg := DefaultCurioConfig()
+	md, err := LoadConfigWithUpgrades(broken, cfg)
+	require.NoError(t, err)
+
+	assert.True(t, cfg.Subsystems.EnablePDP)
+	assert.Equal(t, 2, cfg.Subsystems.PDPUnclaimedUploadKeepHours.Get())
+	assert.Equal(t, 16, cfg.Ingest.MaxQueueDownload.Get())
+	assert.Equal(t, 64, cfg.Ingest.MaxMarketRunningPipelines.Get())
+	assert.False(t, md.IsDefined("Subsystems", "PDPUnclaimedUploadKeepHours"))
+	assert.False(t, md.IsDefined("Ingest", "MaxMarketRunningPipelines"))
+}
+
+func TestStripEmptyDynamicTablesLeavesScalars(t *testing.T) {
+	const ok = `
+[Subsystems]
+PDPUnclaimedUploadKeepHours = 7
+`
+
+	text, err := StripEmptyDynamicTables(ok, DefaultCurioConfig())
+	require.NoError(t, err)
+	assert.Equal(t, ok, text)
+
+	cfg := DefaultCurioConfig()
+	_, err = LoadConfigWithUpgrades(ok, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 7, cfg.Subsystems.PDPUnclaimedUploadKeepHours.Get())
+}
+
+func TestStripEmptyDynamicTablesAddressesWrapper(t *testing.T) {
+	const broken = `
+[Addresses]
+`
+
+	cfg := DefaultCurioConfig()
+	before := len(cfg.Addresses.Get())
+	_, err := LoadConfigWithUpgrades(broken, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, before, len(cfg.Addresses.Get()))
+}
+
+func TestRawEncodeDynamicIsEmptyTable(t *testing.T) {
+	var buf strings.Builder
+	err := toml.NewEncoder(&buf).Encode(DefaultCurioConfig())
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "[Subsystems.PDPUnclaimedUploadKeepHours]")
+
+	cfg := DefaultCurioConfig()
+	_, err = LoadConfigWithUpgrades(buf.String(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 2, cfg.Subsystems.PDPUnclaimedUploadKeepHours.Get())
+}

--- a/deps/config/dynamic_toml_strip_test.go
+++ b/deps/config/dynamic_toml_strip_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestStripEmptyDynamicTables(t *testing.T) {
 	const broken = `
+# keep this comment
 [Subsystems]
 EnablePDP = true
 
@@ -32,6 +33,46 @@ MaxQueueDownload = 16
 	assert.Equal(t, 64, cfg.Ingest.MaxMarketRunningPipelines.Get())
 	assert.False(t, md.IsDefined("Subsystems", "PDPUnclaimedUploadKeepHours"))
 	assert.False(t, md.IsDefined("Ingest", "MaxMarketRunningPipelines"))
+}
+
+func TestRepairEmptyDynamicTablesTextPreservesComments(t *testing.T) {
+	const broken = `
+# layer header
+[Subsystems]
+EnablePDP = true
+
+# should be removed below
+[Subsystems.PDPUnclaimedUploadKeepHours]
+
+[Ingest]
+MaxQueueDownload = 16
+`
+
+	fixed, changed, err := RepairEmptyDynamicTablesText(broken, DefaultCurioConfig())
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Contains(t, fixed, "# layer header")
+	assert.Contains(t, fixed, "EnablePDP = true")
+	assert.Contains(t, fixed, "MaxQueueDownload = 16")
+	assert.NotContains(t, fixed, "[Subsystems.PDPUnclaimedUploadKeepHours]")
+	// Comment lines above the dropped header are preserved.
+	assert.Contains(t, fixed, "# should be removed below")
+	cfg := DefaultCurioConfig()
+	_, err = LoadConfigWithUpgrades(fixed, cfg)
+	require.NoError(t, err)
+	assert.True(t, cfg.Subsystems.EnablePDP)
+	assert.Equal(t, 16, cfg.Ingest.MaxQueueDownload.Get())
+}
+
+func TestRepairEmptyDynamicTablesTextNoop(t *testing.T) {
+	const ok = `
+[Subsystems]
+PDPUnclaimedUploadKeepHours = 7
+`
+	fixed, changed, err := RepairEmptyDynamicTablesText(ok, DefaultCurioConfig())
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Equal(t, ok, fixed)
 }
 
 func TestStripEmptyDynamicTablesLeavesScalars(t *testing.T) {

--- a/deps/config/dynamic_toml_test.go
+++ b/deps/config/dynamic_toml_test.go
@@ -757,6 +757,19 @@ func TestHelperFunctions(t *testing.T) {
 		assert.False(t, extracted.IsValid())
 	})
 
+	t.Run("DynamicInnerType", func(t *testing.T) {
+		inner, ok := DynamicInnerType(reflect.TypeFor[*Dynamic[int]]())
+		assert.True(t, ok)
+		assert.Equal(t, reflect.TypeFor[int](), inner)
+
+		inner, ok = DynamicInnerType(reflect.TypeFor[Dynamic[[]string]]())
+		assert.True(t, ok)
+		assert.Equal(t, reflect.TypeFor[[]string](), inner)
+
+		_, ok = DynamicInnerType(reflect.TypeFor[int]())
+		assert.False(t, ok)
+	})
+
 	t.Run("extractDynamicInnerType", func(t *testing.T) {
 		dynType := reflect.TypeFor[Dynamic[int]]()
 		innerType := extractDynamicInnerType(dynType)

--- a/deps/config/load.go
+++ b/deps/config/load.go
@@ -565,6 +565,14 @@ func LoadConfigWithUpgrades(text string, curioConfigWithDefaults *CurioConfig) (
 
 func LoadConfigWithUpgradesGeneric[T any](text string, curioConfigWithDefaults T, fixupFn func(string, T) error) (toml.MetaData, error) {
 
+	// Drop empty Dynamic wrapper tables before the [addresses] -> [[addresses]]
+	// rewrite so a raw-encoded *Dynamic[[]CurioAddresses] is not turned into
+	// a spurious empty address entry.
+	text, err := StripEmptyDynamicTables(text, curioConfigWithDefaults)
+	if err != nil {
+		return toml.MetaData{}, err
+	}
+
 	// allow migration from old config format that was limited to 1 wallet setup.
 	newText := strings.Join(lo.Map(strings.Split(text, "\n"), func(line string, _ int) string {
 		if strings.EqualFold(line, "[addresses]") {
@@ -573,7 +581,7 @@ func LoadConfigWithUpgradesGeneric[T any](text string, curioConfigWithDefaults T
 		return line
 	}), "\n")
 
-	err := fixupFn(newText, curioConfigWithDefaults)
+	err = fixupFn(newText, curioConfigWithDefaults)
 
 	if err != nil {
 		return toml.MetaData{}, err

--- a/deps/config/utils.go
+++ b/deps/config/utils.go
@@ -37,11 +37,16 @@ func forEachConfig[T any](confs map[string]string, cb func(name string, v T) err
 	for name, tomlStr := range confs {
 		var info T
 
-		if err := prepareCurioAddressesForDecode(tomlStr, &info); err != nil {
+		sanitized, err := StripEmptyDynamicTables(tomlStr, DefaultCurioConfig())
+		if err != nil {
+			return xerrors.Errorf("sanitizing layer %s: %w", name, err)
+		}
+
+		if err := prepareCurioAddressesForDecode(sanitized, &info); err != nil {
 			return xerrors.Errorf("preparing CurioAddresses for layer %s: %w", name, err)
 		}
 
-		if err := toml.Unmarshal([]byte(tomlStr), &info); err != nil {
+		if err := toml.Unmarshal([]byte(sanitized), &info); err != nil {
 			return xerrors.Errorf("unmarshaling %s config: %w", name, err)
 		}
 
@@ -51,6 +56,56 @@ func forEachConfig[T any](confs map[string]string, cb func(name string, v T) err
 	}
 
 	return nil
+}
+
+// RepairStoredEmptyDynamicTables finds layers whose TOML still contains empty
+// Dynamic[T] wrapper tables (from older GUI/raw encodes), removes those tables
+// while preserving comments, and writes the repaired text back. Prior text is
+// snapshotted to harmony_config_history. Returns the titles that were updated.
+func RepairStoredEmptyDynamicTables(ctx context.Context, db *harmonydb.DB) ([]string, error) {
+	if db == nil || db.ReadOnly() {
+		return nil, nil
+	}
+
+	confs, err := loadConfigs(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	sample := DefaultCurioConfig()
+	var repaired []string
+	for title, text := range confs {
+		fixed, changed, err := RepairEmptyDynamicTablesText(text, sample)
+		if err != nil {
+			return repaired, xerrors.Errorf("repairing layer %s: %w", title, err)
+		}
+		if !changed {
+			continue
+		}
+
+		probe := DefaultCurioConfig()
+		if _, err := LoadConfigWithUpgrades(fixed, probe); err != nil {
+			return repaired, xerrors.Errorf("repaired layer %s still unloadable: %w", title, err)
+		}
+
+		_, err = db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (commit bool, err error) {
+			if _, err := tx.Exec(`INSERT INTO harmony_config_history (title, config) VALUES ($1, $2)`, title, text); err != nil {
+				return false, xerrors.Errorf("history snapshot for %s: %w", title, err)
+			}
+			if _, err := tx.Exec(`UPDATE harmony_config SET config=$1 WHERE title=$2`, fixed, title); err != nil {
+				return false, xerrors.Errorf("updating layer %s: %w", title, err)
+			}
+			return true, nil
+		}, harmonydb.OptionRetry())
+		if err != nil {
+			return repaired, err
+		}
+
+		repaired = append(repaired, title)
+		logger.Infof("repaired empty Dynamic wrapper tables in config layer %q", title)
+	}
+
+	return repaired, nil
 }
 
 func prepareCurioAddressesForDecode[T any](tomlStr string, info *T) error {

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -424,6 +424,12 @@ func LoadConfigWithUpgrades(text string, curioConfigWithDefaults *config.CurioCo
 
 func GetConfig(ctx context.Context, layers []string, db *harmonydb.DB) (*config.CurioConfig, error) {
 	if !db.ReadOnly() {
+		// Layers saved before Dynamic-aware GUI encoding may contain empty
+		// wrapper tables that break older decode paths and confuse operators.
+		// Repair them in-place (with history) before applying layers.
+		if _, err := config.RepairStoredEmptyDynamicTables(ctx, db); err != nil {
+			return nil, err
+		}
 		if err := updateBaseLayer(ctx, db); err != nil {
 			return nil, err
 		}

--- a/web/api/config/config.go
+++ b/web/api/config/config.go
@@ -63,24 +63,36 @@ func (c *cfg) addLayer(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 }
 
+func uiSchemaMapper(i reflect.Type) *jsonschema.Schema {
+	if inner, ok := config.DynamicInnerType(i); ok {
+		if mapped := uiSchemaSpecialType(inner); mapped != nil {
+			return mapped
+		}
+		return (&jsonschema.Reflector{Mapper: uiSchemaMapper}).ReflectFromType(inner)
+	}
+	return uiSchemaSpecialType(i)
+}
+
+func uiSchemaSpecialType(i reflect.Type) *jsonschema.Schema {
+	if i == reflect.TypeOf(types.MustParseFIL("1 Fil")) {
+		return &jsonschema.Schema{
+			Type:    "string",
+			Pattern: "1 fil/0.03 fil/0.31/1 attofil",
+		}
+	}
+	if i == reflect.TypeFor[time.Duration]() {
+		return &jsonschema.Schema{
+			Type:        "string",
+			Pattern:     durationPattern,
+			Description: `Go duration string (e.g. "1h30m", "1m1s", "30s"); components may be omitted when zero`,
+		}
+	}
+	return nil
+}
+
 func getSch(w http.ResponseWriter, r *http.Request) {
 	ref := jsonschema.Reflector{
-		Mapper: func(i reflect.Type) *jsonschema.Schema {
-			if i == reflect.TypeOf(types.MustParseFIL("1 Fil")) { // Override the Pattern for types.FIL
-				return &jsonschema.Schema{
-					Type:    "string",
-					Pattern: "1 fil/0.03 fil/0.31/1 attofil",
-				}
-			}
-			if i == reflect.TypeFor[time.Duration]() { // Override the Pattern for duration
-				return &jsonschema.Schema{
-					Type:        "string",
-					Pattern:     durationPattern,
-					Description: `Go duration string (e.g. "1h30m", "1m1s", "30s"); components may be omitted when zero`,
-				}
-			}
-			return nil
-		},
+		Mapper: uiSchemaMapper,
 	}
 	sch := ref.Reflect(uiSchemaRoot())
 

--- a/web/api/config/ui_config_common.go
+++ b/web/api/config/ui_config_common.go
@@ -20,14 +20,18 @@ func configToJSONMap(v any) (map[string]any, error) {
 func tomlToJSONMap(layerToml string) (map[string]any, error) {
 	configStruct := map[string]any{}
 	if layerToml != "" {
-		if _, err := toml.Decode(layerToml, &configStruct); err != nil {
+		sanitized, err := depsconfig.StripEmptyDynamicTables(layerToml, depsconfig.DefaultCurioConfig())
+		if err != nil {
+			return nil, err
+		}
+		if _, err := toml.Decode(sanitized, &configStruct); err != nil {
 			return nil, err
 		}
 	}
 	return configStruct, nil
 }
 
-func prepareCurioLayerSave(layer string, configStruct map[string]any) (string, error) {
+func prepareCurioLayerSave(_ string, configStruct map[string]any) (string, error) {
 	var tomlData bytes.Buffer
 	if err := toml.NewEncoder(&tomlData).Encode(configStruct); err != nil {
 		return "", err
@@ -38,27 +42,22 @@ func prepareCurioLayerSave(layer string, configStruct map[string]any) (string, e
 		return "", err
 	}
 
-	return formatLayerTOML(layer, curioCfg)
+	return formatLayerTOML(curioCfg)
 }
 
-func formatLayerTOML(layer string, curioCfg *depsconfig.CurioConfig) (string, error) {
+func formatLayerTOML(curioCfg *depsconfig.CurioConfig) (string, error) {
 	cb, err := depsconfig.ConfigUpdate(curioCfg, depsconfig.DefaultCurioConfig(), depsconfig.Commented(true), depsconfig.DefaultKeepUncommented(), depsconfig.NoEnv())
 	if err != nil {
 		return "", err
 	}
-
-	configStr := mustEncodeTOML(curioCfg)
-	if layer == "base" {
-		configStr = string(cb)
-	}
-	return configStr, nil
+	return string(cb), nil
 }
 
 // mustEncodeTOML serialises v to TOML or panics.
 func mustEncodeTOML(v any) string {
-	var buf bytes.Buffer
-	if err := toml.NewEncoder(&buf).Encode(v); err != nil {
+	data, err := depsconfig.TransparentMarshal(v)
+	if err != nil {
 		panic(err)
 	}
-	return buf.String()
+	return string(data)
 }

--- a/web/api/config/ui_config_common_test.go
+++ b/web/api/config/ui_config_common_test.go
@@ -65,7 +65,7 @@ func TestMustEncodeTOMLUnwrapsDynamics(t *testing.T) {
 func TestPrepareCurioLayerSaveRepairsEmptyDynamicTables(t *testing.T) {
 	submitted := map[string]any{
 		"Subsystems": map[string]any{
-			"EnablePDP":                     true,
+			"EnablePDP":                   true,
 			"PDPUnclaimedUploadKeepHours": map[string]any{},
 		},
 	}

--- a/web/api/config/ui_config_common_test.go
+++ b/web/api/config/ui_config_common_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/invopop/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	depsconfig "github.com/filecoin-project/curio/deps/config"
+)
+
+func TestSchemaDynamicFieldsUseInnerType(t *testing.T) {
+	ref := jsonschema.Reflector{Mapper: uiSchemaMapper}
+	sch := ref.Reflect(uiSchemaRoot())
+
+	_, isWrapper := sch.Definitions["Dynamic[int]"]
+	assert.False(t, isWrapper, "Dynamic[int] must not appear as a schema object")
+
+	sub, ok := sch.Definitions["CurioSubsystemsConfig"]
+	require.True(t, ok, "named Subsystems type should remain in definitions")
+	prop, ok := sub.Properties.Get("PDPUnclaimedUploadKeepHours")
+	require.True(t, ok)
+	assert.Equal(t, "integer", prop.Type)
+	assert.Empty(t, prop.Ref)
+
+	ingest, ok := sch.Definitions["CurioIngestConfig"]
+	require.True(t, ok)
+	timeout, ok := ingest.Properties.Get("MaxDealWaitTime")
+	require.True(t, ok)
+	assert.Equal(t, "string", timeout.Type)
+}
+
+func TestFormatLayerTOMLDoesNotEmitDynamicTables(t *testing.T) {
+	out, err := formatLayerTOML(depsconfig.DefaultCurioConfig())
+	require.NoError(t, err)
+	assert.Contains(t, out, "PDPUnclaimedUploadKeepHours")
+	assert.NotContains(t, out, "[Subsystems.PDPUnclaimedUploadKeepHours]")
+}
+
+func TestTomlToJSONMapStripsEmptyDynamicTables(t *testing.T) {
+	const broken = `
+[Subsystems]
+EnablePDP = true
+
+[Subsystems.PDPUnclaimedUploadKeepHours]
+`
+
+	m, err := tomlToJSONMap(broken)
+	require.NoError(t, err)
+
+	sub, ok := m["Subsystems"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, sub["EnablePDP"])
+	_, present := sub["PDPUnclaimedUploadKeepHours"]
+	assert.False(t, present)
+}
+
+func TestMustEncodeTOMLUnwrapsDynamics(t *testing.T) {
+	out := mustEncodeTOML(depsconfig.DefaultCurioConfig())
+	assert.Contains(t, out, "PDPUnclaimedUploadKeepHours = 2")
+	assert.NotContains(t, out, "[Subsystems.PDPUnclaimedUploadKeepHours]")
+}
+
+func TestPrepareCurioLayerSaveRepairsEmptyDynamicTables(t *testing.T) {
+	submitted := map[string]any{
+		"Subsystems": map[string]any{
+			"EnablePDP":                     true,
+			"PDPUnclaimedUploadKeepHours": map[string]any{},
+		},
+	}
+
+	out, err := prepareCurioLayerSave("pdp", submitted)
+	require.NoError(t, err)
+	assert.NotContains(t, out, "[Subsystems.PDPUnclaimedUploadKeepHours]")
+	assert.Contains(t, out, "EnablePDP = true")
+}

--- a/web/api/config/ui_config_curio.go
+++ b/web/api/config/ui_config_curio.go
@@ -7,7 +7,7 @@ import (
 )
 
 func uiSchemaRoot() any {
-	return depsconfig.UnwrapDynamics(depsconfig.CurioConfig{})
+	return depsconfig.CurioConfig{}
 }
 
 func uiDefaultJSON() (map[string]any, error) {

--- a/web/api/config/ui_config_skiff.go
+++ b/web/api/config/ui_config_skiff.go
@@ -24,7 +24,7 @@ func jsonRoundTrip(m map[string]any, dst any) error {
 }
 
 func uiSchemaRoot() any {
-	return depsconfig.UnwrapDynamics(depsconfig.SkiffConfig{})
+	return depsconfig.SkiffConfig{}
 }
 
 func uiDefaultJSON() (map[string]any, error) {
@@ -59,5 +59,5 @@ func uiPrepareLayerSave(layer string, submitted map[string]any, existingToml str
 		return "", err
 	}
 
-	return formatLayerTOML(layer, curioCfg)
+	return formatLayerTOML(curioCfg)
 }


### PR DESCRIPTION
Editing Config in the GUI messes-up the saved layer data because of Dynamic fields. 
This change adjusts the GUI verifier to understand dynamic fields correctly so default values are passed-through of the right type. 

Fixes: https://github.com/filecoin-project/curio/issues/1429
