### PR TITLE
pdp: index pdp_piece_pull_items so the pull scheduler stops scanning the whole table

### DIFF
--- a/harmony/harmonydb/downgrade/20260828-pdp-v0-pull-items-indexes.sql
+++ b/harmony/harmonydb/downgrade/20260828-pdp-v0-pull-items-indexes.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_pdp_piece_pull_items_incomplete;
+DROP INDEX IF EXISTS idx_pdp_piece_pull_items_task_id;

--- a/harmony/harmonydb/sql/20260828-pdp-v0-pull-items-indexes.sql
+++ b/harmony/harmonydb/sql/20260828-pdp-v0-pull-items-indexes.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS idx_pdp_piece_pull_items_incomplete
+    ON pdp_piece_pull_items (created_at ASC)
+    WHERE complete = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_pdp_piece_pull_items_task_id
+    ON pdp_piece_pull_items (task_id);

--- a/tasks/pdpv0/task_pull_piece.go
+++ b/tasks/pdpv0/task_pull_piece.go
@@ -331,6 +331,7 @@ func (t *PDPPullPieceTask) expireStalePullItems(ctx context.Context) error {
 				AND failed = TRUE
 				AND task_id IS NULL
 				AND (parked_piece_ref IS NOT NULL OR pull_parked_piece_id IS NOT NULL)
+				AND created_at <= NOW()
 		`)
 		if err != nil {
 			return false, xerrors.Errorf("query failed pull items with refs: %w", err)


### PR DESCRIPTION
## Priority

This is not urgent relative to the contract upgrade work. Nothing is starved by it and no data is at risk. It is continuous wasted database load that scales with pull volume, so it is worth landing when there is room rather than ahead of the release fixes.

## The problem

The PDPv0 pull scheduler polls every 5 seconds and runs three passes over `pdp_piece_pull_items`. The table carries 5 days of pull history, and there is no index matching the predicate every pass filters on, so each pass reads the entire table to find the handful of incomplete rows. A fourth query, the pull backpressure check in `pdp/pull_types.go`, does the same on every incoming pull request.

On my mainnet node the table holds 1,567,863 rows, of which 20 are incomplete. Row ages span exactly the 5-day retention window, so the cascade cleanup from `pdp_piece_pulls` is working and the table is at steady state rather than growing. The cost scales with an SP's pull throughput.

Measured on that node, YugabyteDB 2.25.1.0:

| Query | Before | After |
|---|---|---|
| `expireStalePullItems`, stale select | 14,796 ms | 2.35 ms |
| `expireStalePullItems`, failed-ref cleanup | 16,437 ms | 1.49 ms |
| `schedulePullItems`, group select | 14,769 ms | 3.48 ms |
| `completeAlreadyParkedItems` | 203 ms | 1.86 ms |
| pull backpressure check | full scan | 3.87 ms |

The plans before were an index scan on `task_id IS NULL` that matches every row in the table, plus a full seq scan on the inner side of the `NOT EXISTS` anti-join in `schedulePullItems`. All five now index-scan with `Storage Rows Scanned: 0`.

## Changes

New migration `20260828-pdp-v0-pull-items-indexes.sql`:

```sql
CREATE INDEX IF NOT EXISTS idx_pdp_piece_pull_items_incomplete
    ON pdp_piece_pull_items (created_at ASC)
    WHERE complete = FALSE;

CREATE INDEX IF NOT EXISTS idx_pdp_piece_pull_items_task_id
    ON pdp_piece_pull_items (task_id);
```

`created_at ASC` rather than the YugabyteDB default `HASH` so the range predicates can drive the index.

The second index is the foreign key to `harmony_task(id)`. It has no index, so every `DELETE FROM harmony_task WHERE id = $1` runs the referential integrity check as a full scan of this table. I reported that in #1465 with an `EXPLAIN ANALYZE` showing 3,512 ms per task completion, but #1465 closed on the auto-analyze fix in #1461 and the index was never picked up.

One line in `tasks/pdpv0/task_pull_piece.go`:

```
 				AND (parked_piece_ref IS NOT NULL OR pull_parked_piece_id IS NOT NULL)
+				AND created_at <= NOW()
```

## Why that line is needed

The failed-ref cleanup select is the only one of the four with no `created_at` predicate, and without one it cannot reach the index. On YugabyteDB a partial index reports `pg_class.reltuples = 0`, and `ANALYZE` does not populate it, so the planner substitutes the parent table's row count and prices the index at 150,519 against the `task_id` index at 1,885. Only a range condition on the index key produces a low enough estimate; boolean equality and `IS NULL` both degrade to storage filters. The bound excludes nothing: `created_at` is `TIMESTAMPTZ NOT NULL DEFAULT NOW()`, and the only production insert, `pdp/pull_types.go:327`, omits the column, so no row can carry a future value.

## Verification

Running on a mainnet PDP node on v1.28.6 since 16:35 UTC on 28 August. In the 28 minutes after restart the node logged 5 slow-SQL warnings in total, none of them against `pdp_piece_pull_items`. The equivalent window before the change logged 105 for the failed-ref cleanup query alone.