### PR TITLE
pdp: check PDP key status live for /pdp/ping instead of via cached alert

### DIFF
--- a/alertmanager/alert_maps.go
+++ b/alertmanager/alert_maps.go
@@ -36,6 +36,5 @@ func buildPingHealthFuncs() map[AlertName]AlertFunc {
 		Name_PermanentStorageSpace: af[Name_PermanentStorageSpace],
 		Name_PDPTaskFailures:       af[Name_PDPTaskFailures],
 		Name_IPNISync:              af[Name_IPNISync],
-		Name_PDPKeyConfigured:      af[Name_PDPKeyConfigured],
 	}
 }

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/filecoin-project/curio/lib/paths"
 	ipni_provider "github.com/filecoin-project/curio/market/ipni/ipni-provider"
 	"github.com/filecoin-project/curio/pdp/contract"
+	pdpwallet "github.com/filecoin-project/curio/pdp/wallet"
 	"github.com/filecoin-project/curio/tasks/indexing"
 
 	types2 "github.com/filecoin-project/lotus/chain/types"
@@ -229,6 +230,16 @@ func (p *PDPService) handlePing(w http.ResponseWriter, r *http.Request) {
 	_, err := p.AuthService(r)
 	if err != nil {
 		httpServerError(w, http.StatusUnauthorized, "Failed to authorize request", err)
+		return
+	}
+
+	status, err := pdpwallet.PDPKeyStatus(r.Context(), p.db)
+	if err != nil {
+		httpServerError(w, http.StatusServiceUnavailable, "Service Unavailable", err)
+		return
+	}
+	if !status.Configured {
+		httpServerError(w, http.StatusServiceUnavailable, "PDP wallet not configured", nil)
 		return
 	}
 


### PR DESCRIPTION
https://github.com/filecoin-project/curio/pull/1424 Fixed the error check. So now the issues will be exposed normally.

In fact, there is no problem with its own logic, but there is an alarm cache time. After the user imports the wallet, the status is not refreshed in real time. The check of /pdp/ping is 503. The most obvious impact of this situation is the downstream foc-devnet.