### PR TITLE
Feat/hashspaces

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -35,7 +35,7 @@ runs:
             xxd nasm \
             ocl-icd-opencl-dev libhwloc-dev \
             libfuse3-dev uuid-dev libssl-dev libnuma-dev libaio-dev libarchive-dev libkeyutils-dev libncurses-dev \
-            libgmp-dev libconfig++-dev
+            libgmp-dev libconfig++-dev liburing-dev
         }
         do_install || {
           echo "apt install failed; clearing lists and retrying once..." >&2
@@ -46,6 +46,12 @@ runs:
         }
       shell: bash
       if: ${{ inputs.skip == 'false' }}
+
+    - name: Install liburing
+      run: |
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=5 liburing-dev
+      shell: bash
+      if: ${{ inputs.skip == 'true' }}
 
     - name: Set up GCC 13 as default
       run: |

--- a/lib/fs2/folderSize.go
+++ b/lib/fs2/folderSize.go
@@ -1,0 +1,14 @@
+//go:build (linux || darwin) && cgo
+
+// Package fs2 sums logical sizes of regular files in a single directory.
+package fs2
+
+// Result describes the regular files successfully included in a range sum.
+type Result struct {
+	Bytes    uint64
+	Files    uint64
+	Vanished uint64
+}
+
+// Supports:
+//func SumFileSizesRange(directory, low, high string, queueDepth uint32) (Result, error)

--- a/lib/fs2/folderSize.go
+++ b/lib/fs2/folderSize.go
@@ -1,7 +1,14 @@
-//go:build (linux || darwin) && cgo
-
-// Package fs2 sums logical sizes of regular files in a single directory.
+// Package fs2 sums logical sizes of regular files under a directory tree.
+// Each file's hash is its path relative to the root with separators removed,
+// so ab/cdefg is the hash abcdefg. Bounds use the same half-open convention
+// as hashspacesolver.Transfer: (low, high]. An empty low or high leaves that
+// side open.
 package fs2
+
+import (
+	"fmt"
+	"strings"
+)
 
 // Result describes the regular files successfully included in a range sum.
 type Result struct {
@@ -10,5 +17,46 @@ type Result struct {
 	Vanished uint64
 }
 
-// Supports:
-//func SumFileSizesRange(directory, low, high string, queueDepth uint32) (Result, error)
+func checkSumArgs(directory, low, high string, queueDepth uint32) error {
+	if strings.IndexByte(directory, 0) >= 0 ||
+		strings.IndexByte(low, 0) >= 0 ||
+		strings.IndexByte(high, 0) >= 0 {
+		return fmt.Errorf("sum file sizes: path and bounds cannot contain NUL bytes")
+	}
+	if queueDepth > 4096 {
+		return fmt.Errorf("sum file sizes: queue depth %d exceeds 4096", queueDepth)
+	}
+	return nil
+}
+
+func hashInRange(hash, low, high string) bool {
+	if low != "" && hash <= low {
+		return false
+	}
+	if high != "" && hash > high {
+		return false
+	}
+	return true
+}
+
+func subtreeCanMatch(prefix, low, high string) bool {
+	if prefix == "" {
+		return true
+	}
+	if high != "" && prefix > high {
+		return false
+	}
+	if low == "" || prefix >= low {
+		return true
+	}
+	return strings.HasPrefix(low, prefix)
+}
+
+func hashFromRel(rel string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '/' || r == '\\' {
+			return -1
+		}
+		return r
+	}, rel)
+}

