### PR TITLE
ci: add all issues and PRs to FOC project board

### DIFF
--- a/.github/workflows/add-issues-and-prs-to-foc-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-foc-project-board.yml
@@ -4,33 +4,38 @@
 # See https://github.com/filecoin-project/github-mgmt/blob/master/files/workflows/add-issues-and-prs-to-fs-project-board.yml for more info.
 ######################################################################################
 
-# This action adds all issues and PRs with a "team/fs-wg" label to the FS project board.
-# It is used to keep the FS project board up to date with the issues and PRs.
+# This action adds all issues and PRs to the FOC project board.
+# It is used to keep the project board up to date with the issues and PRs.
 # It is triggered by the issue and PR events.
 # It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
 # This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
-name: Add issues and PRs to FS project board
+name: Add issues and PRs to FOC project board
 
 on:
   issues:
     types:
-      - labeled
+      - opened
   # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
-  # Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input below would otherwise be empty.
+  # pull_request_target has access to secrets even for fork PRs, which is necessary
+  # for this action to authenticate and add items to the project board.
+  # pull_request_target runs the workflow file from the base branch (main),
+  # not from the PR branch, so attackers cannot modify this workflow via PR.
   # This action does not check out nor execute user code so we should be safe.
-  # We also hardcode to specific hash to ensure no unintended changes underneath us.  
+  # We also hardcode to specific hash to ensure no unintended changes underneath us.
   pull_request_target:
     types:
-      - labeled
+      - opened
 
 jobs:
   add-to-project:
-    name: Add all "team/fs-wg" issues and PRs to project
+    name: Add all issues and PRs to project
+    # This job authenticates with the dedicated FILOZZY_CI_ADD_TO_PROJECT PAT and does
+    # not use the default GITHUB_TOKEN, so drop all of its permissions to limit blast radius.
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         continue-on-error: true # Don't fail if item already exists in project. actions/add-to-project does not currently handle this case gracefully.
         with:
           project-url: https://github.com/orgs/FilOzone/projects/14
           github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}
-          labeled: team/fs-wg


### PR DESCRIPTION
## Summary

- Most Curio maintenance now happens within the purview of the rest of the FOC team as part of the Storage Service Workstream, so this adds every new issue and PR to the FOC project board automatically, instead of only ones labeled `team/fs-wg`.
- This should help prevent us from needing to manually find Curio issues/PRs during FOC standup.
- Anything added to the board that shouldn't be there can be removed manually.
- Also updates the `actions/add-to-project` action (v1.0.2 → v2.0.0) and the workflow's naming/style to match the current version used across other FOC repos (`FilOzone/github-mgmt`), including the file rename to `add-issues-and-prs-to-foc-project-board.yml` and minimal job `permissions: {}`.

## Test plan

- [ ] Merge and confirm a newly opened issue/PR (without `team/fs-wg`) gets added to the FOC board at https://github.com/orgs/FilOzone/projects/14
- [ ] Confirm PRs from forks still get added (via `pull_request_target`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UBFkpove925iTZt25PHCUq