### PR TITLE
docs: call out API changes in release notes

### DIFF
--- a/.github/RELEASE_PROCESS.md
+++ b/.github/RELEASE_PROCESS.md
@@ -141,9 +141,7 @@ Before merging the version upgrade PR, verify:
 
 ## Release Notes
 
-Release notes must describe Storage Provider impact, not only list merged PRs.
-
-Curio's release audience is not limited to Storage Providers running the binary. It also includes developers building against Curio's APIs, for example the Synapse SDK or ad hoc integrations against the PDP or market APIs. Historically release notes have focused on why an SP should install a release; they have not reliably called out new or changed API capabilities those integrators now have available. Every release that adds, changes, or deprecates an API surface must call that out explicitly (see [API Changes](#api-changes-in-release-notes)), not bury it inside a generic improvements list.
+Release notes must describe Storage Provider impact and new functionality for Curio clients, not only list merged PRs.
 
 Start with an overview that explains:
 
@@ -152,6 +150,8 @@ Start with an overview that explains:
 - Whether the release is stable or RC.
 - Any build requirement changes.
 - Any schema, migration, config, protocol, market, PDP, PoRep, retrieval, or packaging impact.
+
+Curio's release audience is not limited to Storage Providers running the binary. It also includes developers building against Curio's APIs, for example the Synapse SDK or ad hoc integrations against the PDP or market APIs. Every release that adds, changes, or deprecates an API surface should call that out explicitly.
 
 Use this general structure:
 
@@ -174,10 +174,6 @@ Short release summary and upgrade recommendation.
 
 Major user-visible changes.
 
-## API Changes
-
-New, changed, or deprecated API capabilities for developers integrating with Curio (for example the Synapse SDK, PDP clients, or other ad hoc builders), not just Storage Providers. Include this section whenever the release touches an API surface; omit it otherwise.
-
 ## Upgrade prep for Storage Providers
 
 Only include this section when operators need to take preparation or mitigation steps before upgrading.
@@ -189,6 +185,10 @@ Fixes grouped by operator impact where possible.
 ## Improvements
 
 User-visible improvements and operational changes.
+
+## API Changes
+
+New, changed, or deprecated API capabilities for developers integrating with Curio (for example the Synapse SDK, PDP clients, or other ad hoc builders), not just Storage Providers. Include this section whenever the release touches an API surface; omit it otherwise.
 
 ## Dependencies
 
@@ -210,10 +210,6 @@ Full changelog, issue tracker, and support links.
 ```
 
 The `Upgrade prep for Storage Providers` section is optional. Include it only when operators need to prepare before upgrading or need to know about a specific upgrade risk. Do not include an empty or generic prep section.
-
-## API Changes in Release Notes
-
-Curio ships APIs that developers build against directly (for example the Synapse SDK, PDP clients, and other ad hoc integrations), not only a binary that Storage Providers install. When scoping a release, check merged PRs for API additions, behavior changes, or deprecations across the PDP API, market API, and core API, and surface them in the `API Changes` section of the release notes even if they have no direct SP-facing impact. Do not fold API changes into the general `Improvements` section where an integrator would have to hunt for them.
 
 ## Release Notes Review
 

--- a/.github/RELEASE_PROCESS.md
+++ b/.github/RELEASE_PROCESS.md
@@ -143,6 +143,8 @@ Before merging the version upgrade PR, verify:
 
 Release notes must describe Storage Provider impact, not only list merged PRs.
 
+Curio's release audience is not limited to Storage Providers running the binary. It also includes developers building against Curio's APIs, for example the Synapse SDK or ad hoc integrations against the PDP or market APIs. Historically release notes have focused on why an SP should install a release; they have not reliably called out new or changed API capabilities those integrators now have available. Every release that adds, changes, or deprecates an API surface must call that out explicitly (see [API Changes](#api-changes-in-release-notes)), not bury it inside a generic improvements list.
+
 Start with an overview that explains:
 
 - What changed.
@@ -171,6 +173,10 @@ Short release summary and upgrade recommendation.
 ## Highlights
 
 Major user-visible changes.
+
+## API Changes
+
+New, changed, or deprecated API capabilities for developers integrating with Curio (for example the Synapse SDK, PDP clients, or other ad hoc builders), not just Storage Providers. Include this section whenever the release touches an API surface; omit it otherwise.
 
 ## Upgrade prep for Storage Providers
 
@@ -205,12 +211,17 @@ Full changelog, issue tracker, and support links.
 
 The `Upgrade prep for Storage Providers` section is optional. Include it only when operators need to prepare before upgrading or need to know about a specific upgrade risk. Do not include an empty or generic prep section.
 
+## API Changes in Release Notes
+
+Curio ships APIs that developers build against directly (for example the Synapse SDK, PDP clients, and other ad hoc integrations), not only a binary that Storage Providers install. When scoping a release, check merged PRs for API additions, behavior changes, or deprecations across the PDP API, market API, and core API, and surface them in the `API Changes` section of the release notes even if they have no direct SP-facing impact. Do not fold API changes into the general `Improvements` section where an integrator would have to hunt for them.
+
 ## Release Notes Review
 
 Before publishing, review the notes with the team for:
 
 - Incorrect upgrade guidance.
 - Missing operator-impacting changes.
+- Missing API changes affecting integrators (see [API Changes in Release Notes](#api-changes-in-release-notes)).
 - Missing migration or schema notes.
 - Missing config default changes.
 - Missing build requirement changes.

--- a/.github/RELEASE_PROCESS.md
+++ b/.github/RELEASE_PROCESS.md
@@ -217,7 +217,7 @@ Before publishing, review the notes with the team for:
 
 - Incorrect upgrade guidance.
 - Missing operator-impacting changes.
-- Missing API changes affecting integrators (see [API Changes in Release Notes](#api-changes-in-release-notes)).
+- Missing API changes affecting integrators (see [Release Notes](#release-notes)).
 - Missing migration or schema notes.
 - Missing config default changes.
 - Missing build requirement changes.


### PR DESCRIPTION
## Summary

- Adds an `API Changes` section to the release notes template and calls out the rationale in prose: Curio's release audience isn't just Storage Providers installing the binary, it's also developers building against Curio's APIs (Synapse SDK, PDP clients, other ad hoc integrations). Release notes have historically focused on why an SP should install a release and haven't reliably surfaced new/changed API capabilities for those integrators.
- Adds a review checklist item so a missing `API Changes` section gets caught before publishing.

## Background

Raised at the 2026-09-02 FOC engineering standup:
- Jennifer pushed for all API changes to appear in release highlights, since Curio's audience includes developers, not just SPs.
- Agreed to add an "API Changes" section to the Curio release notes template going forward.
- Andy is adding a highlight for the current release: "Updated IPNI APIs to give more accurate IPNI instance indexing information."

This is process/docs-only; it doesn't touch any release tooling or generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mEZ1W8aNQtvWcxmSWUiuM
