### PR TITLE
fix: keep IPNI announce dedupe when one indexer is down

### DIFF
--- a/documentation/en/configuration/metrics-reference.md
+++ b/documentation/en/configuration/metrics-reference.md
@@ -181,7 +181,7 @@ This document lists Prometheus metrics exported by Curio using the exact metric 
 | `curio_http_request_count` | counter | `path`, `method` | Counter of HTTP requests |
 | `curio_http_response_bytes_count` | counter | `status_code`, `path` | Sum of HTTP response content-length |
 | `curio_http_response_status_count` | counter | `status_code`, `path`, `method` | Counter of HTTP response status codes |
-| `curio_ipni_announce_attempts_total` | counter | `provider`, `result` | Total number of IPNI direct announce attempts. |
+| `curio_ipni_announce_attempts_total` | counter | `provider`, `result` | Total number of IPNI direct announce attempts. result is success when every indexer accepted the announce, partial when some did, error when none did. |
 | `curio_ipni_announce_http_roundtrip_milliseconds` | histogram | `provider`, `status` | Duration of outbound IPNI announce HTTP round trips in milliseconds. |
 | `curio_ipni_announce_to_indexed_latency_seconds` | histogram | `provider` | Duration from a successful head announce to confirmed indexing by an indexer service. |
 | `curio_ipni_entry_cache_hit_wait_milliseconds` | histogram | `request`, `origin`, `state` | Duration callers wait after hitting the IPNI entry cache. |

