### PR TITLE
market: schedule global MK20 stages through the deal poller

### DIFF
--- a/market/mk20/DEVELOPER_FLOW_MAP.md
+++ b/market/mk20/DEVELOPER_FLOW_MAP.md
@@ -119,7 +119,7 @@ If deal has `Data` and matching piece already exists in `parked_pieces`, it inse
    - Offline: create pipeline row with `offline=TRUE, started=FALSE`.
    - Aggregate: one pipeline row per subpiece; HTTP subpieces also get download refs.
 3. `processMK20Deals` then progresses data readiness:
-   - `downloadMk20Deal` calls SQL `mk20_ddo_mark_downloaded` to bind completed refs to `url=pieceref:*` and set `downloaded=TRUE`.
+   - The full piece pass calls SQL `mk20_ddo_mark_downloaded` once before loading its pipeline snapshot. The function binds completed refs to `url=pieceref:*` and sets `downloaded=TRUE`.
    - `findOfflineURLMk20Deal` calls `process_offline_download(...)` and piece-locator probing for offline rows.
 4. At `downloaded=TRUE + url=pieceref:*`, DDO is in pipeline with data.
 5. During sector ingestion, start epoch uses `ddo_v1.start_epoch` when set; otherwise Curio falls back to `head + 2 days`.

