### PR TITLE
seal: exclude failed sectors from precommit batching

### DIFF
--- a/documentation/en/precommit-sql-tests.md
+++ b/documentation/en/precommit-sql-tests.md
@@ -1,0 +1,43 @@
+# PreCommit SQL row-effect tests
+
+The opt-in `integration` tests execute the same candidate, assignment, failed
+detach, and message-CID SQL constants used by the PreCommit poller/task. They
+complement the database-free `SubmitPrecommitTask.Do` tests, whose fake API and
+sender inspect actual outgoing CBOR membership. They do not submit messages,
+prove chain acceptance, or establish exactly-once send/persistence.
+
+Use only an explicitly disposable local PostgreSQL or Yugabyte database. Remove
+normal Curio/HarmonyDB/libpq connection settings and other integration opt-ins
+before supplying all of these dedicated variables:
+
+- `CURIO_PRECOMMIT_ITEST=1`
+- `CURIO_PRECOMMIT_ITEST_HOST=127.0.0.1` (literal loopback only)
+- `CURIO_PRECOMMIT_ITEST_PORT` (explicit nonzero port)
+- `CURIO_PRECOMMIT_ITEST_DATABASE`
+- `CURIO_PRECOMMIT_ITEST_USER`
+- `CURIO_PRECOMMIT_ITEST_PASSWORD`, only if required, supplied privately
+
+The connection disables load balancing and fallback targets. Each test creates
+a random owned schema, uses a 30-second overall context, a 5-second statement
+timeout and a 2-second lock timeout, and drops only that owned schema. The
+projected schema preserves relevant column types, primary keys, initial-piece
+foreign key/cascade, and the upstream removal of task foreign keys.
+
+```sh
+go test -tags=cgo,fvm,nosupraseal,integration ./tasks/seal \
+  -run '^TestPrecommitSQL(CandidatesAndAssignment|DetachAndCIDMembership)$' \
+  -count=1 -timeout=2m -v
+```
+
+`TestPrecommitSQLCandidatesAndAssignment` verifies failed exclusion before batch
+numbering, stale-discovery revalidation, and provider/proof/sector/task scoping.
+`TestPrecommitSQLDetachAndCIDMembership` verifies original failure evidence,
+included-sector-only CID assignment, and transaction rollback. These are SQL
+row-effect tests, not independent-handle contention tests. The stale discovery
+fixture changes state between the actual distinct selection/update statements;
+it does not invent an interleaving within one atomic statement.
+
+Logs identify the database version and reported SQL isolation. Yugabyte effective
+isolation must be independently recorded; `SHOW` alone is not proof of server
+Read Committed or wait-queue configuration. Compilation and skipped opt-ins are
+not database execution evidence.

