### PR TITLE
alertmanager: better /pdp/ping diagnostics + fix two silent alert bugs

### DIFF
--- a/alertmanager/alerts.go
+++ b/alertmanager/alerts.go
@@ -364,9 +364,9 @@ func permanentStorageCheck(al *alerts) {
 
 		sectorMap[key] = false
 
-		for _, strg := range storages {
-			if space <= strg.Available {
-				strg.Available -= space
+		for i := range storages {
+			if space <= storages[i].Available {
+				storages[i].Available -= space
 				sectorMap[key] = true
 				break
 			}
@@ -376,7 +376,7 @@ func permanentStorageCheck(al *alerts) {
 	missingSpace := big.NewInt(0)
 	for sec, accounted := range sectorMap {
 		if !accounted {
-			big.Add(missingSpace, big.NewInt(sec.size))
+			missingSpace = big.Add(missingSpace, big.NewInt(sec.size))
 		}
 	}
 

--- a/alertmanager/alerts.go
+++ b/alertmanager/alerts.go
@@ -140,6 +140,7 @@ func balanceCheck(al *alerts) {
 		balance, err := al.api.WalletBalance(al.ctx, addr)
 		if err != nil {
 			al.alertMap[Name].err = err
+			return
 		}
 
 		if abi.TokenAmount(al.cfg.MinimumWalletBalance).GreaterThanEqual(balance) {

--- a/alertmanager/task_alert.go
+++ b/alertmanager/task_alert.go
@@ -209,12 +209,12 @@ func (a *AlertTask) Do(ctx context.Context, taskID harmonytask.TaskID, stillOwne
 		// Only say unhealthy if PDP IPNI sync is failing, PoRep provider should not fail health check
 		if name == Name_IPNISync {
 			if strings.Contains(out.alertString, "PDP") {
-				log.Warnf("Ping health check problem: %s %s %s", name, out.err, out.alertString)
+				log.Warnf("Ping health check problem: %s %v %s", name, out.err, out.alertString)
 				detail = fmt.Sprintf("%s: %v %s", name, out.err, out.alertString)
 				break
 			}
 		} else {
-			log.Warnf("Ping health check problem: %s %s %s", name, out.err, out.alertString)
+			log.Warnf("Ping health check problem: %s %v %s", name, out.err, out.alertString)
 			detail = fmt.Sprintf("%s: %v %s", name, out.err, out.alertString)
 			break
 		}

--- a/alertmanager/task_alert.go
+++ b/alertmanager/task_alert.go
@@ -56,8 +56,8 @@ type AlertTask struct {
 	db      *harmonydb.DB
 	plugins []plugin.Plugin
 
-	pingMu       sync.Mutex
-	pingProblems bool
+	pingMu            sync.Mutex
+	pingProblemDetail string
 }
 
 type alertOut struct {
@@ -169,14 +169,15 @@ func NewAlertTask(
 	}
 }
 
-// Problems returns the ping-relevant alert results from the most recent
-// AlertTask run (ChainSync, PermanentStorageSpace, Balance Check).
-// Returns nil before the first run — the node is assumed healthy until
-// the first periodic check completes.
-func (a *AlertTask) Problems() bool {
+// ProblemDetail returns which ping-relevant check (ChainSync,
+// PermanentStorageSpace, Balance Check, ...) last reported a problem, empty
+// if healthy. Empty before the first run — the node is assumed healthy until
+// the first periodic check completes. Meant for server-side logging, not for
+// exposing to unauthenticated callers of /pdp/ping.
+func (a *AlertTask) ProblemDetail() string {
 	a.pingMu.Lock()
 	defer a.pingMu.Unlock()
-	return a.pingProblems
+	return a.pingProblemDetail
 }
 
 func (a *AlertTask) Do(ctx context.Context, taskID harmonytask.TaskID, stillOwned func() bool) (done bool, err error) {
@@ -198,7 +199,7 @@ func (a *AlertTask) Do(ctx context.Context, taskID harmonytask.TaskID, stillOwne
 		al(altrs)
 	}
 
-	problme := false
+	detail := ""
 	// Update the ping-relevant subset for the /ping health endpoint.
 	for name := range PingHealthFuncs {
 		out, ok := altrs.alertMap[name]
@@ -209,17 +210,17 @@ func (a *AlertTask) Do(ctx context.Context, taskID harmonytask.TaskID, stillOwne
 		if name == Name_IPNISync {
 			if strings.Contains(out.alertString, "PDP") {
 				log.Warnf("Ping health check problem: %s %s %s", name, out.err, out.alertString)
-				problme = true
+				detail = fmt.Sprintf("%s: %v %s", name, out.err, out.alertString)
 				break
 			}
 		} else {
 			log.Warnf("Ping health check problem: %s %s %s", name, out.err, out.alertString)
-			problme = true
+			detail = fmt.Sprintf("%s: %v %s", name, out.err, out.alertString)
 			break
 		}
 	}
 	a.pingMu.Lock()
-	a.pingProblems = problme
+	a.pingProblemDetail = detail
 	a.pingMu.Unlock()
 
 	if isPingHealthOnly(now) {

--- a/pdp/handlers.go
+++ b/pdp/handlers.go
@@ -243,9 +243,11 @@ func (p *PDPService) handlePing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if p.alertTask != nil && p.alertTask.Problems() {
-		httpServerError(w, http.StatusServiceUnavailable, "Service Unavailable", nil)
-		return
+	if p.alertTask != nil {
+		if detail := p.alertTask.ProblemDetail(); detail != "" {
+			httpServerError(w, http.StatusServiceUnavailable, "Service Unavailable", errors.New(detail))
+			return
+		}
 	}
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")


### PR DESCRIPTION
## Summary
- `/pdp/ping`'s 503 response now names which `PingHealthFuncs` check reported
  the problem (logged server-side via the existing eid mechanism, not exposed
  in the HTTP response body), instead of just an opaque `[eid: ...]` with no
  way to tell what actually failed.
- Fix `balanceCheck`: a failed `WalletBalance` call fell through to the
  threshold comparison with a zero-value balance instead of returning,
  appending a spurious "below minimum" alert on top of the real error.
- Fix `permanentStorageCheck`: two bugs made it never actually fire.
  `big.Add(missingSpace, ...)` is a pure function and its return value was
  discarded, so `missingSpace` stayed 0 forever. Separately, the per-sector
  storage allocation simulation decremented a range-loop copy of
  `storages[i]` instead of the slice element, so a path's tracked capacity
  was never really consumed across sectors.

## Test plan
- [x] `go build ./...`
- [x] Verified the `permanentStorageCheck` fix against a standalone
      simulation covering: enough total space split across paths but no
      single path fits a sector, exactly enough space in one path, and no
      storage paths at all — all three now report the expected result.
- [ ] No existing test coverage for these alertmanager functions; didn't add
      new tests, verification was manual (see above).