### PR TITLE
market: honor unlimited MaxQueueSDR

### DIFF
--- a/market/backpressure/backpressure.go
+++ b/market/backpressure/backpressure.go
@@ -109,24 +109,28 @@ func (c *CachedBackPressure) checkSectorBackpressure(ctx context.Context, cfg *c
 		return false, xerrors.Errorf("counting buffered sectors: %w", err)
 	}
 
+	return sdrQueueBackpressure(cfg, bufferedSDR, bufferedTrees, bufferedPoRep, waitDealSectors), nil
+}
+
+func sdrQueueBackpressure(cfg *config.CurioIngestConfig, bufferedSDR, bufferedTrees, bufferedPoRep, waitDealSectors int) bool {
 	if cfg.MaxQueueDealSector.Get() != 0 && waitDealSectors > cfg.MaxQueueDealSector.Get() {
 		log.Infow("backpressure", "reason", "too many wait deal sectors", "wait_deal_sectors", waitDealSectors, "max", cfg.MaxQueueDealSector.Get())
-		return true, nil
+		return true
 	}
 
-	if bufferedSDR > cfg.MaxQueueSDR.Get() {
+	if cfg.MaxQueueSDR.Get() != 0 && bufferedSDR > cfg.MaxQueueSDR.Get() {
 		log.Infow("backpressure", "reason", "too many SDR tasks", "buffered", bufferedSDR, "max", cfg.MaxQueueSDR.Get())
-		return true, nil
+		return true
 	}
 	if cfg.MaxQueueTrees.Get() != 0 && bufferedTrees > cfg.MaxQueueTrees.Get() {
 		log.Infow("backpressure", "reason", "too many tree tasks", "buffered", bufferedTrees, "max", cfg.MaxQueueTrees.Get())
-		return true, nil
+		return true
 	}
 	if cfg.MaxQueuePoRep.Get() != 0 && bufferedPoRep > cfg.MaxQueuePoRep.Get() {
 		log.Infow("backpressure", "reason", "too many PoRep tasks", "buffered", bufferedPoRep, "max", cfg.MaxQueuePoRep.Get())
-		return true, nil
+		return true
 	}
-	return false, nil
+	return false
 }
 
 func (c *CachedBackPressure) checkMK20Backpressure(ctx context.Context, cfg *config.CurioIngestConfig, db *harmonydb.DB) (bool, error) {

--- a/market/backpressure/backpressure_test.go
+++ b/market/backpressure/backpressure_test.go
@@ -1,0 +1,43 @@
+package backpressure
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/curio/deps/config"
+)
+
+func TestSDRQueueBackpressure(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		limit           int
+		bufferedSDR     int
+		bufferedTrees   int
+		bufferedPoRep   int
+		waitDealSectors int
+		want            bool
+	}{
+		{name: "zero limit empty queue", limit: 0, bufferedSDR: 0},
+		{name: "zero limit nonempty queue", limit: 0, bufferedSDR: 100},
+		{name: "positive limit below", limit: 8, bufferedSDR: 7},
+		{name: "positive limit equal", limit: 8, bufferedSDR: 8},
+		{name: "positive limit above", limit: 8, bufferedSDR: 9, want: true},
+		{name: "zero limit preserves deal pressure", limit: 0, bufferedSDR: 100, waitDealSectors: 9, want: true},
+		{name: "zero limit preserves tree pressure", limit: 0, bufferedSDR: 100, bufferedTrees: 9, want: true},
+		{name: "zero limit preserves PoRep pressure", limit: 0, bufferedSDR: 100, bufferedPoRep: 9, want: true},
+		{name: "other queues at limit", limit: 0, bufferedSDR: 100, waitDealSectors: 8, bufferedTrees: 8, bufferedPoRep: 8},
+		{name: "negative limit unchanged", limit: -1, bufferedSDR: 0, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.CurioIngestConfig{
+				MaxQueueSDR:        config.NewDynamic(test.limit),
+				MaxQueueDealSector: config.NewDynamic(8),
+				MaxQueueTrees:      config.NewDynamic(8),
+				MaxQueuePoRep:      config.NewDynamic(8),
+			}
+			got := sdrQueueBackpressure(cfg, test.bufferedSDR, test.bufferedTrees, test.bufferedPoRep, test.waitDealSectors)
+			if got != test.want {
+				t.Fatalf("sdrQueueBackpressure() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`MaxQueueSDR` documents zero as unlimited, but the SDR queue check currently treats any nonempty queue as backpressure when the limit is zero.

## Change

Apply the SDR threshold only when it is nonzero. Extract the existing queue decisions into a private helper used by the production path so the regression can run without a database.

The default remains `8`, positive limits still use `buffered > limit`, and DealSector, Trees, and PoRep pressure remain effective. SQL accounting, other queue policies, and cache behavior are unchanged.

## Validation

Database-free checks passed on upstream base `0bbdaf9ec3203e62a4d0a1e0e754864047736c7d`:

```sh
go test -tags=cgo,fvm,nosupraseal -count=1 ./market/backpressure ./deps/config
go test -race -tags=cgo,fvm,nosupraseal -count=1 ./market/backpressure ./deps/config
go vet -tags=cgo,fvm,nosupraseal ./market/backpressure ./deps/config
golangci-lint run -v --timeout 15m --concurrency 4 --build-tags cgo,fvm,nosupraseal ./market/backpressure ./deps/config
git diff --check
```

The regression covers zero with empty/nonempty queues, positive-limit boundaries, neighboring queue pressure, and unchanged negative-limit behavior. Lint used v2.11.4. PostgreSQL/Yugabyte execution was not performed; these tests exercise the production queue-decision helper, not SQL row effects.