--- a/tasks/seal/poller_precommit_msg.go
+++ b/tasks/seal/poller_precommit_msg.go
@@ -19,6 +19,54 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
+const PRECOMMIT_BATCH_CANDIDATES_SQL = `
+	WITH initial AS (
+		SELECT
+			p.sp_id,
+			p.sector_number,
+			COALESCE(
+				(SELECT MIN(LEAST(s.f05_deal_start_epoch, s.direct_start_epoch))
+				 FROM sectors_sdr_initial_pieces s
+				 WHERE s.sp_id = p.sp_id AND s.sector_number = p.sector_number),
+				p.ticket_epoch + $1
+			) AS start_epoch,
+			COALESCE(p.precommit_ready_at, '1970-01-01 00:00:00+00'::TIMESTAMPTZ) AS ready_at,
+			p.reg_seal_proof
+		FROM sectors_sdr_pipeline p
+		WHERE p.after_synth = TRUE
+			AND p.task_id_precommit_msg IS NULL
+			AND p.after_precommit_msg = FALSE
+			AND p.failed = FALSE
+	),
+	numbered AS (
+		SELECT l.*,
+			ROW_NUMBER() OVER (
+				PARTITION BY l.sp_id, l.reg_seal_proof
+				ORDER BY l.start_epoch
+			) AS rn
+		FROM initial l
+	)
+	SELECT
+		sp_id,
+		sector_number,
+		start_epoch,
+		ready_at,
+		reg_seal_proof,
+		FLOOR((rn - 1)::NUMERIC / $2)::BIGINT AS batch_index
+	FROM numbered
+	ORDER BY sp_id, reg_seal_proof, batch_index, start_epoch`
+
+const PRECOMMIT_BATCH_ASSIGN_SQL = `
+	UPDATE sectors_sdr_pipeline
+	SET task_id_precommit_msg = $1
+	WHERE sp_id = $2
+		AND reg_seal_proof = $3
+		AND sector_number = ANY($4::bigint[])
+		AND after_synth = TRUE
+		AND task_id_precommit_msg IS NULL
+		AND after_precommit_msg = FALSE
+		AND failed = FALSE`
+
 func (s *SealPoller) pollStartBatchPrecommitMsg(ctx context.Context) {
 	if !s.pollers[pollerPrecommitMsg].IsSet() {
 		return
@@ -43,41 +91,7 @@ func (s *SealPoller) pollStartBatchPrecommitMsg(ctx context.Context) {
 
 	s.pollers[pollerPrecommitMsg].Val(ctx)(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
 		var rows []BatchRow
-		err := tx.Select(&rows, `
-			WITH initial AS (
-				SELECT
-					p.sp_id,
-					p.sector_number,
-					COALESCE(
-						(SELECT MIN(LEAST(s.f05_deal_start_epoch, s.direct_start_epoch))
-						 FROM sectors_sdr_initial_pieces s
-						 WHERE s.sp_id = p.sp_id AND s.sector_number = p.sector_number),
-						p.ticket_epoch + $1
-					) AS start_epoch,
-					COALESCE(p.precommit_ready_at, '1970-01-01 00:00:00+00'::TIMESTAMPTZ) AS ready_at,
-					p.reg_seal_proof
-				FROM sectors_sdr_pipeline p
-				WHERE p.after_synth = TRUE
-					AND p.task_id_precommit_msg IS NULL
-					AND p.after_precommit_msg = FALSE
-			),
-			numbered AS (
-				SELECT l.*,
-					ROW_NUMBER() OVER (
-						PARTITION BY l.sp_id, l.reg_seal_proof
-						ORDER BY l.start_epoch
-					) AS rn
-				FROM initial l
-			)
-			SELECT
-				sp_id,
-				sector_number,
-				start_epoch,
-				ready_at,
-				reg_seal_proof,
-				FLOOR((rn - 1)::NUMERIC / $2)::BIGINT AS batch_index
-			FROM numbered
-			ORDER BY sp_id, reg_seal_proof, batch_index, start_epoch`,
+		err := tx.Select(&rows, PRECOMMIT_BATCH_CANDIDATES_SQL,
 			policy.MaxPreCommitRandomnessLookback,
 			s.cfg.preCommit.MaxPreCommitBatch)
 		if err != nil {
@@ -114,15 +128,7 @@ func (s *SealPoller) pollStartBatchPrecommitMsg(ctx context.Context) {
 			return false, nil
 		}
 
-		n, err := tx.Exec(`
-			UPDATE sectors_sdr_pipeline
-			SET task_id_precommit_msg = $1
-			WHERE sp_id = $2
-				AND reg_seal_proof = $3
-				AND sector_number = ANY($4::bigint[])
-				AND after_synth = TRUE
-				AND task_id_precommit_msg IS NULL
-				AND after_precommit_msg = FALSE`,
+		n, err := tx.Exec(PRECOMMIT_BATCH_ASSIGN_SQL,
 			id, firing.SpID, firing.RegSealProof, firing.SectorNums)
 		if err != nil {
 			return false, xerrors.Errorf("assigning precommit batch: %w", err)

--- a/tasks/seal/poller_precommit_msg_test.go
+++ b/tasks/seal/poller_precommit_msg_test.go
@@ -1,0 +1,26 @@
+package seal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrecommitBatchSQLExcludesFailedSectors(t *testing.T) {
+	normalize := func(query string) string {
+		return strings.ToLower(strings.Join(strings.Fields(query), " "))
+	}
+
+	candidateSQL := normalize(PRECOMMIT_BATCH_CANDIDATES_SQL)
+	require.Contains(t, candidateSQL, "and p.failed = false")
+	require.Less(t,
+		strings.Index(candidateSQL, "and p.failed = false"),
+		strings.Index(candidateSQL, "), numbered as"),
+		"failed sectors must be removed before batches are numbered",
+	)
+
+	assignmentSQL := normalize(PRECOMMIT_BATCH_ASSIGN_SQL)
+	require.Contains(t, assignmentSQL, "and failed = false")
+	require.Contains(t, assignmentSQL, "and sector_number = any($4::bigint[])")
+}

--- a/tasks/seal/precommit_sql_integration_test.go
+++ b/tasks/seal/precommit_sql_integration_test.go
@@ -1,0 +1,207 @@
+//go:build integration && !skiff
+
+package seal
+
+import (
+	"context"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/yugabyte/pgx/v5"
+
+	"github.com/filecoin-project/lotus/chain/actors/policy"
+)
+
+// This fixture executes the production SQL constants, not the chain-facing
+// task. The separate Do tests cover outgoing CBOR membership with a fake API.
+func newPrecommitSQLFixture(t *testing.T) (context.Context, *pgx.Conn) {
+	t.Helper()
+	if os.Getenv("CURIO_PRECOMMIT_ITEST") != "1" {
+		t.Skip("requires CURIO_PRECOMMIT_ITEST=1 and a dedicated disposable loopback target")
+	}
+	const prefix = "CURIO_PRECOMMIT_ITEST_"
+	host, database, user := os.Getenv(prefix+"HOST"), os.Getenv(prefix+"DATABASE"), os.Getenv(prefix+"USER")
+	ip := net.ParseIP(host)
+	require.True(t, ip != nil && ip.IsLoopback(), "HOST must be a literal loopback IP")
+	port, err := strconv.ParseUint(os.Getenv(prefix+"PORT"), 10, 16)
+	require.NoError(t, err, "PORT must be explicitly supplied")
+	require.NotZero(t, port)
+	require.NotEmpty(t, strings.TrimSpace(database), "DATABASE must be explicitly supplied")
+	require.NotEmpty(t, strings.TrimSpace(user), "USER must be explicitly supplied")
+
+	cfg, err := pgx.ParseConfig("postgresql://placeholder@127.0.0.1/placeholder?sslmode=disable&load_balance=false")
+	require.NoError(t, err)
+	cfg.Host, cfg.Port, cfg.Database, cfg.User = host, uint16(port), database, user
+	cfg.Password = os.Getenv(prefix + "PASSWORD")
+	cfg.Fallbacks = nil
+	cfg.ConnectTimeout = 5 * time.Second
+	schema := "itest_precommit_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	cfg.RuntimeParams = map[string]string{"search_path": schema, "application_name": "curio-precommit-itest",
+		"statement_timeout": "5000", "lock_timeout": "2000"}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	conn, err := pgx.ConnectConfig(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanup, stop := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stop()
+		require.NoError(t, conn.Close(cleanup))
+	})
+	_, err = conn.Exec(ctx, "CREATE SCHEMA "+pgx.Identifier{schema}.Sanitize())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanup, stop := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stop()
+		_, err := conn.Exec(cleanup, "DROP SCHEMA "+pgx.Identifier{schema}.Sanitize()+" CASCADE")
+		require.NoError(t, err)
+	})
+	_, err = conn.Exec(ctx, precommitSQLSchema)
+	require.NoError(t, err)
+	var version, isolation string
+	require.NoError(t, conn.QueryRow(ctx, `SELECT version()`).Scan(&version))
+	require.NoError(t, conn.QueryRow(ctx, `SHOW default_transaction_isolation`).Scan(&isolation))
+	t.Logf("version=%s; requested isolation=driver default; SQL default=%s; effective Yugabyte isolation=UNVERIFIED", version, isolation)
+	return ctx, conn
+}
+
+func seedPrecommitSQLRows(t *testing.T, ctx context.Context, conn *pgx.Conn) {
+	t.Helper()
+	_, err := conn.Exec(ctx, `INSERT INTO sectors_sdr_pipeline
+		(sp_id, sector_number, reg_seal_proof, ticket_epoch, after_synth)
+		VALUES (1000,1,8,100,TRUE), (1000,2,8,200,TRUE), (1000,3,8,300,TRUE),
+		(1000,4,8,400,TRUE), (2000,2,8,200,TRUE), (1000,5,9,500,TRUE)`)
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, `UPDATE sectors_sdr_pipeline
+		SET failed=TRUE, failed_reason='original', failed_reason_msg='keep evidence'
+		WHERE sp_id=1000 AND sector_number=1`)
+	require.NoError(t, err)
+}
+
+func precommitSQLSnapshot(t *testing.T, ctx context.Context, conn *pgx.Conn) string {
+	t.Helper()
+	var snapshot string
+	require.NoError(t, conn.QueryRow(ctx, `SELECT jsonb_agg(to_jsonb(p) ORDER BY sp_id,sector_number)::text
+		FROM sectors_sdr_pipeline p`).Scan(&snapshot))
+	return snapshot
+}
+
+func rollbackPrecommitSQL(t *testing.T, tx pgx.Tx) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := tx.Rollback(ctx); err != nil && err != pgx.ErrTxClosed {
+		t.Errorf("rolling back fixture transaction: %v", err)
+	}
+}
+
+func TestPrecommitSQLCandidatesAndAssignment(t *testing.T) {
+	ctx, conn := newPrecommitSQLFixture(t)
+	seedPrecommitSQLRows(t, ctx, conn)
+	rows, err := conn.Query(ctx, PRECOMMIT_BATCH_CANDIDATES_SQL, policy.MaxPreCommitRandomnessLookback, 2)
+	require.NoError(t, err)
+	candidates, err := pgx.CollectRows(rows, pgx.RowToStructByName[BatchRow])
+	require.NoError(t, err)
+	require.Len(t, candidates, 5)
+	// Failed sector 1 must not consume a position before ROW_NUMBER groups 2+3.
+	require.EqualValues(t, 2, candidates[0].SectorNumber)
+	require.EqualValues(t, 3, candidates[1].SectorNumber)
+	require.EqualValues(t, 0, candidates[0].BatchIndex)
+	require.EqualValues(t, 0, candidates[1].BatchIndex)
+	require.EqualValues(t, 4, candidates[2].SectorNumber)
+	require.EqualValues(t, 1, candidates[2].BatchIndex)
+
+	// Separate statements permit a real stale-discovery change. No concurrency
+	// claim is inferred from this conditional-assignment row-effect test.
+	_, err = conn.Exec(ctx, `UPDATE sectors_sdr_pipeline SET failed=TRUE WHERE sp_id=1000 AND sector_number=2`)
+	require.NoError(t, err)
+	tag, err := conn.Exec(ctx, PRECOMMIT_BATCH_ASSIGN_SQL, int64(77), int64(1000), 8, []int64{1, 2, 3, 5})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected())
+	var assigned []int64
+	rows, err = conn.Query(ctx, `SELECT sector_number FROM sectors_sdr_pipeline WHERE task_id_precommit_msg=77`)
+	require.NoError(t, err)
+	assigned, err = pgx.CollectRows(rows, pgx.RowTo[int64])
+	require.NoError(t, err)
+	require.Equal(t, []int64{3}, assigned)
+	before := precommitSQLSnapshot(t, ctx, conn)
+	tag, err = conn.Exec(ctx, PRECOMMIT_BATCH_ASSIGN_SQL, int64(78), int64(1000), 8, []int64{1, 2, 3})
+	require.NoError(t, err)
+	require.Zero(t, tag.RowsAffected())
+	require.Equal(t, before, precommitSQLSnapshot(t, ctx, conn))
+}
+
+func TestPrecommitSQLDetachAndCIDMembership(t *testing.T) {
+	ctx, conn := newPrecommitSQLFixture(t)
+	seedPrecommitSQLRows(t, ctx, conn)
+	_, err := conn.Exec(ctx, `UPDATE sectors_sdr_pipeline SET task_id_precommit_msg=77;
+		UPDATE sectors_sdr_pipeline SET task_id_precommit_msg=88 WHERE sp_id=1000 AND sector_number=4`)
+	require.NoError(t, err)
+	before := precommitSQLSnapshot(t, ctx, conn)
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{})
+	require.NoError(t, err)
+	defer rollbackPrecommitSQL(t, tx)
+	tag, err := tx.Exec(ctx, SUBMIT_PRECOMMIT_DETACH_FAILED_SECTOR_SQL, int64(77), int64(1000), int64(1))
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected())
+	tag, err = tx.Exec(ctx, SUBMIT_PRECOMMIT_SET_MESSAGE_CID_SQL, "test-message", int64(77), int64(1000), []int64{1, 2, 4})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected())
+	require.NoError(t, tx.Rollback(ctx))
+	require.Equal(t, before, precommitSQLSnapshot(t, ctx, conn), "rollback must preserve assignment, failure evidence, and CID state")
+
+	for _, identity := range [][3]int64{{88, 1000, 1}, {77, 2000, 1}, {77, 1000, 2}} {
+		tag, err = conn.Exec(ctx, SUBMIT_PRECOMMIT_DETACH_FAILED_SECTOR_SQL, identity[0], identity[1], identity[2])
+		require.NoError(t, err)
+		require.Zero(t, tag.RowsAffected())
+	}
+	tag, err = conn.Exec(ctx, SUBMIT_PRECOMMIT_DETACH_FAILED_SECTOR_SQL, int64(77), int64(1000), int64(1))
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected())
+	tag, err = conn.Exec(ctx, SUBMIT_PRECOMMIT_SET_MESSAGE_CID_SQL, "test-message", int64(77), int64(1000), []int64{1, 2, 4})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected())
+	var failed bool
+	var reason, message string
+	require.NoError(t, conn.QueryRow(ctx, `SELECT failed,failed_reason,failed_reason_msg
+		FROM sectors_sdr_pipeline WHERE sp_id=1000 AND sector_number=1`).Scan(&failed, &reason, &message))
+	require.True(t, failed)
+	require.Equal(t, "original", reason)
+	require.Equal(t, "keep evidence", message)
+	var count int
+	require.NoError(t, conn.QueryRow(ctx, `SELECT COUNT(*) FROM sectors_sdr_pipeline
+		WHERE precommit_msg_cid IS NOT NULL`).Scan(&count))
+	require.Equal(t, 1, count)
+	require.NoError(t, conn.QueryRow(ctx, `SELECT COUNT(*) FROM sectors_sdr_pipeline
+		WHERE task_id_precommit_msg=77 AND ((sp_id=2000 AND sector_number=2) OR (sp_id=1000 AND sector_number IN (3,5)))`).Scan(&count))
+	require.Equal(t, 3, count, "unselected sectors and another provider retain their task")
+}
+
+// Projection of 20231217-sdr-pipeline plus 20240402 DDO, 20240507 task-FK
+// removal, 20240522 TIMESTAMPTZ, 20240617 synth, 20240802 user duration, and
+// 20241210 batching migrations. The initial-piece composite FK/cascade and
+// both primary keys are retained. No full historical migration is replayed.
+const precommitSQLSchema = `
+CREATE TABLE sectors_sdr_pipeline (
+ sp_id BIGINT NOT NULL, sector_number BIGINT NOT NULL, reg_seal_proof INT NOT NULL,
+ ticket_epoch BIGINT, user_sector_duration_epochs BIGINT,
+ tree_r_cid TEXT, tree_d_cid TEXT, after_synth BOOLEAN NOT NULL DEFAULT FALSE,
+ precommit_ready_at TIMESTAMPTZ, task_id_precommit_msg BIGINT,
+ precommit_msg_cid TEXT, after_precommit_msg BOOLEAN NOT NULL DEFAULT FALSE,
+ failed BOOLEAN NOT NULL DEFAULT FALSE, failed_at TIMESTAMPTZ,
+ failed_reason VARCHAR(20) NOT NULL DEFAULT '', failed_reason_msg TEXT NOT NULL DEFAULT '',
+ PRIMARY KEY (sp_id,sector_number)
+);
+CREATE TABLE sectors_sdr_initial_pieces (
+ sp_id BIGINT NOT NULL, sector_number BIGINT NOT NULL, piece_index BIGINT NOT NULL,
+ piece_cid TEXT NOT NULL, piece_size BIGINT NOT NULL,
+ f05_deal_start_epoch BIGINT, f05_deal_end_epoch BIGINT,
+ direct_start_epoch BIGINT, direct_end_epoch BIGINT,
+ PRIMARY KEY (sp_id,sector_number,piece_index),
+ FOREIGN KEY (sp_id,sector_number) REFERENCES sectors_sdr_pipeline (sp_id,sector_number) ON DELETE CASCADE
+);`