--- a/market/ipni/ipni-provider/announce_test.go
+++ b/market/ipni/ipni-provider/announce_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -16,8 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newAnnounceTestProvider builds a Provider with a single PDP provider (SPID 0, so no
-// announce URL is filtered out) announcing to the given URLs.
+// newAnnounceTestProvider builds a Provider with one PDP provider (SPID 0, so no announce
+// URL is filtered out) announcing to the given URLs.
 func newAnnounceTestProvider(t *testing.T, announceURLs ...string) (*Provider, string) {
 	t.Helper()
 
@@ -63,13 +64,13 @@ func countingIndexer(t *testing.T, status int) (*httptest.Server, *int32) {
 	return srv, &hits
 }
 
-// A dead indexer must not stop a healthy one from receiving the announce, whichever way
-// it signals that it is gone. Anything that is not 200/204 is one code path.
+// An unreachable indexer must not stop a reachable one from receiving the announce,
+// whichever status it rejects with. Anything that is not 200/204 is one code path.
 func TestPublishHTTP_DeadIndexerDoesNotBlockHealthyIndexer(t *testing.T) {
 	for _, status := range []int{
-		http.StatusInternalServerError, // filecoinpin.contact erroring
-		http.StatusGone,                // decommissioned
-		http.StatusNotFound,            // hostname reassigned
+		http.StatusInternalServerError,
+		http.StatusGone,
+		http.StatusNotFound,
 		http.StatusServiceUnavailable,
 	} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
@@ -87,9 +88,8 @@ func TestPublishHTTP_DeadIndexerDoesNotBlockHealthyIndexer(t *testing.T) {
 	}
 }
 
-// The regression under test: with one indexer permanently down (filecoinpin.contact being
-// shut down), the duplicate-announce guard must still suppress re-announcing an unchanged
-// head to the healthy indexer (cid.contact) on every publish tick.
+// One unreachable indexer must not defeat the duplicate-announce guard: an unchanged head
+// is announced to the reachable indexers once, not once per publish tick.
 func TestAnnounceProviderHead_DeadIndexerDoesNotCauseRepublishToHealthyIndexer(t *testing.T) {
 	dead, _ := countingIndexer(t, http.StatusInternalServerError)
 	healthy, healthyHits := countingIndexer(t, http.StatusOK)
@@ -108,7 +108,7 @@ func TestAnnounceProviderHead_DeadIndexerDoesNotCauseRepublishToHealthyIndexer(t
 		"a head accepted by at least one indexer counts as published")
 }
 
-// A new head must still be announced even though one indexer is down.
+// A new head is announced even while one indexer is unreachable.
 func TestAnnounceProviderHead_NewHeadIsStillAnnouncedWhileOneIndexerIsDown(t *testing.T) {
 	dead, _ := countingIndexer(t, http.StatusInternalServerError)
 	healthy, healthyHits := countingIndexer(t, http.StatusOK)
@@ -121,8 +121,8 @@ func TestAnnounceProviderHead_NewHeadIsStillAnnouncedWhileOneIndexerIsDown(t *te
 	require.EqualValues(t, 2, atomic.LoadInt32(healthyHits))
 }
 
-// When no indexer accepted the announce there is nothing to dedupe against, so the next
-// tick must retry rather than silently give up.
+// With no indexer accepting the announce there is nothing to dedupe against, so every
+// tick retries.
 func TestAnnounceProviderHead_RetriesWhenNoIndexerAccepted(t *testing.T) {
 	deadA, hitsA := countingIndexer(t, http.StatusInternalServerError)
 	deadB, hitsB := countingIndexer(t, http.StatusBadGateway)
@@ -139,7 +139,7 @@ func TestAnnounceProviderHead_RetriesWhenNoIndexerAccepted(t *testing.T) {
 	require.Nil(t, p.LastPublishTime(provider), "nothing was published")
 }
 
-// Baseline: with every indexer healthy, an unchanged head is announced once.
+// With every indexer reachable, an unchanged head is announced once.
 func TestAnnounceProviderHead_DedupesWhenAllIndexersHealthy(t *testing.T) {
 	healthy, hits := countingIndexer(t, http.StatusOK)
 
@@ -151,4 +151,34 @@ func TestAnnounceProviderHead_DedupesWhenAllIndexersHealthy(t *testing.T) {
 	}
 
 	require.EqualValues(t, 1, atomic.LoadInt32(hits))
+}
+
+// An indexer that accepts the connection and then never answers must not hold up delivery
+// to the others. The announce context bounds the wait, well inside publishhttp's client
+// timeout.
+func TestPublishHTTP_HangingIndexerDoesNotBlockReachableIndexer(t *testing.T) {
+	release := make(chan struct{})
+	hanging := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(hanging.Close)
+	t.Cleanup(func() { close(release) })
+
+	reachable, reachableHits := countingIndexer(t, http.StatusOK)
+	p, provider := newAnnounceTestProvider(t, hanging.URL, reachable.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	delivered, err := p.publishhttp(ctx, makeTestCid(t, 1), provider)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Equal(t, 1, delivered, "the reachable indexer accepted the announce")
+	require.EqualValues(t, 1, atomic.LoadInt32(reachableHits))
+	require.Less(t, elapsed, 5*time.Second, "the announce must not wait out the client timeout")
 }

--- a/market/ipni/ipni-provider/announce_test.go
+++ b/market/ipni/ipni-provider/announce_test.go
@@ -1,0 +1,154 @@
+package ipni_provider
+
+import (
+	"context"
+	"crypto/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+// newAnnounceTestProvider builds a Provider with a single PDP provider (SPID 0, so no
+// announce URL is filtered out) announcing to the given URLs.
+func newAnnounceTestProvider(t *testing.T, announceURLs ...string) (*Provider, string) {
+	t.Helper()
+
+	priv, pub, err := crypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
+	id, err := peer.IDFromPublicKey(pub)
+	require.NoError(t, err)
+	addr, err := multiaddr.NewMultiaddr("/dns/example.com/tcp/443/https")
+	require.NoError(t, err)
+
+	urls := make([]*url.URL, len(announceURLs))
+	for i, s := range announceURLs {
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		urls[i] = u
+	}
+
+	p := &Provider{
+		announceURLs: urls,
+		providerInfos: map[string]*peerInfo{
+			id.String(): {
+				ID:                  id,
+				Key:                 priv,
+				SPID:                0, // PDP-only: announces to every configured URL
+				httpServerAddresses: addr,
+				providerType:        PDPv1ProviderType,
+			},
+		},
+		latest: make(map[string]cid.Cid),
+	}
+	return p, id.String()
+}
+
+// countingIndexer is an httptest server standing in for an indexer's /announce endpoint.
+func countingIndexer(t *testing.T, status int) (*httptest.Server, *int32) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// A dead indexer must not stop a healthy one from receiving the announce, whichever way
+// it signals that it is gone. Anything that is not 200/204 is one code path.
+func TestPublishHTTP_DeadIndexerDoesNotBlockHealthyIndexer(t *testing.T) {
+	for _, status := range []int{
+		http.StatusInternalServerError, // filecoinpin.contact erroring
+		http.StatusGone,                // decommissioned
+		http.StatusNotFound,            // hostname reassigned
+		http.StatusServiceUnavailable,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			dead, deadHits := countingIndexer(t, status)
+			healthy, healthyHits := countingIndexer(t, http.StatusOK)
+
+			p, provider := newAnnounceTestProvider(t, dead.URL, healthy.URL)
+
+			delivered, err := p.publishhttp(context.Background(), makeTestCid(t, 1), provider)
+			require.Error(t, err, "the dead indexer's failure should still be reported")
+			require.Equal(t, 1, delivered, "exactly one indexer accepted the announce")
+			require.EqualValues(t, 1, atomic.LoadInt32(deadHits))
+			require.EqualValues(t, 1, atomic.LoadInt32(healthyHits), "the healthy indexer must still receive the announce")
+		})
+	}
+}
+
+// The regression under test: with one indexer permanently down (filecoinpin.contact being
+// shut down), the duplicate-announce guard must still suppress re-announcing an unchanged
+// head to the healthy indexer (cid.contact) on every publish tick.
+func TestAnnounceProviderHead_DeadIndexerDoesNotCauseRepublishToHealthyIndexer(t *testing.T) {
+	dead, _ := countingIndexer(t, http.StatusInternalServerError)
+	healthy, healthyHits := countingIndexer(t, http.StatusOK)
+
+	p, provider := newAnnounceTestProvider(t, dead.URL, healthy.URL)
+	head := makeTestCid(t, 1)
+
+	// three publish ticks with an unchanged head
+	for i := 0; i < 3; i++ {
+		p.announceProviderHead(context.Background(), provider, head)
+	}
+
+	require.EqualValues(t, 1, atomic.LoadInt32(healthyHits),
+		"an unchanged head must be announced to the healthy indexer once, not once per tick")
+	require.NotNil(t, p.LastPublishTime(provider),
+		"a head accepted by at least one indexer counts as published")
+}
+
+// A new head must still be announced even though one indexer is down.
+func TestAnnounceProviderHead_NewHeadIsStillAnnouncedWhileOneIndexerIsDown(t *testing.T) {
+	dead, _ := countingIndexer(t, http.StatusInternalServerError)
+	healthy, healthyHits := countingIndexer(t, http.StatusOK)
+
+	p, provider := newAnnounceTestProvider(t, dead.URL, healthy.URL)
+
+	p.announceProviderHead(context.Background(), provider, makeTestCid(t, 1))
+	p.announceProviderHead(context.Background(), provider, makeTestCid(t, 2))
+
+	require.EqualValues(t, 2, atomic.LoadInt32(healthyHits))
+}
+
+// When no indexer accepted the announce there is nothing to dedupe against, so the next
+// tick must retry rather than silently give up.
+func TestAnnounceProviderHead_RetriesWhenNoIndexerAccepted(t *testing.T) {
+	deadA, hitsA := countingIndexer(t, http.StatusInternalServerError)
+	deadB, hitsB := countingIndexer(t, http.StatusBadGateway)
+
+	p, provider := newAnnounceTestProvider(t, deadA.URL, deadB.URL)
+	head := makeTestCid(t, 1)
+
+	for i := 0; i < 3; i++ {
+		p.announceProviderHead(context.Background(), provider, head)
+	}
+
+	require.EqualValues(t, 3, atomic.LoadInt32(hitsA), "a totally failed announce must be retried")
+	require.EqualValues(t, 3, atomic.LoadInt32(hitsB))
+	require.Nil(t, p.LastPublishTime(provider), "nothing was published")
+}
+
+// Baseline: with every indexer healthy, an unchanged head is announced once.
+func TestAnnounceProviderHead_DedupesWhenAllIndexersHealthy(t *testing.T) {
+	healthy, hits := countingIndexer(t, http.StatusOK)
+
+	p, provider := newAnnounceTestProvider(t, healthy.URL)
+	head := makeTestCid(t, 1)
+
+	for i := 0; i < 3; i++ {
+		p.announceProviderHead(context.Background(), provider, head)
+	}
+
+	require.EqualValues(t, 1, atomic.LoadInt32(hits))
+}

--- a/market/ipni/ipni-provider/ipni-provider.go
+++ b/market/ipni/ipni-provider/ipni-provider.go
@@ -674,40 +674,52 @@ func (p *Provider) publishHead(ctx context.Context) {
 			continue
 		}
 
-		if _, ok := p.latest[provider]; ok && p.latest[provider] == c {
-			log.Debugw("Skipping duplicate announce for provider", "provider", provider, "cid", c.String())
-			continue
-		}
-
-		log.Infow("Publishing head for provider", "provider", provider, "cid", c.String())
-		err = p.publishhttp(ctx, c, provider)
-		if err != nil {
-			recordAnnounceAttempt(provider, "error")
-			log.Errorw("failed to publish head for provide", "provider", provider, "error", err)
-		} else {
-			recordAnnounceAttempt(provider, "success")
-			p.latest[provider] = c
-			p.mu.Lock()
-			info, ok := p.providerInfos[provider]
-			if !ok {
-				log.Warnw("cannot update provider announce times", "provider", provider, "error", "provider not found")
-			} else {
-				info.lastPublishTime = new(time.Now())
-			}
-			p.mu.Unlock()
-		}
+		p.announceProviderHead(ctx, provider, c)
 
 		i++
 	}
 }
 
-// publishhttp sends an HTTP announce message for the given advertisement CID and peer ID.
-// It creates an HTTP announce sender using the provided announce URLs and the private key of the peer.
-// It obtains the HTTP addresses for the peer and sends the announce message to those addresses.
-func (p *Provider) publishhttp(ctx context.Context, adCid cid.Cid, peer string) error {
-	// Create the http announce sender.
-	log.Infow("Creating http announce sender", "urls", p.announceURLs)
+// announceProviderHead announces head for provider, unless that same head has already
+// been announced. A head that no indexer accepted is not recorded, so it is retried on
+// the next publish tick.
+func (p *Provider) announceProviderHead(ctx context.Context, provider string, head cid.Cid) {
+	if last, ok := p.latest[provider]; ok && last == head {
+		log.Debugw("Skipping duplicate announce for provider", "provider", provider, "cid", head.String())
+		return
+	}
 
+	log.Infow("Publishing head for provider", "provider", provider, "cid", head.String())
+	delivered, err := p.publishhttp(ctx, head, provider)
+	if err != nil {
+		log.Errorw("failed to publish head for provider", "provider", provider, "delivered", delivered, "error", err)
+	}
+
+	if delivered == 0 {
+		recordAnnounceAttempt(provider, "error")
+		return
+	}
+	if err != nil {
+		recordAnnounceAttempt(provider, "partial")
+	} else {
+		recordAnnounceAttempt(provider, "success")
+	}
+
+	p.latest[provider] = head
+	p.mu.Lock()
+	info, ok := p.providerInfos[provider]
+	if !ok {
+		log.Warnw("cannot update provider announce times", "provider", provider, "error", "provider not found")
+	} else {
+		info.lastPublishTime = new(time.Now())
+	}
+	p.mu.Unlock()
+}
+
+// publishhttp sends an HTTP announce message for the given advertisement CID and peer ID
+// to every configured announce URL. It returns the number of indexers that accepted the
+// announce, along with any error.
+func (p *Provider) publishhttp(ctx context.Context, adCid cid.Cid, peer string) (int, error) {
 	lrt := &loggingRoundTripper{
 		proxied: http.DefaultTransport,
 		peer:    peer,
@@ -727,22 +739,30 @@ func (p *Provider) publishhttp(ctx context.Context, adCid cid.Cid, peer string) 
 	p.mu.RUnlock()
 
 	if !infoOk {
-		return fmt.Errorf("no details found for peer %s", peer)
+		return 0, fmt.Errorf("no details found for peer %s", peer)
 	}
 
 	if info.SPID > 0 {
 		a = FilterAnnounceURLs(a, []string{PinFilter})
 	}
 
-	httpSender, err := httpsender.New(a, info.ID, httpsender.WithClient(c))
-	if err != nil {
-		return fmt.Errorf("cannot create http announce sender: %w", err)
+	if len(a) == 0 {
+		return 0, fmt.Errorf("no announce urls for peer %s", peer)
 	}
 
 	addrs := []multiaddr.Multiaddr{info.httpServerAddresses}
 
-	log.Infow("Announcing advertisements over HTTP", "urls", p.announceURLs)
-	return announce.Send(ctx, adCid, addrs, httpSender)
+	log.Infow("Announcing advertisements over HTTP", "urls", a)
+
+	httpSender, err := httpsender.New(a, info.ID, httpsender.WithClient(c))
+	if err != nil {
+		return 0, fmt.Errorf("cannot create http announce sender: %w", err)
+	}
+
+	if err := announce.Send(ctx, adCid, addrs, httpSender); err != nil {
+		return 0, err
+	}
+	return len(a), nil
 }
 
 type loggingRoundTripper struct {

--- a/market/ipni/ipni-provider/ipni-provider.go
+++ b/market/ipni/ipni-provider/ipni-provider.go
@@ -680,9 +680,8 @@ func (p *Provider) publishHead(ctx context.Context) {
 	}
 }
 
-// announceProviderHead announces head for provider, unless that same head has already
-// been announced. A head that no indexer accepted is not recorded, so it is retried on
-// the next publish tick.
+// announceProviderHead announces head for provider unless it was already announced. A
+// head no indexer accepted is not recorded, so the next publish tick retries it.
 func (p *Provider) announceProviderHead(ctx context.Context, provider string, head cid.Cid) {
 	if last, ok := p.latest[provider]; ok && last == head {
 		log.Debugw("Skipping duplicate announce for provider", "provider", provider, "cid", head.String())
@@ -716,9 +715,9 @@ func (p *Provider) announceProviderHead(ctx context.Context, provider string, he
 	p.mu.Unlock()
 }
 
-// publishhttp sends an HTTP announce message for the given advertisement CID and peer ID
-// to every configured announce URL. It returns the number of indexers that accepted the
-// announce, along with any error.
+// publishhttp announces adCid to every configured announce URL concurrently. It returns
+// the number of indexers that accepted the announce, and the errors from those that did
+// not, so callers can tell a partial failure from a total one.
 func (p *Provider) publishhttp(ctx context.Context, adCid cid.Cid, peer string) (int, error) {
 	lrt := &loggingRoundTripper{
 		proxied: http.DefaultTransport,
@@ -754,15 +753,33 @@ func (p *Provider) publishhttp(ctx context.Context, adCid cid.Cid, peer string) 
 
 	log.Infow("Announcing advertisements over HTTP", "urls", a)
 
-	httpSender, err := httpsender.New(a, info.ID, httpsender.WithClient(c))
-	if err != nil {
-		return 0, fmt.Errorf("cannot create http announce sender: %w", err)
+	// One sender per URL: a single sender joins every outcome into one error, leaving a
+	// partial failure indistinguishable from a total one.
+	var wg sync.WaitGroup
+	errs := make([]error, len(a))
+	for i, u := range a {
+		// copy: httpsender.New fills in an empty Path on the URL it is given
+		announceURL := *u
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sender, err := httpsender.New([]*url.URL{&announceURL}, info.ID, httpsender.WithClient(c))
+			if err != nil {
+				errs[i] = fmt.Errorf("cannot create http announce sender for %s: %w", announceURL.String(), err)
+				return
+			}
+			errs[i] = announce.Send(ctx, adCid, addrs, sender)
+		}()
 	}
+	wg.Wait()
 
-	if err := announce.Send(ctx, adCid, addrs, httpSender); err != nil {
-		return 0, err
+	var delivered int
+	for _, err := range errs {
+		if err == nil {
+			delivered++
+		}
 	}
-	return len(a), nil
+	return delivered, errors.Join(errs...)
 }
 
 type loggingRoundTripper struct {

--- a/market/ipni/ipni-provider/metrics.go
+++ b/market/ipni/ipni-provider/metrics.go
@@ -60,7 +60,7 @@ var (
 	)
 	ipniAnnounceAttempts = stats.Int64(
 		"ipni_announce_attempts_total",
-		"Total number of IPNI direct announce attempts.",
+		"Total number of IPNI direct announce attempts. result is success when every indexer accepted the announce, partial when some did, error when none did.",
 		stats.UnitDimensionless,
 	)
 	ipniAnnounceHTTPRoundTripDuration = stats.Float64(


### PR DESCRIPTION
## What changed

`publishhttp` now announces to each configured indexer through its own sender and returns how many accepted it, instead of handing every URL to a single `httpsender`. `announceProviderHead`, extracted from `publishHead`, records a head as published when at least one indexer accepted it.

Before this, one failing indexer made `publishHead` treat the whole publish as failed, so `p.latest` never recorded the head and the duplicate-announce guard never fired again. An unchanged head was then re-announced to every healthy indexer on every publish tick. With `PublishInterval` at 1s (v1.28.6) that is one announce per second per provider to cid.contact instead of one per new advertisement, plus a matching ERROR log line.

This is worth landing now because filecoinpin.contact is being shut down on 2026-09-01 (filecoin-project/filecoin-pin#664) while the default `DirectAnnounceURLs` in `deps/config/types.go` still lists it. Removing it from the defaults is planned for 2026-09-02, so PDP providers will be announcing to a dead indexer until that ships and SPs pick it up.

## How to verify

Commit 1 adds the tests and fails CI on purpose. Commit 2 makes them pass.

```
go test ./market/ipni/ipni-provider/ -race -count=1
```

At commit 1 CI recorded `test-all` failing: run [33197251504](https://github.com/filecoin-project/curio/actions/runs/33197251504).

## Notes / risks

- A dead indexer never blocked a healthy one: go-libipni already sends to multiple URLs concurrently. Only the dedupe bookkeeping was wrong.
- `recordAnnounceAttempt` gains a `partial` result alongside `success` and `error`. An operator alert matching `result="error"` stops firing when some indexers accepted the announce. The metric description now spells the values out and `metrics-reference.md` is regenerated.
- `sendAnnounce` treats anything that is not 200 or 204 identically, so 410, 5xx and 404 are one path. Covered as subtests.
- An indexer that accepts the connection and never answers is covered by bounding the announce context, so the test runs in 0.2s rather than waiting out the 1 minute client timeout.
- Dropped a duplicate `Infow` in `publishhttp` that logged the unfiltered URL list.
- The web UI has the same trigger and is fixed separately in #1478: `web/api/webrpc/ipni.go` called `http.Get` with no timeout and failed the entire IPNI page when one service URL was bad. That one reaches every Curio node on default config, not just PDP providers.