### PR TITLE
pdp: index ipni for the piece-status ad lookup sort

### DIFF
--- a/harmony/harmonydb/downgrade/20260830-ipni-piece-status-index.sql
+++ b/harmony/harmonydb/downgrade/20260830-ipni-piece-status-index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS ipni_piece_cid_created_at;

--- a/harmony/harmonydb/sql/20260830-ipni-piece-status-index.sql
+++ b/harmony/harmonydb/sql/20260830-ipni-piece-status-index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS ipni_piece_cid_created_at
+    ON ipni (piece_cid HASH, created_at DESC, order_number DESC);

--- a/harmony/harmonydb/sql/20260830-ipni-piece-status-index.sql
+++ b/harmony/harmonydb/sql/20260830-ipni-piece-status-index.sql
@@ -1,2 +1,2 @@
 CREATE INDEX IF NOT EXISTS ipni_piece_cid_created_at
-    ON ipni (piece_cid HASH, created_at DESC, order_number DESC);
+    ON ipni (piece_cid, created_at DESC, order_number DESC);


### PR DESCRIPTION
## Priority

Not urgent relative to the contract upgrade work. One endpoint is slow on some nodes; nothing is starved and no data is at risk.

## The problem

#1450 (v1.28.6) rewrote the piece-status ad lookup in `pdp/handlers.go` into a `LATERAL` ordered by `created_at DESC, order_number DESC`. The supporting index, `ipni_piece_cid_order`, was built for the previous sort, so no index satisfies the new one - the lateral always needs a sort, and the planner's choice between the piece_cid and provider indexes becomes an even-cost tie that breaks arbitrarily per node.

On my mainnet PoRep+PDP node the tie broke badly - `piece_cid` demoted to a storage filter and the provider's entire ad chain read per call:

```
->  Index Scan using ipni_provider_order_number on ipni i  (actual time=21372.3)
      Index Cond: (provider = $0)
      Storage Filter: ((NOT is_rm) AND (piece_cid = 'baga...'::text))
      Storage Table Rows Scanned: 1431359
```

21.4 seconds to return one row, on every `GET /pdp/piece/{pieceCid}/status` call for a PDP piece. The same query against the node's smaller market-provider chain (8,959 ads) runs in 130 ms on the identical plan, so the cost is purely chain size. My PDP-only node's planner happened to pick the piece_cid index and is fine - which way the tie breaks is luck, so any SP is exposed.

## The change

New migration adding an index that matches the query's sort:

```sql
CREATE INDEX IF NOT EXISTS ipni_piece_cid_created_at
    ON ipni (piece_cid HASH, created_at DESC, order_number DESC);
```

With the `ORDER BY` satisfied by the index, the `LIMIT 1` needs no sort and the path is strictly cheaper than either tied alternative, so the plan flip is deterministic. `ipni_piece_cid_order` is left in place for paths that still sort by `order_number` alone.

## Verification

Built online on the mainnet node (1.44M ipni rows, 79 s backfill). The planner picked it immediately: the full piece-status query went from 21,372 ms to 4.9 ms, the lateral itself to 1.7 ms, no sort node in the plan. Smaller-chain lookups unchanged.