--- a/tasks/seal/task_submit_precommit.go
+++ b/tasks/seal/task_submit_precommit.go
@@ -45,11 +45,108 @@ type SubmitPrecommitTaskApi interface {
 	ctladdr.NodeApi
 }
 
+type precommitMessageSender interface {
+	Send(context.Context, *types.Message, *api.MessageSendSpec, string) (cid.Cid, error)
+}
+
+type precommitSectorParams struct {
+	SpID                     int64                   `db:"sp_id"`
+	SectorNumber             int64                   `db:"sector_number"`
+	RegSealProof             abi.RegisteredSealProof `db:"reg_seal_proof"`
+	UserSectorDurationEpochs sql.NullInt64           `db:"user_sector_duration_epochs"`
+	TicketEpoch              abi.ChainEpoch          `db:"ticket_epoch"`
+	SealedCID                string                  `db:"tree_r_cid"`
+	UnsealedCID              string                  `db:"tree_d_cid"`
+	Failed                   bool                    `db:"failed"`
+}
+
+type precommitPiece struct {
+	PieceIndex     int64  `db:"piece_index"`
+	PieceCID       string `db:"piece_cid"`
+	PieceSize      int64  `db:"piece_size"`
+	DealStartEpoch int64  `db:"deal_start_epoch"`
+	DealEndEpoch   int64  `db:"deal_end_epoch"`
+}
+
+type precommitTaskStore interface {
+	loadSectors(context.Context, harmonytask.TaskID) ([]precommitSectorParams, error)
+	detachFailedSector(context.Context, harmonytask.TaskID, int64, int64) error
+	loadPieces(context.Context, int64, int64) ([]precommitPiece, error)
+	setMessageCID(context.Context, harmonytask.TaskID, int64, []int64, cid.Cid) error
+	addMessageWait(context.Context, cid.Cid) error
+}
+
+type harmonyPrecommitTaskStore struct {
+	db *harmonydb.DB
+}
+
+const SUBMIT_PRECOMMIT_LOAD_SECTORS_SQL = `
+	SELECT sp_id, sector_number, reg_seal_proof, user_sector_duration_epochs,
+		ticket_epoch, tree_r_cid, tree_d_cid, failed
+	FROM sectors_sdr_pipeline
+	WHERE task_id_precommit_msg = $1
+	ORDER BY sector_number ASC`
+
+const SUBMIT_PRECOMMIT_DETACH_FAILED_SECTOR_SQL = `
+	UPDATE sectors_sdr_pipeline
+	SET task_id_precommit_msg = NULL
+	WHERE task_id_precommit_msg = $1
+		AND sp_id = $2
+		AND sector_number = $3
+		AND failed = TRUE`
+
+const SUBMIT_PRECOMMIT_LOAD_PIECES_SQL = `
+	SELECT piece_index,
+		piece_cid,
+		piece_size,
+		COALESCE(f05_deal_end_epoch, direct_end_epoch, 0) AS deal_end_epoch,
+		COALESCE(f05_deal_start_epoch, direct_start_epoch, 0) AS deal_start_epoch
+	FROM sectors_sdr_initial_pieces
+	WHERE sp_id = $1 AND sector_number = $2
+	ORDER BY piece_index ASC`
+
+const SUBMIT_PRECOMMIT_SET_MESSAGE_CID_SQL = `
+	UPDATE sectors_sdr_pipeline
+	SET precommit_msg_cid = $1, after_precommit_msg = TRUE, task_id_precommit_msg = NULL
+	WHERE task_id_precommit_msg = $2
+		AND sp_id = $3
+		AND sector_number = ANY($4::bigint[])
+		AND after_precommit_msg = FALSE
+		AND failed = FALSE`
+
+func (h *harmonyPrecommitTaskStore) loadSectors(ctx context.Context, taskID harmonytask.TaskID) ([]precommitSectorParams, error) {
+	var sectors []precommitSectorParams
+	err := h.db.Select(ctx, &sectors, SUBMIT_PRECOMMIT_LOAD_SECTORS_SQL, taskID)
+	return sectors, err
+}
+
+func (h *harmonyPrecommitTaskStore) detachFailedSector(ctx context.Context, taskID harmonytask.TaskID, spID, sectorNumber int64) error {
+	_, err := h.db.Exec(ctx, SUBMIT_PRECOMMIT_DETACH_FAILED_SECTOR_SQL, taskID, spID, sectorNumber)
+	return err
+}
+
+func (h *harmonyPrecommitTaskStore) loadPieces(ctx context.Context, spID, sectorNumber int64) ([]precommitPiece, error) {
+	var pieces []precommitPiece
+	err := h.db.Select(ctx, &pieces, SUBMIT_PRECOMMIT_LOAD_PIECES_SQL, spID, sectorNumber)
+	return pieces, err
+}
+
+func (h *harmonyPrecommitTaskStore) setMessageCID(ctx context.Context, taskID harmonytask.TaskID, spID int64, sectors []int64, mcid cid.Cid) error {
+	_, err := h.db.Exec(ctx, SUBMIT_PRECOMMIT_SET_MESSAGE_CID_SQL, mcid, taskID, spID, sectors)
+	return err
+}
+
+func (h *harmonyPrecommitTaskStore) addMessageWait(ctx context.Context, mcid cid.Cid) error {
+	_, err := h.db.Exec(ctx, `INSERT INTO message_waits (signed_message_cid) VALUES ($1)`, mcid)
+	return err
+}
+
 type SubmitPrecommitTask struct {
 	sp     *SealPoller
 	db     *harmonydb.DB
+	store  precommitTaskStore
 	api    SubmitPrecommitTaskApi
-	sender *message.Sender
+	sender precommitMessageSender
 	as     *multictladdr.MultiAddressSelector
 	feeCfg *config.CurioFees
 }