--- a/lib/fs2/folderSize_darwin.go
+++ b/lib/fs2/folderSize_darwin.go
@@ -1,0 +1,333 @@
+//go:build darwin && cgo
+
+package fs2
+
+/*
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/attr.h>
+#include <sys/vnode.h>
+#include <unistd.h>
+
+static void set_error(char *dst, size_t dst_len, const char *operation,
+			  const char *name, int error_number) {
+	if (dst == NULL || dst_len == 0) {
+		return;
+	}
+
+	if (name != NULL) {
+		snprintf(dst, dst_len, "%s %s: %s", operation, name,
+			 strerror(error_number));
+	} else {
+		snprintf(dst, dst_len, "%s: %s", operation,
+			 strerror(error_number));
+	}
+}
+
+static int parse_u32(char **field, const char *end, uint32_t *out) {
+	if (*field == NULL || (size_t)(end - *field) < sizeof(*out)) {
+		return -1;
+	}
+	memcpy(out, *field, sizeof(*out));
+	*field += sizeof(*out);
+	return 0;
+}
+
+static int parse_obj_type(char **field, const char *end, fsobj_type_t *out) {
+	if (*field == NULL || (size_t)(end - *field) < sizeof(*out)) {
+		return -1;
+	}
+	memcpy(out, *field, sizeof(*out));
+	*field += sizeof(*out);
+	return 0;
+}
+
+static int parse_size(char **field, const char *end, uint64_t *out) {
+	off_t size;
+
+	if (*field == NULL || (size_t)(end - *field) < sizeof(size)) {
+		return -1;
+	}
+	memcpy(&size, *field, sizeof(size));
+	*field += sizeof(size);
+	if (size < 0) {
+		return -1;
+	}
+	*out = (uint64_t)size;
+	return 0;
+}
+
+// sum_file_sizes_range scans one directory, selecting regular files whose
+// names compare in the bytewise interval [low, high). An empty bound is open.
+// queue_depth sizes the getattrlistbulk attribute buffer (512 bytes/entry).
+static int sum_file_sizes_range(const char *path, const char *low,
+				const char *high, unsigned queue_depth,
+				uint64_t *total, uint64_t *files,
+				uint64_t *vanished, char *err, size_t err_len) {
+	int dirfd = -1;
+	char *buf = NULL;
+	int status = -1;
+	int saved_errno;
+
+	*total = 0;
+	*files = 0;
+	*vanished = 0;
+	if (err != NULL && err_len != 0) {
+		err[0] = '\0';
+	}
+
+	if (queue_depth == 0) {
+		queue_depth = 128;
+	}
+
+	size_t buf_len = (size_t)queue_depth * 512;
+	if (buf_len < 8192) {
+		buf_len = 8192;
+	}
+
+	dirfd = open(path, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+	if (dirfd == -1) {
+		set_error(err, err_len, "open", path, errno);
+		goto done;
+	}
+
+	buf = malloc(buf_len);
+	if (buf == NULL) {
+		set_error(err, err_len, "malloc", NULL, ENOMEM);
+		goto done;
+	}
+
+	struct attrlist attr_list;
+	memset(&attr_list, 0, sizeof(attr_list));
+	attr_list.bitmapcount = ATTR_BIT_MAP_COUNT;
+	attr_list.commonattr = ATTR_CMN_RETURNED_ATTRS | ATTR_CMN_NAME |
+			       ATTR_CMN_ERROR | ATTR_CMN_OBJTYPE;
+	attr_list.fileattr = ATTR_FILE_DATALENGTH;
+
+	for (;;) {
+		int retcount;
+
+		do {
+			retcount = getattrlistbulk(dirfd, &attr_list, buf,
+						   buf_len, 0);
+		} while (retcount == -1 && errno == EINTR);
+
+		if (retcount == -1) {
+			set_error(err, err_len, "getattrlistbulk", path, errno);
+			goto done;
+		}
+		if (retcount == 0) {
+			break;
+		}
+
+		char *entry = buf;
+		const char *buf_end = buf + buf_len;
+
+		for (int i = 0; i < retcount; i++) {
+			uint32_t length;
+
+			if (parse_u32(&entry, buf_end, &length) != 0) {
+				snprintf(err, err_len, "getattrlistbulk %s: truncated entry length",
+					 path);
+				goto done;
+			}
+			if (length < sizeof(length) ||
+			    entry + (length - sizeof(length)) > buf_end) {
+				snprintf(err, err_len, "getattrlistbulk %s: invalid entry length",
+					 path);
+				goto done;
+			}
+
+			char *field = entry;
+			const char *entry_end = (entry - sizeof(length)) + length;
+			entry = (char *)entry_end;
+
+			attribute_set_t returned;
+			if ((size_t)(entry_end - field) < sizeof(returned)) {
+				snprintf(err, err_len, "getattrlistbulk %s: truncated returned attributes",
+					 path);
+				goto done;
+			}
+			memcpy(&returned, field, sizeof(returned));
+			field += sizeof(returned);
+
+			uint32_t entry_error = 0;
+			if ((returned.commonattr & ATTR_CMN_ERROR) != 0) {
+				if (parse_u32(&field, entry_end, &entry_error) != 0) {
+					snprintf(err, err_len, "getattrlistbulk %s: truncated entry error",
+						 path);
+					goto done;
+				}
+			}
+
+			const char *name = NULL;
+			if ((returned.commonattr & ATTR_CMN_NAME) != 0) {
+				attrreference_t name_info;
+				if ((size_t)(entry_end - field) < sizeof(name_info)) {
+					snprintf(err, err_len, "getattrlistbulk %s: truncated name",
+						 path);
+					goto done;
+				}
+				memcpy(&name_info, field, sizeof(name_info));
+				if (name_info.attr_dataoffset < 0 ||
+				    name_info.attr_length == 0 ||
+				    field + name_info.attr_dataoffset < field ||
+				    field + name_info.attr_dataoffset +
+					    name_info.attr_length > entry_end) {
+					snprintf(err, err_len, "getattrlistbulk %s: invalid name",
+						 path);
+					goto done;
+				}
+				name = field + name_info.attr_dataoffset;
+				field += sizeof(name_info);
+			}
+
+			if (entry_error != 0) {
+				if (entry_error == ENOENT) {
+					(*vanished)++;
+					continue;
+				}
+				set_error(err, err_len, "getattrlistbulk", name,
+					  (int)entry_error);
+				goto done;
+			}
+
+			if (name == NULL) {
+				snprintf(err, err_len, "getattrlistbulk %s: filesystem did not return name",
+					 path);
+				goto done;
+			}
+
+			if (name[0] == '.' &&
+			    (name[1] == '\0' ||
+			     (name[1] == '.' && name[2] == '\0'))) {
+				continue;
+			}
+
+			if (low[0] != '\0' && strcmp(name, low) < 0) {
+				continue;
+			}
+			if (high[0] != '\0' && strcmp(name, high) >= 0) {
+				continue;
+			}
+
+			if ((returned.commonattr & ATTR_CMN_OBJTYPE) == 0) {
+				snprintf(err, err_len, "getattrlistbulk %s: filesystem did not return type",
+					 name);
+				goto done;
+			}
+
+			fsobj_type_t obj_type;
+			if (parse_obj_type(&field, entry_end, &obj_type) != 0) {
+				snprintf(err, err_len, "getattrlistbulk %s: truncated type",
+					 name);
+				goto done;
+			}
+			if (obj_type != VREG) {
+				continue;
+			}
+
+			if ((returned.fileattr & ATTR_FILE_DATALENGTH) == 0) {
+				snprintf(err, err_len, "getattrlistbulk %s: filesystem did not return size",
+					 name);
+				goto done;
+			}
+
+			uint64_t size;
+			if (parse_size(&field, entry_end, &size) != 0) {
+				snprintf(err, err_len, "getattrlistbulk %s: truncated size",
+					 name);
+				goto done;
+			}
+
+			if (UINT64_MAX - *total < size) {
+				snprintf(err, err_len, "sum overflow at %s", name);
+				goto done;
+			}
+
+			*total += size;
+			(*files)++;
+		}
+	}
+
+	status = 0;
+
+done:
+	saved_errno = errno;
+	free(buf);
+	if (dirfd != -1 && close(dirfd) == -1 && status == 0) {
+		set_error(err, err_len, "close", path, errno);
+		status = -1;
+	}
+	errno = saved_errno;
+	return status;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+)
+
+// SumFileSizesRange sums logical file sizes for regular files immediately
+// within directory whose names compare in the bytewise interval [low, high).
+// An empty low or high bound leaves that side of the interval open.
+//
+// QueueDepth sizes the getattrlistbulk attribute buffer. Zero selects 128.
+// This function makes one long cgo call; it does not allocate Go objects
+// per directory entry and cannot be canceled midway.
+func SumFileSizesRange(directory, low, high string, queueDepth uint32) (Result, error) {
+	if strings.IndexByte(directory, 0) >= 0 ||
+		strings.IndexByte(low, 0) >= 0 ||
+		strings.IndexByte(high, 0) >= 0 {
+		return Result{}, fmt.Errorf("sum file sizes: path and bounds cannot contain NUL bytes")
+	}
+	if queueDepth > 4096 {
+		return Result{}, fmt.Errorf("sum file sizes: queue depth %d exceeds 4096", queueDepth)
+	}
+
+	cDirectory := C.CString(directory)
+	cLow := C.CString(low)
+	cHigh := C.CString(high)
+	defer C.free(unsafe.Pointer(cDirectory))
+	defer C.free(unsafe.Pointer(cLow))
+	defer C.free(unsafe.Pointer(cHigh))
+
+	var result Result
+	var total C.uint64_t
+	var files C.uint64_t
+	var vanished C.uint64_t
+	var errorBuffer [512]C.char
+
+	status := C.sum_file_sizes_range(
+		cDirectory,
+		cLow,
+		cHigh,
+		C.uint(queueDepth),
+		&total,
+		&files,
+		&vanished,
+		&errorBuffer[0],
+		C.size_t(len(errorBuffer)),
+	)
+
+	result.Bytes = uint64(total)
+	result.Files = uint64(files)
+	result.Vanished = uint64(vanished)
+
+	if status != 0 {
+		message := C.GoString(&errorBuffer[0])
+		if message == "" {
+			message = "directory scan failed"
+		}
+		return result, fmt.Errorf("sum file sizes: %s", message)
+	}
+
+	return result, nil
+}

--- a/lib/fs2/folderSize_darwin.go
+++ b/lib/fs2/folderSize_darwin.go
@@ -5,6 +5,7 @@ package fs2
 /*
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -12,6 +13,10 @@ package fs2
 #include <sys/attr.h>
 #include <sys/vnode.h>
 #include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 
 static void set_error(char *dst, size_t dst_len, const char *operation,
 			  const char *name, int error_number) {
@@ -61,28 +66,93 @@ static int parse_size(char **field, const char *end, uint64_t *out) {
 	return 0;
 }
 
-// sum_file_sizes_range scans one directory, selecting regular files whose
-// names compare in the bytewise interval [low, high). An empty bound is open.
-// queue_depth sizes the getattrlistbulk attribute buffer (512 bytes/entry).
+static int join_hash(char *out, size_t out_len, const char *prefix,
+			 const char *name) {
+	size_t prefix_len = strlen(prefix);
+	size_t name_len = strlen(name);
+	if (prefix_len + name_len + 1 > out_len) {
+		return -1;
+	}
+	memcpy(out, prefix, prefix_len);
+	memcpy(out + prefix_len, name, name_len + 1);
+	return 0;
+}
+
+static int join_path(char *out, size_t out_len, const char *dir,
+			 const char *name) {
+	size_t dir_len = strlen(dir);
+	size_t name_len = strlen(name);
+	int need_slash = (dir_len > 0 && dir[dir_len - 1] != '/');
+	if (dir_len + (size_t)need_slash + name_len + 1 > out_len) {
+		return -1;
+	}
+	memcpy(out, dir, dir_len);
+	size_t offset = dir_len;
+	if (need_slash) {
+		out[offset++] = '/';
+	}
+	memcpy(out + offset, name, name_len + 1);
+	return 0;
+}
+
+static int hash_in_range(const char *hash, const char *low, const char *high) {
+	if (low[0] != '\0' && strcmp(hash, low) <= 0) {
+		return 0;
+	}
+	if (high[0] != '\0' && strcmp(hash, high) > 0) {
+		return 0;
+	}
+	return 1;
+}
+
+static int subtree_can_match(const char *prefix, const char *low,
+				 const char *high) {
+	if (prefix[0] == '\0') {
+		return 1;
+	}
+	if (high[0] != '\0' && strcmp(prefix, high) > 0) {
+		return 0;
+	}
+	if (low[0] == '\0' || strcmp(prefix, low) >= 0) {
+		return 1;
+	}
+	return strncmp(low, prefix, strlen(prefix)) == 0;
+}
+
+static int sum_dir(const char *path, const char *prefix, const char *low,
+		       const char *high, unsigned queue_depth, uint64_t *total,
+		       uint64_t *files, uint64_t *vanished, char *err,
+		       size_t err_len);
+
+// sum_file_sizes_range walks the directory tree, selecting regular files whose
+// concatenated hash paths compare in the bytewise interval (low, high]. An
+// empty bound is open. queue_depth sizes the getattrlistbulk attribute buffer
+// (512 bytes/entry).
 static int sum_file_sizes_range(const char *path, const char *low,
 				const char *high, unsigned queue_depth,
 				uint64_t *total, uint64_t *files,
 				uint64_t *vanished, char *err, size_t err_len) {
-	int dirfd = -1;
-	char *buf = NULL;
-	int status = -1;
-	int saved_errno;
-
 	*total = 0;
 	*files = 0;
 	*vanished = 0;
 	if (err != NULL && err_len != 0) {
 		err[0] = '\0';
 	}
-
 	if (queue_depth == 0) {
 		queue_depth = 128;
 	}
+	return sum_dir(path, "", low, high, queue_depth, total, files, vanished,
+		       err, err_len);
+}
+
+static int sum_dir(const char *path, const char *prefix, const char *low,
+		       const char *high, unsigned queue_depth, uint64_t *total,
+		       uint64_t *files, uint64_t *vanished, char *err,
+		       size_t err_len) {
+	int dirfd = -1;
+	char *buf = NULL;
+	int status = -1;
+	int saved_errno;
 
 	size_t buf_len = (size_t)queue_depth * 512;
 	if (buf_len < 8192) {
@@ -208,13 +278,6 @@ static int sum_file_sizes_range(const char *path, const char *low,
 				continue;
 			}
 
-			if (low[0] != '\0' && strcmp(name, low) < 0) {
-				continue;
-			}
-			if (high[0] != '\0' && strcmp(name, high) >= 0) {
-				continue;
-			}
-
 			if ((returned.commonattr & ATTR_CMN_OBJTYPE) == 0) {
 				snprintf(err, err_len, "getattrlistbulk %s: filesystem did not return type",
 					 name);
@@ -227,7 +290,34 @@ static int sum_file_sizes_range(const char *path, const char *low,
 					 name);
 				goto done;
 			}
+
+			char hash[PATH_MAX];
+			if (join_hash(hash, sizeof(hash), prefix, name) != 0) {
+				snprintf(err, err_len, "hash path exceeds PATH_MAX: %s%s",
+					 prefix, name);
+				goto done;
+			}
+
+			if (obj_type == VDIR) {
+				char child_path[PATH_MAX];
+				if (join_path(child_path, sizeof(child_path), path, name) != 0) {
+					snprintf(err, err_len, "path exceeds PATH_MAX under %s: %s",
+						 path, name);
+					goto done;
+				}
+				if (!subtree_can_match(hash, low, high)) {
+					continue;
+				}
+				if (sum_dir(child_path, hash, low, high, queue_depth,
+					    total, files, vanished, err, err_len) != 0) {
+					goto done;
+				}
+				continue;
+			}
 			if (obj_type != VREG) {
+				continue;
+			}
+			if (!hash_in_range(hash, low, high)) {
 				continue;
 			}
 
@@ -271,25 +361,19 @@ import "C"
 
 import (
 	"fmt"
-	"strings"
 	"unsafe"
 )
 
-// SumFileSizesRange sums logical file sizes for regular files immediately
-// within directory whose names compare in the bytewise interval [low, high).
+// SumFileSizesRange sums logical file sizes for regular files under directory
+// whose concatenated hash paths compare in the bytewise interval (low, high].
 // An empty low or high bound leaves that side of the interval open.
 //
 // QueueDepth sizes the getattrlistbulk attribute buffer. Zero selects 128.
 // This function makes one long cgo call; it does not allocate Go objects
 // per directory entry and cannot be canceled midway.
 func SumFileSizesRange(directory, low, high string, queueDepth uint32) (Result, error) {
-	if strings.IndexByte(directory, 0) >= 0 ||
-		strings.IndexByte(low, 0) >= 0 ||
-		strings.IndexByte(high, 0) >= 0 {
-		return Result{}, fmt.Errorf("sum file sizes: path and bounds cannot contain NUL bytes")
-	}
-	if queueDepth > 4096 {
-		return Result{}, fmt.Errorf("sum file sizes: queue depth %d exceeds 4096", queueDepth)
+	if err := checkSumArgs(directory, low, high, queueDepth); err != nil {
+		return Result{}, err
 	}
 
 	cDirectory := C.CString(directory)

--- a/lib/fs2/folderSize_generic.go
+++ b/lib/fs2/folderSize_generic.go
@@ -1,0 +1,80 @@
+//go:build !((linux || darwin) && cgo)
+
+package fs2
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// SumFileSizesRange sums logical file sizes for regular files under directory
+// whose concatenated hash paths compare in the bytewise interval (low, high].
+// An empty low or high bound leaves that side of the interval open.
+//
+// QueueDepth is accepted for API compatibility and ignored.
+func SumFileSizesRange(directory, low, high string, queueDepth uint32) (Result, error) {
+	if err := checkSumArgs(directory, low, high, queueDepth); err != nil {
+		return Result{}, err
+	}
+
+	var result Result
+	err := filepath.WalkDir(directory, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				result.Vanished++
+				return nil
+			}
+			return err
+		}
+		rel, err := filepath.Rel(directory, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		hash := hashFromRel(rel)
+		if d.IsDir() {
+			if !subtreeCanMatch(hash, low, high) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !hashInRange(hash, low, high) {
+			return nil
+		}
+
+		mode := d.Type()
+		if mode != 0 && !mode.IsRegular() {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			if os.IsNotExist(err) {
+				result.Vanished++
+				return nil
+			}
+			return fmt.Errorf("stat %s: %w", rel, err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		if info.Size() < 0 {
+			return fmt.Errorf("stat %s: negative size", rel)
+		}
+		size := uint64(info.Size())
+		if result.Bytes > ^uint64(0)-size {
+			return fmt.Errorf("sum overflow at %s", rel)
+		}
+		result.Bytes += size
+		result.Files++
+		return nil
+	})
+	if err != nil {
+		return result, fmt.Errorf("sum file sizes: %w", err)
+	}
+	return result, nil
+}

--- a/lib/fs2/folderSize_linux.go
+++ b/lib/fs2/folderSize_linux.go
@@ -1,0 +1,366 @@
+//go:build linux && cgo
+
+package fs2
+
+/*
+#cgo CFLAGS: -D_GNU_SOURCE -std=gnu11
+#cgo pkg-config: liburing
+
+#define _GNU_SOURCE
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <liburing.h>
+
+#ifndef NAME_MAX
+#define NAME_MAX 255
+#endif
+#ifndef AT_NO_AUTOMOUNT
+#define AT_NO_AUTOMOUNT 0x800
+#endif
+#ifndef AT_STATX_DONT_SYNC
+#define AT_STATX_DONT_SYNC 0x4000
+#endif
+#ifndef STATX_TYPE
+#include <linux/stat.h>
+#endif
+
+struct sum_slot {
+	char name[NAME_MAX + 1];
+	struct statx stx;
+};
+
+static void set_error(char *dst, size_t dst_len, const char *operation,
+			  const char *name, int error_number) {
+	if (dst == NULL || dst_len == 0) {
+		return;
+	}
+
+	if (name != NULL) {
+		snprintf(dst, dst_len, "%s %s: %s", operation, name,
+			 strerror(error_number));
+	} else {
+		snprintf(dst, dst_len, "%s: %s", operation,
+			 strerror(error_number));
+	}
+}
+
+// submit_all submits every SQE currently prepared for this batch. It reports
+// how many requests reached the kernel so the caller can drain them before
+// releasing their pathname and output buffers after an error.
+static int submit_all(struct io_uring *ring, unsigned wanted,
+			  unsigned *submitted, char *err, size_t err_len) {
+	*submitted = 0;
+
+	while (*submitted < wanted) {
+		int rc = io_uring_submit(ring);
+		if (rc == -EINTR) {
+			continue;
+		}
+		if (rc < 0) {
+			set_error(err, err_len, "io_uring_submit", NULL, -rc);
+			return -1;
+		}
+		if (rc == 0) {
+			set_error(err, err_len, "io_uring_submit", NULL, EIO);
+			return -1;
+		}
+
+		*submitted += (unsigned)rc;
+	}
+
+	return 0;
+}
+
+// drain_batch consumes exactly pending completions. It remembers the first
+// per-file failure but continues draining so every slot can safely be reused.
+static int drain_batch(struct io_uring *ring, unsigned pending,
+			   uint64_t *total, uint64_t *files,
+			   uint64_t *vanished, char *err, size_t err_len) {
+	int failed = 0;
+
+	for (unsigned i = 0; i < pending; i++) {
+		struct io_uring_cqe *cqe;
+		int rc;
+
+		do {
+			rc = io_uring_wait_cqe(ring, &cqe);
+		} while (rc == -EINTR);
+
+		if (rc < 0) {
+			if (!failed) {
+				set_error(err, err_len, "io_uring_wait_cqe", NULL, -rc);
+			}
+			return -1;
+		}
+
+		struct sum_slot *slot = (struct sum_slot *)io_uring_cqe_get_data(cqe);
+		int result = cqe->res;
+		io_uring_cqe_seen(ring, cqe);
+
+		if (result == -ENOENT) {
+			(*vanished)++;
+			continue;
+		}
+
+		if (result < 0) {
+			if (!failed) {
+				set_error(err, err_len, "statx", slot->name, -result);
+				failed = 1;
+			}
+			continue;
+		}
+
+		if ((slot->stx.stx_mask & STATX_SIZE) == 0) {
+			if (!failed) {
+				snprintf(err, err_len, "statx %s: filesystem did not return size",
+					 slot->name);
+				failed = 1;
+			}
+			continue;
+		}
+
+		if ((slot->stx.stx_mode & S_IFMT) != S_IFREG) {
+			continue;
+		}
+
+		if (UINT64_MAX - *total < slot->stx.stx_size) {
+			if (!failed) {
+				snprintf(err, err_len, "sum overflow at %s", slot->name);
+				failed = 1;
+			}
+			continue;
+		}
+
+		*total += slot->stx.stx_size;
+		(*files)++;
+	}
+
+	return failed ? -1 : 0;
+}
+
+// sum_file_sizes_range scans one directory, selecting regular files whose
+// names compare in the bytewise interval [low, high). An empty bound is open.
+// queue_depth is both the ring size and the maximum number of outstanding
+// statx requests.
+int sum_file_sizes_range(const char *path, const char *low,
+				const char *high, unsigned queue_depth,
+				uint64_t *total, uint64_t *files,
+				uint64_t *vanished, char *err, size_t err_len) {
+	DIR *directory = NULL;
+	struct io_uring ring;
+	struct sum_slot *slots = NULL;
+	int ring_ready = 0;
+	int status = -1;
+	int saved_errno;
+
+	*total = 0;
+	*files = 0;
+	*vanished = 0;
+	if (err != NULL && err_len != 0) {
+		err[0] = '\0';
+	}
+
+	if (queue_depth == 0) {
+		queue_depth = 128;
+	}
+
+	directory = opendir(path);
+	if (directory == NULL) {
+		set_error(err, err_len, "opendir", path, errno);
+		goto done;
+	}
+
+	int rc = io_uring_queue_init(queue_depth, &ring, 0);
+	if (rc < 0) {
+		set_error(err, err_len, "io_uring_queue_init", NULL, -rc);
+		goto done;
+	}
+	ring_ready = 1;
+
+	slots = calloc(queue_depth, sizeof(*slots));
+	if (slots == NULL) {
+		set_error(err, err_len, "calloc", NULL, ENOMEM);
+		goto done;
+	}
+
+	int directory_fd = dirfd(directory);
+	if (directory_fd == -1) {
+		set_error(err, err_len, "dirfd", path, errno);
+		goto done;
+	}
+
+	int at_flags = AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT |
+		       AT_STATX_DONT_SYNC;
+	int reached_end = 0;
+
+	while (!reached_end) {
+		unsigned pending = 0;
+
+		while (pending < queue_depth) {
+			errno = 0;
+			struct dirent *entry = readdir(directory);
+			if (entry == NULL) {
+				if (errno != 0) {
+					set_error(err, err_len, "readdir", path, errno);
+					goto done;
+				}
+				reached_end = 1;
+				break;
+			}
+
+			const char *name = entry->d_name;
+			if (name[0] == '.' &&
+			    (name[1] == '\0' ||
+			     (name[1] == '.' && name[2] == '\0'))) {
+				continue;
+			}
+
+			if (low[0] != '\0' && strcmp(name, low) < 0) {
+				continue;
+			}
+			if (high[0] != '\0' && strcmp(name, high) >= 0) {
+				continue;
+			}
+
+			// A filesystem may report DT_UNKNOWN, so those entries still
+			// need statx. Known non-regular entries can be skipped.
+			if (entry->d_type != DT_REG && entry->d_type != DT_UNKNOWN) {
+				continue;
+			}
+
+			size_t name_len = strlen(name);
+			if (name_len >= sizeof(slots[pending].name)) {
+				snprintf(err, err_len, "filename exceeds NAME_MAX: %s", name);
+				goto done;
+			}
+
+			memcpy(slots[pending].name, name, name_len + 1);
+			memset(&slots[pending].stx, 0, sizeof(slots[pending].stx));
+
+			struct io_uring_sqe *sqe = io_uring_get_sqe(&ring);
+			if (sqe == NULL) {
+				set_error(err, err_len, "io_uring_get_sqe", NULL, EBUSY);
+				goto done;
+			}
+
+			io_uring_prep_statx(sqe, directory_fd,
+					    slots[pending].name, at_flags,
+					    STATX_TYPE | STATX_SIZE,
+					    &slots[pending].stx);
+			io_uring_sqe_set_data(sqe, &slots[pending]);
+			pending++;
+		}
+
+		if (pending == 0) {
+			continue;
+		}
+
+		unsigned submitted = 0;
+		if (submit_all(&ring, pending, &submitted, err, err_len) != 0) {
+			// Requests accepted before a partial-submit failure still
+			// reference slot memory. Drain those before cleanup.
+			if (submitted != 0) {
+				char ignored[1];
+				drain_batch(&ring, submitted, total, files, vanished,
+					    ignored, sizeof(ignored));
+			}
+			goto done;
+		}
+
+		if (drain_batch(&ring, pending, total, files, vanished,
+					err, err_len) != 0) {
+			goto done;
+		}
+	}
+
+	status = 0;
+
+done:
+	// Preserve errno only for closedir diagnostics; liburing returns
+	// negative errno values directly and does not reliably set errno.
+	saved_errno = errno;
+	if (ring_ready) {
+		io_uring_queue_exit(&ring);
+	}
+	free(slots);
+	if (directory != NULL && closedir(directory) == -1 && status == 0) {
+		set_error(err, err_len, "closedir", path, errno);
+		status = -1;
+	}
+	errno = saved_errno;
+	return status;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+)
+
+// SumFileSizesRange sums logical file sizes for regular files immediately
+// within directory whose names compare in the bytewise interval [low, high).
+// An empty low or high bound leaves that side of the interval open.
+//
+// QueueDepth controls the maximum number of outstanding io_uring statx
+// requests. Zero selects 128. This function makes one long cgo call; it does
+// not allocate Go objects per directory entry and cannot be canceled midway.
+func SumFileSizesRange(directory, low, high string, queueDepth uint32) (Result, error) {
+	if strings.IndexByte(directory, 0) >= 0 ||
+		strings.IndexByte(low, 0) >= 0 ||
+		strings.IndexByte(high, 0) >= 0 {
+		return Result{}, fmt.Errorf("sum file sizes: path and bounds cannot contain NUL bytes")
+	}
+	if queueDepth > 4096 {
+		return Result{}, fmt.Errorf("sum file sizes: queue depth %d exceeds 4096", queueDepth)
+	}
+
+	cDirectory := C.CString(directory)
+	cLow := C.CString(low)
+	cHigh := C.CString(high)
+	defer C.free(unsafe.Pointer(cDirectory))
+	defer C.free(unsafe.Pointer(cLow))
+	defer C.free(unsafe.Pointer(cHigh))
+
+	var result Result
+	var total C.uint64_t
+	var files C.uint64_t
+	var vanished C.uint64_t
+	var errorBuffer [512]C.char
+
+	status := C.sum_file_sizes_range(
+		cDirectory,
+		cLow,
+		cHigh,
+		C.uint(queueDepth),
+		&total,
+		&files,
+		&vanished,
+		&errorBuffer[0],
+		C.size_t(len(errorBuffer)),
+	)
+
+	result.Bytes = uint64(total)
+	result.Files = uint64(files)
+	result.Vanished = uint64(vanished)
+
+	if status != 0 {
+		message := C.GoString(&errorBuffer[0])
+		if message == "" {
+			message = "directory scan failed"
+		}
+		return result, fmt.Errorf("sum file sizes: %s", message)
+	}
+
+	return result, nil
+}

--- a/lib/fs2/folderSize_linux.go
+++ b/lib/fs2/folderSize_linux.go
@@ -147,31 +147,101 @@ static int drain_batch(struct io_uring *ring, unsigned pending,
 	return failed ? -1 : 0;
 }
 
-// sum_file_sizes_range scans one directory, selecting regular files whose
-// names compare in the bytewise interval [low, high). An empty bound is open.
-// queue_depth is both the ring size and the maximum number of outstanding
-// statx requests.
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+static int join_hash(char *out, size_t out_len, const char *prefix,
+			 const char *name) {
+	size_t prefix_len = strlen(prefix);
+	size_t name_len = strlen(name);
+	if (prefix_len + name_len + 1 > out_len) {
+		return -1;
+	}
+	memcpy(out, prefix, prefix_len);
+	memcpy(out + prefix_len, name, name_len + 1);
+	return 0;
+}
+
+static int join_path(char *out, size_t out_len, const char *dir,
+			 const char *name) {
+	size_t dir_len = strlen(dir);
+	size_t name_len = strlen(name);
+	int need_slash = (dir_len > 0 && dir[dir_len - 1] != '/');
+	if (dir_len + (size_t)need_slash + name_len + 1 > out_len) {
+		return -1;
+	}
+	memcpy(out, dir, dir_len);
+	size_t offset = dir_len;
+	if (need_slash) {
+		out[offset++] = '/';
+	}
+	memcpy(out + offset, name, name_len + 1);
+	return 0;
+}
+
+static int hash_in_range(const char *hash, const char *low, const char *high) {
+	if (low[0] != '\0' && strcmp(hash, low) <= 0) {
+		return 0;
+	}
+	if (high[0] != '\0' && strcmp(hash, high) > 0) {
+		return 0;
+	}
+	return 1;
+}
+
+static int subtree_can_match(const char *prefix, const char *low,
+				 const char *high) {
+	if (prefix[0] == '\0') {
+		return 1;
+	}
+	if (high[0] != '\0' && strcmp(prefix, high) > 0) {
+		return 0;
+	}
+	if (low[0] == '\0' || strcmp(prefix, low) >= 0) {
+		return 1;
+	}
+	return strncmp(low, prefix, strlen(prefix)) == 0;
+}
+
+static int sum_dir(const char *path, const char *prefix, const char *low,
+		       const char *high, unsigned queue_depth, uint64_t *total,
+		       uint64_t *files, uint64_t *vanished, char *err,
+		       size_t err_len);
+
+// sum_file_sizes_range walks the directory tree, selecting regular files whose
+// concatenated hash paths compare in the bytewise interval (low, high]. An
+// empty bound is open. queue_depth is both the ring size and the maximum
+// number of outstanding statx requests per directory.
 int sum_file_sizes_range(const char *path, const char *low,
 				const char *high, unsigned queue_depth,
 				uint64_t *total, uint64_t *files,
 				uint64_t *vanished, char *err, size_t err_len) {
-	DIR *directory = NULL;
-	struct io_uring ring;
-	struct sum_slot *slots = NULL;
-	int ring_ready = 0;
-	int status = -1;
-	int saved_errno;
-
 	*total = 0;
 	*files = 0;
 	*vanished = 0;
 	if (err != NULL && err_len != 0) {
 		err[0] = '\0';
 	}
-
 	if (queue_depth == 0) {
 		queue_depth = 128;
 	}
+	return sum_dir(path, "", low, high, queue_depth, total, files, vanished,
+		       err, err_len);
+}
+
+static int sum_dir(const char *path, const char *prefix, const char *low,
+		       const char *high, unsigned queue_depth, uint64_t *total,
+		       uint64_t *files, uint64_t *vanished, char *err,
+		       size_t err_len) {
+	DIR *directory = NULL;
+	struct io_uring ring;
+	struct sum_slot *slots = NULL;
+	int ring_ready = 0;
+	int status = -1;
+	int saved_errno;
+	int at_flags = AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT |
+		       AT_STATX_DONT_SYNC;
 
 	directory = opendir(path);
 	if (directory == NULL) {
@@ -198,8 +268,6 @@ int sum_file_sizes_range(const char *path, const char *low,
 		goto done;
 	}
 
-	int at_flags = AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT |
-		       AT_STATX_DONT_SYNC;
 	int reached_end = 0;
 
 	while (!reached_end) {
@@ -224,16 +292,79 @@ int sum_file_sizes_range(const char *path, const char *low,
 				continue;
 			}
 
-			if (low[0] != '\0' && strcmp(name, low) < 0) {
-				continue;
+			unsigned char dtype = entry->d_type;
+			if (dtype == DT_UNKNOWN) {
+				struct statx stx;
+				memset(&stx, 0, sizeof(stx));
+				if (statx(directory_fd, name, at_flags,
+					  STATX_TYPE | STATX_SIZE, &stx) != 0) {
+					if (errno == ENOENT) {
+						(*vanished)++;
+						continue;
+					}
+					set_error(err, err_len, "statx", name, errno);
+					goto done;
+				}
+				unsigned type = stx.stx_mode & S_IFMT;
+				if (type == S_IFDIR) {
+					dtype = DT_DIR;
+				} else if (type == S_IFREG) {
+					char hash[PATH_MAX];
+					if (join_hash(hash, sizeof(hash), prefix, name) != 0) {
+						snprintf(err, err_len, "hash path exceeds PATH_MAX: %s%s",
+							 prefix, name);
+						goto done;
+					}
+					if (!hash_in_range(hash, low, high)) {
+						continue;
+					}
+					if ((stx.stx_mask & STATX_SIZE) == 0) {
+						snprintf(err, err_len, "statx %s: filesystem did not return size",
+							 name);
+						goto done;
+					}
+					if (UINT64_MAX - *total < stx.stx_size) {
+						snprintf(err, err_len, "sum overflow at %s", name);
+						goto done;
+					}
+					*total += stx.stx_size;
+					(*files)++;
+					continue;
+				} else {
+					continue;
+				}
 			}
-			if (high[0] != '\0' && strcmp(name, high) >= 0) {
+
+			if (dtype == DT_DIR) {
+				char child_hash[PATH_MAX];
+				char child_path[PATH_MAX];
+				if (join_hash(child_hash, sizeof(child_hash), prefix, name) != 0 ||
+				    join_path(child_path, sizeof(child_path), path, name) != 0) {
+					snprintf(err, err_len, "path exceeds PATH_MAX under %s: %s",
+						 path, name);
+					goto done;
+				}
+				if (!subtree_can_match(child_hash, low, high)) {
+					continue;
+				}
+				if (sum_dir(child_path, child_hash, low, high, queue_depth,
+					    total, files, vanished, err, err_len) != 0) {
+					goto done;
+				}
 				continue;
 			}
 
-			// A filesystem may report DT_UNKNOWN, so those entries still
-			// need statx. Known non-regular entries can be skipped.
-			if (entry->d_type != DT_REG && entry->d_type != DT_UNKNOWN) {
+			if (dtype != DT_REG) {
+				continue;
+			}
+
+			char hash[PATH_MAX];
+			if (join_hash(hash, sizeof(hash), prefix, name) != 0) {
+				snprintf(err, err_len, "hash path exceeds PATH_MAX: %s%s",
+					 prefix, name);
+				goto done;
+			}
+			if (!hash_in_range(hash, low, high)) {
 				continue;
 			}
 
@@ -304,25 +435,19 @@ import "C"
 
 import (
 	"fmt"
-	"strings"
 	"unsafe"
 )
 
-// SumFileSizesRange sums logical file sizes for regular files immediately
-// within directory whose names compare in the bytewise interval [low, high).
+// SumFileSizesRange sums logical file sizes for regular files under directory
+// whose concatenated hash paths compare in the bytewise interval (low, high].
 // An empty low or high bound leaves that side of the interval open.
 //
 // QueueDepth controls the maximum number of outstanding io_uring statx
 // requests. Zero selects 128. This function makes one long cgo call; it does
 // not allocate Go objects per directory entry and cannot be canceled midway.
 func SumFileSizesRange(directory, low, high string, queueDepth uint32) (Result, error) {
-	if strings.IndexByte(directory, 0) >= 0 ||
-		strings.IndexByte(low, 0) >= 0 ||
-		strings.IndexByte(high, 0) >= 0 {
-		return Result{}, fmt.Errorf("sum file sizes: path and bounds cannot contain NUL bytes")
-	}
-	if queueDepth > 4096 {
-		return Result{}, fmt.Errorf("sum file sizes: queue depth %d exceeds 4096", queueDepth)
+	if err := checkSumArgs(directory, low, high, queueDepth); err != nil {
+		return Result{}, err
 	}
 
 	cDirectory := C.CString(directory)

--- a/lib/fs2/folderSize_test.go
+++ b/lib/fs2/folderSize_test.go
@@ -1,0 +1,64 @@
+//go:build (linux || darwin) && cgo
+
+package fs2
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSumFileSizesRange(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, "a"), 100)
+	writeFile(t, filepath.Join(dir, "b"), 200)
+	writeFile(t, filepath.Join(dir, "c"), 50)
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "subdir", "nested"), 999)
+	if err := os.Symlink(filepath.Join(dir, "a"), filepath.Join(dir, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := SumFileSizesRange(dir, "", "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Bytes != 350 || result.Files != 3 {
+		t.Fatalf("full range: got %+v, want 350 bytes / 3 files", result)
+	}
+
+	result, err = SumFileSizesRange(dir, "a", "c", 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Bytes != 300 || result.Files != 2 {
+		t.Fatalf("[a, c): got %+v, want 300 bytes / 2 files", result)
+	}
+
+	result, err = SumFileSizesRange(dir, "c", "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Bytes != 50 || result.Files != 1 {
+		t.Fatalf("[c, +inf): got %+v, want 50 bytes / 1 file", result)
+	}
+
+	empty := t.TempDir()
+	result, err = SumFileSizesRange(empty, "", "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Bytes != 0 || result.Files != 0 || result.Vanished != 0 {
+		t.Fatalf("empty dir: got %+v, want zero", result)
+	}
+}
+
+func writeFile(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/lib/fs2/folderSize_test.go
+++ b/lib/fs2/folderSize_test.go
@@ -1,5 +1,3 @@
-//go:build (linux || darwin) && cgo
-
 package fs2
 
 import (
@@ -26,24 +24,24 @@ func TestSumFileSizesRange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Bytes != 350 || result.Files != 3 {
-		t.Fatalf("full range: got %+v, want 350 bytes / 3 files", result)
+	if result.Bytes != 1349 || result.Files != 4 {
+		t.Fatalf("full range: got %+v, want 1349 bytes / 4 files", result)
 	}
 
 	result, err = SumFileSizesRange(dir, "a", "c", 8)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Bytes != 300 || result.Files != 2 {
-		t.Fatalf("[a, c): got %+v, want 300 bytes / 2 files", result)
+	if result.Bytes != 250 || result.Files != 2 {
+		t.Fatalf("(a, c]: got %+v, want 250 bytes / 2 files", result)
 	}
 
-	result, err = SumFileSizesRange(dir, "c", "", 1)
+	result, err = SumFileSizesRange(dir, "b", "", 1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Bytes != 50 || result.Files != 1 {
-		t.Fatalf("[c, +inf): got %+v, want 50 bytes / 1 file", result)
+	if result.Bytes != 1049 || result.Files != 2 {
+		t.Fatalf("(b, +inf]: got %+v, want 1049 bytes / 2 files", result)
 	}
 
 	empty := t.TempDir()
@@ -53,6 +51,100 @@ func TestSumFileSizesRange(t *testing.T) {
 	}
 	if result.Bytes != 0 || result.Files != 0 || result.Vanished != 0 {
 		t.Fatalf("empty dir: got %+v, want zero", result)
+	}
+
+	if _, err := SumFileSizesRange("dir\x00", "", "", 0); err == nil {
+		t.Fatal("expected error for NUL in path")
+	}
+	if _, err := SumFileSizesRange(".", "", "", 4097); err == nil {
+		t.Fatal("expected error for queue depth over 4096")
+	}
+}
+
+func TestConcatenatedHashPath(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "ab"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "ab", "cdefg"), 42)
+	if err := os.MkdirAll(filepath.Join(dir, "xy", "zt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "xy", "zt", "uvw"), 9)
+
+	result, err := SumFileSizesRange(dir, "abcdefe", "abcdefg", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Bytes != 42 || result.Files != 1 {
+		t.Fatalf("(abcdefe, abcdefg]: got %+v, want 42 bytes / 1 file", result)
+	}
+
+	result, err = SumFileSizesRange(dir, "abcdefg", "abcdefh", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Bytes != 0 || result.Files != 0 {
+		t.Fatalf("(abcdefg, abcdefh]: got %+v, want empty (exclusive low)", result)
+	}
+
+	result, err = SumFileSizesRange(dir, "ab", "ac", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Bytes != 42 || result.Files != 1 {
+		t.Fatalf("(ab, ac]: got %+v, want 42 bytes / 1 file", result)
+	}
+
+	result, err = SumFileSizesRange(dir, "xyztuvv", "xyztuvw", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Bytes != 9 || result.Files != 1 {
+		t.Fatalf("xy/zt/uvw hash: got %+v, want 9 bytes / 1 file", result)
+	}
+}
+
+func TestSubtreePrune(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "zz"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "zz", "file"), 100)
+	writeFile(t, filepath.Join(dir, "a"), 7)
+
+	result, err := SumFileSizesRange(dir, "", "a", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Bytes != 7 || result.Files != 1 {
+		t.Fatalf("('', a]: got %+v, want only root file a", result)
+	}
+}
+
+func TestHashHelpers(t *testing.T) {
+	if got := hashFromRel("ab/cdefg"); got != "abcdefg" {
+		t.Fatalf("hashFromRel(ab/cdefg)=%q", got)
+	}
+	if got := hashFromRel("ab/cd/efg"); got != "abcdefg" {
+		t.Fatalf("hashFromRel(ab/cd/efg)=%q", got)
+	}
+
+	if !hashInRange("abcdefg", "abcdefe", "abcdefg") {
+		t.Fatal("abcdefg should be in (abcdefe, abcdefg]")
+	}
+	if hashInRange("abcdefg", "abcdefg", "abcdefh") {
+		t.Fatal("abcdefg should not be in (abcdefg, abcdefh]")
+	}
+
+	if !subtreeCanMatch("ab", "abcdefe", "abcdefg") {
+		t.Fatal("prefix ab can match (abcdefe, abcdefg]")
+	}
+	if subtreeCanMatch("zz", "", "a") {
+		t.Fatal("prefix zz cannot match ('', a]")
+	}
+	if subtreeCanMatch("aa", "b", "") {
+		t.Fatal("prefix aa cannot match (b, +inf]")
 	}
 }
 

--- a/lib/hashspacesolver/slice.go
+++ b/lib/hashspacesolver/slice.go
@@ -1,0 +1,145 @@
+package hashspacesolver
+
+import (
+	"bytes"
+	"math/big"
+)
+
+// SliceSize returns how much of r's data lies in (startHash, endHash].
+// startHash is the EndHash of the preceding range. Data is treated as
+// uniform across the hash interval. The full range is SliceSize(r, start, r.EndHash).
+func SliceSize(r Range, startHash, endHash []byte) int64 {
+	if r.Size <= 0 || len(r.EndHash) == 0 {
+		return 0
+	}
+	if bytes.Equal(endHash, r.EndHash) {
+		return r.Size
+	}
+	if bytes.Equal(endHash, startHash) {
+		return 0
+	}
+
+	total := interval(startHash, r.EndHash)
+	part := interval(startHash, endHash)
+	if total.Sign() == 0 {
+		return 0
+	}
+	n := new(big.Int).Mul(big.NewInt(r.Size), part)
+	return n.Div(n, total).Int64()
+}
+
+// StartHash returns the start of ranges[i] (the previous range's EndHash).
+func StartHash(ranges []Range, i int) []byte {
+	n := len(ranges)
+	if n == 0 || i < 0 || i >= n {
+		return nil
+	}
+	return cloneHash(ranges[(i-1+n)%n].EndHash)
+}
+
+func splitHash(r Range, startHash []byte, prefixSize int64) []byte {
+	return splitHashBound(r, startHash, prefixSize, false)
+}
+
+func splitHashMin(r Range, startHash []byte, prefixSize int64) []byte {
+	return splitHashBound(r, startHash, prefixSize, true)
+}
+
+func splitHashBound(r Range, startHash []byte, prefixSize int64, ceil bool) []byte {
+	if prefixSize <= 0 {
+		return cloneHash(startHash)
+	}
+	if prefixSize >= r.Size {
+		return cloneHash(r.EndHash)
+	}
+	total := interval(startHash, r.EndHash)
+	if total.Sign() == 0 {
+		return cloneHash(r.EndHash)
+	}
+	delta := new(big.Int).Mul(total, big.NewInt(prefixSize))
+	if ceil {
+		delta.Add(delta, big.NewInt(r.Size-1))
+	}
+	delta.Div(delta, big.NewInt(r.Size))
+	if delta.Cmp(total) >= 0 {
+		return cloneHash(r.EndHash)
+	}
+	if delta.Sign() == 0 && ceil {
+		delta.SetInt64(1)
+	}
+	return addHash(startHash, delta)
+}
+
+func interval(from, to []byte) *big.Int {
+	n := hashLen(from, to)
+	if n == 0 {
+		return new(big.Int)
+	}
+	space := hashSpace(n)
+	a := hashInt(from, n)
+	b := hashInt(to, n)
+	if a.Cmp(b) == 0 {
+		return space
+	}
+	d := new(big.Int).Sub(b, a)
+	if d.Sign() < 0 {
+		d.Add(d, space)
+	}
+	return d
+}
+
+func hashLen(a, b []byte) int {
+	if len(a) > len(b) {
+		return len(a)
+	}
+	return len(b)
+}
+
+func hashSpace(n int) *big.Int {
+	return new(big.Int).Lsh(big.NewInt(1), uint(8*n))
+}
+
+func hashInt(h []byte, n int) *big.Int {
+	if len(h) >= n {
+		return new(big.Int).SetBytes(h[len(h)-n:])
+	}
+	padded := make([]byte, n)
+	copy(padded[n-len(h):], h)
+	return new(big.Int).SetBytes(padded)
+}
+
+func addHash(start []byte, delta *big.Int) []byte {
+	n := len(start)
+	if n == 0 {
+		return nil
+	}
+	space := hashSpace(n)
+	v := hashInt(start, n)
+	v.Add(v, delta)
+	v.Mod(v, space)
+	return intHash(v, n)
+}
+
+func intHash(v *big.Int, n int) []byte {
+	raw := v.Bytes()
+	out := make([]byte, n)
+	if len(raw) > n {
+		copy(out, raw[len(raw)-n:])
+		return out
+	}
+	copy(out[n-len(raw):], raw)
+	return out
+}
+
+func cloneHash(h []byte) []byte {
+	if h == nil {
+		return nil
+	}
+	out := make([]byte, len(h))
+	copy(out, h)
+	return out
+}
+
+func hashEq(a, b []byte) bool {
+	return bytes.Equal(a, b)
+}

--- a/lib/hashspacesolver/slice_test.go
+++ b/lib/hashspacesolver/slice_test.go
@@ -1,0 +1,42 @@
+package hashspacesolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSliceSizeLinear(t *testing.T) {
+	r := Range{EndHash: []byte{0x40}, Size: 64}
+	start := []byte{0x00}
+	require.Equal(t, int64(64), SliceSize(r, start, []byte{0x40}))
+	require.Equal(t, int64(0), SliceSize(r, start, []byte{0x00}))
+	require.Equal(t, int64(32), SliceSize(r, start, []byte{0x20}))
+	require.Equal(t, int64(16), SliceSize(r, start, []byte{0x10}))
+}
+
+func TestSliceSizeWrap(t *testing.T) {
+	r := Range{EndHash: []byte{0x40}, Size: 128}
+	start := []byte{0xC0}
+	// (0xC0, 0x40] is 128 hash units; half is 0x00.
+	require.Equal(t, int64(128), SliceSize(r, start, []byte{0x40}))
+	require.Equal(t, int64(64), SliceSize(r, start, []byte{0x00}))
+}
+
+func TestSliceSizeFullCircle(t *testing.T) {
+	r := Range{EndHash: []byte{0x80}, Size: 80}
+	start := []byte{0x80}
+	require.Equal(t, int64(80), SliceSize(r, start, []byte{0x80}))
+	require.Equal(t, int64(40), SliceSize(r, start, splitHash(r, start, 40)))
+}
+
+func TestStartHash(t *testing.T) {
+	ranges := []Range{
+		{EndHash: []byte{0x10}, Size: 1},
+		{EndHash: []byte{0x30}, Size: 1},
+		{EndHash: []byte{0xFF}, Size: 1},
+	}
+	require.Equal(t, []byte{0xFF}, StartHash(ranges, 0))
+	require.Equal(t, []byte{0x10}, StartHash(ranges, 1))
+	require.Equal(t, []byte{0x30}, StartHash(ranges, 2))
+}

--- a/lib/hashspacesolver/solve.go
+++ b/lib/hashspacesolver/solve.go
@@ -1,0 +1,550 @@
+package hashspacesolver
+
+import (
+	"golang.org/x/xerrors"
+)
+
+// Solve computes a minimum-movement plan for a disk arriving, filling, or
+// vacating. The resulting assignment keeps every active disk at or under
+// capacity and at or under MAX_RANGES_PER_DISK contiguous ranges.
+//
+// Cost is lexicographic: fewer bytes moved, then fewer moves. Cuts are
+// whole ranges or SliceSize prefixes/suffixes. Hash space is a circle.
+func Solve(state State, event Event) (Plan, error) {
+	w, err := newWorld(state)
+	if err != nil {
+		return Plan{}, err
+	}
+	if event.Disk < 0 || event.Disk >= len(w.disks) {
+		return Plan{}, xerrors.Errorf("unknown event disk %d", event.Disk)
+	}
+
+	switch event.Kind {
+	case EventArrive:
+		if err := w.repair(); err != nil {
+			return Plan{}, err
+		}
+		w.arrive(event.Disk)
+	case EventFull:
+		if err := w.repair(); err != nil {
+			return Plan{}, err
+		}
+		if err := w.shed(event.Disk); err != nil {
+			return Plan{}, err
+		}
+	case EventVacate:
+		if err := w.vacate(event.Disk); err != nil {
+			return Plan{}, err
+		}
+	default:
+		return Plan{}, xerrors.Errorf("unknown event kind %d", event.Kind)
+	}
+
+	if err := w.repair(); err != nil {
+		return Plan{}, err
+	}
+	if err := w.checkSolved(event); err != nil {
+		return Plan{}, err
+	}
+	return w.plan(), nil
+}
+
+// Validate reports whether state is structurally sound and satisfies capacity
+// and range-count limits.
+func Validate(state State) error {
+	w, err := newWorld(state)
+	if err != nil {
+		return err
+	}
+	return w.checkLimits()
+}
+
+// Apply returns a copy of state with plan applied.
+func Apply(state State, plan Plan) (State, error) {
+	w, err := newWorld(state)
+	if err != nil {
+		return State{}, err
+	}
+	for i, m := range plan.Moves {
+		if err := w.replay(m); err != nil {
+			return State{}, xerrors.Errorf("move %d: %w", i, err)
+		}
+	}
+	return w.snapshot(), nil
+}
+
+func (w *world) replay(m Move) error {
+	if m.To < 0 || m.To >= len(w.disks) {
+		return xerrors.Errorf("unknown dest disk %d", m.To)
+	}
+	idx := w.find(m.EndHash)
+	if idx < 0 {
+		return xerrors.Errorf("no range ending at %x", m.EndHash)
+	}
+	from := w.owner[idx]
+	if m.From != from {
+		return xerrors.Errorf("range is on disk %d, not %d", from, m.From)
+	}
+	if m.Split == nil || hashEq(m.Split, m.EndHash) {
+		w.moveWholeSilent(idx, m.To)
+		return nil
+	}
+	if m.Size <= 0 || m.Size >= w.ranges[idx].Size {
+		return xerrors.Errorf("invalid slice size %d", m.Size)
+	}
+	if m.Prefix {
+		w.ranges[idx].Size -= m.Size
+		w.used[from] -= m.Size
+		w.insert(idx, Range{EndHash: cloneHash(m.Split), Size: m.Size}, m.To)
+	} else {
+		end := cloneHash(w.ranges[idx].EndHash)
+		w.ranges[idx].EndHash = cloneHash(m.Split)
+		w.ranges[idx].Size -= m.Size
+		w.used[from] -= m.Size
+		w.insert(idx+1, Range{EndHash: end, Size: m.Size}, m.To)
+	}
+	w.merge()
+	return nil
+}
+
+func (w *world) moveWholeSilent(idx, dest int) {
+	from := w.owner[idx]
+	if from == dest {
+		return
+	}
+	sz := w.ranges[idx].Size
+	w.owner[idx] = dest
+	w.used[from] -= sz
+	w.used[dest] += sz
+	w.merge()
+}
+
+func (w *world) checkLimits() error {
+	for _, d := range w.activeDisks() {
+		if w.used[d] > w.disks[d] {
+			return xerrors.Errorf("disk %d used %d exceeds size %d", d, w.used[d], w.disks[d])
+		}
+		if rc := w.rangeCount(d); rc > MAX_RANGES_PER_DISK {
+			return xerrors.Errorf("disk %d holds %d ranges, max %d", d, rc, MAX_RANGES_PER_DISK)
+		}
+	}
+	return nil
+}
+
+func (w *world) checkSolved(event Event) error {
+	if err := w.checkLimits(); err != nil {
+		return err
+	}
+	switch event.Kind {
+	case EventVacate:
+		if w.used[event.Disk] != 0 {
+			return xerrors.Errorf("disk %d was not emptied", event.Disk)
+		}
+	case EventFull:
+		if w.used[event.Disk] > w.disks[event.Disk] {
+			return xerrors.Errorf("disk %d still over capacity", event.Disk)
+		}
+	}
+	return nil
+}
+
+type candidate struct {
+	idx, kind, dest int
+	size            int64
+	dlt             int
+	over            int64
+}
+
+func (w *world) repair() error {
+	for guard := 0; guard < len(w.ranges)+len(w.disks)+8; guard++ {
+		var over []int
+		for _, d := range w.activeDisks() {
+			if w.rangeCount(d) > MAX_RANGES_PER_DISK {
+				over = append(over, d)
+			}
+		}
+		if len(over) == 0 {
+			return nil
+		}
+		progress := false
+		for _, d := range over {
+			if w.donateRange(d) {
+				progress = true
+				break
+			}
+		}
+		if !progress {
+			return xerrors.New("range repair did not converge")
+		}
+	}
+	return xerrors.New("range repair did not converge")
+}
+
+func (w *world) donateRange(src int) bool {
+	idxs := w.rangeIndexes(src)
+	if len(idxs) <= MAX_RANGES_PER_DISK {
+		return false
+	}
+	var best *candidate
+	for _, idx := range idxs {
+		sz := w.ranges[idx].Size
+		for _, dest := range w.activeDisks() {
+			if !w.canTake(idx, cutWhole, dest, sz) {
+				continue
+			}
+			c := candidate{idx: idx, kind: cutWhole, dest: dest, size: sz, dlt: w.destDelta(idx, cutWhole, dest)}
+			if best == nil || c.size < best.size || (c.size == best.size && (c.dlt < best.dlt || (c.dlt == best.dlt && c.dest < best.dest))) {
+				cp := c
+				best = &cp
+			}
+		}
+	}
+	if best != nil {
+		w.applyCut(best.idx, best.kind, best.dest, best.size)
+		return true
+	}
+	smallest := idxs[0]
+	for _, idx := range idxs[1:] {
+		if w.ranges[idx].Size < w.ranges[smallest].Size {
+			smallest = idx
+		}
+	}
+	return w.splitOntoOthers(smallest, src)
+}
+
+func (w *world) arrive(newDisk int) {
+	target := w.fairShare(newDisk)
+	if target <= 0 || w.used[newDisk] >= target {
+		return
+	}
+	for guard := 0; guard < len(w.ranges)+4; guard++ {
+		need := target - w.used[newDisk]
+		if need <= 0 {
+			return
+		}
+		cut, ok := w.bestSteal(newDisk, need)
+		if !ok {
+			return
+		}
+		w.applyCut(cut.idx, cut.kind, newDisk, cut.size)
+	}
+}
+
+func (w *world) bestSteal(newDisk int, need int64) (candidate, bool) {
+	var best *candidate
+	for _, src := range w.activeDisks() {
+		if src == newDisk {
+			continue
+		}
+		excess := w.used[src] - w.fairShare(src)
+		if excess <= 0 {
+			continue
+		}
+		for _, idx := range w.rangeIndexes(src) {
+			for _, c := range w.sizedCuts(idx, need, excess, newDisk) {
+				c.over = excess
+				c.dest = newDisk
+				if best == nil || betterSteal(c, *best, need) {
+					cp := c
+					best = &cp
+				}
+			}
+		}
+	}
+	if best == nil {
+		return candidate{}, false
+	}
+	return *best, true
+}
+
+func (w *world) sizedCuts(idx int, need, limit int64, dest int) []candidate {
+	sz := w.ranges[idx].Size
+	if sz <= 0 {
+		return nil
+	}
+	var out []candidate
+	add := func(kind int, size int64) {
+		if size <= 0 || size > sz {
+			return
+		}
+		if kind != cutWhole {
+			_, size = w.cutActual(idx, kind, size)
+			if size <= 0 || size >= sz {
+				return
+			}
+		}
+		if !w.canTake(idx, kind, dest, size) {
+			return
+		}
+		out = append(out, candidate{
+			idx:  idx,
+			kind: kind,
+			dest: dest,
+			size: size,
+			dlt:  w.destDelta(idx, kind, dest),
+		})
+	}
+	add(cutWhole, sz)
+	want := need
+	if limit > 0 && limit < want {
+		want = limit
+	}
+	if destFree := w.free(dest); destFree < want {
+		want = destFree
+	}
+	if want > 0 && want < sz {
+		add(cutPrefix, want)
+		add(cutSuffix, want)
+	}
+	return out
+}
+
+func betterSteal(a, b candidate, need int64) bool {
+	aFit, bFit := a.size <= need, b.size <= need
+	if aFit != bFit {
+		return aFit
+	}
+	aKeep, bKeep := a.size <= a.over, b.size <= b.over
+	if aKeep != bKeep {
+		return aKeep
+	}
+	aAbs, bAbs := a.dlt <= 0, b.dlt <= 0
+	if aAbs != bAbs {
+		return aAbs
+	}
+	if a.size != b.size {
+		if aFit {
+			return a.size > b.size
+		}
+		return a.size < b.size
+	}
+	if a.over != b.over {
+		return a.over > b.over
+	}
+	if a.dlt != b.dlt {
+		return a.dlt < b.dlt
+	}
+	if a.idx != b.idx {
+		return a.idx < b.idx
+	}
+	return a.kind < b.kind
+}
+
+func (w *world) shed(full int) error {
+	if w.frozen[full] {
+		return xerrors.Errorf("cannot shed from vacated disk %d", full)
+	}
+	for guard := 0; guard < len(w.ranges)+4; guard++ {
+		need := w.used[full] - w.disks[full]
+		if need <= 0 {
+			return nil
+		}
+		cut, ok := w.bestShed(full, need)
+		if !ok {
+			if w.makeRoom(full) {
+				continue
+			}
+			return xerrors.Errorf("cannot shed %d bytes from disk %d", need, full)
+		}
+		w.applyCut(cut.idx, cut.kind, cut.dest, cut.size)
+	}
+	if w.used[full] > w.disks[full] {
+		return xerrors.Errorf("cannot shed enough from disk %d", full)
+	}
+	return nil
+}
+
+func (w *world) bestShed(full int, need int64) (candidate, bool) {
+	var best *candidate
+	for _, idx := range w.rangeIndexes(full) {
+		for _, dest := range w.activeDisks() {
+			if dest == full {
+				continue
+			}
+			for _, c := range w.sizedCuts(idx, need, w.ranges[idx].Size, dest) {
+				if best == nil || betterShed(c, *best, need) {
+					cp := c
+					best = &cp
+				}
+			}
+		}
+	}
+	if best == nil {
+		return candidate{}, false
+	}
+	return *best, true
+}
+
+func betterShed(a, b candidate, need int64) bool {
+	aCov, bCov := a.size >= need, b.size >= need
+	if aCov != bCov {
+		return aCov
+	}
+	if a.size != b.size {
+		if aCov {
+			return a.size < b.size
+		}
+		return a.size > b.size
+	}
+	if a.dlt != b.dlt {
+		return a.dlt < b.dlt
+	}
+	if a.dest != b.dest {
+		return a.dest < b.dest
+	}
+	return a.idx < b.idx
+}
+
+func (w *world) vacate(id int) error {
+	w.frozen[id] = true
+	if w.used[id] == 0 {
+		return nil
+	}
+	if w.totalCapacity() < w.totalUsed() {
+		return xerrors.Errorf("not enough remaining capacity to vacate disk %d", id)
+	}
+
+	for guard := 0; guard < len(w.ranges)+8; guard++ {
+		idxs := w.rangeIndexes(id)
+		if len(idxs) == 0 {
+			return nil
+		}
+		best := idxs[0]
+		for _, idx := range idxs[1:] {
+			if w.ranges[idx].Size > w.ranges[best].Size || (w.ranges[idx].Size == w.ranges[best].Size && idx < best) {
+				best = idx
+			}
+		}
+		if w.placeRange(best, id) {
+			continue
+		}
+		if w.makeRoom(id) && w.placeRange(best, id) {
+			continue
+		}
+		return xerrors.Errorf("cannot place range on disk %d elsewhere", id)
+	}
+	if w.used[id] != 0 {
+		return xerrors.Errorf("failed to vacate disk %d", id)
+	}
+	return nil
+}
+
+func (w *world) placeRange(idx, src int) bool {
+	if idx < 0 || idx >= len(w.ranges) || w.owner[idx] != src {
+		return true
+	}
+	sz := w.ranges[idx].Size
+	left, right, okL, okR := w.neighbors(idx)
+
+	if okL && okR && left == right && w.canTake(idx, cutWhole, left, sz) {
+		w.moveWhole(idx, left)
+		return true
+	}
+
+	var best *candidate
+	consider := func(dest int) {
+		if !w.canTake(idx, cutWhole, dest, sz) {
+			return
+		}
+		c := candidate{idx: idx, kind: cutWhole, dest: dest, size: sz, dlt: w.destDelta(idx, cutWhole, dest), over: w.free(dest)}
+		if best == nil || c.dlt < best.dlt || (c.dlt == best.dlt && (c.over > best.over || (c.over == best.over && c.dest < best.dest))) {
+			cp := c
+			best = &cp
+		}
+	}
+	if okL {
+		consider(left)
+	}
+	if okR {
+		consider(right)
+	}
+	for _, dest := range w.activeDisks() {
+		consider(dest)
+	}
+	if best != nil {
+		w.moveWhole(idx, best.dest)
+		return true
+	}
+
+	if okL && okR && left != right {
+		end := cloneHash(w.ranges[idx].EndHash)
+		pref := min(w.free(left), sz)
+		if pref > 0 && w.canTake(idx, cutPrefix, left, pref) {
+			if pref >= sz {
+				w.moveWhole(idx, left)
+				return true
+			}
+			w.applyCut(idx, cutPrefix, left, pref)
+			idx = w.find(end)
+			if idx >= 0 && w.owner[idx] == src && w.canTake(idx, cutWhole, right, w.ranges[idx].Size) {
+				w.moveWhole(idx, right)
+				return true
+			}
+		}
+	}
+
+	return w.splitOntoOthers(idx, src)
+}
+
+func (w *world) splitOntoOthers(idx, src int) bool {
+	if idx < 0 || idx >= len(w.ranges) || w.owner[idx] != src {
+		return true
+	}
+	end := cloneHash(w.ranges[idx].EndHash)
+	for w.find(end) >= 0 && w.owner[w.find(end)] == src {
+		idx = w.find(end)
+		remain := w.ranges[idx].Size
+		var best *candidate
+		for _, dest := range w.activeDisks() {
+			if dest == src {
+				continue
+			}
+			take := min(remain, w.free(dest))
+			for _, kind := range []int{cutPrefix, cutWhole} {
+				sz := take
+				if kind == cutWhole {
+					sz = remain
+				}
+				if sz <= 0 || !w.canTake(idx, kind, dest, sz) {
+					continue
+				}
+				c := candidate{idx: idx, kind: kind, dest: dest, size: sz, dlt: w.destDelta(idx, kind, dest)}
+				if best == nil || c.dlt < best.dlt || (c.dlt == best.dlt && (c.size > best.size || (c.size == best.size && c.dest < best.dest))) {
+					cp := c
+					best = &cp
+				}
+			}
+		}
+		if best == nil {
+			return false
+		}
+		w.applyCut(best.idx, best.kind, best.dest, best.size)
+	}
+	return w.find(end) < 0 || w.owner[w.find(end)] != src
+}
+
+func (w *world) makeRoom(avoid int) bool {
+	for _, src := range w.activeDisks() {
+		if src != avoid && w.rangeCount(src) >= MAX_RANGES_PER_DISK && w.donateRange(src) {
+			return true
+		}
+	}
+	fullest := -1
+	for _, src := range w.activeDisks() {
+		if src == avoid || w.used[src] == 0 {
+			continue
+		}
+		if fullest < 0 || w.used[src] > w.used[fullest] || (w.used[src] == w.used[fullest] && src < fullest) {
+			fullest = src
+		}
+	}
+	if fullest < 0 {
+		return false
+	}
+	cut, ok := w.bestShed(fullest, 1)
+	if !ok {
+		return false
+	}
+	w.applyCut(cut.idx, cut.kind, cut.dest, cut.size)
+	return true
+}

--- a/lib/hashspacesolver/solve.go
+++ b/lib/hashspacesolver/solve.go
@@ -1,56 +1,67 @@
 package hashspacesolver
 
 import (
+	"bytes"
+
 	"golang.org/x/xerrors"
 )
 
-// Solve computes a minimum-movement plan for a disk arriving, filling, or
+// Solve computes a minimum-movement target for a disk arriving, filling, or
 // vacating. The resulting assignment keeps every active disk at or under
-// capacity and at or under MAX_RANGES_PER_DISK contiguous ranges.
+// capacity and at or under MAX_RANGES_PER_DISK contiguous ranges per space.
 //
-// Cost is lexicographic: fewer bytes moved, then fewer moves. Cuts are
-// whole ranges or SliceSize prefixes/suffixes. Hash space is a circle.
-func Solve(state State, event Event) (Plan, error) {
+// Cost is lexicographic: fewer bytes moved, then fewer moves. Cuts may come
+// from any space. Hash space within each Space is a circle.
+//
+// Result.State is the finished layout. Result.Diff is an order-independent
+// list of absolute interval transfers for delayed application.
+func Solve(state State, event Event) (Result, error) {
 	w, err := newWorld(state)
 	if err != nil {
-		return Plan{}, err
+		return Result{}, err
 	}
 	if event.Disk < 0 || event.Disk >= len(w.disks) {
-		return Plan{}, xerrors.Errorf("unknown event disk %d", event.Disk)
+		return Result{}, xerrors.Errorf("unknown event disk %d", event.Disk)
 	}
 
 	switch event.Kind {
 	case EventArrive:
 		if err := w.repair(); err != nil {
-			return Plan{}, err
+			return Result{}, err
 		}
 		w.arrive(event.Disk)
 	case EventFull:
 		if err := w.repair(); err != nil {
-			return Plan{}, err
+			return Result{}, err
 		}
 		if err := w.shed(event.Disk); err != nil {
-			return Plan{}, err
+			return Result{}, err
 		}
 	case EventVacate:
 		if err := w.vacate(event.Disk); err != nil {
-			return Plan{}, err
+			return Result{}, err
 		}
 	default:
-		return Plan{}, xerrors.Errorf("unknown event kind %d", event.Kind)
+		return Result{}, xerrors.Errorf("unknown event kind %d", event.Kind)
 	}
 
 	if err := w.repair(); err != nil {
-		return Plan{}, err
+		return Result{}, err
 	}
 	if err := w.checkSolved(event); err != nil {
-		return Plan{}, err
+		return Result{}, err
 	}
-	return w.plan(), nil
+
+	diff := mergeTransfers(w.diff)
+	var bytes int64
+	for _, t := range diff {
+		bytes += t.Size
+	}
+	return Result{State: w.snapshot(), Diff: diff, BytesMoved: bytes}, nil
 }
 
 // Validate reports whether state is structurally sound and satisfies capacity
-// and range-count limits.
+// and per-space range-count limits.
 func Validate(state State) error {
 	w, err := newWorld(state)
 	if err != nil {
@@ -59,64 +70,178 @@ func Validate(state State) error {
 	return w.checkLimits()
 }
 
-// Apply returns a copy of state with plan applied.
-func Apply(state State, plan Plan) (State, error) {
+// Apply returns a copy of state with all transfers applied. Transfers may be
+// applied in any order when they are disjoint within a space.
+func Apply(state State, diff []Transfer) (State, error) {
 	w, err := newWorld(state)
 	if err != nil {
 		return State{}, err
 	}
-	for i, m := range plan.Moves {
-		if err := w.replay(m); err != nil {
-			return State{}, xerrors.Errorf("move %d: %w", i, err)
+	for i, t := range diff {
+		if err := w.applyTransfer(t); err != nil {
+			return State{}, xerrors.Errorf("transfer %d: %w", i, err)
 		}
 	}
 	return w.snapshot(), nil
 }
 
-func (w *world) replay(m Move) error {
-	if m.To < 0 || m.To >= len(w.disks) {
-		return xerrors.Errorf("unknown dest disk %d", m.To)
+func (w *world) applyTransfer(t Transfer) error {
+	if t.Space < 0 || t.Space >= len(w.spaces) {
+		return xerrors.Errorf("unknown space %d", t.Space)
 	}
-	idx := w.find(m.EndHash)
-	if idx < 0 {
-		return xerrors.Errorf("no range ending at %x", m.EndHash)
+	if t.To < 0 || t.To >= len(w.disks) {
+		return xerrors.Errorf("unknown dest disk %d", t.To)
 	}
-	from := w.owner[idx]
-	if m.From != from {
-		return xerrors.Errorf("range is on disk %d, not %d", from, m.From)
-	}
-	if m.Split == nil || hashEq(m.Split, m.EndHash) {
-		w.moveWholeSilent(idx, m.To)
+	if t.Size <= 0 {
 		return nil
 	}
-	if m.Size <= 0 || m.Size >= w.ranges[idx].Size {
-		return xerrors.Errorf("invalid slice size %d", m.Size)
+	sp := &w.spaces[t.Space]
+	idx := -1
+	for i, r := range sp.ranges {
+		start := StartHash(sp.ranges, i)
+		if coversInterval(start, r.EndHash, t.StartHash, t.EndHash) {
+			idx = i
+			break
+		}
 	}
-	if m.Prefix {
-		w.ranges[idx].Size -= m.Size
-		w.used[from] -= m.Size
-		w.insert(idx, Range{EndHash: cloneHash(m.Split), Size: m.Size}, m.To)
-	} else {
-		end := cloneHash(w.ranges[idx].EndHash)
-		w.ranges[idx].EndHash = cloneHash(m.Split)
-		w.ranges[idx].Size -= m.Size
-		w.used[from] -= m.Size
-		w.insert(idx+1, Range{EndHash: end, Size: m.Size}, m.To)
+	if idx < 0 {
+		return xerrors.Errorf("no range covering (%x, %x]", t.StartHash, t.EndHash)
 	}
-	w.merge()
-	return nil
+	from := sp.owner[idx]
+	if t.From >= 0 && from != t.From {
+		return xerrors.Errorf("interval owned by %d, want %d", from, t.From)
+	}
+	r := sp.ranges[idx]
+	start := StartHash(sp.ranges, idx)
+	if hashEq(t.StartHash, start) && hashEq(t.EndHash, r.EndHash) {
+		if t.Size != r.Size && t.Size > 0 {
+			// whole-range move; size should match but tolerate after merges
+		}
+		w.moveWholeSilent(t.Space, idx, t.To)
+		return nil
+	}
+	if hashEq(t.StartHash, start) {
+		if t.Size >= r.Size {
+			w.moveWholeSilent(t.Space, idx, t.To)
+			return nil
+		}
+		w.splitMovePrefix(t.Space, idx, t.EndHash, t.Size, t.To)
+		return nil
+	}
+	if hashEq(t.EndHash, r.EndHash) {
+		if t.Size >= r.Size {
+			w.moveWholeSilent(t.Space, idx, t.To)
+			return nil
+		}
+		w.splitMoveSuffix(t.Space, idx, t.StartHash, t.Size, t.To)
+		return nil
+	}
+	return xerrors.Errorf("transfer must be a prefix, suffix, or whole of one range")
 }
 
-func (w *world) moveWholeSilent(idx, dest int) {
-	from := w.owner[idx]
+func coversInterval(rStart, rEnd, tStart, tEnd []byte) bool {
+	// Full-circle transfer: start == end means the whole circle.
+	if hashEq(tStart, tEnd) {
+		return hashEq(rStart, rEnd) && hashEq(rStart, tStart)
+	}
+	okStart := hashEq(tStart, rStart) || pointInArc(rStart, rEnd, tStart)
+	okEnd := hashEq(tEnd, rEnd) || pointInArc(rStart, rEnd, tEnd)
+	return okStart && okEnd
+}
+
+func pointInArc(start, end, p []byte) bool {
+	if hashEq(start, end) {
+		return !hashEq(p, start)
+	}
+	if bytes.Compare(start, end) < 0 {
+		return bytes.Compare(start, p) < 0 && bytes.Compare(p, end) <= 0
+	}
+	return bytes.Compare(start, p) < 0 || bytes.Compare(p, end) <= 0
+}
+
+func (w *world) moveWholeSilent(space, idx, dest int) {
+	sp := &w.spaces[space]
+	from := sp.owner[idx]
 	if from == dest {
 		return
 	}
-	sz := w.ranges[idx].Size
-	w.owner[idx] = dest
+	sz := sp.ranges[idx].Size
+	sp.owner[idx] = dest
 	w.used[from] -= sz
 	w.used[dest] += sz
-	w.merge()
+	w.mergeSpace(space)
+}
+
+func (w *world) splitMovePrefix(space, idx int, split []byte, size int64, dest int) {
+	sp := &w.spaces[space]
+	from := sp.owner[idx]
+	r := sp.ranges[idx]
+	if size >= r.Size {
+		w.moveWholeSilent(space, idx, dest)
+		return
+	}
+	sp.ranges[idx].Size -= size
+	w.used[from] -= size
+	w.insert(space, idx, Range{EndHash: cloneHash(split), Size: size}, dest)
+	w.mergeSpace(space)
+}
+
+func (w *world) splitMoveSuffix(space, idx int, split []byte, size int64, dest int) {
+	sp := &w.spaces[space]
+	from := sp.owner[idx]
+	r := sp.ranges[idx]
+	if size >= r.Size {
+		w.moveWholeSilent(space, idx, dest)
+		return
+	}
+	end := cloneHash(r.EndHash)
+	sp.ranges[idx].EndHash = cloneHash(split)
+	sp.ranges[idx].Size -= size
+	w.used[from] -= size
+	w.insert(space, idx+1, Range{EndHash: end, Size: size}, dest)
+	w.mergeSpace(space)
+}
+
+func mergeTransfers(in []Transfer) []Transfer {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Transfer, 0, len(in))
+	for _, t := range in {
+		if t.Size <= 0 || t.From == t.To {
+			continue
+		}
+		merged := false
+		for i := range out {
+			o := &out[i]
+			if o.Space != t.Space || o.From != t.From || o.To != t.To {
+				continue
+			}
+			if hashEq(o.EndHash, t.StartHash) {
+				o.EndHash = cloneHash(t.EndHash)
+				o.Size += t.Size
+				merged = true
+				break
+			}
+			if hashEq(t.EndHash, o.StartHash) {
+				o.StartHash = cloneHash(t.StartHash)
+				o.Size += t.Size
+				merged = true
+				break
+			}
+		}
+		if !merged {
+			out = append(out, Transfer{
+				Space:     t.Space,
+				StartHash: cloneHash(t.StartHash),
+				EndHash:   cloneHash(t.EndHash),
+				From:      t.From,
+				To:        t.To,
+				Size:      t.Size,
+			})
+		}
+	}
+	return out
 }
 
 func (w *world) checkLimits() error {
@@ -124,8 +249,10 @@ func (w *world) checkLimits() error {
 		if w.used[d] > w.disks[d] {
 			return xerrors.Errorf("disk %d used %d exceeds size %d", d, w.used[d], w.disks[d])
 		}
-		if rc := w.rangeCount(d); rc > MAX_RANGES_PER_DISK {
-			return xerrors.Errorf("disk %d holds %d ranges, max %d", d, rc, MAX_RANGES_PER_DISK)
+		for s := range w.spaces {
+			if rc := w.rangeCount(s, d); rc > MAX_RANGES_PER_DISK {
+				return xerrors.Errorf("disk %d space %d holds %d ranges, max %d", d, s, rc, MAX_RANGES_PER_DISK)
+			}
 		}
 	}
 	return nil
@@ -149,26 +276,33 @@ func (w *world) checkSolved(event Event) error {
 }
 
 type candidate struct {
-	idx, kind, dest int
-	size            int64
-	dlt             int
-	over            int64
+	space, idx, kind, dest int
+	size                   int64
+	dlt                    int
+	over                   int64
 }
 
 func (w *world) repair() error {
-	for guard := 0; guard < len(w.ranges)+len(w.disks)+8; guard++ {
-		var over []int
+	totalRanges := 0
+	for _, sp := range w.spaces {
+		totalRanges += len(sp.ranges)
+	}
+	for guard := 0; guard < totalRanges+len(w.disks)+8; guard++ {
+		type overKey struct{ space, disk int }
+		var over []overKey
 		for _, d := range w.activeDisks() {
-			if w.rangeCount(d) > MAX_RANGES_PER_DISK {
-				over = append(over, d)
+			for s := range w.spaces {
+				if w.rangeCount(s, d) > MAX_RANGES_PER_DISK {
+					over = append(over, overKey{s, d})
+				}
 			}
 		}
 		if len(over) == 0 {
 			return nil
 		}
 		progress := false
-		for _, d := range over {
-			if w.donateRange(d) {
+		for _, o := range over {
+			if w.donateRange(o.space, o.disk) {
 				progress = true
 				break
 			}
@@ -180,36 +314,36 @@ func (w *world) repair() error {
 	return xerrors.New("range repair did not converge")
 }
 
-func (w *world) donateRange(src int) bool {
-	idxs := w.rangeIndexes(src)
+func (w *world) donateRange(space, src int) bool {
+	idxs := w.rangeIndexes(space, src)
 	if len(idxs) <= MAX_RANGES_PER_DISK {
 		return false
 	}
 	var best *candidate
 	for _, idx := range idxs {
-		sz := w.ranges[idx].Size
+		sz := w.spaces[space].ranges[idx].Size
 		for _, dest := range w.activeDisks() {
-			if !w.canTake(idx, cutWhole, dest, sz) {
+			if !w.canTake(space, idx, cutWhole, dest, sz) {
 				continue
 			}
-			c := candidate{idx: idx, kind: cutWhole, dest: dest, size: sz, dlt: w.destDelta(idx, cutWhole, dest)}
-			if best == nil || c.size < best.size || (c.size == best.size && (c.dlt < best.dlt || (c.dlt == best.dlt && c.dest < best.dest))) {
+			c := candidate{space: space, idx: idx, kind: cutWhole, dest: dest, size: sz, dlt: w.destDelta(space, idx, cutWhole, dest)}
+			if best == nil || c.size < best.size || (c.size == best.size && (c.dlt < best.dlt || (c.dlt == best.dlt && (c.dest < best.dest || (c.dest == best.dest && c.space < best.space))))) {
 				cp := c
 				best = &cp
 			}
 		}
 	}
 	if best != nil {
-		w.applyCut(best.idx, best.kind, best.dest, best.size)
+		w.applyCut(best.space, best.idx, best.kind, best.dest, best.size)
 		return true
 	}
 	smallest := idxs[0]
 	for _, idx := range idxs[1:] {
-		if w.ranges[idx].Size < w.ranges[smallest].Size {
+		if w.spaces[space].ranges[idx].Size < w.spaces[space].ranges[smallest].Size {
 			smallest = idx
 		}
 	}
-	return w.splitOntoOthers(smallest, src)
+	return w.splitOntoOthers(space, smallest, src)
 }
 
 func (w *world) arrive(newDisk int) {
@@ -217,7 +351,11 @@ func (w *world) arrive(newDisk int) {
 	if target <= 0 || w.used[newDisk] >= target {
 		return
 	}
-	for guard := 0; guard < len(w.ranges)+4; guard++ {
+	totalRanges := 0
+	for _, sp := range w.spaces {
+		totalRanges += len(sp.ranges)
+	}
+	for guard := 0; guard < totalRanges+4; guard++ {
 		need := target - w.used[newDisk]
 		if need <= 0 {
 			return
@@ -226,7 +364,7 @@ func (w *world) arrive(newDisk int) {
 		if !ok {
 			return
 		}
-		w.applyCut(cut.idx, cut.kind, newDisk, cut.size)
+		w.applyCut(cut.space, cut.idx, cut.kind, newDisk, cut.size)
 	}
 }
 
@@ -240,13 +378,15 @@ func (w *world) bestSteal(newDisk int, need int64) (candidate, bool) {
 		if excess <= 0 {
 			continue
 		}
-		for _, idx := range w.rangeIndexes(src) {
-			for _, c := range w.sizedCuts(idx, need, excess, newDisk) {
-				c.over = excess
-				c.dest = newDisk
-				if best == nil || betterSteal(c, *best, need) {
-					cp := c
-					best = &cp
+		for s := range w.spaces {
+			for _, idx := range w.rangeIndexes(s, src) {
+				for _, c := range w.sizedCuts(s, idx, need, excess, newDisk) {
+					c.over = excess
+					c.dest = newDisk
+					if best == nil || betterSteal(c, *best, need) {
+						cp := c
+						best = &cp
+					}
 				}
 			}
 		}
@@ -257,8 +397,8 @@ func (w *world) bestSteal(newDisk int, need int64) (candidate, bool) {
 	return *best, true
 }
 
-func (w *world) sizedCuts(idx int, need, limit int64, dest int) []candidate {
-	sz := w.ranges[idx].Size
+func (w *world) sizedCuts(space, idx int, need, limit int64, dest int) []candidate {
+	sz := w.spaces[space].ranges[idx].Size
 	if sz <= 0 {
 		return nil
 	}
@@ -268,20 +408,21 @@ func (w *world) sizedCuts(idx int, need, limit int64, dest int) []candidate {
 			return
 		}
 		if kind != cutWhole {
-			_, size = w.cutActual(idx, kind, size)
+			_, size = w.cutActual(space, idx, kind, size)
 			if size <= 0 || size >= sz {
 				return
 			}
 		}
-		if !w.canTake(idx, kind, dest, size) {
+		if !w.canTake(space, idx, kind, dest, size) {
 			return
 		}
 		out = append(out, candidate{
-			idx:  idx,
-			kind: kind,
-			dest: dest,
-			size: size,
-			dlt:  w.destDelta(idx, kind, dest),
+			space: space,
+			idx:   idx,
+			kind:  kind,
+			dest:  dest,
+			size:  size,
+			dlt:   w.destDelta(space, idx, kind, dest),
 		})
 	}
 	add(cutWhole, sz)
@@ -324,6 +465,9 @@ func betterSteal(a, b candidate, need int64) bool {
 	if a.dlt != b.dlt {
 		return a.dlt < b.dlt
 	}
+	if a.space != b.space {
+		return a.space < b.space
+	}
 	if a.idx != b.idx {
 		return a.idx < b.idx
 	}
@@ -334,7 +478,11 @@ func (w *world) shed(full int) error {
 	if w.frozen[full] {
 		return xerrors.Errorf("cannot shed from vacated disk %d", full)
 	}
-	for guard := 0; guard < len(w.ranges)+4; guard++ {
+	totalRanges := 0
+	for _, sp := range w.spaces {
+		totalRanges += len(sp.ranges)
+	}
+	for guard := 0; guard < totalRanges+4; guard++ {
 		need := w.used[full] - w.disks[full]
 		if need <= 0 {
 			return nil
@@ -346,7 +494,7 @@ func (w *world) shed(full int) error {
 			}
 			return xerrors.Errorf("cannot shed %d bytes from disk %d", need, full)
 		}
-		w.applyCut(cut.idx, cut.kind, cut.dest, cut.size)
+		w.applyCut(cut.space, cut.idx, cut.kind, cut.dest, cut.size)
 	}
 	if w.used[full] > w.disks[full] {
 		return xerrors.Errorf("cannot shed enough from disk %d", full)
@@ -356,15 +504,17 @@ func (w *world) shed(full int) error {
 
 func (w *world) bestShed(full int, need int64) (candidate, bool) {
 	var best *candidate
-	for _, idx := range w.rangeIndexes(full) {
-		for _, dest := range w.activeDisks() {
-			if dest == full {
-				continue
-			}
-			for _, c := range w.sizedCuts(idx, need, w.ranges[idx].Size, dest) {
-				if best == nil || betterShed(c, *best, need) {
-					cp := c
-					best = &cp
+	for s := range w.spaces {
+		for _, idx := range w.rangeIndexes(s, full) {
+			for _, dest := range w.activeDisks() {
+				if dest == full {
+					continue
+				}
+				for _, c := range w.sizedCuts(s, idx, need, w.spaces[s].ranges[idx].Size, dest) {
+					if best == nil || betterShed(c, *best, need) {
+						cp := c
+						best = &cp
+					}
 				}
 			}
 		}
@@ -392,6 +542,9 @@ func betterShed(a, b candidate, need int64) bool {
 	if a.dest != b.dest {
 		return a.dest < b.dest
 	}
+	if a.space != b.space {
+		return a.space < b.space
+	}
 	return a.idx < b.idx
 }
 
@@ -404,21 +557,28 @@ func (w *world) vacate(id int) error {
 		return xerrors.Errorf("not enough remaining capacity to vacate disk %d", id)
 	}
 
-	for guard := 0; guard < len(w.ranges)+8; guard++ {
-		idxs := w.rangeIndexes(id)
-		if len(idxs) == 0 {
-			return nil
-		}
-		best := idxs[0]
-		for _, idx := range idxs[1:] {
-			if w.ranges[idx].Size > w.ranges[best].Size || (w.ranges[idx].Size == w.ranges[best].Size && idx < best) {
-				best = idx
+	totalRanges := 0
+	for _, sp := range w.spaces {
+		totalRanges += len(sp.ranges)
+	}
+	for guard := 0; guard < totalRanges+8; guard++ {
+		bestSpace, bestIdx := -1, -1
+		var bestSize int64 = -1
+		for s := range w.spaces {
+			for _, idx := range w.rangeIndexes(s, id) {
+				sz := w.spaces[s].ranges[idx].Size
+				if sz > bestSize || (sz == bestSize && (s < bestSpace || (s == bestSpace && idx < bestIdx))) {
+					bestSpace, bestIdx, bestSize = s, idx, sz
+				}
 			}
 		}
-		if w.placeRange(best, id) {
+		if bestSpace < 0 {
+			return nil
+		}
+		if w.placeRange(bestSpace, bestIdx, id) {
 			continue
 		}
-		if w.makeRoom(id) && w.placeRange(best, id) {
+		if w.makeRoom(id) && w.placeRange(bestSpace, bestIdx, id) {
 			continue
 		}
 		return xerrors.Errorf("cannot place range on disk %d elsewhere", id)
@@ -429,24 +589,25 @@ func (w *world) vacate(id int) error {
 	return nil
 }
 
-func (w *world) placeRange(idx, src int) bool {
-	if idx < 0 || idx >= len(w.ranges) || w.owner[idx] != src {
+func (w *world) placeRange(space, idx, src int) bool {
+	sp := &w.spaces[space]
+	if idx < 0 || idx >= len(sp.ranges) || sp.owner[idx] != src {
 		return true
 	}
-	sz := w.ranges[idx].Size
-	left, right, okL, okR := w.neighbors(idx)
+	sz := sp.ranges[idx].Size
+	left, right, okL, okR := w.neighbors(space, idx)
 
-	if okL && okR && left == right && w.canTake(idx, cutWhole, left, sz) {
-		w.moveWhole(idx, left)
+	if okL && okR && left == right && w.canTake(space, idx, cutWhole, left, sz) {
+		w.moveWhole(space, idx, left)
 		return true
 	}
 
 	var best *candidate
 	consider := func(dest int) {
-		if !w.canTake(idx, cutWhole, dest, sz) {
+		if !w.canTake(space, idx, cutWhole, dest, sz) {
 			return
 		}
-		c := candidate{idx: idx, kind: cutWhole, dest: dest, size: sz, dlt: w.destDelta(idx, cutWhole, dest), over: w.free(dest)}
+		c := candidate{space: space, idx: idx, kind: cutWhole, dest: dest, size: sz, dlt: w.destDelta(space, idx, cutWhole, dest), over: w.free(dest)}
 		if best == nil || c.dlt < best.dlt || (c.dlt == best.dlt && (c.over > best.over || (c.over == best.over && c.dest < best.dest))) {
 			cp := c
 			best = &cp
@@ -462,38 +623,39 @@ func (w *world) placeRange(idx, src int) bool {
 		consider(dest)
 	}
 	if best != nil {
-		w.moveWhole(idx, best.dest)
+		w.moveWhole(space, idx, best.dest)
 		return true
 	}
 
 	if okL && okR && left != right {
-		end := cloneHash(w.ranges[idx].EndHash)
+		end := cloneHash(sp.ranges[idx].EndHash)
 		pref := min(w.free(left), sz)
-		if pref > 0 && w.canTake(idx, cutPrefix, left, pref) {
+		if pref > 0 && w.canTake(space, idx, cutPrefix, left, pref) {
 			if pref >= sz {
-				w.moveWhole(idx, left)
+				w.moveWhole(space, idx, left)
 				return true
 			}
-			w.applyCut(idx, cutPrefix, left, pref)
-			idx = w.find(end)
-			if idx >= 0 && w.owner[idx] == src && w.canTake(idx, cutWhole, right, w.ranges[idx].Size) {
-				w.moveWhole(idx, right)
+			w.applyCut(space, idx, cutPrefix, left, pref)
+			idx = w.find(space, end)
+			if idx >= 0 && sp.owner[idx] == src && w.canTake(space, idx, cutWhole, right, sp.ranges[idx].Size) {
+				w.moveWhole(space, idx, right)
 				return true
 			}
 		}
 	}
 
-	return w.splitOntoOthers(idx, src)
+	return w.splitOntoOthers(space, idx, src)
 }
 
-func (w *world) splitOntoOthers(idx, src int) bool {
-	if idx < 0 || idx >= len(w.ranges) || w.owner[idx] != src {
+func (w *world) splitOntoOthers(space, idx, src int) bool {
+	sp := &w.spaces[space]
+	if idx < 0 || idx >= len(sp.ranges) || sp.owner[idx] != src {
 		return true
 	}
-	end := cloneHash(w.ranges[idx].EndHash)
-	for w.find(end) >= 0 && w.owner[w.find(end)] == src {
-		idx = w.find(end)
-		remain := w.ranges[idx].Size
+	end := cloneHash(sp.ranges[idx].EndHash)
+	for w.find(space, end) >= 0 && sp.owner[w.find(space, end)] == src {
+		idx = w.find(space, end)
+		remain := sp.ranges[idx].Size
 		var best *candidate
 		for _, dest := range w.activeDisks() {
 			if dest == src {
@@ -505,10 +667,10 @@ func (w *world) splitOntoOthers(idx, src int) bool {
 				if kind == cutWhole {
 					sz = remain
 				}
-				if sz <= 0 || !w.canTake(idx, kind, dest, sz) {
+				if sz <= 0 || !w.canTake(space, idx, kind, dest, sz) {
 					continue
 				}
-				c := candidate{idx: idx, kind: kind, dest: dest, size: sz, dlt: w.destDelta(idx, kind, dest)}
+				c := candidate{space: space, idx: idx, kind: kind, dest: dest, size: sz, dlt: w.destDelta(space, idx, kind, dest)}
 				if best == nil || c.dlt < best.dlt || (c.dlt == best.dlt && (c.size > best.size || (c.size == best.size && c.dest < best.dest))) {
 					cp := c
 					best = &cp
@@ -518,15 +680,20 @@ func (w *world) splitOntoOthers(idx, src int) bool {
 		if best == nil {
 			return false
 		}
-		w.applyCut(best.idx, best.kind, best.dest, best.size)
+		w.applyCut(best.space, best.idx, best.kind, best.dest, best.size)
 	}
-	return w.find(end) < 0 || w.owner[w.find(end)] != src
+	return w.find(space, end) < 0 || sp.owner[w.find(space, end)] != src
 }
 
 func (w *world) makeRoom(avoid int) bool {
 	for _, src := range w.activeDisks() {
-		if src != avoid && w.rangeCount(src) >= MAX_RANGES_PER_DISK && w.donateRange(src) {
-			return true
+		if src == avoid {
+			continue
+		}
+		for s := range w.spaces {
+			if w.rangeCount(s, src) >= MAX_RANGES_PER_DISK && w.donateRange(s, src) {
+				return true
+			}
 		}
 	}
 	fullest := -1
@@ -545,6 +712,6 @@ func (w *world) makeRoom(avoid int) bool {
 	if !ok {
 		return false
 	}
-	w.applyCut(cut.idx, cut.kind, cut.dest, cut.size)
+	w.applyCut(cut.space, cut.idx, cut.kind, cut.dest, cut.size)
 	return true
 }

--- a/lib/hashspacesolver/solve.go
+++ b/lib/hashspacesolver/solve.go
@@ -114,9 +114,6 @@ func (w *world) applyTransfer(t Transfer) error {
 	r := sp.ranges[idx]
 	start := StartHash(sp.ranges, idx)
 	if hashEq(t.StartHash, start) && hashEq(t.EndHash, r.EndHash) {
-		if t.Size != r.Size && t.Size > 0 {
-			// whole-range move; size should match but tolerate after merges
-		}
 		w.moveWholeSilent(t.Space, idx, t.To)
 		return nil
 	}
@@ -211,37 +208,54 @@ func mergeTransfers(in []Transfer) []Transfer {
 		if t.Size <= 0 || t.From == t.To {
 			continue
 		}
-		merged := false
-		for i := range out {
-			o := &out[i]
-			if o.Space != t.Space || o.From != t.From || o.To != t.To {
-				continue
-			}
-			if hashEq(o.EndHash, t.StartHash) {
-				o.EndHash = cloneHash(t.EndHash)
-				o.Size += t.Size
-				merged = true
+		out = append(out, Transfer{
+			Space:     t.Space,
+			StartHash: cloneHash(t.StartHash),
+			EndHash:   cloneHash(t.EndHash),
+			From:      t.From,
+			To:        t.To,
+			Size:      t.Size,
+		})
+	}
+	for {
+		progress := false
+		for i := 0; i < len(out); i++ {
+			for j := i + 1; j < len(out); j++ {
+				joined, ok := joinAdjacent(out[i], out[j])
+				if !ok {
+					continue
+				}
+				out[i] = joined
+				out = append(out[:j], out[j+1:]...)
+				progress = true
 				break
 			}
-			if hashEq(t.EndHash, o.StartHash) {
-				o.StartHash = cloneHash(t.StartHash)
-				o.Size += t.Size
-				merged = true
+			if progress {
 				break
 			}
 		}
-		if !merged {
-			out = append(out, Transfer{
-				Space:     t.Space,
-				StartHash: cloneHash(t.StartHash),
-				EndHash:   cloneHash(t.EndHash),
-				From:      t.From,
-				To:        t.To,
-				Size:      t.Size,
-			})
+		if !progress {
+			break
 		}
 	}
 	return out
+}
+
+func joinAdjacent(a, b Transfer) (Transfer, bool) {
+	if a.Space != b.Space || a.From != b.From || a.To != b.To {
+		return Transfer{}, false
+	}
+	if hashEq(a.EndHash, b.StartHash) {
+		a.EndHash = cloneHash(b.EndHash)
+		a.Size += b.Size
+		return a, true
+	}
+	if hashEq(b.EndHash, a.StartHash) {
+		a.StartHash = cloneHash(b.StartHash)
+		a.Size += b.Size
+		return a, true
+	}
+	return Transfer{}, false
 }
 
 func (w *world) checkLimits() error {
@@ -266,10 +280,6 @@ func (w *world) checkSolved(event Event) error {
 	case EventVacate:
 		if w.used[event.Disk] != 0 {
 			return xerrors.Errorf("disk %d was not emptied", event.Disk)
-		}
-	case EventFull:
-		if w.used[event.Disk] > w.disks[event.Disk] {
-			return xerrors.Errorf("disk %d still over capacity", event.Disk)
 		}
 	}
 	return nil
@@ -347,20 +357,18 @@ func (w *world) donateRange(space, src int) bool {
 }
 
 func (w *world) arrive(newDisk int) {
-	target := w.fairShare(newDisk)
-	if target <= 0 || w.used[newDisk] >= target {
+	if w.fillHeadroom(newDisk) <= 0 {
 		return
 	}
 	totalRanges := 0
 	for _, sp := range w.spaces {
 		totalRanges += len(sp.ranges)
 	}
-	for guard := 0; guard < totalRanges+4; guard++ {
-		need := target - w.used[newDisk]
-		if need <= 0 {
+	for guard := 0; guard < totalRanges*MAX_RANGES_PER_DISK+len(w.disks)+8; guard++ {
+		if w.overflow(newDisk) == 0 && !w.anyOverflow(newDisk) {
 			return
 		}
-		cut, ok := w.bestSteal(newDisk, need)
+		cut, ok := w.bestSteal(newDisk)
 		if !ok {
 			return
 		}
@@ -368,20 +376,43 @@ func (w *world) arrive(newDisk int) {
 	}
 }
 
-func (w *world) bestSteal(newDisk int, need int64) (candidate, bool) {
+func (w *world) anyOverflow(except int) bool {
+	for _, d := range w.activeDisks() {
+		if d != except && w.overflow(d) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *world) bestSteal(newDisk int) (candidate, bool) {
+	if c, ok := w.pickSteal(newDisk, true); ok {
+		return c, true
+	}
+	return w.pickSteal(newDisk, false)
+}
+
+func (w *world) pickSteal(newDisk int, absorbOnly bool) (candidate, bool) {
+	need := w.fillHeadroom(newDisk)
+	if need <= 0 {
+		return candidate{}, false
+	}
 	var best *candidate
 	for _, src := range w.activeDisks() {
 		if src == newDisk {
 			continue
 		}
-		excess := w.used[src] - w.fairShare(src)
-		if excess <= 0 {
+		over := w.overflow(src)
+		if over <= 0 {
 			continue
 		}
 		for s := range w.spaces {
 			for _, idx := range w.rangeIndexes(s, src) {
-				for _, c := range w.sizedCuts(s, idx, need, excess, newDisk) {
-					c.over = excess
+				for _, c := range w.sizedCuts(s, idx, need, over, newDisk) {
+					if absorbOnly && c.dlt > 0 {
+						continue
+					}
+					c.over = over
 					c.dest = newDisk
 					if best == nil || betterSteal(c, *best, need) {
 						cp := c
@@ -416,6 +447,9 @@ func (w *world) sizedCuts(space, idx int, need, limit int64, dest int) []candida
 		if !w.canTake(space, idx, kind, dest, size) {
 			return
 		}
+		if size > w.fillHeadroom(dest) {
+			return
+		}
 		out = append(out, candidate{
 			space: space,
 			idx:   idx,
@@ -425,13 +459,15 @@ func (w *world) sizedCuts(space, idx int, need, limit int64, dest int) []candida
 			dlt:   w.destDelta(space, idx, kind, dest),
 		})
 	}
-	add(cutWhole, sz)
+	if limit <= 0 || sz <= limit {
+		add(cutWhole, sz)
+	}
 	want := need
 	if limit > 0 && limit < want {
 		want = limit
 	}
-	if destFree := w.free(dest); destFree < want {
-		want = destFree
+	if destHead := w.fillHeadroom(dest); destHead < want {
+		want = destHead
 	}
 	if want > 0 && want < sz {
 		add(cutPrefix, want)
@@ -483,7 +519,7 @@ func (w *world) shed(full int) error {
 		totalRanges += len(sp.ranges)
 	}
 	for guard := 0; guard < totalRanges+4; guard++ {
-		need := w.used[full] - w.disks[full]
+		need := w.overflow(full)
 		if need <= 0 {
 			return nil
 		}
@@ -492,7 +528,10 @@ func (w *world) shed(full int) error {
 			if w.makeRoom(full) {
 				continue
 			}
-			return xerrors.Errorf("cannot shed %d bytes from disk %d", need, full)
+			if w.used[full] > w.disks[full] {
+				return xerrors.Errorf("cannot shed %d bytes from disk %d", need, full)
+			}
+			return nil
 		}
 		w.applyCut(cut.space, cut.idx, cut.kind, cut.dest, cut.size)
 	}

--- a/lib/hashspacesolver/solver_test.go
+++ b/lib/hashspacesolver/solver_test.go
@@ -1,0 +1,349 @@
+package hashspacesolver
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func h(b byte) []byte { return []byte{b} }
+
+func mk(disks []int64, end []byte, size []int64, owner []int) State {
+	rs := make([]Range, len(end))
+	for i := range end {
+		rs[i] = Range{EndHash: []byte{end[i]}, Size: size[i]}
+	}
+	return State{Disks: append([]int64(nil), disks...), Ranges: rs, Owner: append([]int(nil), owner...)}
+}
+
+func solveOK(t *testing.T, st State, ev Event) (State, Plan) {
+	t.Helper()
+	plan, err := Solve(st, ev)
+	require.NoError(t, err)
+	out, err := Apply(st, plan)
+	require.NoError(t, err)
+	require.NoError(t, Validate(out))
+	require.Equal(t, plan.BytesMoved, sumMoved(st, out))
+	if ev.Kind == EventVacate {
+		require.Zero(t, usedOf(out, ev.Disk))
+	}
+	if ev.Kind == EventFull {
+		require.LessOrEqual(t, usedOf(out, ev.Disk), out.Disks[ev.Disk])
+	}
+	return out, plan
+}
+
+func usedOf(st State, d int) int64 {
+	var u int64
+	for i, r := range st.Ranges {
+		if st.Owner[i] == d {
+			u += r.Size
+		}
+	}
+	return u
+}
+
+func sumMoved(a, b State) int64 {
+	usedA := make(map[string]int)
+	for i, r := range a.Ranges {
+		usedA[string(r.EndHash)] = a.Owner[i]
+	}
+	// Byte movement is the plan's job; compare total per-disk used as a sanity check.
+	var before, after int64
+	for i := range a.Disks {
+		ba, bb := usedOf(a, i), usedOf(b, i)
+		if bb > ba {
+			after += bb - ba
+		} else {
+			before += ba - bb
+		}
+	}
+	if after != before {
+		return after
+	}
+	return after
+}
+
+func rangeCountOf(st State, d int) int {
+	w, err := newWorld(st)
+	if err != nil {
+		return -1
+	}
+	return w.rangeCount(d)
+}
+
+func TestVacateNeighborAbsorbs(t *testing.T) {
+	st := mk(
+		[]int64{50, 50},
+		[]byte{0x10, 0x30},
+		[]int64{20, 20},
+		[]int{0, 1},
+	)
+	out, plan := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
+	require.Equal(t, int64(20), plan.BytesMoved)
+	require.Equal(t, 1, rangeCountOf(out, 0))
+	require.Zero(t, rangeCountOf(out, 1))
+}
+
+func TestVacateSplitsBetweenNeighbors(t *testing.T) {
+	st := mk(
+		[]int64{15, 40, 15},
+		[]byte{0x10, 0x30, 0xFF},
+		[]int64{5, 20, 5},
+		[]int{0, 1, 2},
+	)
+	out, plan := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
+	require.Equal(t, int64(20), plan.BytesMoved)
+	require.Zero(t, usedOf(out, 1))
+	require.Equal(t, int64(15), usedOf(out, 0))
+	require.Equal(t, int64(15), usedOf(out, 2))
+	require.Equal(t, 1, rangeCountOf(out, 0))
+	require.Equal(t, 1, rangeCountOf(out, 2))
+}
+
+func TestVacateBridgesSameNeighbor(t *testing.T) {
+	st := mk(
+		[]int64{40, 20},
+		[]byte{0x10, 0x20, 0x30},
+		[]int64{10, 10, 10},
+		[]int{0, 1, 0},
+	)
+	// newWorld merges the wrap-adjacent disk-0 ranges? 0x10 and 0x30 are not
+	// adjacent: order 0x10 (disk0), 0x20 (disk1), 0x30 (disk0). Adjacent pairs
+	// are (0x10,0x20), (0x20,0x30), (0x30,0x10). Last pair is both disk 0.
+	out, plan := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
+	require.Equal(t, int64(10), plan.BytesMoved)
+	require.Equal(t, 1, rangeCountOf(out, 0))
+}
+
+func TestVacateEmptyPlan(t *testing.T) {
+	st := mk([]int64{10, 10}, []byte{0x80}, []int64{5}, []int{0})
+	_, plan := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
+	require.Empty(t, plan.Moves)
+}
+
+func TestVacateInsufficientCapacity(t *testing.T) {
+	st := mk(
+		[]int64{10, 20},
+		[]byte{0x10, 0xFF},
+		[]int64{10, 20},
+		[]int{0, 1},
+	)
+	_, err := Solve(st, Event{Kind: EventVacate, Disk: 1})
+	require.Error(t, err)
+}
+
+func TestVacateOnlyDisk(t *testing.T) {
+	st := mk([]int64{20}, []byte{0x80}, []int64{10}, []int{0})
+	_, err := Solve(st, Event{Kind: EventVacate, Disk: 0})
+	require.Error(t, err)
+}
+
+func TestArriveStealsFairShare(t *testing.T) {
+	st := mk([]int64{100, 100}, []byte{0x80}, []int64{80}, []int{0})
+	out, plan := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
+	require.NotEmpty(t, plan.Moves)
+	require.Equal(t, int64(80), usedOf(out, 0)+usedOf(out, 1))
+	require.Equal(t, int64(40), usedOf(out, 1))
+	require.Equal(t, 1, rangeCountOf(out, 0))
+	require.Equal(t, 1, rangeCountOf(out, 1))
+}
+
+func TestArriveNoData(t *testing.T) {
+	st := State{Disks: []int64{10, 10}}
+	_, plan := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
+	require.Empty(t, plan.Moves)
+}
+
+func TestArriveAlreadyBalanced(t *testing.T) {
+	st := mk(
+		[]int64{20, 20},
+		[]byte{0x80, 0xFF},
+		[]int64{10, 10},
+		[]int{0, 1},
+	)
+	_, plan := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
+	require.Empty(t, plan.Moves)
+}
+
+func TestFullPeelsMinimum(t *testing.T) {
+	// (0x00, 0x80] is 128 hash units and 32 bytes, so a 7-byte peel is exact.
+	st := mk(
+		[]int64{25, 50},
+		[]byte{0x00, 0x80},
+		[]int64{5, 32},
+		[]int{1, 0},
+	)
+	require.Error(t, Validate(st))
+	out, plan := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
+	require.LessOrEqual(t, usedOf(out, 0), int64(25))
+	require.Equal(t, int64(7), plan.BytesMoved)
+	require.Len(t, plan.Moves, 1)
+}
+
+func TestFullAlreadyUnderCapacity(t *testing.T) {
+	st := mk(
+		[]int64{20, 20},
+		[]byte{0x80, 0xFF},
+		[]int64{10, 10},
+		[]int{0, 1},
+	)
+	_, plan := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
+	require.Empty(t, plan.Moves)
+}
+
+func TestFullCannotShed(t *testing.T) {
+	st := mk(
+		[]int64{5, 10},
+		[]byte{0x80, 0xFF},
+		[]int64{20, 10},
+		[]int{0, 1},
+	)
+	_, err := Solve(st, Event{Kind: EventFull, Disk: 0})
+	require.Error(t, err)
+}
+
+func TestRepairTooManyRanges(t *testing.T) {
+	st := mk(
+		[]int64{50, 50},
+		[]byte{0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80},
+		[]int64{5, 5, 5, 5, 5, 5, 5, 5},
+		[]int{0, 1, 0, 1, 0, 1, 0, 1},
+	)
+	require.Equal(t, 4, rangeCountOf(st, 0))
+	require.Error(t, Validate(st))
+	out, _ := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
+	require.LessOrEqual(t, rangeCountOf(out, 0), MAX_RANGES_PER_DISK)
+	require.LessOrEqual(t, rangeCountOf(out, 1), MAX_RANGES_PER_DISK)
+}
+
+func TestUnknownEventDisk(t *testing.T) {
+	st := State{Disks: []int64{10}}
+	_, err := Solve(st, Event{Kind: EventArrive, Disk: 3})
+	require.Error(t, err)
+}
+
+func TestUnknownEventKind(t *testing.T) {
+	st := State{Disks: []int64{10}}
+	_, err := Solve(st, Event{Kind: 0, Disk: 0})
+	require.Error(t, err)
+}
+
+func TestStructuralErrors(t *testing.T) {
+	t.Run("owner length", func(t *testing.T) {
+		st := State{Disks: []int64{10}, Ranges: []Range{{EndHash: h(1), Size: 1}}}
+		_, err := Solve(st, Event{Kind: EventFull, Disk: 0})
+		require.Error(t, err)
+	})
+	t.Run("negative disk", func(t *testing.T) {
+		st := State{Disks: []int64{-1}}
+		_, err := Solve(st, Event{Kind: EventFull, Disk: 0})
+		require.Error(t, err)
+	})
+	t.Run("duplicate end hash", func(t *testing.T) {
+		st := mk([]int64{10}, []byte{0x10, 0x10}, []int64{1, 1}, []int{0, 0})
+		_, err := Solve(st, Event{Kind: EventFull, Disk: 0})
+		require.Error(t, err)
+	})
+}
+
+func TestSolveDoesNotMutateInput(t *testing.T) {
+	st := mk([]int64{30, 30}, []byte{0x80}, []int64{40}, []int{0})
+	before := usedOf(st, 0)
+	end := append([]byte(nil), st.Ranges[0].EndHash...)
+	_, _ = solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
+	require.Equal(t, before, usedOf(st, 0))
+	require.Equal(t, end, st.Ranges[0].EndHash)
+	require.Equal(t, 0, st.Owner[0])
+}
+
+func TestDeterministic(t *testing.T) {
+	st := mk(
+		[]int64{80, 80, 80},
+		[]byte{0x20, 0x40, 0xFF},
+		[]int64{20, 20, 10},
+		[]int{0, 1, 2},
+	)
+	p1, err := Solve(st, Event{Kind: EventVacate, Disk: 2})
+	require.NoError(t, err)
+	p2, err := Solve(st, Event{Kind: EventVacate, Disk: 2})
+	require.NoError(t, err)
+	require.Equal(t, p1, p2)
+}
+
+func TestArriveAtMostThreeRanges(t *testing.T) {
+	st := mk(
+		[]int64{100, 100, 100, 100, 100},
+		[]byte{0x18, 0x20, 0x38, 0x40, 0x58, 0x60, 0x78, 0x80},
+		[]int64{10, 10, 10, 10, 10, 10, 10, 10},
+		[]int{0, 0, 1, 1, 2, 2, 3, 3},
+	)
+	out, plan := solveOK(t, st, Event{Kind: EventArrive, Disk: 4})
+	require.NotEmpty(t, plan.Moves)
+	require.LessOrEqual(t, rangeCountOf(out, 4), MAX_RANGES_PER_DISK)
+	require.Greater(t, usedOf(out, 4), int64(0))
+}
+
+func TestRandomClusterEvents(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	for i := 0; i < 64; i++ {
+		st := randomValidState(rng)
+		require.NoError(t, Validate(st), "iter %d seed state", i)
+		st, ev := randomEvent(rng, st)
+		plan, err := Solve(st, ev)
+		if err != nil {
+			if ev.Kind == EventVacate || ev.Kind == EventFull {
+				continue
+			}
+			t.Fatalf("iter %d: unexpected solve error: %v", i, err)
+		}
+		out, err := Apply(st, plan)
+		require.NoError(t, err, "iter %d", i)
+		require.NoError(t, Validate(out), "iter %d", i)
+		if ev.Kind == EventVacate {
+			require.Zero(t, usedOf(out, ev.Disk), "iter %d", i)
+		}
+	}
+}
+
+func randomValidState(rng *rand.Rand) State {
+	nDisks := 2 + rng.Intn(3)
+	nRanges := nDisks + rng.Intn(4)
+	disks := make([]int64, nDisks)
+	for i := range disks {
+		disks[i] = int64(80 + rng.Intn(80))
+	}
+	ranges := make([]Range, nRanges)
+	owner := make([]int, nRanges)
+	used := make([]int64, nDisks)
+	di := 0
+	for i := 0; i < nRanges; i++ {
+		sz := int64(8 + rng.Intn(16))
+		for di < nDisks-1 && used[di]+sz > disks[di]/2 {
+			di++
+		}
+		ranges[i] = Range{EndHash: []byte{byte((i + 1) * 17)}, Size: sz}
+		owner[i] = di
+		used[di] += sz
+	}
+	return State{Disks: disks, Ranges: ranges, Owner: owner}
+}
+
+func randomEvent(rng *rand.Rand, st State) (State, Event) {
+	switch rng.Intn(3) {
+	case 0:
+		st.Disks = append(append([]int64(nil), st.Disks...), 60+int64(rng.Intn(40)))
+		return st, Event{Kind: EventArrive, Disk: len(st.Disks) - 1}
+	case 1:
+		return st, Event{Kind: EventFull, Disk: rng.Intn(len(st.Disks))}
+	default:
+		return st, Event{Kind: EventVacate, Disk: rng.Intn(len(st.Disks))}
+	}
+}
+
+func TestApplyRejectsUnknownRange(t *testing.T) {
+	st := mk([]int64{20, 20}, []byte{0x80}, []int64{5}, []int{0})
+	_, err := Apply(st, Plan{Moves: []Move{{From: 0, To: 1, EndHash: h(0x01), Size: 5}}})
+	require.Error(t, err)
+}

--- a/lib/hashspacesolver/solver_test.go
+++ b/lib/hashspacesolver/solver_test.go
@@ -1,6 +1,7 @@
 package hashspacesolver
 
 import (
+	"bytes"
 	"math/rand"
 	"testing"
 
@@ -9,68 +10,99 @@ import (
 
 func h(b byte) []byte { return []byte{b} }
 
+// mk builds a single-space state for simple tests.
 func mk(disks []int64, end []byte, size []int64, owner []int) State {
 	rs := make([]Range, len(end))
 	for i := range end {
 		rs[i] = Range{EndHash: []byte{end[i]}, Size: size[i]}
 	}
-	return State{Disks: append([]int64(nil), disks...), Ranges: rs, Owner: append([]int(nil), owner...)}
+	return State{
+		Disks: append([]int64(nil), disks...),
+		Spaces: []Space{{
+			Ranges: rs,
+			Owner:  append([]int(nil), owner...),
+		}},
+	}
 }
 
-func solveOK(t *testing.T, st State, ev Event) (State, Plan) {
+func mk2(disks []int64, a, b Space) State {
+	return State{
+		Disks:  append([]int64(nil), disks...),
+		Spaces: []Space{cloneSpace(a), cloneSpace(b)},
+	}
+}
+
+func spaceOf(end []byte, size []int64, owner []int) Space {
+	rs := make([]Range, len(end))
+	for i := range end {
+		rs[i] = Range{EndHash: []byte{end[i]}, Size: size[i]}
+	}
+	return Space{Ranges: rs, Owner: append([]int(nil), owner...)}
+}
+
+func solveOK(t *testing.T, st State, ev Event) (State, Result) {
 	t.Helper()
-	plan, err := Solve(st, ev)
+	res, err := Solve(st, ev)
 	require.NoError(t, err)
-	out, err := Apply(st, plan)
+	out, err := Apply(st, res.Diff)
 	require.NoError(t, err)
 	require.NoError(t, Validate(out))
-	require.Equal(t, plan.BytesMoved, sumMoved(st, out))
+	require.NoError(t, Validate(res.State))
+	requireEqualState(t, res.State, out)
+	require.Equal(t, res.BytesMoved, sumDiff(res.Diff))
 	if ev.Kind == EventVacate {
 		require.Zero(t, usedOf(out, ev.Disk))
 	}
 	if ev.Kind == EventFull {
 		require.LessOrEqual(t, usedOf(out, ev.Disk), out.Disks[ev.Disk])
 	}
-	return out, plan
+	return out, res
+}
+
+func requireEqualState(t *testing.T, a, b State) {
+	t.Helper()
+	require.Equal(t, a.Disks, b.Disks)
+	require.Equal(t, len(a.Spaces), len(b.Spaces))
+	for s := range a.Spaces {
+		wa, err := newWorld(State{Disks: a.Disks, Spaces: []Space{a.Spaces[s]}})
+		require.NoError(t, err)
+		wb, err := newWorld(State{Disks: b.Disks, Spaces: []Space{b.Spaces[s]}})
+		require.NoError(t, err)
+		require.Equal(t, wa.spaces[0].owner, wb.spaces[0].owner, "space %d owners", s)
+		require.Equal(t, len(wa.spaces[0].ranges), len(wb.spaces[0].ranges), "space %d ranges", s)
+		for i := range wa.spaces[0].ranges {
+			require.True(t, hashEq(wa.spaces[0].ranges[i].EndHash, wb.spaces[0].ranges[i].EndHash), "space %d end %d", s, i)
+			require.Equal(t, wa.spaces[0].ranges[i].Size, wb.spaces[0].ranges[i].Size, "space %d size %d", s, i)
+		}
+	}
 }
 
 func usedOf(st State, d int) int64 {
 	var u int64
-	for i, r := range st.Ranges {
-		if st.Owner[i] == d {
-			u += r.Size
+	for _, sp := range st.Spaces {
+		for i, r := range sp.Ranges {
+			if sp.Owner[i] == d {
+				u += r.Size
+			}
 		}
 	}
 	return u
 }
 
-func sumMoved(a, b State) int64 {
-	usedA := make(map[string]int)
-	for i, r := range a.Ranges {
-		usedA[string(r.EndHash)] = a.Owner[i]
+func sumDiff(diff []Transfer) int64 {
+	var n int64
+	for _, t := range diff {
+		n += t.Size
 	}
-	// Byte movement is the plan's job; compare total per-disk used as a sanity check.
-	var before, after int64
-	for i := range a.Disks {
-		ba, bb := usedOf(a, i), usedOf(b, i)
-		if bb > ba {
-			after += bb - ba
-		} else {
-			before += ba - bb
-		}
-	}
-	if after != before {
-		return after
-	}
-	return after
+	return n
 }
 
-func rangeCountOf(st State, d int) int {
+func rangeCountOf(st State, space, d int) int {
 	w, err := newWorld(st)
 	if err != nil {
 		return -1
 	}
-	return w.rangeCount(d)
+	return w.rangeCount(space, d)
 }
 
 func TestVacateNeighborAbsorbs(t *testing.T) {
@@ -80,10 +112,10 @@ func TestVacateNeighborAbsorbs(t *testing.T) {
 		[]int64{20, 20},
 		[]int{0, 1},
 	)
-	out, plan := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
-	require.Equal(t, int64(20), plan.BytesMoved)
-	require.Equal(t, 1, rangeCountOf(out, 0))
-	require.Zero(t, rangeCountOf(out, 1))
+	out, res := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
+	require.Equal(t, int64(20), res.BytesMoved)
+	require.Equal(t, 1, rangeCountOf(out, 0, 0))
+	require.Zero(t, rangeCountOf(out, 0, 1))
 }
 
 func TestVacateSplitsBetweenNeighbors(t *testing.T) {
@@ -93,13 +125,13 @@ func TestVacateSplitsBetweenNeighbors(t *testing.T) {
 		[]int64{5, 20, 5},
 		[]int{0, 1, 2},
 	)
-	out, plan := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
-	require.Equal(t, int64(20), plan.BytesMoved)
+	out, res := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
+	require.Equal(t, int64(20), res.BytesMoved)
 	require.Zero(t, usedOf(out, 1))
 	require.Equal(t, int64(15), usedOf(out, 0))
 	require.Equal(t, int64(15), usedOf(out, 2))
-	require.Equal(t, 1, rangeCountOf(out, 0))
-	require.Equal(t, 1, rangeCountOf(out, 2))
+	require.Equal(t, 1, rangeCountOf(out, 0, 0))
+	require.Equal(t, 1, rangeCountOf(out, 0, 2))
 }
 
 func TestVacateBridgesSameNeighbor(t *testing.T) {
@@ -109,18 +141,15 @@ func TestVacateBridgesSameNeighbor(t *testing.T) {
 		[]int64{10, 10, 10},
 		[]int{0, 1, 0},
 	)
-	// newWorld merges the wrap-adjacent disk-0 ranges? 0x10 and 0x30 are not
-	// adjacent: order 0x10 (disk0), 0x20 (disk1), 0x30 (disk0). Adjacent pairs
-	// are (0x10,0x20), (0x20,0x30), (0x30,0x10). Last pair is both disk 0.
-	out, plan := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
-	require.Equal(t, int64(10), plan.BytesMoved)
-	require.Equal(t, 1, rangeCountOf(out, 0))
+	out, res := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
+	require.Equal(t, int64(10), res.BytesMoved)
+	require.Equal(t, 1, rangeCountOf(out, 0, 0))
 }
 
 func TestVacateEmptyPlan(t *testing.T) {
 	st := mk([]int64{10, 10}, []byte{0x80}, []int64{5}, []int{0})
-	_, plan := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
-	require.Empty(t, plan.Moves)
+	_, res := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
+	require.Empty(t, res.Diff)
 }
 
 func TestVacateInsufficientCapacity(t *testing.T) {
@@ -142,18 +171,18 @@ func TestVacateOnlyDisk(t *testing.T) {
 
 func TestArriveStealsFairShare(t *testing.T) {
 	st := mk([]int64{100, 100}, []byte{0x80}, []int64{80}, []int{0})
-	out, plan := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
-	require.NotEmpty(t, plan.Moves)
+	out, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
+	require.NotEmpty(t, res.Diff)
 	require.Equal(t, int64(80), usedOf(out, 0)+usedOf(out, 1))
 	require.Equal(t, int64(40), usedOf(out, 1))
-	require.Equal(t, 1, rangeCountOf(out, 0))
-	require.Equal(t, 1, rangeCountOf(out, 1))
+	require.Equal(t, 1, rangeCountOf(out, 0, 0))
+	require.Equal(t, 1, rangeCountOf(out, 0, 1))
 }
 
 func TestArriveNoData(t *testing.T) {
 	st := State{Disks: []int64{10, 10}}
-	_, plan := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
-	require.Empty(t, plan.Moves)
+	_, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
+	require.Empty(t, res.Diff)
 }
 
 func TestArriveAlreadyBalanced(t *testing.T) {
@@ -163,12 +192,11 @@ func TestArriveAlreadyBalanced(t *testing.T) {
 		[]int64{10, 10},
 		[]int{0, 1},
 	)
-	_, plan := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
-	require.Empty(t, plan.Moves)
+	_, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
+	require.Empty(t, res.Diff)
 }
 
 func TestFullPeelsMinimum(t *testing.T) {
-	// (0x00, 0x80] is 128 hash units and 32 bytes, so a 7-byte peel is exact.
 	st := mk(
 		[]int64{25, 50},
 		[]byte{0x00, 0x80},
@@ -176,10 +204,10 @@ func TestFullPeelsMinimum(t *testing.T) {
 		[]int{1, 0},
 	)
 	require.Error(t, Validate(st))
-	out, plan := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
+	out, res := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
 	require.LessOrEqual(t, usedOf(out, 0), int64(25))
-	require.Equal(t, int64(7), plan.BytesMoved)
-	require.Len(t, plan.Moves, 1)
+	require.Equal(t, int64(7), res.BytesMoved)
+	require.Len(t, res.Diff, 1)
 }
 
 func TestFullAlreadyUnderCapacity(t *testing.T) {
@@ -189,8 +217,8 @@ func TestFullAlreadyUnderCapacity(t *testing.T) {
 		[]int64{10, 10},
 		[]int{0, 1},
 	)
-	_, plan := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
-	require.Empty(t, plan.Moves)
+	_, res := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
+	require.Empty(t, res.Diff)
 }
 
 func TestFullCannotShed(t *testing.T) {
@@ -211,11 +239,11 @@ func TestRepairTooManyRanges(t *testing.T) {
 		[]int64{5, 5, 5, 5, 5, 5, 5, 5},
 		[]int{0, 1, 0, 1, 0, 1, 0, 1},
 	)
-	require.Equal(t, 4, rangeCountOf(st, 0))
+	require.Equal(t, 4, rangeCountOf(st, 0, 0))
 	require.Error(t, Validate(st))
 	out, _ := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
-	require.LessOrEqual(t, rangeCountOf(out, 0), MAX_RANGES_PER_DISK)
-	require.LessOrEqual(t, rangeCountOf(out, 1), MAX_RANGES_PER_DISK)
+	require.LessOrEqual(t, rangeCountOf(out, 0, 0), MAX_RANGES_PER_DISK)
+	require.LessOrEqual(t, rangeCountOf(out, 0, 1), MAX_RANGES_PER_DISK)
 }
 
 func TestUnknownEventDisk(t *testing.T) {
@@ -232,7 +260,7 @@ func TestUnknownEventKind(t *testing.T) {
 
 func TestStructuralErrors(t *testing.T) {
 	t.Run("owner length", func(t *testing.T) {
-		st := State{Disks: []int64{10}, Ranges: []Range{{EndHash: h(1), Size: 1}}}
+		st := State{Disks: []int64{10}, Spaces: []Space{{Ranges: []Range{{EndHash: h(1), Size: 1}}}}}
 		_, err := Solve(st, Event{Kind: EventFull, Disk: 0})
 		require.Error(t, err)
 	})
@@ -251,11 +279,11 @@ func TestStructuralErrors(t *testing.T) {
 func TestSolveDoesNotMutateInput(t *testing.T) {
 	st := mk([]int64{30, 30}, []byte{0x80}, []int64{40}, []int{0})
 	before := usedOf(st, 0)
-	end := append([]byte(nil), st.Ranges[0].EndHash...)
+	end := append([]byte(nil), st.Spaces[0].Ranges[0].EndHash...)
 	_, _ = solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
 	require.Equal(t, before, usedOf(st, 0))
-	require.Equal(t, end, st.Ranges[0].EndHash)
-	require.Equal(t, 0, st.Owner[0])
+	require.Equal(t, end, st.Spaces[0].Ranges[0].EndHash)
+	require.Equal(t, 0, st.Spaces[0].Owner[0])
 }
 
 func TestDeterministic(t *testing.T) {
@@ -269,7 +297,15 @@ func TestDeterministic(t *testing.T) {
 	require.NoError(t, err)
 	p2, err := Solve(st, Event{Kind: EventVacate, Disk: 2})
 	require.NoError(t, err)
-	require.Equal(t, p1, p2)
+	require.Equal(t, p1.BytesMoved, p2.BytesMoved)
+	require.Equal(t, len(p1.Diff), len(p2.Diff))
+	for i := range p1.Diff {
+		require.Equal(t, p1.Diff[i].From, p2.Diff[i].From)
+		require.Equal(t, p1.Diff[i].To, p2.Diff[i].To)
+		require.Equal(t, p1.Diff[i].Size, p2.Diff[i].Size)
+		require.True(t, bytes.Equal(p1.Diff[i].StartHash, p2.Diff[i].StartHash))
+		require.True(t, bytes.Equal(p1.Diff[i].EndHash, p2.Diff[i].EndHash))
+	}
 }
 
 func TestArriveAtMostThreeRanges(t *testing.T) {
@@ -279,10 +315,108 @@ func TestArriveAtMostThreeRanges(t *testing.T) {
 		[]int64{10, 10, 10, 10, 10, 10, 10, 10},
 		[]int{0, 0, 1, 1, 2, 2, 3, 3},
 	)
-	out, plan := solveOK(t, st, Event{Kind: EventArrive, Disk: 4})
-	require.NotEmpty(t, plan.Moves)
-	require.LessOrEqual(t, rangeCountOf(out, 4), MAX_RANGES_PER_DISK)
+	out, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 4})
+	require.NotEmpty(t, res.Diff)
+	require.LessOrEqual(t, rangeCountOf(out, 0, 4), MAX_RANGES_PER_DISK)
 	require.Greater(t, usedOf(out, 4), int64(0))
+}
+
+func TestTwoSpacesUnequalSharedCapacity(t *testing.T) {
+	// A is large, B is small; shared disks must not exceed capacity.
+	st := mk2(
+		[]int64{100, 100},
+		spaceOf([]byte{0x80}, []int64{80}, []int{0}),
+		spaceOf([]byte{0x40}, []int64{20}, []int{0}),
+	)
+	require.NoError(t, Validate(st))
+	out, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
+	require.NotEmpty(t, res.Diff)
+	require.Equal(t, int64(100), usedOf(out, 0)+usedOf(out, 1))
+	require.Equal(t, int64(50), usedOf(out, 1))
+	require.LessOrEqual(t, usedOf(out, 0), out.Disks[0])
+	require.LessOrEqual(t, usedOf(out, 1), out.Disks[1])
+}
+
+func TestArriveStealsFromEitherSpace(t *testing.T) {
+	// Disk 0 holds most of A; disk 1 holds all of B. New disk 2 should take
+	// peels from whichever space fits best toward fair share.
+	st := mk2(
+		[]int64{100, 100, 100},
+		spaceOf([]byte{0x80}, []int64{60}, []int{0}),
+		spaceOf([]byte{0x40}, []int64{30}, []int{1}),
+	)
+	out, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 2})
+	require.NotEmpty(t, res.Diff)
+	require.Equal(t, int64(30), usedOf(out, 2)) // fair share of 90 total
+	spacesUsed := make(map[int]bool)
+	for _, tr := range res.Diff {
+		spacesUsed[tr.Space] = true
+		require.Equal(t, 2, tr.To)
+	}
+	require.NotEmpty(t, spacesUsed)
+}
+
+func TestFullShedsCheapestSpace(t *testing.T) {
+	// Disk 0 is over capacity; B has an exact small peel, A has a large block.
+	st := mk2(
+		[]int64{50, 100},
+		spaceOf([]byte{0x80}, []int64{40}, []int{0}),
+		spaceOf([]byte{0x00, 0x40}, []int64{5, 16}, []int{1, 0}), // 16 on disk 0 in B
+	)
+	// used[0] = 40+16 = 56 > 50; need to shed 6.
+	require.Error(t, Validate(st))
+	out, res := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
+	require.LessOrEqual(t, usedOf(out, 0), int64(50))
+	require.Equal(t, int64(6), res.BytesMoved)
+}
+
+func TestVacateBothSpaces(t *testing.T) {
+	st := mk2(
+		[]int64{80, 40, 80},
+		spaceOf([]byte{0x20, 0x40}, []int64{10, 20}, []int{0, 1}),
+		spaceOf([]byte{0x30, 0x60}, []int64{10, 15}, []int{2, 1}),
+	)
+	out, res := solveOK(t, st, Event{Kind: EventVacate, Disk: 1})
+	require.Zero(t, usedOf(out, 1))
+	require.Equal(t, int64(35), res.BytesMoved)
+	require.LessOrEqual(t, rangeCountOf(out, 0, 0), MAX_RANGES_PER_DISK)
+	require.LessOrEqual(t, rangeCountOf(out, 1, 0), MAX_RANGES_PER_DISK)
+	require.LessOrEqual(t, rangeCountOf(out, 0, 2), MAX_RANGES_PER_DISK)
+	require.LessOrEqual(t, rangeCountOf(out, 1, 2), MAX_RANGES_PER_DISK)
+}
+
+func TestDiffDisjointPerSpace(t *testing.T) {
+	st := mk2(
+		[]int64{100, 100},
+		spaceOf([]byte{0x80}, []int64{80}, []int{0}),
+		spaceOf([]byte{0x40}, []int64{20}, []int{0}),
+	)
+	_, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
+	for s := 0; s < 2; s++ {
+		var segs []Transfer
+		for _, tr := range res.Diff {
+			if tr.Space == s {
+				segs = append(segs, tr)
+			}
+		}
+		for i := 0; i < len(segs); i++ {
+			for j := i + 1; j < len(segs); j++ {
+				require.False(t, intervalsOverlap(segs[i], segs[j]), "overlapping diffs in space %d", s)
+			}
+		}
+	}
+}
+
+func intervalsOverlap(a, b Transfer) bool {
+	// Two half-open arcs overlap if either endpoint of one lies in the other.
+	return (pointInArc(a.StartHash, a.EndHash, b.EndHash) && !hashEq(b.EndHash, a.StartHash)) ||
+		(pointInArc(b.StartHash, b.EndHash, a.EndHash) && !hashEq(a.EndHash, b.StartHash))
+}
+
+func TestApplyRejectsUnknownRange(t *testing.T) {
+	st := mk([]int64{20, 20}, []byte{0x80}, []int64{5}, []int{0})
+	_, err := Apply(st, []Transfer{{Space: 0, From: 0, To: 1, StartHash: h(0x00), EndHash: h(0x01), Size: 5}})
+	require.Error(t, err)
 }
 
 func TestRandomClusterEvents(t *testing.T) {
@@ -291,16 +425,17 @@ func TestRandomClusterEvents(t *testing.T) {
 		st := randomValidState(rng)
 		require.NoError(t, Validate(st), "iter %d seed state", i)
 		st, ev := randomEvent(rng, st)
-		plan, err := Solve(st, ev)
+		res, err := Solve(st, ev)
 		if err != nil {
 			if ev.Kind == EventVacate || ev.Kind == EventFull {
 				continue
 			}
 			t.Fatalf("iter %d: unexpected solve error: %v", i, err)
 		}
-		out, err := Apply(st, plan)
+		out, err := Apply(st, res.Diff)
 		require.NoError(t, err, "iter %d", i)
 		require.NoError(t, Validate(out), "iter %d", i)
+		requireEqualState(t, res.State, out)
 		if ev.Kind == EventVacate {
 			require.Zero(t, usedOf(out, ev.Disk), "iter %d", i)
 		}
@@ -309,25 +444,30 @@ func TestRandomClusterEvents(t *testing.T) {
 
 func randomValidState(rng *rand.Rand) State {
 	nDisks := 2 + rng.Intn(3)
-	nRanges := nDisks + rng.Intn(4)
 	disks := make([]int64, nDisks)
 	for i := range disks {
-		disks[i] = int64(80 + rng.Intn(80))
+		disks[i] = int64(120 + rng.Intn(80))
 	}
-	ranges := make([]Range, nRanges)
-	owner := make([]int, nRanges)
+	nSpaces := 1 + rng.Intn(2)
+	spaces := make([]Space, nSpaces)
 	used := make([]int64, nDisks)
-	di := 0
-	for i := 0; i < nRanges; i++ {
-		sz := int64(8 + rng.Intn(16))
-		for di < nDisks-1 && used[di]+sz > disks[di]/2 {
-			di++
+	for s := 0; s < nSpaces; s++ {
+		nRanges := nDisks + rng.Intn(3)
+		ranges := make([]Range, nRanges)
+		owner := make([]int, nRanges)
+		di := 0
+		for i := 0; i < nRanges; i++ {
+			sz := int64(6 + rng.Intn(10))
+			for di < nDisks-1 && used[di]+sz > disks[di]/3 {
+				di++
+			}
+			ranges[i] = Range{EndHash: []byte{byte((s+1)*40 + (i+1)*11)}, Size: sz}
+			owner[i] = di % nDisks
+			used[owner[i]] += sz
 		}
-		ranges[i] = Range{EndHash: []byte{byte((i + 1) * 17)}, Size: sz}
-		owner[i] = di
-		used[di] += sz
+		spaces[s] = Space{Ranges: ranges, Owner: owner}
 	}
-	return State{Disks: disks, Ranges: ranges, Owner: owner}
+	return State{Disks: disks, Spaces: spaces}
 }
 
 func randomEvent(rng *rand.Rand, st State) (State, Event) {
@@ -340,10 +480,4 @@ func randomEvent(rng *rand.Rand, st State) (State, Event) {
 	default:
 		return st, Event{Kind: EventVacate, Disk: rng.Intn(len(st.Disks))}
 	}
-}
-
-func TestApplyRejectsUnknownRange(t *testing.T) {
-	st := mk([]int64{20, 20}, []byte{0x80}, []int64{5}, []int{0})
-	_, err := Apply(st, Plan{Moves: []Move{{From: 0, To: 1, EndHash: h(0x01), Size: 5}}})
-	require.Error(t, err)
 }

--- a/lib/hashspacesolver/solver_test.go
+++ b/lib/hashspacesolver/solver_test.go
@@ -169,14 +169,25 @@ func TestVacateOnlyDisk(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestArriveStealsFairShare(t *testing.T) {
-	st := mk([]int64{100, 100}, []byte{0x80}, []int64{80}, []int{0})
+func TestArriveRelievesOverflow(t *testing.T) {
+	st := mk([]int64{50, 100}, []byte{0x80}, []int64{80}, []int{0})
 	out, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
 	require.NotEmpty(t, res.Diff)
 	require.Equal(t, int64(80), usedOf(out, 0)+usedOf(out, 1))
+	require.Equal(t, int64(40), usedOf(out, 0))
 	require.Equal(t, int64(40), usedOf(out, 1))
 	require.Equal(t, 1, rangeCountOf(out, 0, 0))
 	require.Equal(t, 1, rangeCountOf(out, 0, 1))
+}
+
+func TestArriveRelievesOverflowLargeDisks(t *testing.T) {
+	const tib = int64(1) << 40
+	st := mk([]int64{40 * tib, 100 * tib}, []byte{0x80}, []int64{80 * tib}, []int{0})
+	out, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
+	require.NotEmpty(t, res.Diff)
+	require.Equal(t, 80*tib, usedOf(out, 0)+usedOf(out, 1))
+	require.LessOrEqual(t, usedOf(out, 0), fillLimitOf(40*tib))
+	require.LessOrEqual(t, usedOf(out, 1), fillLimitOf(100*tib))
 }
 
 func TestArriveNoData(t *testing.T) {
@@ -185,7 +196,7 @@ func TestArriveNoData(t *testing.T) {
 	require.Empty(t, res.Diff)
 }
 
-func TestArriveAlreadyBalanced(t *testing.T) {
+func TestArriveIdleWhenUnderFillLimit(t *testing.T) {
 	st := mk(
 		[]int64{20, 20},
 		[]byte{0x80, 0xFF},
@@ -196,21 +207,49 @@ func TestArriveAlreadyBalanced(t *testing.T) {
 	require.Empty(t, res.Diff)
 }
 
+func TestArriveClusterOverFillLimit(t *testing.T) {
+	// Cluster is already ~90% full. The new disk can only take up to its
+	// own 80% fill limit; remaining disks stay above 80%.
+	st := mk(
+		[]int64{100, 100, 10},
+		[]byte{0x80, 0xFF},
+		[]int64{90, 90},
+		[]int{0, 1},
+	)
+	out, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 2})
+	require.NotEmpty(t, res.Diff)
+	require.LessOrEqual(t, usedOf(out, 2), fillLimitOf(10))
+	require.Greater(t, usedOf(out, 0), fillLimitOf(100))
+	require.Greater(t, usedOf(out, 1), fillLimitOf(100))
+}
+
+func TestFullStopsWhenDestsAtFillLimit(t *testing.T) {
+	st := mk(
+		[]int64{100, 100},
+		[]byte{0x80, 0xFF},
+		[]int64{90, 80},
+		[]int{0, 1},
+	)
+	out, res := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
+	require.Empty(t, res.Diff)
+	require.Equal(t, int64(90), usedOf(out, 0))
+}
+
 func TestFullPeelsMinimum(t *testing.T) {
 	st := mk(
 		[]int64{25, 50},
 		[]byte{0x00, 0x80},
-		[]int64{5, 32},
+		[]int64{5, 22},
 		[]int{1, 0},
 	)
-	require.Error(t, Validate(st))
+	require.NoError(t, Validate(st))
 	out, res := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
-	require.LessOrEqual(t, usedOf(out, 0), int64(25))
-	require.Equal(t, int64(7), res.BytesMoved)
+	require.LessOrEqual(t, usedOf(out, 0), fillLimitOf(25))
+	require.GreaterOrEqual(t, res.BytesMoved, int64(2))
 	require.Len(t, res.Diff, 1)
 }
 
-func TestFullAlreadyUnderCapacity(t *testing.T) {
+func TestFullAlreadyUnderFillLimit(t *testing.T) {
 	st := mk(
 		[]int64{20, 20},
 		[]byte{0x80, 0xFF},
@@ -310,64 +349,65 @@ func TestDeterministic(t *testing.T) {
 
 func TestArriveAtMostThreeRanges(t *testing.T) {
 	st := mk(
-		[]int64{100, 100, 100, 100, 100},
-		[]byte{0x18, 0x20, 0x38, 0x40, 0x58, 0x60, 0x78, 0x80},
+		[]int64{8, 8, 8, 8, 400},
+		[]byte{0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80},
 		[]int64{10, 10, 10, 10, 10, 10, 10, 10},
-		[]int{0, 0, 1, 1, 2, 2, 3, 3},
+		[]int{0, 1, 2, 3, 0, 1, 2, 3},
 	)
 	out, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 4})
 	require.NotEmpty(t, res.Diff)
 	require.LessOrEqual(t, rangeCountOf(out, 0, 4), MAX_RANGES_PER_DISK)
-	require.Greater(t, usedOf(out, 4), int64(0))
+	for d := 0; d < 4; d++ {
+		require.LessOrEqual(t, usedOf(out, d), fillLimitOf(out.Disks[d]), "disk %d", d)
+	}
+	require.GreaterOrEqual(t, usedOf(out, 4), int64(56))
 }
 
 func TestTwoSpacesUnequalSharedCapacity(t *testing.T) {
 	// A is large, B is small; shared disks must not exceed capacity.
 	st := mk2(
-		[]int64{100, 100},
+		[]int64{70, 100},
 		spaceOf([]byte{0x80}, []int64{80}, []int{0}),
 		spaceOf([]byte{0x40}, []int64{20}, []int{0}),
 	)
-	require.NoError(t, Validate(st))
+	require.Error(t, Validate(st))
 	out, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 1})
 	require.NotEmpty(t, res.Diff)
 	require.Equal(t, int64(100), usedOf(out, 0)+usedOf(out, 1))
-	require.Equal(t, int64(50), usedOf(out, 1))
-	require.LessOrEqual(t, usedOf(out, 0), out.Disks[0])
-	require.LessOrEqual(t, usedOf(out, 1), out.Disks[1])
+	require.Equal(t, fillLimitOf(70), usedOf(out, 0))
+	require.Equal(t, int64(44), usedOf(out, 1))
 }
 
 func TestArriveStealsFromEitherSpace(t *testing.T) {
-	// Disk 0 holds most of A; disk 1 holds all of B. New disk 2 should take
-	// peels from whichever space fits best toward fair share.
+	// Disk 0 is above the fill limit in A; disk 1 is under. The new disk
+	// only takes the overflow, from whichever space that overflow lives in.
 	st := mk2(
-		[]int64{100, 100, 100},
+		[]int64{50, 100, 100},
 		spaceOf([]byte{0x80}, []int64{60}, []int{0}),
 		spaceOf([]byte{0x40}, []int64{30}, []int{1}),
 	)
 	out, res := solveOK(t, st, Event{Kind: EventArrive, Disk: 2})
 	require.NotEmpty(t, res.Diff)
-	require.Equal(t, int64(30), usedOf(out, 2)) // fair share of 90 total
-	spacesUsed := make(map[int]bool)
+	require.Equal(t, int64(20), usedOf(out, 2))
+	require.Equal(t, fillLimitOf(50), usedOf(out, 0))
 	for _, tr := range res.Diff {
-		spacesUsed[tr.Space] = true
 		require.Equal(t, 2, tr.To)
+		require.Equal(t, 0, tr.Space)
 	}
-	require.NotEmpty(t, spacesUsed)
 }
 
 func TestFullShedsCheapestSpace(t *testing.T) {
 	// Disk 0 is over capacity; B has an exact small peel, A has a large block.
 	st := mk2(
 		[]int64{50, 100},
-		spaceOf([]byte{0x80}, []int64{40}, []int{0}),
-		spaceOf([]byte{0x00, 0x40}, []int64{5, 16}, []int{1, 0}), // 16 on disk 0 in B
+		spaceOf([]byte{0x80}, []int64{30}, []int{0}),
+		spaceOf([]byte{0x00, 0x40}, []int64{5, 15}, []int{1, 0}),
 	)
-	// used[0] = 40+16 = 56 > 50; need to shed 6.
-	require.Error(t, Validate(st))
+	// used[0] = 30+15 = 45; fill limit 40; need to shed 5.
+	require.NoError(t, Validate(st))
 	out, res := solveOK(t, st, Event{Kind: EventFull, Disk: 0})
-	require.LessOrEqual(t, usedOf(out, 0), int64(50))
-	require.Equal(t, int64(6), res.BytesMoved)
+	require.LessOrEqual(t, usedOf(out, 0), fillLimitOf(50))
+	require.GreaterOrEqual(t, res.BytesMoved, int64(5))
 }
 
 func TestVacateBothSpaces(t *testing.T) {
@@ -387,7 +427,7 @@ func TestVacateBothSpaces(t *testing.T) {
 
 func TestDiffDisjointPerSpace(t *testing.T) {
 	st := mk2(
-		[]int64{100, 100},
+		[]int64{90, 100},
 		spaceOf([]byte{0x80}, []int64{80}, []int{0}),
 		spaceOf([]byte{0x40}, []int64{20}, []int{0}),
 	)
@@ -411,6 +451,32 @@ func intervalsOverlap(a, b Transfer) bool {
 	// Two half-open arcs overlap if either endpoint of one lies in the other.
 	return (pointInArc(a.StartHash, a.EndHash, b.EndHash) && !hashEq(b.EndHash, a.StartHash)) ||
 		(pointInArc(b.StartHash, b.EndHash, a.EndHash) && !hashEq(a.EndHash, b.StartHash))
+}
+
+func TestMergeTransfersFixpoint(t *testing.T) {
+	got := mergeTransfers([]Transfer{
+		{Space: 0, From: 0, To: 1, StartHash: h(0x10), EndHash: h(0x20), Size: 1},
+		{Space: 0, From: 0, To: 1, StartHash: h(0x30), EndHash: h(0x40), Size: 1},
+		{Space: 0, From: 0, To: 1, StartHash: h(0x20), EndHash: h(0x30), Size: 1},
+		{Space: 1, From: 0, To: 1, StartHash: h(0x00), EndHash: h(0x10), Size: 4},
+	})
+	require.Len(t, got, 2)
+	var combined, other Transfer
+	for _, tr := range got {
+		if tr.Space == 0 {
+			combined = tr
+		} else {
+			other = tr
+		}
+	}
+	require.Equal(t, 0, combined.From)
+	require.Equal(t, 1, combined.To)
+	require.Equal(t, int64(3), combined.Size)
+	require.True(t, hashEq(combined.StartHash, h(0x10)))
+	require.True(t, hashEq(combined.EndHash, h(0x40)))
+	require.Equal(t, int64(4), other.Size)
+	require.True(t, hashEq(other.StartHash, h(0x00)))
+	require.True(t, hashEq(other.EndHash, h(0x10)))
 }
 
 func TestApplyRejectsUnknownRange(t *testing.T) {

--- a/lib/hashspacesolver/types.go
+++ b/lib/hashspacesolver/types.go
@@ -1,15 +1,18 @@
 // Package hashspacesolver plans range moves across disks so each disk holds
-// fewer than four contiguous hash-space ranges while moving as little data
-// as possible.
+// fewer than four contiguous hash-space ranges per space while moving as
+// little data as possible.
 //
-// Disks are a list of total sizes (capacities). Ranges are a circular
-// partition of hash space: each range is the half-open interval from the
-// previous range's EndHash to its own, with Size bytes of data. SliceSize
-// reports how much of a range's data lies in a sub-interval.
+// Disks are a list of total sizes (capacities) shared by all spaces. Each
+// Space is an independent circular hash partition: ranges are half-open
+// intervals from the previous EndHash to their own, with Size bytes of data.
+// SliceSize reports how much of a range's data lies in a sub-interval.
+//
+// Solve returns a target State plus an order-independent Diff of absolute
+// interval transfers for delayed application.
 package hashspacesolver
 
-// MAX_RANGES_PER_DISK is the maximum number of contiguous hash-space ranges
-// a disk may hold (fewer than 4).
+// MAX_RANGES_PER_DISK is the maximum number of contiguous ranges a disk may
+// hold in one space (fewer than 4). Caps are per disk per space.
 const MAX_RANGES_PER_DISK = 3
 
 // Range is one contiguous hash-space interval. It covers hashes after the
@@ -19,14 +22,19 @@ type Range struct {
 	Size    int64
 }
 
-// State is an assignment of ranges to disks.
-//
-// Disks[i] is disk i's total size (capacity). Owner[j] is the disk index
-// holding Ranges[j]. Ranges are ordered by EndHash around the circle.
-type State struct {
-	Disks  []int64
+// Space is one independent hash circle assigned across disks.
+type Space struct {
 	Ranges []Range
 	Owner  []int
+}
+
+// State is an assignment of ranges to disks across one or more spaces.
+//
+// Disks[i] is disk i's shared capacity. Spaces are independent circles that
+// share that capacity; Owner[j] within a space is the disk holding Ranges[j].
+type State struct {
+	Disks  []int64
+	Spaces []Space
 }
 
 // EventKind selects which disk-lifecycle problem to solve.
@@ -34,7 +42,7 @@ type EventKind int
 
 const (
 	// EventArrive fills a newly added disk toward its capacity-weighted fair
-	// share, stealing prefixes or suffixes of existing ranges.
+	// share, stealing prefixes or suffixes of existing ranges from any space.
 	EventArrive EventKind = iota + 1
 	// EventFull sheds the minimum data from an over-capacity disk.
 	EventFull
@@ -49,20 +57,20 @@ type Event struct {
 	Disk int
 }
 
-// Move transfers a whole range, or a prefix/suffix slice of one, between disks.
-// EndHash identifies the source range at the time of the move. Split is the
-// EndHash of the moved slice; if nil or equal to EndHash, the whole range moves.
-type Move struct {
-	From    int
-	To      int
-	EndHash []byte
-	Split   []byte
-	Prefix  bool
-	Size    int64
+// Transfer moves an absolute hash interval from one disk to another within
+// one space. Intervals are half-open (StartHash, EndHash].
+type Transfer struct {
+	Space     int
+	StartHash []byte
+	EndHash   []byte
+	From      int
+	To        int
+	Size      int64
 }
 
-// Plan is a sequentially applicable list of range moves.
-type Plan struct {
-	Moves      []Move
+// Result is the finished assignment plus an order-independent work list.
+type Result struct {
+	State      State
+	Diff       []Transfer
 	BytesMoved int64
 }

--- a/lib/hashspacesolver/types.go
+++ b/lib/hashspacesolver/types.go
@@ -1,0 +1,68 @@
+// Package hashspacesolver plans range moves across disks so each disk holds
+// fewer than four contiguous hash-space ranges while moving as little data
+// as possible.
+//
+// Disks are a list of total sizes (capacities). Ranges are a circular
+// partition of hash space: each range is the half-open interval from the
+// previous range's EndHash to its own, with Size bytes of data. SliceSize
+// reports how much of a range's data lies in a sub-interval.
+package hashspacesolver
+
+// MAX_RANGES_PER_DISK is the maximum number of contiguous hash-space ranges
+// a disk may hold (fewer than 4).
+const MAX_RANGES_PER_DISK = 3
+
+// Range is one contiguous hash-space interval. It covers hashes after the
+// previous range's EndHash up to EndHash, and holds Size bytes.
+type Range struct {
+	EndHash []byte
+	Size    int64
+}
+
+// State is an assignment of ranges to disks.
+//
+// Disks[i] is disk i's total size (capacity). Owner[j] is the disk index
+// holding Ranges[j]. Ranges are ordered by EndHash around the circle.
+type State struct {
+	Disks  []int64
+	Ranges []Range
+	Owner  []int
+}
+
+// EventKind selects which disk-lifecycle problem to solve.
+type EventKind int
+
+const (
+	// EventArrive fills a newly added disk toward its capacity-weighted fair
+	// share, stealing prefixes or suffixes of existing ranges.
+	EventArrive EventKind = iota + 1
+	// EventFull sheds the minimum data from an over-capacity disk.
+	EventFull
+	// EventVacate empties a disk so it can leave the cluster.
+	EventVacate
+)
+
+// Event asks the solver to react to one disk arriving, filling, or vacating.
+// Disk is an index into State.Disks.
+type Event struct {
+	Kind EventKind
+	Disk int
+}
+
+// Move transfers a whole range, or a prefix/suffix slice of one, between disks.
+// EndHash identifies the source range at the time of the move. Split is the
+// EndHash of the moved slice; if nil or equal to EndHash, the whole range moves.
+type Move struct {
+	From    int
+	To      int
+	EndHash []byte
+	Split   []byte
+	Prefix  bool
+	Size    int64
+}
+
+// Plan is a sequentially applicable list of range moves.
+type Plan struct {
+	Moves      []Move
+	BytesMoved int64
+}

--- a/lib/hashspacesolver/types.go
+++ b/lib/hashspacesolver/types.go
@@ -15,6 +15,12 @@ package hashspacesolver
 // hold in one space (fewer than 4). Caps are per disk per space.
 const MAX_RANGES_PER_DISK = 3
 
+// FILL_LIMIT_PERCENT is the rebalance target as a percent of physical
+// capacity. Planning moves data to get disks to or under this fraction.
+// A tight cluster may still sit above it after a best-effort plan; 100%
+// remains the hard physical limit.
+const FILL_LIMIT_PERCENT = 80
+
 // Range is one contiguous hash-space interval. It covers hashes after the
 // previous range's EndHash up to EndHash, and holds Size bytes.
 type Range struct {
@@ -41,10 +47,12 @@ type State struct {
 type EventKind int
 
 const (
-	// EventArrive fills a newly added disk toward its capacity-weighted fair
-	// share, stealing prefixes or suffixes of existing ranges from any space.
+	// EventArrive uses a newly added disk to take overflow off other disks.
+	// Steals grow an existing dest range when possible; a new fragment is
+	// opened only while dest is under MAX_RANGES_PER_DISK.
 	EventArrive EventKind = iota + 1
-	// EventFull sheds the minimum data from an over-capacity disk.
+	// EventFull sheds from a disk that is above FILL_LIMIT_PERCENT of
+	// physical capacity.
 	EventFull
 	// EventVacate empties a disk so it can leave the cluster.
 	EventVacate

--- a/lib/hashspacesolver/world.go
+++ b/lib/hashspacesolver/world.go
@@ -13,14 +13,18 @@ const (
 	cutSuffix
 )
 
-type world struct {
-	disks  []int64
+type spaceWorld struct {
 	ranges []Range
 	owner  []int
+}
+
+type world struct {
+	disks  []int64
+	spaces []spaceWorld
 	used   []int64
 	frozen []bool
-	moves  []Move
 	bytes  int64
+	diff   []Transfer
 }
 
 func newWorld(state State) (*world, error) {
@@ -29,16 +33,21 @@ func newWorld(state State) (*world, error) {
 	}
 	w := &world{
 		disks:  append([]int64(nil), state.Disks...),
-		ranges: cloneRanges(state.Ranges),
-		owner:  append([]int(nil), state.Owner...),
+		spaces: make([]spaceWorld, len(state.Spaces)),
 		used:   make([]int64, len(state.Disks)),
 		frozen: make([]bool, len(state.Disks)),
 	}
-	for i, r := range w.ranges {
-		w.used[w.owner[i]] += r.Size
+	for s, sp := range state.Spaces {
+		w.spaces[s] = spaceWorld{
+			ranges: cloneRanges(sp.Ranges),
+			owner:  append([]int(nil), sp.Owner...),
+		}
+		w.sortSpace(s)
+		w.mergeSpace(s)
+		for i, r := range w.spaces[s].ranges {
+			w.used[w.spaces[s].owner[i]] += r.Size
+		}
 	}
-	w.sortRanges()
-	w.merge()
 	return w, nil
 }
 
@@ -50,20 +59,29 @@ func cloneRanges(in []Range) []Range {
 	return out
 }
 
-func (w *world) snapshot() State {
-	return State{
-		Disks:  append([]int64(nil), w.disks...),
-		Ranges: cloneRanges(w.ranges),
-		Owner:  append([]int(nil), w.owner...),
+func cloneSpace(sp Space) Space {
+	return Space{
+		Ranges: cloneRanges(sp.Ranges),
+		Owner:  append([]int(nil), sp.Owner...),
 	}
 }
 
-func (w *world) plan() Plan {
-	return Plan{Moves: append([]Move(nil), w.moves...), BytesMoved: w.bytes}
+func (w *world) snapshot() State {
+	spaces := make([]Space, len(w.spaces))
+	for i, sp := range w.spaces {
+		spaces[i] = Space{
+			Ranges: cloneRanges(sp.ranges),
+			Owner:  append([]int(nil), sp.owner...),
+		}
+	}
+	return State{
+		Disks:  append([]int64(nil), w.disks...),
+		Spaces: spaces,
+	}
 }
 
-func (w *world) startHash(i int) []byte {
-	return StartHash(w.ranges, i)
+func (w *world) startHash(space, i int) []byte {
+	return StartHash(w.spaces[space].ranges, i)
 }
 
 func (w *world) free(d int) int64 {
@@ -72,8 +90,10 @@ func (w *world) free(d int) int64 {
 
 func (w *world) totalUsed() int64 {
 	var s int64
-	for _, r := range w.ranges {
-		s += r.Size
+	for _, sp := range w.spaces {
+		for _, r := range sp.ranges {
+			s += r.Size
+		}
 	}
 	return s
 }
@@ -96,9 +116,9 @@ func (w *world) fairShare(d int) int64 {
 	return w.totalUsed() * w.disks[d] / cap
 }
 
-func (w *world) rangeCount(d int) int {
+func (w *world) rangeCount(space, d int) int {
 	n := 0
-	for _, o := range w.owner {
+	for _, o := range w.spaces[space].owner {
 		if o == d {
 			n++
 		}
@@ -106,9 +126,9 @@ func (w *world) rangeCount(d int) int {
 	return n
 }
 
-func (w *world) rangeIndexes(d int) []int {
+func (w *world) rangeIndexes(space, d int) []int {
 	var out []int
-	for i, o := range w.owner {
+	for i, o := range w.spaces[space].owner {
 		if o == d {
 			out = append(out, i)
 		}
@@ -126,18 +146,19 @@ func (w *world) activeDisks() []int {
 	return out
 }
 
-func (w *world) destDelta(idx, kind, dest int) int {
-	n := len(w.ranges)
+func (w *world) destDelta(space, idx, kind, dest int) int {
+	sp := &w.spaces[space]
+	n := len(sp.ranges)
 	if n == 0 {
 		return 1
 	}
 	if n == 1 && kind == cutWhole {
-		return 1 - w.rangeCount(dest)
+		return 1 - w.rangeCount(space, dest)
 	}
 	prev := (idx - 1 + n) % n
 	next := (idx + 1) % n
-	left := n > 1 && w.owner[prev] == dest && kind != cutSuffix
-	right := n > 1 && w.owner[next] == dest && kind != cutPrefix
+	left := n > 1 && sp.owner[prev] == dest && kind != cutSuffix
+	right := n > 1 && sp.owner[next] == dest && kind != cutPrefix
 	switch {
 	case left && right:
 		return -1
@@ -148,59 +169,63 @@ func (w *world) destDelta(idx, kind, dest int) int {
 	}
 }
 
-func (w *world) canAccept(dest int, size int64, delta int) bool {
+func (w *world) canAccept(space, dest int, size int64, delta int) bool {
 	if dest < 0 || dest >= len(w.disks) || w.frozen[dest] {
 		return false
 	}
 	if w.used[dest]+size > w.disks[dest] {
 		return false
 	}
-	return w.rangeCount(dest)+delta <= MAX_RANGES_PER_DISK
+	return w.rangeCount(space, dest)+delta <= MAX_RANGES_PER_DISK
 }
 
-func (w *world) canTake(idx, kind, dest int, size int64) bool {
-	if dest == w.owner[idx] {
+func (w *world) canTake(space, idx, kind, dest int, size int64) bool {
+	if dest == w.spaces[space].owner[idx] {
 		return false
 	}
-	return w.canAccept(dest, size, w.destDelta(idx, kind, dest))
+	return w.canAccept(space, dest, size, w.destDelta(space, idx, kind, dest))
 }
 
-func (w *world) applyCut(idx, kind, dest int, size int64) {
-	r := w.ranges[idx]
-	from := w.owner[idx]
+func (w *world) applyCut(space, idx, kind, dest int, size int64) {
+	sp := &w.spaces[space]
+	r := sp.ranges[idx]
+	from := sp.owner[idx]
 	if size <= 0 {
 		return
 	}
 	if size >= r.Size || kind == cutWhole {
-		w.moveWhole(idx, dest)
+		w.moveWhole(space, idx, dest)
 		return
 	}
-	split, moved := w.cutActual(idx, kind, size)
+	split, moved := w.cutActual(space, idx, kind, size)
 	if moved <= 0 || moved >= r.Size {
 		return
 	}
 	if w.used[dest]+moved > w.disks[dest] {
 		return
 	}
+	start := w.startHash(space, idx)
 	if kind == cutPrefix {
-		w.ranges[idx].Size -= moved
+		w.recordTransfer(space, start, split, from, dest, moved)
+		sp.ranges[idx].Size -= moved
 		w.used[from] -= moved
-		w.insert(idx, Range{EndHash: split, Size: moved}, dest)
-		w.record(from, dest, r.EndHash, split, true, moved)
+		w.insert(space, idx, Range{EndHash: split, Size: moved}, dest)
 	} else {
 		end := cloneHash(r.EndHash)
-		w.ranges[idx].EndHash = split
-		w.ranges[idx].Size = r.Size - moved
+		w.recordTransfer(space, split, end, from, dest, moved)
+		sp.ranges[idx].EndHash = split
+		sp.ranges[idx].Size = r.Size - moved
 		w.used[from] -= moved
-		w.insert(idx+1, Range{EndHash: end, Size: moved}, dest)
-		w.record(from, dest, end, split, false, moved)
+		w.insert(space, idx+1, Range{EndHash: end, Size: moved}, dest)
 	}
-	w.merge()
+	w.bytes += moved
+	w.mergeSpace(space)
 }
 
-func (w *world) cutActual(idx, kind int, want int64) ([]byte, int64) {
-	r := w.ranges[idx]
-	start := w.startHash(idx)
+func (w *world) cutActual(space, idx, kind int, want int64) ([]byte, int64) {
+	sp := &w.spaces[space]
+	r := sp.ranges[idx]
+	start := w.startHash(space, idx)
 	if want <= 0 {
 		return cloneHash(start), 0
 	}
@@ -231,33 +256,39 @@ func (w *world) cutActual(idx, kind int, want int64) ([]byte, int64) {
 	return split, moved
 }
 
-func (w *world) moveWhole(idx, dest int) {
-	from := w.owner[idx]
+func (w *world) moveWhole(space, idx, dest int) {
+	sp := &w.spaces[space]
+	from := sp.owner[idx]
 	if from == dest {
 		return
 	}
-	sz := w.ranges[idx].Size
-	w.owner[idx] = dest
+	sz := sp.ranges[idx].Size
+	start := w.startHash(space, idx)
+	end := cloneHash(sp.ranges[idx].EndHash)
+	w.recordTransfer(space, start, end, from, dest, sz)
+	sp.owner[idx] = dest
 	w.used[from] -= sz
 	w.used[dest] += sz
-	w.record(from, dest, w.ranges[idx].EndHash, nil, false, sz)
-	w.merge()
+	w.bytes += sz
+	w.mergeSpace(space)
 }
 
-func (w *world) record(from, to int, end, split []byte, prefix bool, size int64) {
-	w.moves = append(w.moves, Move{
-		From:    from,
-		To:      to,
-		EndHash: cloneHash(end),
-		Split:   cloneHash(split),
-		Prefix:  prefix,
-		Size:    size,
+func (w *world) recordTransfer(space int, start, end []byte, from, to int, size int64) {
+	if size <= 0 || from == to {
+		return
+	}
+	w.diff = append(w.diff, Transfer{
+		Space:     space,
+		StartHash: cloneHash(start),
+		EndHash:   cloneHash(end),
+		From:      from,
+		To:        to,
+		Size:      size,
 	})
-	w.bytes += size
 }
 
-func (w *world) find(end []byte) int {
-	for i, r := range w.ranges {
+func (w *world) find(space int, end []byte) int {
+	for i, r := range w.spaces[space].ranges {
 		if hashEq(r.EndHash, end) {
 			return i
 		}
@@ -265,48 +296,48 @@ func (w *world) find(end []byte) int {
 	return -1
 }
 
-func (w *world) insert(i int, r Range, dest int) {
-	w.ranges = slices.Insert(w.ranges, i, r)
-	w.owner = slices.Insert(w.owner, i, dest)
+func (w *world) insert(space, i int, r Range, dest int) {
+	sp := &w.spaces[space]
+	sp.ranges = slices.Insert(sp.ranges, i, r)
+	sp.owner = slices.Insert(sp.owner, i, dest)
 	w.used[dest] += r.Size
 }
 
-func (w *world) sortRanges() {
+func (w *world) sortSpace(space int) {
+	sp := &w.spaces[space]
 	type pair struct {
 		r Range
 		d int
 	}
-	ps := make([]pair, len(w.ranges))
-	for i := range w.ranges {
-		ps[i] = pair{r: w.ranges[i], d: w.owner[i]}
+	ps := make([]pair, len(sp.ranges))
+	for i := range sp.ranges {
+		ps[i] = pair{r: sp.ranges[i], d: sp.owner[i]}
 	}
 	slices.SortFunc(ps, func(a, b pair) int {
 		return bytes.Compare(a.r.EndHash, b.r.EndHash)
 	})
 	for i, p := range ps {
-		w.ranges[i] = p.r
-		w.owner[i] = p.d
+		sp.ranges[i] = p.r
+		sp.owner[i] = p.d
 	}
 }
 
-func (w *world) merge() {
-	if len(w.ranges) < 2 {
+func (w *world) mergeSpace(space int) {
+	sp := &w.spaces[space]
+	if len(sp.ranges) < 2 {
 		return
 	}
 	for {
-		n := len(w.ranges)
+		n := len(sp.ranges)
 		merged := false
 		for i := 0; i < n; i++ {
 			j := (i + 1) % n
-			if w.owner[i] != w.owner[j] {
+			if sp.owner[i] != sp.owner[j] || i == j {
 				continue
 			}
-			if i == j {
-				continue
-			}
-			w.ranges[j].Size += w.ranges[i].Size
-			w.ranges = append(w.ranges[:i], w.ranges[i+1:]...)
-			w.owner = append(w.owner[:i], w.owner[i+1:]...)
+			sp.ranges[j].Size += sp.ranges[i].Size
+			sp.ranges = append(sp.ranges[:i], sp.ranges[i+1:]...)
+			sp.owner = append(sp.owner[:i], sp.owner[i+1:]...)
 			merged = true
 			break
 		}
@@ -316,14 +347,15 @@ func (w *world) merge() {
 	}
 }
 
-func (w *world) neighbors(idx int) (left, right int, okL, okR bool) {
-	n := len(w.ranges)
+func (w *world) neighbors(space, idx int) (left, right int, okL, okR bool) {
+	sp := &w.spaces[space]
+	n := len(sp.ranges)
 	if n < 2 {
 		return 0, 0, false, false
 	}
-	src := w.owner[idx]
-	l := w.owner[(idx-1+n)%n]
-	r := w.owner[(idx+1)%n]
+	src := sp.owner[idx]
+	l := sp.owner[(idx-1+n)%n]
+	r := sp.owner[(idx+1)%n]
 	if l != src && !w.frozen[l] {
 		left, okL = l, true
 	}
@@ -334,35 +366,37 @@ func (w *world) neighbors(idx int) (left, right int, okL, okR bool) {
 }
 
 func checkStructure(state State) error {
-	if len(state.Owner) != len(state.Ranges) {
-		return xerrors.Errorf("owner length %d != ranges length %d", len(state.Owner), len(state.Ranges))
-	}
-	var hlen int
-	seen := make(map[string]struct{}, len(state.Ranges))
-	for i, r := range state.Ranges {
-		if r.Size < 0 {
-			return xerrors.Errorf("range %d has negative size", i)
-		}
-		if len(r.EndHash) == 0 {
-			return xerrors.Errorf("range %d has empty EndHash", i)
-		}
-		if hlen == 0 {
-			hlen = len(r.EndHash)
-		} else if len(r.EndHash) != hlen {
-			return xerrors.Errorf("range %d EndHash length %d != %d", i, len(r.EndHash), hlen)
-		}
-		key := string(r.EndHash)
-		if _, ok := seen[key]; ok {
-			return xerrors.Errorf("duplicate EndHash at range %d", i)
-		}
-		seen[key] = struct{}{}
-		if state.Owner[i] < 0 || state.Owner[i] >= len(state.Disks) {
-			return xerrors.Errorf("range %d owner %d out of range", i, state.Owner[i])
-		}
-	}
 	for i, sz := range state.Disks {
 		if sz < 0 {
 			return xerrors.Errorf("disk %d has negative size", i)
+		}
+	}
+	for s, sp := range state.Spaces {
+		if len(sp.Owner) != len(sp.Ranges) {
+			return xerrors.Errorf("space %d: owner length %d != ranges length %d", s, len(sp.Owner), len(sp.Ranges))
+		}
+		var hlen int
+		seen := make(map[string]struct{}, len(sp.Ranges))
+		for i, r := range sp.Ranges {
+			if r.Size < 0 {
+				return xerrors.Errorf("space %d range %d has negative size", s, i)
+			}
+			if len(r.EndHash) == 0 {
+				return xerrors.Errorf("space %d range %d has empty EndHash", s, i)
+			}
+			if hlen == 0 {
+				hlen = len(r.EndHash)
+			} else if len(r.EndHash) != hlen {
+				return xerrors.Errorf("space %d range %d EndHash length %d != %d", s, i, len(r.EndHash), hlen)
+			}
+			key := string(r.EndHash)
+			if _, ok := seen[key]; ok {
+				return xerrors.Errorf("space %d: duplicate EndHash at range %d", s, i)
+			}
+			seen[key] = struct{}{}
+			if sp.Owner[i] < 0 || sp.Owner[i] >= len(state.Disks) {
+				return xerrors.Errorf("space %d range %d owner %d out of range", s, i, sp.Owner[i])
+			}
 		}
 	}
 	return nil

--- a/lib/hashspacesolver/world.go
+++ b/lib/hashspacesolver/world.go
@@ -1,0 +1,369 @@
+package hashspacesolver
+
+import (
+	"bytes"
+	"slices"
+
+	"golang.org/x/xerrors"
+)
+
+const (
+	cutWhole = iota
+	cutPrefix
+	cutSuffix
+)
+
+type world struct {
+	disks  []int64
+	ranges []Range
+	owner  []int
+	used   []int64
+	frozen []bool
+	moves  []Move
+	bytes  int64
+}
+
+func newWorld(state State) (*world, error) {
+	if err := checkStructure(state); err != nil {
+		return nil, err
+	}
+	w := &world{
+		disks:  append([]int64(nil), state.Disks...),
+		ranges: cloneRanges(state.Ranges),
+		owner:  append([]int(nil), state.Owner...),
+		used:   make([]int64, len(state.Disks)),
+		frozen: make([]bool, len(state.Disks)),
+	}
+	for i, r := range w.ranges {
+		w.used[w.owner[i]] += r.Size
+	}
+	w.sortRanges()
+	w.merge()
+	return w, nil
+}
+
+func cloneRanges(in []Range) []Range {
+	out := make([]Range, len(in))
+	for i, r := range in {
+		out[i] = Range{EndHash: cloneHash(r.EndHash), Size: r.Size}
+	}
+	return out
+}
+
+func (w *world) snapshot() State {
+	return State{
+		Disks:  append([]int64(nil), w.disks...),
+		Ranges: cloneRanges(w.ranges),
+		Owner:  append([]int(nil), w.owner...),
+	}
+}
+
+func (w *world) plan() Plan {
+	return Plan{Moves: append([]Move(nil), w.moves...), BytesMoved: w.bytes}
+}
+
+func (w *world) startHash(i int) []byte {
+	return StartHash(w.ranges, i)
+}
+
+func (w *world) free(d int) int64 {
+	return w.disks[d] - w.used[d]
+}
+
+func (w *world) totalUsed() int64 {
+	var s int64
+	for _, r := range w.ranges {
+		s += r.Size
+	}
+	return s
+}
+
+func (w *world) totalCapacity() int64 {
+	var s int64
+	for i, cap := range w.disks {
+		if !w.frozen[i] {
+			s += cap
+		}
+	}
+	return s
+}
+
+func (w *world) fairShare(d int) int64 {
+	cap := w.totalCapacity()
+	if cap == 0 {
+		return 0
+	}
+	return w.totalUsed() * w.disks[d] / cap
+}
+
+func (w *world) rangeCount(d int) int {
+	n := 0
+	for _, o := range w.owner {
+		if o == d {
+			n++
+		}
+	}
+	return n
+}
+
+func (w *world) rangeIndexes(d int) []int {
+	var out []int
+	for i, o := range w.owner {
+		if o == d {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func (w *world) activeDisks() []int {
+	out := make([]int, 0, len(w.disks))
+	for i := range w.disks {
+		if !w.frozen[i] {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func (w *world) destDelta(idx, kind, dest int) int {
+	n := len(w.ranges)
+	if n == 0 {
+		return 1
+	}
+	if n == 1 && kind == cutWhole {
+		return 1 - w.rangeCount(dest)
+	}
+	prev := (idx - 1 + n) % n
+	next := (idx + 1) % n
+	left := n > 1 && w.owner[prev] == dest && kind != cutSuffix
+	right := n > 1 && w.owner[next] == dest && kind != cutPrefix
+	switch {
+	case left && right:
+		return -1
+	case left || right:
+		return 0
+	default:
+		return 1
+	}
+}
+
+func (w *world) canAccept(dest int, size int64, delta int) bool {
+	if dest < 0 || dest >= len(w.disks) || w.frozen[dest] {
+		return false
+	}
+	if w.used[dest]+size > w.disks[dest] {
+		return false
+	}
+	return w.rangeCount(dest)+delta <= MAX_RANGES_PER_DISK
+}
+
+func (w *world) canTake(idx, kind, dest int, size int64) bool {
+	if dest == w.owner[idx] {
+		return false
+	}
+	return w.canAccept(dest, size, w.destDelta(idx, kind, dest))
+}
+
+func (w *world) applyCut(idx, kind, dest int, size int64) {
+	r := w.ranges[idx]
+	from := w.owner[idx]
+	if size <= 0 {
+		return
+	}
+	if size >= r.Size || kind == cutWhole {
+		w.moveWhole(idx, dest)
+		return
+	}
+	split, moved := w.cutActual(idx, kind, size)
+	if moved <= 0 || moved >= r.Size {
+		return
+	}
+	if w.used[dest]+moved > w.disks[dest] {
+		return
+	}
+	if kind == cutPrefix {
+		w.ranges[idx].Size -= moved
+		w.used[from] -= moved
+		w.insert(idx, Range{EndHash: split, Size: moved}, dest)
+		w.record(from, dest, r.EndHash, split, true, moved)
+	} else {
+		end := cloneHash(r.EndHash)
+		w.ranges[idx].EndHash = split
+		w.ranges[idx].Size = r.Size - moved
+		w.used[from] -= moved
+		w.insert(idx+1, Range{EndHash: end, Size: moved}, dest)
+		w.record(from, dest, end, split, false, moved)
+	}
+	w.merge()
+}
+
+func (w *world) cutActual(idx, kind int, want int64) ([]byte, int64) {
+	r := w.ranges[idx]
+	start := w.startHash(idx)
+	if want <= 0 {
+		return cloneHash(start), 0
+	}
+	if want >= r.Size || kind == cutWhole {
+		return cloneHash(r.EndHash), r.Size
+	}
+	var split []byte
+	if kind == cutPrefix {
+		split = splitHash(r, start, want)
+		moved := SliceSize(r, start, split)
+		if moved == 0 {
+			split = splitHashMin(r, start, 1)
+			moved = SliceSize(r, start, split)
+		}
+		return split, moved
+	}
+	split = splitHash(r, start, r.Size-want)
+	kept := SliceSize(r, start, split)
+	moved := r.Size - kept
+	if moved == 0 {
+		split = splitHash(r, start, r.Size-1)
+		if bytes.Equal(split, start) {
+			split = splitHashMin(r, start, 1)
+		}
+		kept = SliceSize(r, start, split)
+		moved = r.Size - kept
+	}
+	return split, moved
+}
+
+func (w *world) moveWhole(idx, dest int) {
+	from := w.owner[idx]
+	if from == dest {
+		return
+	}
+	sz := w.ranges[idx].Size
+	w.owner[idx] = dest
+	w.used[from] -= sz
+	w.used[dest] += sz
+	w.record(from, dest, w.ranges[idx].EndHash, nil, false, sz)
+	w.merge()
+}
+
+func (w *world) record(from, to int, end, split []byte, prefix bool, size int64) {
+	w.moves = append(w.moves, Move{
+		From:    from,
+		To:      to,
+		EndHash: cloneHash(end),
+		Split:   cloneHash(split),
+		Prefix:  prefix,
+		Size:    size,
+	})
+	w.bytes += size
+}
+
+func (w *world) find(end []byte) int {
+	for i, r := range w.ranges {
+		if hashEq(r.EndHash, end) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (w *world) insert(i int, r Range, dest int) {
+	w.ranges = slices.Insert(w.ranges, i, r)
+	w.owner = slices.Insert(w.owner, i, dest)
+	w.used[dest] += r.Size
+}
+
+func (w *world) sortRanges() {
+	type pair struct {
+		r Range
+		d int
+	}
+	ps := make([]pair, len(w.ranges))
+	for i := range w.ranges {
+		ps[i] = pair{r: w.ranges[i], d: w.owner[i]}
+	}
+	slices.SortFunc(ps, func(a, b pair) int {
+		return bytes.Compare(a.r.EndHash, b.r.EndHash)
+	})
+	for i, p := range ps {
+		w.ranges[i] = p.r
+		w.owner[i] = p.d
+	}
+}
+
+func (w *world) merge() {
+	if len(w.ranges) < 2 {
+		return
+	}
+	for {
+		n := len(w.ranges)
+		merged := false
+		for i := 0; i < n; i++ {
+			j := (i + 1) % n
+			if w.owner[i] != w.owner[j] {
+				continue
+			}
+			if i == j {
+				continue
+			}
+			w.ranges[j].Size += w.ranges[i].Size
+			w.ranges = append(w.ranges[:i], w.ranges[i+1:]...)
+			w.owner = append(w.owner[:i], w.owner[i+1:]...)
+			merged = true
+			break
+		}
+		if !merged {
+			return
+		}
+	}
+}
+
+func (w *world) neighbors(idx int) (left, right int, okL, okR bool) {
+	n := len(w.ranges)
+	if n < 2 {
+		return 0, 0, false, false
+	}
+	src := w.owner[idx]
+	l := w.owner[(idx-1+n)%n]
+	r := w.owner[(idx+1)%n]
+	if l != src && !w.frozen[l] {
+		left, okL = l, true
+	}
+	if r != src && !w.frozen[r] {
+		right, okR = r, true
+	}
+	return
+}
+
+func checkStructure(state State) error {
+	if len(state.Owner) != len(state.Ranges) {
+		return xerrors.Errorf("owner length %d != ranges length %d", len(state.Owner), len(state.Ranges))
+	}
+	var hlen int
+	seen := make(map[string]struct{}, len(state.Ranges))
+	for i, r := range state.Ranges {
+		if r.Size < 0 {
+			return xerrors.Errorf("range %d has negative size", i)
+		}
+		if len(r.EndHash) == 0 {
+			return xerrors.Errorf("range %d has empty EndHash", i)
+		}
+		if hlen == 0 {
+			hlen = len(r.EndHash)
+		} else if len(r.EndHash) != hlen {
+			return xerrors.Errorf("range %d EndHash length %d != %d", i, len(r.EndHash), hlen)
+		}
+		key := string(r.EndHash)
+		if _, ok := seen[key]; ok {
+			return xerrors.Errorf("duplicate EndHash at range %d", i)
+		}
+		seen[key] = struct{}{}
+		if state.Owner[i] < 0 || state.Owner[i] >= len(state.Disks) {
+			return xerrors.Errorf("range %d owner %d out of range", i, state.Owner[i])
+		}
+	}
+	for i, sz := range state.Disks {
+		if sz < 0 {
+			return xerrors.Errorf("disk %d has negative size", i)
+		}
+	}
+	return nil
+}

--- a/lib/hashspacesolver/world.go
+++ b/lib/hashspacesolver/world.go
@@ -23,7 +23,6 @@ type world struct {
 	spaces []spaceWorld
 	used   []int64
 	frozen []bool
-	bytes  int64
 	diff   []Transfer
 }
 
@@ -88,6 +87,33 @@ func (w *world) free(d int) int64 {
 	return w.disks[d] - w.used[d]
 }
 
+func fillLimitOf(cap int64) int64 {
+	if cap <= 0 {
+		return 0
+	}
+	return cap * FILL_LIMIT_PERCENT / 100
+}
+
+func (w *world) fillLimit(d int) int64 {
+	return fillLimitOf(w.disks[d])
+}
+
+func (w *world) fillHeadroom(d int) int64 {
+	n := w.fillLimit(d) - w.used[d]
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+func (w *world) overflow(d int) int64 {
+	n := w.used[d] - w.fillLimit(d)
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
 func (w *world) totalUsed() int64 {
 	var s int64
 	for _, sp := range w.spaces {
@@ -106,14 +132,6 @@ func (w *world) totalCapacity() int64 {
 		}
 	}
 	return s
-}
-
-func (w *world) fairShare(d int) int64 {
-	cap := w.totalCapacity()
-	if cap == 0 {
-		return 0
-	}
-	return w.totalUsed() * w.disks[d] / cap
 }
 
 func (w *world) rangeCount(space, d int) int {
@@ -218,7 +236,6 @@ func (w *world) applyCut(space, idx, kind, dest int, size int64) {
 		w.used[from] -= moved
 		w.insert(space, idx+1, Range{EndHash: end, Size: moved}, dest)
 	}
-	w.bytes += moved
 	w.mergeSpace(space)
 }
 
@@ -269,7 +286,6 @@ func (w *world) moveWhole(space, idx, dest int) {
 	sp.owner[idx] = dest
 	w.used[from] -= sz
 	w.used[dest] += sz
-	w.bytes += sz
 	w.mergeSpace(space)
 }
 


### PR DESCRIPTION
Completes #1493 

This is the "hash-space solver" that takes 
- a list of disk sizes 
- hash ranges in each of N hash spaces that are stored by each disk
- a reality change: New disk arrived, old disk being remvoed (or size reduced), disk size limit approaching

as a result, it produces a Plan: a list of transfers up to a given byte limit. The result should be more stable than the initial condition, but with a minimal transfer set. It does not care "which machine" the disk is on. 

This will fit in a piece management architecture that senses these matters, stores data in hash-named files, and transfers data around in a way that keeps it available for operations. 

A workflow including this may be: 
1. detect a reality change
2. a task gets hash sizes & disk capacities, then uses this code to build a transfer plan. 
3. machine-specific tasks pull data according to the plan. 
4. after plan completes, the watchers resume.