### PR TITLE
Remove PDPv0_PullPiece/PDPv0_SaveCache from sensitiveTasks

### DIFF
--- a/alertmanager/alerts.go
+++ b/alertmanager/alerts.go
@@ -220,8 +220,6 @@ var pdpTasks = []string{
 	tasknames.AggregatePDPDeal,
 	// PDP v0
 	tasknames.PDPv0_Prove,
-	tasknames.PDPv0_PullPiece,
-	tasknames.PDPv0_SaveCache,
 	tasknames.PDPv0_InitPP,
 	tasknames.PDPv0_ProvPeriod,
 	tasknames.PDPv0_Notify,


### PR DESCRIPTION
https://filecoinproject.slack.com/archives/C08TVNKJV7C/p1787835052626179?thread_ts=1787765725.120559&cid=C08TVNKJV7C

These tasks are likely to fail, and they are not necessarily caused by themselves. This is just removed from the sensitive list. He will still meet the normal alarm rules.