@@ -58,6 +155,7 @@ func NewSubmitPrecommitTask(sp *SealPoller, db *harmonydb.DB, api SubmitPrecommi
 	return &SubmitPrecommitTask{
 		sp:     sp,
 		db:     db,
+		store:  &harmonyPrecommitTaskStore{db: db},
 		api:    api,
 		sender: sender,
 		as:     as,
@@ -92,26 +190,31 @@ func (s *SubmitPrecommitTask) Do(ctx context.Context, taskID harmonytask.TaskID,
 
 	// 1. Load sector info
 
-	var sectorParamsArr []struct {
-		SpID                     int64                   `db:"sp_id"`
-		SectorNumber             int64                   `db:"sector_number"`
-		RegSealProof             abi.RegisteredSealProof `db:"reg_seal_proof"`
-		UserSectorDurationEpochs sql.NullInt64           `db:"user_sector_duration_epochs"`
-		TicketEpoch              abi.ChainEpoch          `db:"ticket_epoch"`
-		SealedCID                string                  `db:"tree_r_cid"`
-		UnsealedCID              string                  `db:"tree_d_cid"`
-	}
-
-	err = s.db.Select(ctx, &sectorParamsArr, `
-		SELECT sp_id, sector_number, reg_seal_proof, user_sector_duration_epochs, ticket_epoch, tree_r_cid, tree_d_cid
-		FROM sectors_sdr_pipeline
-		WHERE task_id_precommit_msg = $1 ORDER BY sector_number ASC`, taskID)
+	sectorParamsArr, err := s.store.loadSectors(ctx, taskID)
 	if err != nil {
 		return false, xerrors.Errorf("getting sector params: %w", err)
 	}
 
 	if len(sectorParamsArr) == 0 {
 		return true, xerrors.Errorf("expected at least 1 sector params, got 0")
+	}
+
+	activeSectors := make([]precommitSectorParams, 0, len(sectorParamsArr))
+	for _, sectorParams := range sectorParamsArr {
+		if !sectorParams.Failed {
+			activeSectors = append(activeSectors, sectorParams)
+			continue
+		}
+
+		if err := s.store.detachFailedSector(ctx, taskID, sectorParams.SpID, sectorParams.SectorNumber); err != nil {
+			return false, xerrors.Errorf("detaching failed sector from precommit task: %w", err)
+		}
+	}
+	sectorParamsArr = activeSectors
+
+	if len(sectorParamsArr) == 0 {
+		log.Warnw("no non-failed sectors to precommit", "task_id", taskID)
+		return true, nil
 	}
 
 	head, err := s.api.ChainHead(ctx)
@@ -146,6 +249,7 @@ func (s *SubmitPrecommitTask) Do(ctx context.Context, taskID harmonytask.TaskID,
 		Sectors: make([]miner.SectorPreCommitInfo, 0, len(sectorParamsArr)),
 	}
 	collateral := big.Zero()
+	includedSectors := make([]int64, 0, len(sectorParamsArr))
 
 	// 2. Prepare preCommit info and PreCommitSectorBatchParams
 	for _, sectorParams := range sectorParamsArr {
@@ -202,22 +306,7 @@ func (s *SubmitPrecommitTask) Do(ctx context.Context, taskID harmonytask.TaskID,
 			expiration = sectorParams.TicketEpoch + abi.ChainEpoch(sectorParams.UserSectorDurationEpochs.Int64)
 		}
 
-		var pieces []struct {
-			PieceIndex     int64  `db:"piece_index"`
-			PieceCID       string `db:"piece_cid"`
-			PieceSize      int64  `db:"piece_size"`
-			DealStartEpoch int64  `db:"deal_start_epoch"`
-			DealEndEpoch   int64  `db:"deal_end_epoch"`
-		}
-
-		err = s.db.Select(ctx, &pieces, `
-               SELECT piece_index,
-                      piece_cid,
-                      piece_size,
-                      COALESCE(f05_deal_end_epoch, direct_end_epoch, 0) AS deal_end_epoch,
-                      COALESCE(f05_deal_start_epoch, direct_start_epoch, 0) AS deal_start_epoch
-				FROM sectors_sdr_initial_pieces
-				WHERE sp_id = $1 AND sector_number = $2 ORDER BY piece_index ASC`, sectorParams.SpID, sectorParams.SectorNumber)
+		pieces, err := s.store.loadPieces(ctx, sectorParams.SpID, sectorParams.SectorNumber)
 		if err != nil {
 			return false, xerrors.Errorf("getting pieces: %w", err)
 		}
@@ -259,6 +348,7 @@ func (s *SubmitPrecommitTask) Do(ctx context.Context, taskID harmonytask.TaskID,
 		collateral = big.Add(collateral, collateralPerSector)
 
 		params.Sectors = append(params.Sectors, param)
+		includedSectors = append(includedSectors, sectorParams.SectorNumber)
 	}
 
 	// Check if we have any valid sectors
@@ -333,16 +423,13 @@ func (s *SubmitPrecommitTask) Do(ctx context.Context, taskID harmonytask.TaskID,
 		return false, xerrors.Errorf("sending message: %w", err)
 	}
 
-	// set precommit_msg_cid
-	_, err = s.db.Exec(ctx, `UPDATE sectors_sdr_pipeline
-		SET precommit_msg_cid = $1, after_precommit_msg = TRUE, task_id_precommit_msg = NULL
-		WHERE task_id_precommit_msg = $2`, mcid, taskID)
-	if err != nil {
+	// Set precommit_msg_cid only on non-failed sectors included in this message
+	// which are still assigned to this task.
+	if err := s.store.setMessageCID(ctx, taskID, sectorParamsArr[0].SpID, includedSectors, mcid); err != nil {
 		return false, xerrors.Errorf("updating precommit_msg_cid: %w", err)
 	}
 
-	_, err = s.db.Exec(ctx, `INSERT INTO message_waits (signed_message_cid) VALUES ($1)`, mcid)
-	if err != nil {
+	if err := s.store.addMessageWait(ctx, mcid); err != nil {
 		return false, xerrors.Errorf("inserting into message_waits: %w", err)
 	}
 

--- a/tasks/seal/task_submit_precommit_test.go
+++ b/tasks/seal/task_submit_precommit_test.go
@@ -1,18 +1,25 @@
 package seal
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/curio/deps/config"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
 	"github.com/filecoin-project/curio/lib/multictladdr"
 
 	"github.com/filecoin-project/lotus/api"
@@ -25,10 +32,14 @@ type mockPrecommitAPI struct {
 	walletBalances map[address.Address]big.Int
 	walletHas      map[address.Address]bool
 	minerBalance   big.Int
+	head           *types.TipSet
+	minerInfo      api.MinerInfo
+	chainHeadCalls int
 }
 
 func (m *mockPrecommitAPI) ChainHead(context.Context) (*types.TipSet, error) {
-	return nil, nil
+	m.chainHeadCalls++
+	return m.head, nil
 }
 
 func (m *mockPrecommitAPI) StateMinerPreCommitDepositForPower(context.Context, address.Address, miner.SectorPreCommitInfo, types.TipSetKey) (big.Int, error) {
@@ -36,7 +47,7 @@ func (m *mockPrecommitAPI) StateMinerPreCommitDepositForPower(context.Context, a
 }
 
 func (m *mockPrecommitAPI) StateMinerInfo(context.Context, address.Address, types.TipSetKey) (api.MinerInfo, error) {
-	return api.MinerInfo{}, nil
+	return m.minerInfo, nil
 }
 
 func (m *mockPrecommitAPI) StateNetworkVersion(context.Context, types.TipSetKey) (network.Version, error) {
@@ -72,6 +83,133 @@ func (m *mockPrecommitAPI) StateAccountKey(ctx context.Context, addr address.Add
 
 func (m *mockPrecommitAPI) StateLookupID(ctx context.Context, addr address.Address, tsk types.TipSetKey) (address.Address, error) {
 	return addr, nil
+}
+
+type precommitSectorKey struct {
+	spID         int64
+	sectorNumber int64
+}
+
+type mockPrecommitTaskStore struct {
+	sectors        []precommitSectorParams
+	pieces         map[precommitSectorKey][]precommitPiece
+	detached       []precommitSectorKey
+	detachErr      error
+	messageSectors []int64
+	messageSPID    int64
+	messageTaskID  harmonytask.TaskID
+	messageCID     cid.Cid
+	messageWaits   []cid.Cid
+}
+
+func (m *mockPrecommitTaskStore) loadSectors(context.Context, harmonytask.TaskID) ([]precommitSectorParams, error) {
+	return append([]precommitSectorParams(nil), m.sectors...), nil
+}
+
+func (m *mockPrecommitTaskStore) detachFailedSector(_ context.Context, _ harmonytask.TaskID, spID, sectorNumber int64) error {
+	if m.detachErr != nil {
+		return m.detachErr
+	}
+	m.detached = append(m.detached, precommitSectorKey{spID: spID, sectorNumber: sectorNumber})
+	return nil
+}
+
+func (m *mockPrecommitTaskStore) loadPieces(_ context.Context, spID, sectorNumber int64) ([]precommitPiece, error) {
+	return append([]precommitPiece(nil), m.pieces[precommitSectorKey{spID: spID, sectorNumber: sectorNumber}]...), nil
+}
+
+func (m *mockPrecommitTaskStore) setMessageCID(_ context.Context, taskID harmonytask.TaskID, spID int64, sectors []int64, mcid cid.Cid) error {
+	m.messageTaskID = taskID
+	m.messageSPID = spID
+	m.messageSectors = append([]int64(nil), sectors...)
+	m.messageCID = mcid
+	return nil
+}
+
+func (m *mockPrecommitTaskStore) addMessageWait(_ context.Context, mcid cid.Cid) error {
+	m.messageWaits = append(m.messageWaits, mcid)
+	return nil
+}
+
+type mockPrecommitMessageSender struct {
+	messages []*types.Message
+	cid      cid.Cid
+}
+
+func (m *mockPrecommitMessageSender) Send(_ context.Context, msg *types.Message, _ *api.MessageSendSpec, _ string) (cid.Cid, error) {
+	m.messages = append(m.messages, msg)
+	return m.cid, nil
+}
+
+func makePrecommitTipSet(t *testing.T, height abi.ChainEpoch) *types.TipSet {
+	t.Helper()
+
+	minerAddr, err := address.NewIDAddress(1000)
+	require.NoError(t, err)
+	root, err := cid.Decode("bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4")
+	require.NoError(t, err)
+
+	ts, err := types.NewTipSet([]*types.BlockHeader{{
+		Miner:                 minerAddr,
+		Ticket:                &types.Ticket{VRFProof: []byte{1}},
+		Height:                height,
+		ParentStateRoot:       root,
+		Messages:              root,
+		ParentMessageReceipts: root,
+		BlockSig:              &crypto.Signature{Type: crypto.SigTypeSecp256k1},
+		BLSAggregate:          &crypto.Signature{Type: crypto.SigTypeSecp256k1},
+		Timestamp:             uint64(time.Now().Unix()),
+		ParentBaseFee:         types.NewInt(100),
+	}})
+	require.NoError(t, err)
+	return ts
+}
+
+func makeSubmitPrecommitTaskForTest(t *testing.T, sectors []precommitSectorParams, pieces map[precommitSectorKey][]precommitPiece) (*SubmitPrecommitTask, *mockPrecommitTaskStore, *mockPrecommitMessageSender, *mockPrecommitAPI) {
+	t.Helper()
+
+	worker, err := address.NewIDAddress(1001)
+	require.NoError(t, err)
+	messageCID, err := cid.Decode("bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4")
+	require.NoError(t, err)
+
+	store := &mockPrecommitTaskStore{
+		sectors: sectors,
+		pieces:  pieces,
+	}
+	sender := &mockPrecommitMessageSender{cid: messageCID}
+	testAPI := &mockPrecommitAPI{
+		head:      makePrecommitTipSet(t, 1000),
+		minerInfo: api.MinerInfo{Worker: worker},
+	}
+	task := &SubmitPrecommitTask{
+		store:  store,
+		api:    testAPI,
+		sender: sender,
+		feeCfg: &config.CurioFees{},
+	}
+	return task, store, sender, testAPI
+}
+
+func makePrecommitSector(sectorNumber int64) precommitSectorParams {
+	const COMMITMENT_CID = "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+
+	return precommitSectorParams{
+		SpID:         1000,
+		SectorNumber: sectorNumber,
+		RegSealProof: abi.RegisteredSealProof_StackedDrg32GiBV1_1,
+		TicketEpoch:  900,
+		SealedCID:    COMMITMENT_CID,
+		UnsealedCID:  COMMITMENT_CID,
+	}
+}
+
+func decodePrecommitParams(t *testing.T, msg *types.Message) miner.PreCommitSectorBatchParams2 {
+	t.Helper()
+
+	var params miner.PreCommitSectorBatchParams2
+	require.NoError(t, params.UnmarshalCBOR(bytes.NewReader(msg.Params)))
+	return params
 }
 
 // calculatePrecommitNeedFunds simulates the needFunds calculation in SubmitPrecommitTask.Do
@@ -503,4 +641,76 @@ func TestPrecommitFeeCfgIntegration(t *testing.T) {
 			assert.Equal(t, tt.expectedGoodFunds, goodFunds, "goodFunds should be needFunds + 10%% of maxFee")
 		})
 	}
+}
+
+func TestSubmitPrecommitDetachesPreviouslyFailedSector(t *testing.T) {
+	taskID := harmonytask.TaskID(44)
+	failed := makePrecommitSector(301)
+	failed.Failed = true
+	valid := makePrecommitSector(302)
+	task, store, sender, _ := makeSubmitPrecommitTaskForTest(t, []precommitSectorParams{failed, valid}, nil)
+
+	done, err := task.Do(t.Context(), taskID, func() bool { return true })
+	require.NoError(t, err)
+	require.True(t, done)
+	require.Equal(t, []precommitSectorKey{{spID: failed.SpID, sectorNumber: failed.SectorNumber}}, store.detached)
+	require.Len(t, sender.messages, 1)
+	params := decodePrecommitParams(t, sender.messages[0])
+	require.Len(t, params.Sectors, 1)
+	require.Equal(t, abi.SectorNumber(valid.SectorNumber), params.Sectors[0].SectorNumber)
+	require.Equal(t, []int64{valid.SectorNumber}, store.messageSectors)
+	require.Equal(t, valid.SpID, store.messageSPID)
+	require.Equal(t, taskID, store.messageTaskID)
+	require.Equal(t, sender.cid, store.messageCID)
+	require.Equal(t, []cid.Cid{sender.cid}, store.messageWaits)
+}
+
+func TestSubmitPrecommitAllPreviouslyFailedCompletesWithoutMessage(t *testing.T) {
+	first := makePrecommitSector(401)
+	first.Failed = true
+	second := makePrecommitSector(402)
+	second.Failed = true
+	task, store, sender, testAPI := makeSubmitPrecommitTaskForTest(t, []precommitSectorParams{first, second}, nil)
+
+	done, err := task.Do(t.Context(), harmonytask.TaskID(45), func() bool { return true })
+	require.NoError(t, err)
+	require.True(t, done)
+	require.ElementsMatch(t, []precommitSectorKey{
+		{spID: first.SpID, sectorNumber: first.SectorNumber},
+		{spID: second.SpID, sectorNumber: second.SectorNumber},
+	}, store.detached)
+	require.Empty(t, sender.messages)
+	require.Empty(t, store.messageSectors)
+	require.Empty(t, store.messageWaits)
+	require.Zero(t, testAPI.chainHeadCalls, "an all-failed task must not make chain calls")
+}
+
+func TestSubmitPrecommitDetachFailureStopsBeforeMessage(t *testing.T) {
+	failed := makePrecommitSector(501)
+	failed.Failed = true
+	valid := makePrecommitSector(502)
+	task, store, sender, testAPI := makeSubmitPrecommitTaskForTest(t, []precommitSectorParams{failed, valid}, nil)
+	store.detachErr = errors.New("detach failed")
+
+	done, err := task.Do(t.Context(), harmonytask.TaskID(46), func() bool { return true })
+	require.ErrorContains(t, err, "detaching failed sector from precommit task")
+	require.False(t, done)
+	require.Empty(t, sender.messages)
+	require.Zero(t, testAPI.chainHeadCalls)
+}
+
+func TestSubmitPrecommitSQLScopesFailedDetachAndMessageAssociation(t *testing.T) {
+	normalize := func(query string) string {
+		return strings.ToLower(strings.Join(strings.Fields(query), " "))
+	}
+
+	loadSQL := normalize(SUBMIT_PRECOMMIT_LOAD_SECTORS_SQL)
+	require.Contains(t, loadSQL, "tree_d_cid, failed from sectors_sdr_pipeline")
+
+	detachSQL := normalize(SUBMIT_PRECOMMIT_DETACH_FAILED_SECTOR_SQL)
+	require.Contains(t, detachSQL, "where task_id_precommit_msg = $1 and sp_id = $2 and sector_number = $3 and failed = true")
+
+	messageSQL := normalize(SUBMIT_PRECOMMIT_SET_MESSAGE_CID_SQL)
+	require.Contains(t, messageSQL, "where task_id_precommit_msg = $2 and sp_id = $3 and sector_number = any($4::bigint[])")
+	require.Contains(t, messageSQL, "and after_precommit_msg = false and failed = false")
 }


### PR DESCRIPTION
## Summary

Exclude failed sectors before PreCommit batch numbering and recheck the failed
state when assigning a batch. If an already-created task contains failed
sectors, detach only their task/provider/sector assignments and preserve the
failure evidence. Send and associate a CID only with the remaining sectors;
an all-failed task completes without sending a message.

Batch size, ordering, timeout/slack policy, sector schedules and expiration
calculation are unchanged. This does not provide exactly-once chain submission
or repair historical tasks.

## Validation

- `go test -p=2 -tags=cgo,fvm,nosupraseal ./tasks/seal -count=1 -timeout=3m`
- Same package with `-race`: PASS.
- Exact-tag `go vet`, golangci-lint 2.11.4, repository fiximports and diff check: PASS.
- Production-SQL tests on disposable PostgreSQL 16.15, reported Read Committed:
  `TestPrecommitSQLCandidatesAndAssignment` and
  `TestPrecommitSQLDetachAndCIDMembership`: PASS.
- Removing the failed candidate predicate produced the expected row-count and
  ordering regression; the restored baseline passed.
- `SubmitPrecommitTask.Do` tests inspect the actual outgoing CBOR using a fake
  chain API/sender. SQL tests execute production constants; they are row-effect
  and rollback tests, not deliberate cross-connection contention tests.

Yugabyte execution of the new SQL tests and live actor/message execution were
not performed. Opt-in target safeguards and exact test invocation are documented
in `documentation/en/precommit-sql-tests.md`.
