### PR TITLE
pdp: accept DropPiece tasks for pieces that have no storage location

### DIFF
--- a/tasks/piece/task_cleanup_piece.go
+++ b/tasks/piece/task_cleanup_piece.go
@@ -186,9 +186,13 @@ func (c *CleanupPieceTask) CanAccept(ids []harmonytask.TaskID, _ *harmonytask.Ta
 	err = c.db.QueryRow(ctx, `SELECT COALESCE(array_agg(cleanup_task_id), '{}')::bigint[] AS cleanup_task_ids FROM 
 										(
 										    SELECT pp.cleanup_task_id FROM parked_pieces pp
-											INNER JOIN sector_location l ON l.miner_id = 0 AND l.sector_num = pp.id AND l.sector_filetype = 32
-											WHERE cleanup_task_id = ANY ($1) 
-											  AND l.storage_id = ANY ($2)
+											LEFT JOIN LATERAL (
+												SELECT bool_or(l.storage_id = ANY ($2)) AS here, count(*) AS n
+												FROM sector_location l
+												WHERE l.miner_id = 0 AND l.sector_num = pp.id AND l.sector_filetype = 32
+											) loc ON TRUE
+											WHERE pp.cleanup_task_id = ANY ($1)
+											  AND (COALESCE(loc.here, FALSE) OR loc.n = 0)
 											  LIMIT 100
 										) s`, indIDs, storageIDs).Scan(&acceptedIDs)
 	if err != nil {

--- a/tasks/piece/task_cleanup_piece.go
+++ b/tasks/piece/task_cleanup_piece.go
@@ -185,14 +185,16 @@ func (c *CleanupPieceTask) CanAccept(ids []harmonytask.TaskID, _ *harmonytask.Ta
 	var acceptedIDs []harmonytask.TaskID
 	err = c.db.QueryRow(ctx, `SELECT COALESCE(array_agg(cleanup_task_id), '{}')::bigint[] AS cleanup_task_ids FROM 
 										(
-										    SELECT pp.cleanup_task_id FROM parked_pieces pp
+										    SELECT DISTINCT pp.cleanup_task_id FROM parked_pieces pp
 											LEFT JOIN LATERAL (
-												SELECT bool_or(l.storage_id = ANY ($2)) AS here, count(*) AS n
-												FROM sector_location l
-												WHERE l.miner_id = 0 AND l.sector_num = pp.id AND l.sector_filetype = 32
-											) loc ON TRUE
+												SELECT sl.storage_id
+												FROM sector_location sl
+												WHERE sl.miner_id = 0 AND sl.sector_num = pp.id AND sl.sector_filetype = 32
+												ORDER BY (sl.storage_id = ANY ($2)) DESC
+												LIMIT 1
+											) sl ON TRUE
 											WHERE pp.cleanup_task_id = ANY ($1)
-											  AND (COALESCE(loc.here, FALSE) OR loc.n = 0)
+											  AND (sl.storage_id IS NULL OR sl.storage_id = ANY ($2))
 											  LIMIT 100
 										) s`, indIDs, storageIDs).Scan(&acceptedIDs)
 	if err != nil {


### PR DESCRIPTION
## Priority

Not urgent relative to the contract upgrade work. Nothing is starved; the stuck tasks accumulate quietly and cost only log noise and permanent queue rows. It closes a stranded-work leak, so worth landing when there is room.

## The problem

`CleanupPieceTask.CanAccept` only accepts a task if the piece has a `sector_location` row (`miner_id = 0, sector_filetype = 32`) on the node's own storage. A parked piece that never got a location row can therefore never be accepted by any node, and its DropPiece task sits in `harmony_task` forever. `MaxFailures` never engages because the task never runs.

Such pieces exist in normal operation. `releaseStreamingUploadClaim` drops an abandoned streaming upload's ref and leaves the zero-ref provisional piece "for normal piece cleanup" — but that piece never completed, so no file was written and no location was ever declared. The cleanup poller schedules a DropPiece for it, and the task is born unschedulable.

On my calibnet SP: 5 stuck DropPiece tasks accrued over 32 hours, the oldest unschedulable for 38 hours, each pinned to a `skip = TRUE, complete = FALSE` piece with zero `sector_location` rows at any filetype, created in the same transaction as a streaming upload session that was later released. The scheduler logged the matching refusal continuously:

```
"did not accept task","task_ids":[69634852,69700952,69767126,70197805,70204539],
"reason":"CanAccept() refused","name":"DropPiece"
```

DropPiece itself was healthy throughout — 52 completions in the same window, zero failures. Only the locationless tasks strand.

## Notes on the change

The fix accepts a task when the piece has no location row anywhere: there is nothing on disk to be local to, so any node can run the deletion. Locally-stored pieces accept exactly as before, remotely-stored pieces are still refused, and `Do()` needs no change — it already deletes the DB row ref-guarded first and treats storage removal as best-effort. Race safety is unchanged: cleanup is only scheduled at `ref_count = 0`, every writer path holds a ref while writing, and the delete re-checks refs.

`LEFT JOIN LATERAL` rather than `NOT EXISTS` is deliberate: the anti-join form plans as a hash anti-join reading every piece-location row (75 ms over 21,283 rows on calibnet; a mainnet node here holds ~4M), and `CanAccept` runs on the scheduler goroutine where a slow query starves all task types (#1425). The lateral form probes `sectorlocation_pk` once per candidate: 1.5 ms measured.

## Verification

Running on the calibnet SP. On the first scheduler poll after restart, all 5 stuck tasks were claimed within 3 seconds of startup and completed successfully in under 120 ms each; the 5 orphaned `parked_pieces` rows are deleted and the refusal log line is gone. Pieces with real files continue to be accepted (checked against completed pieces on the same node) and the mainnet nodes show no regression.