### PR TITLE
fix(cli): correct guided setup and argument diagnostics

### DIFF
--- a/cmd/curio/guidedsetup/guidedsetup.go
+++ b/cmd/curio/guidedsetup/guidedsetup.go
@@ -325,7 +325,7 @@ func doc(d *MigrationData) {
 	d.say(plain, "Filecoin %s channels: %s and %s", "Slack", "#fil-curio-help", "#fil-curio-dev")
 
 	d.say(plain, "Increase reliability using redundancy: start multiple machines with at-least the post layer: 'curio run --layers=post'")
-	//d.say(plain, "Point your browser to your web GUI to complete setup with %s and advanced featues.", "Boost")
+	//d.say(plain, "Point your browser to your web GUI to complete setup with %s and advanced features.", "Boost")
 	d.say(plain, "One database can serve multiple miner IDs: Run a migration for each lotus-miner.")
 }
 

--- a/cmd/curio/market.go
+++ b/cmd/curio/market.go
@@ -262,7 +262,7 @@ var marketMoveToEscrowCmd = &cli.Command{
 	ArgsUsage: "<amount>",
 	Action: func(cctx *cli.Context) error {
 		if cctx.Args().Len() != 1 {
-			return xerrors.Errorf("incorrect number of agruments")
+			return xerrors.Errorf("incorrect number of arguments")
 		}
 		amount, err := types.ParseFIL(cctx.Args().First())
 		if err != nil {


### PR DESCRIPTION
Correct the argument and feature wording emitted by the market and guided-setup commands. 

Diagnostics change only; command parsing and market behavior are unchanged.