### PR TITLE
fix(indexstore, ipni): batch PieceBlockOffsetSize deletes in RemoveIndexes and keep piece_cleanup rows on their own IPNI scheduler

### DIFF
--- a/market/indexstore/indexstore.go
+++ b/market/indexstore/indexstore.go
@@ -325,17 +325,27 @@ func (i *IndexStore) RemoveIndexes(ctx context.Context, pieceCidv2 cid.Cid) erro
 		}
 	}
 
-	if len(batch.Entries) >= 0 {
+	if len(batch.Entries) > 0 {
 		if err := i.executeBatchWithRetry(ctx, batch, pieceCidv2); err != nil {
 			return xerrors.Errorf("executing batch delete for PayloadToPieces for piece %s: %w", pieceCidv2, err)
 		}
 	}
 
 	// Delete from PieceBlockOffsetSize
-	delPieceBlockOffsetSizeQry := `DELETE FROM PieceBlockOffsetSize WHERE PieceCid = ?`
-	err := i.session.Query(delPieceBlockOffsetSizeQry, pieceCidBytes).WithContext(ctx).Exec()
-	if err != nil {
-		return xerrors.Errorf("deleting PieceBlockOffsetSize for piece %s: %w", pieceCidv2, err)
+	delPieceBlockOffsetSizeRowQry := `DELETE FROM PieceBlockOffsetSize WHERE PieceCid = ? AND PayloadMultihash = ?`
+	batch = i.session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
+	for idx, payloadMH := range payloadMultihashes {
+		batch.Entries = append(batch.Entries, gocql.BatchEntry{
+			Stmt:       delPieceBlockOffsetSizeRowQry,
+			Args:       []any{pieceCidBytes, payloadMH},
+			Idempotent: true,
+		})
+		if len(batch.Entries) >= batchSize || idx == len(payloadMultihashes)-1 {
+			if err := i.executeBatchWithRetry(ctx, batch, pieceCidv2); err != nil {
+				return xerrors.Errorf("executing batch delete for PieceBlockOffsetSize for piece %s: %w", pieceCidv2, err)
+			}
+			batch = i.session.NewBatch(gocql.UnloggedBatch).WithContext(ctx)
+		}
 	}
 
 	return nil

--- a/tasks/indexing/task_ipni.go
+++ b/tasks/indexing/task_ipni.go
@@ -524,6 +524,7 @@ func (I *IPNITask) schedule(ctx context.Context, taskFunc harmonytask.AddTaskFun
 												FROM piece_cleanup
 												WHERE after_cleanup = TRUE
 												  AND complete = FALSE
+												  AND pdp = FALSE
 											)
 											SELECT *
 											FROM unioned

--- a/tasks/indexing/task_pdp_ipni.go
+++ b/tasks/indexing/task_pdp_ipni.go
@@ -497,6 +497,7 @@ func (P *PDPIPNITask) schedule(ctx context.Context, taskFunc harmonytask.AddTask
 											  FROM piece_cleanup pc
 											  WHERE pc.after_cleanup = TRUE
 												AND pc.complete = FALSE
+												AND pc.pdp = TRUE
 											)
 											SELECT *
 											FROM unioned


### PR DESCRIPTION
Two fixes found while publishing IPNI removal advertisements for expired PoRep deals on a mainnet node (Curio 1.28.6, YugabyteDB 2.25.1.0). Background in #1489.

## RemoveIndexes

The last step was a single partition-wide `DELETE FROM PieceBlockOffsetSize WHERE PieceCid = ?`. On YugabyteDB that is one replicate operation, and once the partition is large enough it exceeds the leader's single op limit:

```
Operation replicate msg size (545878234) exceeds limit of leader side single op size (254017536)
```

The function already holds every `PayloadMultihash` for the piece from the select at the top, so the delete now goes through the same batched, idempotent path as the `PayloadToPieces` delete, using `InsertBatchSize` per batch and `executeBatchWithRetry`. The `len(batch.Entries) >= 0` check after the loop is always true and executed an empty batch; it is now `> 0`.

## IPNI schedulers

`task_ipni.go` and `task_pdp_ipni.go` both select from `piece_cleanup` where `after_cleanup = TRUE AND complete = FALSE` with no check on `pdp`. When a PoRep row (`pdp = false`) reaches that state the PDP scheduler can claim it and fail with `not original ad found for removal ad`, because the original advertisement lives on the market publisher chain. Each scheduler now takes only its own rows.

## Tested

Mainnet, f08403. On the unpatched binary three 8 GiB pieces failed nine times with the error above. All three completed after the change. Since the change went in, 63 PoRep pieces have been cleaned and 63 removal advertisements published through this path (38 of 32 GiB, 24 of 8 GiB, 1 of 4 GiB). No PDP rows were touched, no PDP removal advertisements were published, and the PDP IPNI scheduler has not claimed a row since the filter went in.

One note for anyone removing many large pieces at once. Per-row deletes leave one tombstone per row. After about 60 pieces, scans on the affected `PieceBlockOffsetSize` tablets hit the YCQL 60 second deadline (`Deadline for query passed`) until the table was compacted. Compaction cleared it.

## Files

- `market/indexstore/indexstore.go` (+15, -5)
- `tasks/indexing/task_ipni.go` (+1)
- `tasks/indexing/task_pdp_ipni.go` (+1)