### PR TITLE
fix: query eth account nonce and header at latest, not chain head

### DIFF
--- a/tasks/message/replace_eth.go
+++ b/tasks/message/replace_eth.go
@@ -153,7 +153,7 @@ func (t *ethMessageReplacer) loadEthMessageCandidates(ctx context.Context, stuck
 	for _, fromAddress := range fromAddresses {
 		queue := senderQueues[fromAddress]
 		ethCtx, cancel := context.WithTimeout(ctx, defaultEthCallTimeout)
-		nonce, err := t.client.NonceAt(ethCtx, queue.From, big.NewInt(int64(height)))
+		nonce, err := t.client.NonceAt(ethCtx, queue.From, nil)
 		cancel()
 		if err != nil {
 			log.Warnw("skipping eth message replacement sender; account nonce lookup failed", "from", fromAddress, "error", err)
@@ -449,7 +449,7 @@ func (t *ethMessageReplacer) prepareFeeReplacementEthMessage(ctx context.Context
 	ethCtx, cancel := context.WithTimeout(ctx, defaultEthCallTimeout)
 	defer cancel()
 
-	header, err := t.client.HeaderByNumber(ethCtx, big.NewInt(int64(height)))
+	header, err := t.client.HeaderByNumber(ethCtx, nil)
 	if err != nil {
 		return nil, false, fmt.Errorf("getting latest eth header for %s nonce %d: %w", from.Hex(), candidate.Nonce, err)
 	}


### PR DESCRIPTION
Fixes #1464.

`runEthMessageReplacement` takes its height from `apply.Height()` in `replacer.go`, which is the chain head. The eth JSON-RPC `latest` block is the last executed tipset and sits one epoch behind head, so both lookups request a block that does not exist yet:

```
WARN curio/message message/replace_eth.go:159
  skipping eth message replacement sender; account nonce lookup failed
  from=0x32c90c26bCA6eD3945De9b29BA4e19D38314D618
  error="chain: requested a future epoch (beyond 'latest')"
```

Every cycle fails, so no candidates are loaded and no replacement is ever sent. Across eight SPs shipping logs in a two hour window on v1.28.5: hundreds of nonce lookup failures, zero candidates loaded, zero replacements sent.

Passing `nil` requests latest, which is the correct reference both for an account nonce and for the base fee used to construct the replacement.

Running on a mainnet PDP node since 27 August, replacement warnings went from several hundred an hour to zero.