### PR TITLE
fix: keep IPNI summary alive when an indexer is unreachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,8 @@ jobs:
             target: "./itests/dyncfg_test.go"
           - name: test-itest-harmonyDB
             target: "./itests/harmonydb_test.go"
+          - name: test-itest-ipni-summary
+            target: "./itests/ipni_summary_test.go"
           - name: test-itest-park-piece
             target: "./itests/park_piece_test.go"
           - name: test-itest-pdp-prove

--- a/itests/ipni_summary_test.go
+++ b/itests/ipni_summary_test.go
@@ -1,0 +1,107 @@
+package itests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/curio/deps"
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/web/api/webrpc"
+)
+
+const (
+	ipniSummaryPeerID = "12D3KooWPRuubsz8p49yAFBZGwsKVEF9MqxN1CQ1QRMeaDE4VCZu"
+	ipniSummaryAdCid  = "baguqeeraopdunfoiljzoxrn2ozzmi2ndzq3npr5rmpfjxxvfvenwscsxsyva"
+)
+
+// seedIPNIProvider inserts one IPNI provider with an advertisement chain head.
+func seedIPNIProvider(ctx context.Context, t *testing.T, db *harmonydb.DB) {
+	t.Helper()
+
+	_, err := db.Exec(ctx, `INSERT INTO ipni (ad_cid, context_id, is_rm, provider, addresses, signature, entries, piece_cid, piece_size)
+		VALUES ($1, '\x00', false, $2, '', '\x00', $1, 'x', 1)`, ipniSummaryAdCid, ipniSummaryPeerID)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `INSERT INTO ipni_head (provider, head) VALUES ($1, $2)`, ipniSummaryPeerID, ipniSummaryAdCid)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `INSERT INTO ipni_peerid (priv_key, peer_id, sp_id) VALUES ('\x01', $1, 0)`, ipniSummaryPeerID)
+	require.NoError(t, err)
+}
+
+// setIPNIServiceURLs points the IPNI summary at the given indexer services.
+func setIPNIServiceURLs(ctx context.Context, t *testing.T, db *harmonydb.DB, urls ...string) {
+	t.Helper()
+
+	quoted, err := json.Marshal(urls)
+	require.NoError(t, err)
+
+	layer := fmt.Sprintf(`
+[Market]
+  [Market.StorageMarketConfig]
+    [Market.StorageMarketConfig.IPNI]
+      ServiceURL = %s
+`, string(quoted))
+
+	_, err = db.Exec(ctx, `INSERT INTO harmony_config (title, config) VALUES ('itest-ipni-summary', $1)`, layer)
+	require.NoError(t, err)
+}
+
+// reachableIndexer answers /providers/{peerID} the way an indexer does.
+func reachableIndexer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(webrpc.ParsedResponse{
+			AddrInfo:          webrpc.AddrInfo{ID: ipniSummaryPeerID, Addrs: []string{"/dns/example.com/tcp/443/https"}},
+			LastAdvertisement: webrpc.Advertisement{Slash: ipniSummaryAdCid},
+			Publisher:         webrpc.AddrInfo{ID: ipniSummaryPeerID},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// An indexer service that cannot be reached must not take down the whole IPNI summary:
+// the failure is reported against that service and the reachable services still report.
+func TestIPNISummaryUnreachableIndexerService(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := harmonydb.NewFromConfigWithITestID(t)
+	require.NoError(t, err)
+
+	seedIPNIProvider(ctx, t, db)
+
+	reachable := reachableIndexer(t)
+
+	// a server that is closed immediately refuses connections, the way a decommissioned
+	// indexer hostname does
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	downURL := down.URL
+	down.Close()
+
+	setIPNIServiceURLs(ctx, t, db, downURL, reachable.URL)
+
+	a := &webrpc.WebRPC{Deps: &deps.Deps{DB: db}}
+
+	summary, err := a.IPNISummary(ctx)
+	require.NoError(t, err, "an unreachable indexer service must not fail the whole summary")
+	require.Len(t, summary, 1)
+
+	byService := map[string]webrpc.IpniSyncStatus{}
+	for _, s := range summary[0].SyncStatus {
+		byService[s.Service] = s
+	}
+
+	require.Contains(t, byService, reachable.URL, "the reachable service must still be reported")
+	require.Equal(t, ipniSummaryAdCid, byService[reachable.URL].RemoteAd)
+
+	require.Contains(t, byService, downURL, "the unreachable service must be reported as failing")
+	require.NotEmpty(t, byService[downURL].Error)
+}

--- a/web/api/webrpc/ipni.go
+++ b/web/api/webrpc/ipni.go
@@ -239,6 +239,44 @@ type ParsedResponse struct {
 	LastError             string         `json:"LastError"`
 }
 
+// ipniServiceTimeout bounds a single indexer lookup so one unresponsive service cannot
+// stall the IPNI summary.
+const ipniServiceTimeout = 10 * time.Second
+
+// fetchIPNIProvider reads one provider's record from an indexer service.
+func fetchIPNIProvider(ctx context.Context, service, peerID string) (ParsedResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, ipniServiceTimeout)
+	defer cancel()
+
+	var parsed ParsedResponse
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, service+"/providers/"+peerID, nil)
+	if err != nil {
+		return parsed, xerrors.Errorf("building request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return parsed, xerrors.Errorf("fetching data from IPNI service: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return parsed, xerrors.Errorf("failed to fetch data from IPNI service: %s", resp.Status)
+	}
+
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return parsed, xerrors.Errorf("failed to read response body: %w", err)
+	}
+
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		return parsed, xerrors.Errorf("failed to unmarshal IPNI service response: %w", err)
+	}
+
+	return parsed, nil
+}
+
 func (a *WebRPC) IPNISummary(ctx context.Context) ([]*IPNI, error) {
 	var summary []*IPNI
 
@@ -291,29 +329,13 @@ func (a *WebRPC) IPNISummary(ctx context.Context) ([]*IPNI, error) {
 
 	for _, service := range lists.UniqNoAlloc(services) {
 		for _, d := range summary {
-			url := service + "/providers/" + d.PeerID
-			resp, err := http.Get(url)
+			parsed, err := fetchIPNIProvider(ctx, service, d.PeerID)
 			if err != nil {
-				return nil, xerrors.Errorf("Error fetching data from IPNI service: %w", err)
-			}
-			defer func(Body io.ReadCloser) {
-				_ = Body.Close()
-			}(resp.Body)
-			if resp.StatusCode != http.StatusOK {
 				d.SyncStatus = append(d.SyncStatus, IpniSyncStatus{
 					Service: service,
-					Error:   fmt.Sprintf("failed to fetch data from IPNI service: %s", resp.Status),
+					Error:   err.Error(),
 				})
 				continue
-			}
-			out, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read response body: %w", err)
-			}
-			var parsed ParsedResponse
-			err = json.Unmarshal(out, &parsed)
-			if err != nil {
-				return nil, fmt.Errorf("failed to unmarshal IPNI service response: %w", err)
 			}
 			sync := IpniSyncStatus{
 				Service:               service,


### PR DESCRIPTION
## What changed

`IPNISummary` probed each configured indexer service with `http.Get` and returned on any transport error, so a single unreachable service took down the entire IPNI page for every provider. `http.Get` also ignores the request context, and `DefaultClient` sets no timeout, so a service that accepts the connection and never answers hung the call with nothing to cancel it.

The probe moves into `fetchIPNIProvider`, which builds the request with the caller's context under a 10s bound and returns the failure instead of aborting. `IPNISummary` records it against that service and carries on with the rest.

This matters on the same date as #1477: filecoinpin.contact is being shut down on 2026-09-01 (filecoin-project/filecoin-pin#664) while the default `ServiceURL` in `deps/config/types.go` still lists it. Unlike `DirectAnnounceURLs`, that default is not filtered by `SPID`, so this reaches every Curio node on default config, PoRep-only included, not just PDP providers.

Which shutdown shape you get decides the damage. A deleted DNS record or a refused connection breaks the page outright; a host that connects and never answers hung it indefinitely; 410 or 5xx was already handled gracefully.

## How to verify

Commit 1 adds the itest and fails. Commit 2 makes it pass. The test needs a database, so it runs as its own CI matrix entry, `test-itest-ipni-summary`.

```
go test ./itests/ -run TestIPNISummaryUnreachableIndexerService -count=1
```

At commit 1 it fails at `web/api/webrpc/ipni.go:297` with `connection refused`, against unmodified source.

## Notes / risks

- Also fixes response bodies being closed by a `defer` inside a nested loop, which held every body open until the whole summary returned.
- A service returning 410 or a 5xx behaved correctly before and still does; only transport failures changed.
- The 10s bound is a constant, so the timeout path itself has no test. Testing it means either a 10s test or making the bound injectable.
- Config still beats code for the deadline: dropping filecoinpin.contact from `ServiceURL` needs no release and fixes this for any SP who does it.

Related: #1477 fixes the announce-side bug with the same trigger.