--- a/tasks/storage-market/mk20.go
+++ b/tasks/storage-market/mk20.go
@@ -566,7 +566,8 @@ func insertPiecesInTransaction(ctx context.Context, tx *harmonydb.Tx, deal *mk20
 
 func (d *CurioStorageDealMarket) processMK20DealPieces(ctx context.Context) {
 	var pieces []MK20PipelinePiece
-	err := d.db.Select(ctx, &pieces, `SELECT 
+	err := markThenLoadMK20Pieces(ctx, d.markMK20Downloaded, func(ctx context.Context) error {
+		return d.db.Select(ctx, &pieces, `SELECT
 											id,
 											sp_id,
 											contract,
@@ -600,8 +601,9 @@ func (d *CurioStorageDealMarket) processMK20DealPieces(ctx context.Context) {
 											market_mk20_pipeline
 										WHERE complete = false ORDER BY created_at ASC;
 										`)
+	})
 	if err != nil {
-		log.Errorw("failed to get deals from DB", "error", err)
+		log.Errorw("failed to mark downloads and get deals from DB", "error", err)
 		return
 	}
 
@@ -615,13 +617,15 @@ func (d *CurioStorageDealMarket) processMK20DealPieces(ctx context.Context) {
 
 }
 
-func (d *CurioStorageDealMarket) processMk20Pieces(ctx context.Context, piece MK20PipelinePiece) error {
-	err := d.downloadMk20Deal(ctx, piece)
-	if err != nil {
+func markThenLoadMK20Pieces(ctx context.Context, markDownloaded, loadPieces func(context.Context) error) error {
+	if err := markDownloaded(ctx); err != nil {
 		return err
 	}
+	return loadPieces(ctx)
+}
 
-	err = d.findOfflineURLMk20Deal(ctx, piece)
+func (d *CurioStorageDealMarket) processMk20Pieces(ctx context.Context, piece MK20PipelinePiece) error {
+	err := d.findOfflineURLMk20Deal(ctx, piece)
 	if err != nil {
 		return err
 	}
@@ -639,10 +643,7 @@ func (d *CurioStorageDealMarket) processMk20Pieces(ctx context.Context, piece MK
 	return nil
 }
 
-// downloadMk20Deal handles the downloading process of an MK20 pipeline piece by scheduling it in the database and updating its status.
-// If the pieces are part of an aggregation deal then we download for short term otherwise,
-// we download for long term to avoid the need to have unsealed copy
-func (d *CurioStorageDealMarket) downloadMk20Deal(ctx context.Context, _ MK20PipelinePiece) error {
+func (d *CurioStorageDealMarket) markMK20Downloaded(ctx context.Context) error {
 	var n int
 	err := d.db.QueryRow(ctx, `SELECT mk20_ddo_mark_downloaded($1)`, mk20.ProductNameDDOV1).Scan(&n)
 	if err != nil {

--- a/tasks/storage-market/mk20_poller_test.go
+++ b/tasks/storage-market/mk20_poller_test.go
@@ -1,0 +1,332 @@
+package storage_market
+
+import (
+	"context"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestFullMK20PiecePassMarksBeforeLoading(t *testing.T) {
+	ctx := context.Background()
+	stored := []MK20PipelinePiece{
+		{ID: "deal-1"},
+		{ID: "deal-2"},
+		{ID: "deal-3"},
+	}
+	var snapshot []MK20PipelinePiece
+	var operations []string
+
+	err := markThenLoadMK20Pieces(ctx, func(context.Context) error {
+		operations = append(operations, "mark")
+		for i := range stored {
+			stored[i].Downloaded = true
+		}
+		return nil
+	}, func(context.Context) error {
+		operations = append(operations, "load")
+		snapshot = append(snapshot, stored...)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(operations, []string{"mark", "load"}) {
+		t.Fatalf("operations = %v, want [mark load]", operations)
+	}
+	if len(snapshot) != len(stored) {
+		t.Fatalf("loaded %d pieces, want %d", len(snapshot), len(stored))
+	}
+	for _, piece := range snapshot {
+		if !piece.Downloaded {
+			t.Fatalf("piece %s has stale downloaded=false", piece.ID)
+		}
+	}
+}
+
+func TestFullMK20PiecePassStopsWhenMarkingFails(t *testing.T) {
+	markErr := errors.New("mark failed")
+	loaded := false
+	err := markThenLoadMK20Pieces(context.Background(), func(context.Context) error {
+		return markErr
+	}, func(context.Context) error {
+		loaded = true
+		return nil
+	})
+	if !errors.Is(err, markErr) {
+		t.Fatalf("error = %v, want %v", err, markErr)
+	}
+	if loaded {
+		t.Fatal("loaded a pipeline snapshot after downloaded marking failed")
+	}
+}
+
+func TestSignalNextMK20ProcessesOnlyLoadedDealAndWakes(t *testing.T) {
+	ctx := context.Background()
+	requestedID := "requested-deal"
+	stored := []MK20PipelinePiece{
+		{ID: requestedID, PieceCID: "piece-1"},
+		{ID: requestedID, PieceCID: "piece-2"},
+		{ID: "other-deal", PieceCID: "piece-3"},
+	}
+	var processed []string
+	var operations []string
+	wakes := 0
+
+	err := runSignalNextMK20(ctx, requestedID, func(_ context.Context, id string) ([]MK20PipelinePiece, error) {
+		operations = append(operations, "load:"+id)
+		var pieces []MK20PipelinePiece
+		for _, piece := range stored {
+			if piece.ID == id {
+				pieces = append(pieces, piece)
+			}
+		}
+		return pieces, nil
+	}, func(_ context.Context, piece MK20PipelinePiece) error {
+		operations = append(operations, "piece:"+piece.PieceCID)
+		processed = append(processed, piece.ID)
+		return nil
+	}, func(piece MK20PipelinePiece, err error) {
+		t.Fatalf("unexpected error for piece %s: %v", piece.PieceCID, err)
+	}, func() {
+		operations = append(operations, "wake")
+		wakes++
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(processed, []string{requestedID, requestedID}) {
+		t.Fatalf("processed deal IDs = %v", processed)
+	}
+	wantOperations := []string{"load:" + requestedID, "piece:piece-1", "piece:piece-2", "wake"}
+	if !reflect.DeepEqual(operations, wantOperations) {
+		t.Fatalf("operations = %v, want %v", operations, wantOperations)
+	}
+	if wakes != 1 {
+		t.Fatalf("wake calls = %d, want 1", wakes)
+	}
+}
+
+func TestSignalNextMK20PieceErrorContinuesAndWakesOnce(t *testing.T) {
+	pieceErr := errors.New("piece failed")
+	pieces := []MK20PipelinePiece{{ID: "deal", PieceCID: "first"}, {ID: "deal", PieceCID: "second"}}
+	var processed, failed []string
+	wakes := 0
+
+	err := runSignalNextMK20(context.Background(), "deal", func(context.Context, string) ([]MK20PipelinePiece, error) {
+		return pieces, nil
+	}, func(_ context.Context, piece MK20PipelinePiece) error {
+		processed = append(processed, piece.PieceCID)
+		if piece.PieceCID == "first" {
+			return pieceErr
+		}
+		return nil
+	}, func(piece MK20PipelinePiece, err error) {
+		if !errors.Is(err, pieceErr) {
+			t.Fatalf("piece error = %v, want %v", err, pieceErr)
+		}
+		failed = append(failed, piece.PieceCID)
+	}, func() {
+		wakes++
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(processed, []string{"first", "second"}) {
+		t.Fatalf("processed = %v", processed)
+	}
+	if !reflect.DeepEqual(failed, []string{"first"}) {
+		t.Fatalf("failed = %v", failed)
+	}
+	if wakes != 1 {
+		t.Fatalf("wake calls = %d, want 1", wakes)
+	}
+}
+
+func TestSignalNextMK20CancellationStopsWithoutWake(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	pieces := []MK20PipelinePiece{{ID: "deal", PieceCID: "first"}, {ID: "deal", PieceCID: "second"}}
+	var processed []string
+	wakes := 0
+
+	err := runSignalNextMK20(ctx, "deal", func(context.Context, string) ([]MK20PipelinePiece, error) {
+		return pieces, nil
+	}, func(_ context.Context, piece MK20PipelinePiece) error {
+		processed = append(processed, piece.PieceCID)
+		cancel()
+		return context.Canceled
+	}, func(MK20PipelinePiece, error) {}, func() {
+		wakes++
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context canceled", err)
+	}
+	if !reflect.DeepEqual(processed, []string{"first"}) {
+		t.Fatalf("processed = %v, want [first]", processed)
+	}
+	if wakes != 0 {
+		t.Fatalf("wake calls = %d, want 0", wakes)
+	}
+}
+
+func TestSignalNextMK20LoadErrorDoesNotWake(t *testing.T) {
+	loadErr := errors.New("load failed")
+	wakes := 0
+	err := runSignalNextMK20(context.Background(), "deal", func(context.Context, string) ([]MK20PipelinePiece, error) {
+		return nil, loadErr
+	}, func(context.Context, MK20PipelinePiece) error {
+		t.Fatal("processor called after load error")
+		return nil
+	}, func(MK20PipelinePiece, error) {
+		t.Fatal("error handler called after load error")
+	}, func() {
+		wakes++
+	})
+	if !errors.Is(err, loadErr) {
+		t.Fatalf("error = %v, want %v", err, loadErr)
+	}
+	if wakes != 0 {
+		t.Fatalf("wake calls = %d, want 0", wakes)
+	}
+}
+
+func TestSignalNextMK20RepeatedCallbacksCoalesceWake(t *testing.T) {
+	d := &CurioStorageDealMarket{
+		wakePollReq:        make(chan struct{}),
+		wakePollLoopCtx:    context.Background(),
+		lastWakeDrivenPoll: time.Now().Add(time.Hour),
+	}
+	t.Cleanup(func() {
+		d.wakeMu.Lock()
+		defer d.wakeMu.Unlock()
+		if d.wakePollTimer != nil {
+			d.wakePollTimer.Stop()
+			d.wakePollTimer = nil
+		}
+	})
+
+	run := func() {
+		err := runSignalNextMK20(context.Background(), "deal", func(context.Context, string) ([]MK20PipelinePiece, error) {
+			return nil, nil
+		}, func(context.Context, MK20PipelinePiece) error {
+			return nil
+		}, func(MK20PipelinePiece, error) {}, d.WakeDealPoller)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	run()
+	d.wakeMu.Lock()
+	firstTimer := d.wakePollTimer
+	d.wakeMu.Unlock()
+	if firstTimer == nil {
+		t.Fatal("first callback did not schedule a wake")
+	}
+
+	run()
+	d.wakeMu.Lock()
+	secondTimer := d.wakePollTimer
+	d.wakeMu.Unlock()
+	if secondTimer != firstTimer {
+		t.Fatal("second callback scheduled a second wake")
+	}
+}
+
+func TestWakeDealPollerShutdownDoesNotBlockDelivery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	d := &CurioStorageDealMarket{
+		wakePollReq:     make(chan struct{}),
+		wakePollLoopCtx: ctx,
+	}
+
+	d.WakeDealPoller()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		d.wakeMu.Lock()
+		pending := d.wakePollTimer != nil
+		d.wakeMu.Unlock()
+		if !pending {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("wake delivery remained blocked after shutdown")
+}
+
+func TestMK20GlobalStagesRemainInFullPollOrder(t *testing.T) {
+	calls := methodCallsInFunction(t, "mk20.go", "processMK20Deals")
+	want := []string{"processMK20DealPieces", "processMK20DealAggregation", "processMK20DealIngestion"}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("global stage calls = %v, want %v", calls, want)
+	}
+}
+
+func TestSignalNextMK20ProductionPathHasNoGlobalStages(t *testing.T) {
+	calls := methodCallsInFunction(t, "storage_market.go", "signalNextMK20")
+	for _, call := range calls {
+		if call == "processMK20DealAggregation" || call == "processMK20DealIngestion" || call == "markMK20Downloaded" {
+			t.Fatalf("signalNextMK20 directly calls global stage %s", call)
+		}
+	}
+}
+
+func TestPerPieceMK20ProcessingDoesNotMarkDownloadsGlobally(t *testing.T) {
+	calls := methodCallsInFunction(t, "mk20.go", "processMk20Pieces")
+	for _, call := range calls {
+		if call == "markMK20Downloaded" {
+			t.Fatal("processMk20Pieces calls global downloaded marking")
+		}
+	}
+}
+
+func methodCallsInFunction(t *testing.T, filename, function string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var body *ast.BlockStmt
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == function {
+			body = fn.Body
+			break
+		}
+	}
+	if body == nil {
+		t.Fatalf("function %s not found in %s", function, filename)
+	}
+
+	wanted := map[string]struct{}{
+		"processMK20DealPieces":      {},
+		"processMK20DealAggregation": {},
+		"processMK20DealIngestion":   {},
+		"markMK20Downloaded":         {},
+	}
+	var calls []string
+	ast.Inspect(body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if _, ok := wanted[sel.Sel.Name]; ok {
+			calls = append(calls, sel.Sel.Name)
+		}
+		return true
+	})
+	return calls
+}

--- a/tasks/storage-market/storage_market.go
+++ b/tasks/storage-market/storage_market.go
@@ -238,6 +238,15 @@ func (d *CurioStorageDealMarket) signalNextMK12(ctx context.Context, uuid string
 }
 
 func (d *CurioStorageDealMarket) signalNextMK20(ctx context.Context, id string) {
+	err := runSignalNextMK20(ctx, id, d.loadSignalNextMK20Pieces, d.processMk20Pieces, func(piece MK20PipelinePiece, err error) {
+		log.Errorw("SignalNext MK20: process piece", "error", err, "id", piece.ID)
+	}, d.WakeDealPoller)
+	if err != nil {
+		log.Errorw("SignalNext MK20: process deal", "error", err, "id", id)
+	}
+}
+
+func (d *CurioStorageDealMarket) loadSignalNextMK20Pieces(ctx context.Context, id string) ([]MK20PipelinePiece, error) {
 	var pieces []MK20PipelinePiece
 	err := d.db.Select(ctx, &pieces, `SELECT 
 		id, sp_id, contract, client, piece_cid_v2, piece_cid,
@@ -248,19 +257,35 @@ func (d *CurioStorageDealMarket) signalNextMK20(ctx context.Context, id string) 
 		sector_offset, indexing_created_at, indexing_task_id, indexed
 	FROM market_mk20_pipeline
 	WHERE id = $1 AND complete = false`, id)
-	if err != nil {
-		log.Errorw("SignalNext MK20: select pipeline", "error", err, "id", id)
-		return
-	}
+	return pieces, err
+}
 
+type mk20SignalNextLoader func(context.Context, string) ([]MK20PipelinePiece, error)
+type mk20SignalNextProcessor func(context.Context, MK20PipelinePiece) error
+type mk20SignalNextErrorHandler func(MK20PipelinePiece, error)
+
+func runSignalNextMK20(ctx context.Context, id string, load mk20SignalNextLoader, process mk20SignalNextProcessor, onError mk20SignalNextErrorHandler, wake func()) error {
+	pieces, err := load(ctx, id)
+	if err != nil {
+		return err
+	}
 	for _, piece := range pieces {
-		if err := d.processMk20Pieces(ctx, piece); err != nil {
-			log.Errorw("SignalNext MK20: process piece", "error", err, "id", id)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := process(ctx, piece); err != nil {
+			onError(piece, err)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 		}
 	}
 
-	d.processMK20DealAggregation(ctx)
-	d.processMK20DealIngestion(ctx)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	wake()
+	return nil
 }
 
 func (d *CurioStorageDealMarket) StartMarket(ctx context.Context) error {


### PR DESCRIPTION
## Summary

Keep MK20 completion callbacks deal-local and schedule global aggregation/ingestion through the existing deal poller. Concurrent callbacks currently invoke those global stages directly and can overlap their passes.

`signalNextMK20` now processes only the requested deal's loaded pieces, then requests a coalesced poller wake. The full piece pass marks completed downloads before loading fresh rows; individual piece callbacks no longer run that global marking query. The existing full-poll order, idle/wake timing and cancellation behavior remain unchanged.

This is process-local poller ownership, not cross-process allocation safety or exactly-once processing. It adds no scheduler, configuration or schema and has no dependency on another proposed patch.

## Validation

Validated on upstream base `86e95967cd602dbf8db5ea538abe986c3968e2e3`, topic `065f0d0973f3df02873ebbce573506f015caf251`, with Go 1.26.1:

```sh
go test -p=2 -tags=cgo,fvm,nosupraseal -count=1 -timeout=3m \
  -skip '^(TestIntegration_CheckExpiry|TestIntegration_FailMK20DealBeforeSector)$' ./tasks/storage-market
go test -race -p=2 -tags=cgo,fvm,nosupraseal -count=1 -timeout=3m \
  -skip '^(TestIntegration_CheckExpiry|TestIntegration_FailMK20DealBeforeSector)$' ./tasks/storage-market
go vet -p=2 -tags=cgo,fvm,nosupraseal ./tasks/storage-market
```

All passed in a sanitized, database-free environment. The two explicitly excluded pre-existing integration tests can connect through fallback database settings and are unrelated to this scheduling change.

Executable tests cover mark-before-load, requested-deal processing, piece/load errors, cancellation, wake coalescing and shutdown. AST call-site tests additionally protect full-poll ordering and the absence of direct global stages in completion callbacks; these are source-shape checks, not SQL concurrency evidence. No database, chain API or actual sealing execution is claimed for this topic's new tests.
