### PR TITLE
storageingest: bound and serialize ready-sector transfers

### DIFF
--- a/market/storageingest/deal_ingest_batch.go
+++ b/market/storageingest/deal_ingest_batch.go
@@ -1,0 +1,510 @@
+package storageingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/yugabyte/pgx/v5/pgconn"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/tasks/seal"
+)
+
+// sealBatchSize bounds a ready-sector transfer transaction. It is an
+// internal work quantum, not a limit on sealing work in progress.
+const sealBatchSize = 64
+
+const selectSealCandidatesSQL = `SELECT sector_number
+	FROM open_sector_pieces
+	WHERE sp_id = $1
+	  AND NOT (sector_number = ANY($3::bigint[]))
+	GROUP BY sector_number
+	HAVING BOOL_AND(is_snap = $2)
+	   AND (SUM(piece_size) = $4
+	        OR MIN(created_at) < $5
+	        OR MIN(COALESCE(direct_start_epoch, f05_deal_start_epoch, 0)) < $6)
+	ORDER BY sector_number
+	LIMIT $7`
+
+type sealBatchParams struct {
+	spID                 int64
+	proof                int64
+	sectorSize           int64
+	isSnap               bool
+	maxWaitBefore        time.Time
+	sealBeforeChainEpoch abi.ChainEpoch
+}
+
+type sealBatchAttempt struct {
+	candidates []abi.SectorNumber
+	committed  int
+}
+
+type sealProviderBatchResult struct {
+	candidates int
+	committed  int
+	resolved   int
+	hasMore    bool
+	warnings   []error
+}
+
+type sealProviderDrainState struct {
+	params sealBatchParams
+	failed map[abi.SectorNumber]struct{}
+	done   bool
+}
+
+type sealBatchFunc func(failed map[abi.SectorNumber]struct{}, limit int) (sealBatchAttempt, error)
+type sealSectorFunc func(sector abi.SectorNumber) (sealSectorResult, error)
+type sealProviderBatchFunc func(state *sealProviderDrainState) (sealProviderBatchResult, error)
+
+type sealSectorDisposition int
+
+const (
+	sealSectorReady sealSectorDisposition = iota
+	sealSectorMoved
+	sealSectorAlreadyTransferred
+	sealSectorDisappeared
+	sealSectorNotEligible
+	sealSectorInconsistent
+)
+
+type sealSectorResult struct {
+	disposition sealSectorDisposition
+}
+
+type sealCandidateError struct {
+	err error
+}
+
+func (e *sealCandidateError) Error() string { return e.err.Error() }
+func (e *sealCandidateError) Unwrap() error { return e.err }
+
+func newSealCandidateError(format string, args ...any) error {
+	return &sealCandidateError{err: fmt.Errorf(format, args...)}
+}
+
+// isDeterministicSealCandidateError is deliberately conservative. Only
+// explicit candidate-state errors, PL/pgSQL candidate exceptions, and unique
+// conflicts from pipeline/initial-piece insertion are isolated per sector.
+// Connection, cancellation, serialization, generic data/integrity, and
+// unknown errors stop the pass instead of fanning out into more transactions.
+func isDeterministicSealCandidateError(err error) bool {
+	var candidateErr *sealCandidateError
+	if errors.As(err, &candidateErr) {
+		return true
+	}
+
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == "P0001" || pgErr.Code == "23505"
+}
+
+// drainSealProviders gives every provider at most one bounded transaction per
+// round, then immediately starts another round while work remains.
+func drainSealProviders(ctx context.Context, db *harmonydb.DB, params []sealBatchParams) error {
+	return drainSealProvidersWith(ctx, params, func(state *sealProviderDrainState) (sealProviderBatchResult, error) {
+		return drainSealProviderBatch(ctx, db, state)
+	})
+}
+
+func drainSealProvidersWith(ctx context.Context, params []sealBatchParams, run sealProviderBatchFunc) error {
+	states := make([]sealProviderDrainState, 0, len(params))
+	for _, provider := range params {
+		states = append(states, sealProviderDrainState{
+			params: provider,
+			failed: make(map[abi.SectorNumber]struct{}),
+		})
+	}
+
+	var warnings []error
+	for {
+		if err := ctx.Err(); err != nil {
+			return errors.Join(append(warnings, err)...)
+		}
+
+		active := 0
+		resolved := 0
+		for i := range states {
+			state := &states[i]
+			if state.done {
+				continue
+			}
+			active++
+
+			result, err := run(state)
+			warnings = append(warnings, result.warnings...)
+			if err != nil {
+				return errors.Join(append(warnings, err)...)
+			}
+			resolved += result.resolved
+			if !result.hasMore {
+				state.done = true
+			}
+		}
+
+		remaining := 0
+		for i := range states {
+			if !states[i].done {
+				remaining++
+			}
+		}
+		if active == 0 || remaining == 0 {
+			return errors.Join(warnings...)
+		}
+		if resolved == 0 {
+			return errors.Join(append(warnings, xerrors.New("storage ingest seal drain made no progress"))...)
+		}
+	}
+}
+
+func drainSealProviderBatch(ctx context.Context, db *harmonydb.DB, state *sealProviderDrainState) (sealProviderBatchResult, error) {
+	return drainSealProviderBatchWith(ctx, state,
+		func(failed map[abi.SectorNumber]struct{}, limit int) (sealBatchAttempt, error) {
+			return sealReadyBatch(ctx, db, state.params, failed, limit)
+		},
+		func(sector abi.SectorNumber) (sealSectorResult, error) {
+			return sealReadySector(ctx, db, state.params, sector)
+		},
+	)
+}
+
+func drainSealProviderBatchWith(ctx context.Context, state *sealProviderDrainState, sealBatch sealBatchFunc, sealSector sealSectorFunc) (sealProviderBatchResult, error) {
+	started := time.Now()
+	attempt, err := sealBatch(state.failed, sealBatchSize)
+	result := sealProviderBatchResult{
+		candidates: len(attempt.candidates),
+		hasMore:    len(attempt.candidates) == sealBatchSize,
+	}
+	if err == nil {
+		result.committed = attempt.committed
+		result.resolved = len(attempt.candidates)
+		if len(attempt.candidates) > 0 {
+			log.Infow("committed storage ingest seal batch",
+				"sp_id", state.params.spID,
+				"candidate_count", len(attempt.candidates),
+				"committed_count", attempt.committed,
+				"failed_count", 0,
+				"elapsed", time.Since(started),
+				"another_batch", result.hasMore,
+			)
+		}
+		return result, nil
+	}
+
+	if len(attempt.candidates) == 0 || !isDeterministicSealCandidateError(err) {
+		return result, err
+	}
+
+	log.Warnw("storage ingest seal batch has a candidate-specific failure; isolating its bounded candidates",
+		"sp_id", state.params.spID,
+		"candidate_count", len(attempt.candidates),
+		"error", err,
+	)
+
+	failedCount := 0
+	for _, sector := range attempt.candidates {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+
+		sectorResult, sectorErr := sealSector(sector)
+		if sectorErr != nil {
+			if !isDeterministicSealCandidateError(sectorErr) {
+				return result, sectorErr
+			}
+			state.failed[sector] = struct{}{}
+			failedCount++
+			result.resolved++
+			wrapped := xerrors.Errorf("sealing provider %d sector %d: %w", state.params.spID, sector, sectorErr)
+			result.warnings = append(result.warnings, wrapped)
+			log.Errorw("failed to move open sector to sealing pipeline",
+				"sp_id", state.params.spID,
+				"sector_number", sector,
+				"error", sectorErr,
+			)
+			continue
+		}
+
+		result.resolved++
+		if sectorResult.disposition == sealSectorMoved {
+			result.committed++
+		}
+	}
+
+	log.Infow("completed bounded storage ingest candidate isolation",
+		"sp_id", state.params.spID,
+		"candidate_count", len(attempt.candidates),
+		"committed_count", result.committed,
+		"failed_count", failedCount,
+		"elapsed", time.Since(started),
+		"another_batch", result.hasMore,
+	)
+	return result, nil
+}
+
+func sealReadyBatch(ctx context.Context, db *harmonydb.DB, params sealBatchParams, failed map[abi.SectorNumber]struct{}, limit int) (sealBatchAttempt, error) {
+	var result sealBatchAttempt
+	committed, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		// The callback can be rerun after a serialization failure. Never expose
+		// candidates or counts from an attempt which rolled back.
+		result = sealBatchAttempt{}
+		if err := seal.LockSectorState(ctx, tx, params.spID); err != nil {
+			return false, err
+		}
+
+		candidates, err := selectSealCandidates(tx, params, failed, limit)
+		if err != nil {
+			return false, err
+		}
+		result.candidates = candidates
+		if len(candidates) == 0 {
+			return true, nil
+		}
+
+		result.committed, err = transferSealCandidates(tx, params, candidates)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}, harmonydb.OptionRetry())
+	if err != nil {
+		return result, err
+	}
+	if !committed {
+		return result, xerrors.Errorf("provider %d seal batch transaction did not commit", params.spID)
+	}
+	return result, nil
+}
+
+func selectSealCandidates(tx *harmonydb.Tx, params sealBatchParams, failed map[abi.SectorNumber]struct{}, limit int) ([]abi.SectorNumber, error) {
+	failedNumbers := make([]int64, 0, len(failed))
+	for sector := range failed {
+		failedNumbers = append(failedNumbers, int64(sector))
+	}
+
+	var rows []struct {
+		Sector abi.SectorNumber `db:"sector_number"`
+	}
+	err := tx.Select(&rows, selectSealCandidatesSQL,
+		params.spID,
+		params.isSnap,
+		failedNumbers,
+		params.sectorSize,
+		params.maxWaitBefore,
+		params.sealBeforeChainEpoch,
+		limit,
+	)
+	if err != nil {
+		return nil, xerrors.Errorf("selecting seal candidates for provider %d: %w", params.spID, err)
+	}
+
+	candidates := make([]abi.SectorNumber, 0, len(rows))
+	for _, row := range rows {
+		candidates = append(candidates, row.Sector)
+	}
+	return candidates, nil
+}
+
+func transferSealCandidates(tx *harmonydb.Tx, params sealBatchParams, candidates []abi.SectorNumber) (int, error) {
+	sectorNumbers := make([]int64, 0, len(candidates))
+	for _, sector := range candidates {
+		sectorNumbers = append(sectorNumbers, int64(sector))
+	}
+
+	var inserted int
+	var err error
+	if params.isSnap {
+		inserted, err = tx.Exec(`INSERT INTO sectors_snap_pipeline (sp_id, sector_number, upgrade_proof)
+			SELECT $2, sector_number, $3
+			FROM unnest($1::bigint[]) AS candidate(sector_number)`, sectorNumbers, params.spID, params.proof)
+	} else {
+		inserted, err = tx.Exec(`INSERT INTO sectors_sdr_pipeline (sp_id, sector_number, reg_seal_proof)
+			SELECT $2, sector_number, $3
+			FROM unnest($1::bigint[]) AS candidate(sector_number)`, sectorNumbers, params.spID, params.proof)
+	}
+	if err != nil {
+		return 0, xerrors.Errorf("adding seal candidates for provider %d: %w", params.spID, err)
+	}
+	if inserted != len(candidates) {
+		return 0, newSealCandidateError("adding seal candidates for provider %d: inserted %d of %d candidates", params.spID, inserted, len(candidates))
+	}
+
+	var transferRows *harmonydb.Query
+	if params.isSnap {
+		transferRows, err = tx.Query(`SELECT transfer_and_delete_sorted_open_piece_snap($2, sector_number)
+			FROM unnest($1::bigint[]) AS inserted(sector_number)
+			ORDER BY sector_number`, sectorNumbers, params.spID)
+	} else {
+		transferRows, err = tx.Query(`SELECT transfer_and_delete_sorted_open_piece($2, sector_number)
+			FROM unnest($1::bigint[]) AS inserted(sector_number)
+			ORDER BY sector_number`, sectorNumbers, params.spID)
+	}
+	if err != nil {
+		return 0, xerrors.Errorf("starting transfer for provider %d: %w", params.spID, err)
+	}
+	defer transferRows.Close()
+
+	moved := 0
+	for transferRows.Next() {
+		moved++
+	}
+	if err := transferRows.Err(); err != nil {
+		return 0, xerrors.Errorf("transferring open sectors for provider %d: %w", params.spID, err)
+	}
+	if moved != len(candidates) {
+		return moved, newSealCandidateError("transferring open sectors for provider %d: moved %d of %d candidates", params.spID, moved, len(candidates))
+	}
+	return moved, nil
+}
+
+type sealSectorState struct {
+	openPieces      int64
+	modeMatches     bool
+	eligible        bool
+	pipelineExists  bool
+	pipelineMatches bool
+}
+
+func classifySealSectorState(params sealBatchParams, sector abi.SectorNumber, state sealSectorState) (sealSectorDisposition, error) {
+	if state.openPieces == 0 {
+		if state.pipelineMatches {
+			return sealSectorAlreadyTransferred, nil
+		}
+		if state.pipelineExists {
+			return sealSectorInconsistent, newSealCandidateError("provider %d sector %d has a non-matching pipeline row after its open pieces disappeared", params.spID, sector)
+		}
+		return sealSectorDisappeared, newSealCandidateError("provider %d sector %d disappeared without a matching pipeline row", params.spID, sector)
+	}
+	if !state.modeMatches {
+		return sealSectorInconsistent, newSealCandidateError("provider %d sector %d contains mixed normal and snap open pieces", params.spID, sector)
+	}
+	if state.pipelineExists {
+		return sealSectorInconsistent, newSealCandidateError("provider %d sector %d has an existing pipeline row while %d open pieces remain", params.spID, sector, state.openPieces)
+	}
+	if !state.eligible {
+		return sealSectorNotEligible, nil
+	}
+	return sealSectorReady, nil
+}
+
+func loadSealSectorState(tx *harmonydb.Tx, params sealBatchParams, sector abi.SectorNumber) (sealSectorState, error) {
+	var state sealSectorState
+	var err error
+	if params.isSnap {
+		err = tx.QueryRow(`WITH open_state AS (
+			SELECT COUNT(*) AS open_pieces,
+			       COALESCE(BOOL_AND(is_snap = TRUE), FALSE) AS mode_matches,
+			       COALESCE(
+			           SUM(piece_size) = $4
+			           OR MIN(created_at) < $5
+			           OR MIN(COALESCE(direct_start_epoch, f05_deal_start_epoch, 0)) < $6,
+			           FALSE
+			       ) AS eligible
+			FROM open_sector_pieces
+			WHERE sp_id = $1 AND sector_number = $2
+		)
+		SELECT open_pieces,
+		       mode_matches,
+		       eligible,
+		       EXISTS (SELECT 1 FROM sectors_snap_pipeline WHERE sp_id = $1 AND sector_number = $2),
+		       EXISTS (SELECT 1 FROM sectors_snap_pipeline WHERE sp_id = $1 AND sector_number = $2 AND upgrade_proof = $3)
+		FROM open_state`, params.spID, sector, params.proof, params.sectorSize, params.maxWaitBefore, params.sealBeforeChainEpoch).
+			Scan(&state.openPieces, &state.modeMatches, &state.eligible, &state.pipelineExists, &state.pipelineMatches)
+	} else {
+		err = tx.QueryRow(`WITH open_state AS (
+			SELECT COUNT(*) AS open_pieces,
+			       COALESCE(BOOL_AND(is_snap = FALSE), FALSE) AS mode_matches,
+			       COALESCE(
+			           SUM(piece_size) = $4
+			           OR MIN(created_at) < $5
+			           OR MIN(COALESCE(direct_start_epoch, f05_deal_start_epoch, 0)) < $6,
+			           FALSE
+			       ) AS eligible
+			FROM open_sector_pieces
+			WHERE sp_id = $1 AND sector_number = $2
+		)
+		SELECT open_pieces,
+		       mode_matches,
+		       eligible,
+		       EXISTS (SELECT 1 FROM sectors_sdr_pipeline WHERE sp_id = $1 AND sector_number = $2),
+		       EXISTS (SELECT 1 FROM sectors_sdr_pipeline WHERE sp_id = $1 AND sector_number = $2 AND reg_seal_proof = $3)
+		FROM open_state`, params.spID, sector, params.proof, params.sectorSize, params.maxWaitBefore, params.sealBeforeChainEpoch).
+			Scan(&state.openPieces, &state.modeMatches, &state.eligible, &state.pipelineExists, &state.pipelineMatches)
+	}
+	if err != nil {
+		return sealSectorState{}, xerrors.Errorf("revalidating provider %d sector %d: %w", params.spID, sector, err)
+	}
+	return state, nil
+}
+
+func sealReadySector(ctx context.Context, db *harmonydb.DB, params sealBatchParams, sector abi.SectorNumber) (sealSectorResult, error) {
+	var result sealSectorResult
+	committed, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		result = sealSectorResult{}
+		if err := seal.LockSectorState(ctx, tx, params.spID); err != nil {
+			return false, err
+		}
+
+		state, err := loadSealSectorState(tx, params, sector)
+		if err != nil {
+			return false, err
+		}
+		disposition, err := classifySealSectorState(params, sector, state)
+		if err != nil {
+			return false, err
+		}
+		result.disposition = disposition
+		if disposition != sealSectorReady {
+			return true, nil
+		}
+
+		if params.isSnap {
+			_, err = tx.Exec(`INSERT INTO sectors_snap_pipeline (sp_id, sector_number, upgrade_proof)
+				VALUES ($1, $2, $3)`, params.spID, sector, params.proof)
+		} else {
+			_, err = tx.Exec(`INSERT INTO sectors_sdr_pipeline (sp_id, sector_number, reg_seal_proof)
+				VALUES ($1, $2, $3)`, params.spID, sector, params.proof)
+		}
+		if err != nil {
+			return false, xerrors.Errorf("adding provider %d sector %d to pipeline: %w", params.spID, sector, err)
+		}
+
+		if params.isSnap {
+			_, err = tx.Exec(`SELECT transfer_and_delete_sorted_open_piece_snap($1, $2)`, params.spID, sector)
+		} else {
+			_, err = tx.Exec(`SELECT transfer_and_delete_sorted_open_piece($1, $2)`, params.spID, sector)
+		}
+		if err != nil {
+			return false, xerrors.Errorf("transferring provider %d sector %d: %w", params.spID, sector, err)
+		}
+
+		var stillOpen bool
+		if err := tx.QueryRow(`SELECT EXISTS (
+			SELECT 1 FROM open_sector_pieces
+			WHERE sp_id = $1 AND sector_number = $2
+		)`, params.spID, sector).Scan(&stillOpen); err != nil {
+			return false, xerrors.Errorf("checking provider %d sector %d transfer postcondition: %w", params.spID, sector, err)
+		}
+		if stillOpen {
+			return false, newSealCandidateError("provider %d sector %d still has open pieces after transfer", params.spID, sector)
+		}
+
+		result.disposition = sealSectorMoved
+		return true, nil
+	}, harmonydb.OptionRetry())
+	if err != nil {
+		return result, err
+	}
+	if !committed {
+		return result, xerrors.Errorf("provider %d sector %d transaction did not commit", params.spID, sector)
+	}
+	return result, nil
+}

--- a/market/storageingest/deal_ingest_batch_test.go
+++ b/market/storageingest/deal_ingest_batch_test.go
@@ -1,0 +1,363 @@
+package storageingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/yugabyte/pgx/v5/pgconn"
+
+	"github.com/filecoin-project/go-state-types/abi"
+)
+
+func TestDrainSealProvidersEmptyIsSuccessful(t *testing.T) {
+	calls := 0
+	err := drainSealProvidersWith(context.Background(), []sealBatchParams{{spID: 1000}}, func(state *sealProviderDrainState) (sealProviderBatchResult, error) {
+		calls++
+		return sealProviderBatchResult{}, nil
+	})
+	if err != nil {
+		t.Fatalf("empty drain failed: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("batch calls = %d, want 1", calls)
+	}
+}
+
+func TestDrainSealProvidersUsesBoundedFairRounds(t *testing.T) {
+	remaining := map[int64]int{1001: 2*sealBatchSize + 1, 1002: 2*sealBatchSize + 1}
+	var order []int64
+	var batchSizes []int
+	err := drainSealProvidersWith(context.Background(), []sealBatchParams{{spID: 1001}, {spID: 1002}}, func(state *sealProviderDrainState) (sealProviderBatchResult, error) {
+		order = append(order, state.params.spID)
+		count := min(remaining[state.params.spID], sealBatchSize)
+		remaining[state.params.spID] -= count
+		batchSizes = append(batchSizes, count)
+		return sealProviderBatchResult{
+			candidates: count,
+			committed:  count,
+			resolved:   count,
+			hasMore:    count == sealBatchSize,
+		}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := order, []int64{1001, 1002, 1001, 1002, 1001, 1002}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("provider order = %v, want %v", got, want)
+	}
+	if got, want := batchSizes, []int{sealBatchSize, sealBatchSize, sealBatchSize, sealBatchSize, 1, 1}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("batch sizes = %v, want %v", got, want)
+	}
+	for provider, count := range remaining {
+		if count != 0 {
+			t.Fatalf("provider %d has %d candidates left", provider, count)
+		}
+	}
+}
+
+func TestDrainSealProviderBatchUsesExactQuantum(t *testing.T) {
+	state := sealProviderDrainState{params: sealBatchParams{spID: 1000}, failed: make(map[abi.SectorNumber]struct{})}
+	gotLimit := 0
+	_, err := drainSealProviderBatchWith(context.Background(), &state,
+		func(_ map[abi.SectorNumber]struct{}, limit int) (sealBatchAttempt, error) {
+			gotLimit = limit
+			return sealBatchAttempt{}, nil
+		},
+		func(abi.SectorNumber) (sealSectorResult, error) {
+			t.Fatal("empty batch must not use individual fallback")
+			return sealSectorResult{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sealBatchSize != 64 {
+		t.Fatalf("sealBatchSize = %d, want 64", sealBatchSize)
+	}
+	if gotLimit != sealBatchSize {
+		t.Fatalf("batch limit = %d, want sealBatchSize=%d", gotLimit, sealBatchSize)
+	}
+}
+
+func TestDrainSealProvidersPartialAndExactlyFullTermination(t *testing.T) {
+	tests := []struct {
+		name      string
+		firstSize int
+		wantCalls int
+	}{
+		{name: "partial", firstSize: sealBatchSize - 1, wantCalls: 1},
+		{name: "exactly full", firstSize: sealBatchSize, wantCalls: 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			var limits []int
+			err := drainSealProvidersWith(context.Background(), []sealBatchParams{{spID: 1000}}, func(state *sealProviderDrainState) (sealProviderBatchResult, error) {
+				return drainSealProviderBatchWith(context.Background(), state,
+					func(_ map[abi.SectorNumber]struct{}, limit int) (sealBatchAttempt, error) {
+						limits = append(limits, limit)
+						calls++
+						if calls > 1 {
+							return sealBatchAttempt{}, nil
+						}
+						candidates := make([]abi.SectorNumber, test.firstSize)
+						return sealBatchAttempt{candidates: candidates, committed: len(candidates)}, nil
+					},
+					func(abi.SectorNumber) (sealSectorResult, error) {
+						t.Fatal("successful batch must not use individual fallback")
+						return sealSectorResult{}, nil
+					},
+				)
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if calls != test.wantCalls {
+				t.Fatalf("batch calls = %d, want %d", calls, test.wantCalls)
+			}
+			for _, limit := range limits {
+				if limit != sealBatchSize {
+					t.Fatalf("batch limit = %d, want %d", limit, sealBatchSize)
+				}
+			}
+		})
+	}
+}
+
+func TestDrainSealProvidersDetectsNoProgress(t *testing.T) {
+	calls := 0
+	err := drainSealProvidersWith(context.Background(), []sealBatchParams{{spID: 1000}}, func(state *sealProviderDrainState) (sealProviderBatchResult, error) {
+		calls++
+		return sealProviderBatchResult{candidates: sealBatchSize, hasMore: true}, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "made no progress") {
+		t.Fatalf("drain error = %v, want no-progress error", err)
+	}
+	if calls != 1 {
+		t.Fatalf("batch calls = %d, want 1", calls)
+	}
+}
+
+func TestDrainSealProviderBatchIsolatesCandidateAndContinues(t *testing.T) {
+	const total = sealBatchSize + 1
+	poison := abi.SectorNumber(7)
+	open := make(map[abi.SectorNumber]bool, total)
+	for sector := 1; sector <= total; sector++ {
+		open[abi.SectorNumber(sector)] = true
+	}
+
+	state := sealProviderDrainState{params: sealBatchParams{spID: 1000}, failed: make(map[abi.SectorNumber]struct{})}
+	run := func(state *sealProviderDrainState) (sealProviderBatchResult, error) {
+		return drainSealProviderBatchWith(context.Background(), state,
+			func(failed map[abi.SectorNumber]struct{}, limit int) (sealBatchAttempt, error) {
+				candidates := nextSealTestCandidates(open, failed, limit)
+				for _, sector := range candidates {
+					if sector == poison {
+						return sealBatchAttempt{candidates: candidates}, newSealCandidateError("poison candidate")
+					}
+				}
+				for _, sector := range candidates {
+					delete(open, sector)
+				}
+				return sealBatchAttempt{candidates: candidates, committed: len(candidates)}, nil
+			},
+			func(sector abi.SectorNumber) (sealSectorResult, error) {
+				if sector == poison {
+					return sealSectorResult{}, newSealCandidateError("poison sector")
+				}
+				delete(open, sector)
+				return sealSectorResult{disposition: sealSectorMoved}, nil
+			},
+		)
+	}
+
+	err := drainSealProvidersWith(context.Background(), []sealBatchParams{state.params}, run)
+	if err == nil || !strings.Contains(err.Error(), "poison sector") {
+		t.Fatalf("drain error = %v, want isolated poison warning", err)
+	}
+	if len(open) != 1 || !open[poison] {
+		t.Fatalf("open sectors = %v, want only poison %d", open, poison)
+	}
+}
+
+func TestDrainSealProviderBatchRetainsOpenPipelineInconsistency(t *testing.T) {
+	state := sealProviderDrainState{params: sealBatchParams{spID: 1000}, failed: make(map[abi.SectorNumber]struct{})}
+	transfers := 0
+	result, err := drainSealProviderBatchWith(context.Background(), &state,
+		func(map[abi.SectorNumber]struct{}, int) (sealBatchAttempt, error) {
+			return sealBatchAttempt{candidates: []abi.SectorNumber{1, 2}}, newSealCandidateError("batch conflict")
+		},
+		func(sector abi.SectorNumber) (sealSectorResult, error) {
+			candidateState := sealSectorState{openPieces: 1, modeMatches: true, eligible: true}
+			if sector == 1 {
+				candidateState.pipelineExists = true
+				candidateState.pipelineMatches = true
+			}
+			disposition, classifyErr := classifySealSectorState(state.params, sector, candidateState)
+			if classifyErr != nil {
+				return sealSectorResult{disposition: disposition}, classifyErr
+			}
+			transfers++
+			return sealSectorResult{disposition: sealSectorMoved}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transfers != 1 || result.committed != 1 {
+		t.Fatalf("transfers=%d committed=%d, want one valid transfer", transfers, result.committed)
+	}
+	if _, excluded := state.failed[1]; !excluded {
+		t.Fatal("inconsistent sector was not retained in the per-pass exclusion set")
+	}
+	if len(result.warnings) != 1 || !strings.Contains(result.warnings[0].Error(), "while 1 open pieces remain") {
+		t.Fatalf("warnings = %v, want the retained inconsistency", result.warnings)
+	}
+}
+
+func TestDrainSealProviderBatchStopsOnInfrastructureError(t *testing.T) {
+	sectorCalls := 0
+	state := sealProviderDrainState{params: sealBatchParams{spID: 1000}, failed: make(map[abi.SectorNumber]struct{})}
+	_, err := drainSealProviderBatchWith(context.Background(), &state,
+		func(map[abi.SectorNumber]struct{}, int) (sealBatchAttempt, error) {
+			return sealBatchAttempt{candidates: []abi.SectorNumber{1, 2}}, errors.New("database unavailable")
+		},
+		func(abi.SectorNumber) (sealSectorResult, error) {
+			sectorCalls++
+			return sealSectorResult{}, nil
+		},
+	)
+	if err == nil || err.Error() != "database unavailable" {
+		t.Fatalf("batch error = %v, want infrastructure error", err)
+	}
+	if sectorCalls != 0 {
+		t.Fatalf("individual fallback calls = %d, want 0", sectorCalls)
+	}
+}
+
+func TestDrainSealProviderBatchStopsOnSerializationError(t *testing.T) {
+	sectorCalls := 0
+	state := sealProviderDrainState{params: sealBatchParams{spID: 1000}, failed: make(map[abi.SectorNumber]struct{})}
+	_, err := drainSealProviderBatchWith(context.Background(), &state,
+		func(map[abi.SectorNumber]struct{}, int) (sealBatchAttempt, error) {
+			return sealBatchAttempt{candidates: []abi.SectorNumber{1}}, &pgconn.PgError{Code: "40001", Message: "serialization failure"}
+		},
+		func(abi.SectorNumber) (sealSectorResult, error) {
+			sectorCalls++
+			return sealSectorResult{}, nil
+		},
+	)
+	if err == nil {
+		t.Fatal("expected serialization error")
+	}
+	if sectorCalls != 0 {
+		t.Fatalf("individual fallback calls = %d, want 0", sectorCalls)
+	}
+}
+
+func TestDrainSealProviderBatchStopsFallbackAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	state := sealProviderDrainState{params: sealBatchParams{spID: 1000}, failed: make(map[abi.SectorNumber]struct{})}
+	sectorCalls := 0
+	_, err := drainSealProviderBatchWith(ctx, &state,
+		func(map[abi.SectorNumber]struct{}, int) (sealBatchAttempt, error) {
+			return sealBatchAttempt{candidates: []abi.SectorNumber{1, 2}}, newSealCandidateError("candidate failure")
+		},
+		func(abi.SectorNumber) (sealSectorResult, error) {
+			sectorCalls++
+			cancel()
+			return sealSectorResult{disposition: sealSectorMoved}, nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("fallback error = %v, want context cancellation", err)
+	}
+	if sectorCalls != 1 {
+		t.Fatalf("individual fallback calls = %d, want 1", sectorCalls)
+	}
+}
+
+func TestClassifySealSectorState(t *testing.T) {
+	params := sealBatchParams{spID: 1000}
+	tests := []struct {
+		name        string
+		state       sealSectorState
+		want        sealSectorDisposition
+		wantErrPart string
+	}{
+		{name: "ready", state: sealSectorState{openPieces: 1, modeMatches: true, eligible: true}, want: sealSectorReady},
+		{name: "not eligible", state: sealSectorState{openPieces: 1, modeMatches: true}, want: sealSectorNotEligible},
+		{name: "already transferred", state: sealSectorState{pipelineExists: true, pipelineMatches: true}, want: sealSectorAlreadyTransferred},
+		{name: "disappeared", state: sealSectorState{}, want: sealSectorDisappeared, wantErrPart: "disappeared"},
+		{name: "non-matching transferred", state: sealSectorState{pipelineExists: true}, want: sealSectorInconsistent, wantErrPart: "non-matching"},
+		{name: "open plus pipeline", state: sealSectorState{openPieces: 1, modeMatches: true, eligible: true, pipelineExists: true, pipelineMatches: true}, want: sealSectorInconsistent, wantErrPart: "while 1 open pieces remain"},
+		{name: "mixed normal and snap", state: sealSectorState{openPieces: 2, eligible: true}, want: sealSectorInconsistent, wantErrPart: "mixed normal and snap"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := classifySealSectorState(params, 7, test.state)
+			if got != test.want {
+				t.Fatalf("disposition = %d, want %d", got, test.want)
+			}
+			if test.wantErrPart == "" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if test.wantErrPart != "" && (err == nil || !strings.Contains(err.Error(), test.wantErrPart)) {
+				t.Fatalf("error = %v, want substring %q", err, test.wantErrPart)
+			}
+		})
+	}
+}
+
+func TestCandidateSelectionRequiresOneOpenSectorMode(t *testing.T) {
+	if !strings.Contains(selectSealCandidatesSQL, "HAVING BOOL_AND(is_snap = $2)") {
+		t.Fatal("candidate query does not reject mixed normal/Snap sectors")
+	}
+	beforeGrouping := strings.Split(selectSealCandidatesSQL, "GROUP BY")[0]
+	if strings.Contains(beforeGrouping, "is_snap = $2") {
+		t.Fatal("candidate query filters pieces by mode before validating the complete sector")
+	}
+}
+
+func TestDeterministicSealCandidateErrorClassification(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{err: newSealCandidateError("inconsistent candidate"), want: true},
+		{err: &pgconn.PgError{Code: "P0001"}, want: true},
+		{err: &pgconn.PgError{Code: "23505"}, want: true},
+		{err: &pgconn.PgError{Code: "22000"}, want: false},
+		{err: &pgconn.PgError{Code: "23502"}, want: false},
+		{err: &pgconn.PgError{Code: "40001"}, want: false},
+		{err: &pgconn.PgError{Code: "08006"}, want: false},
+		{err: context.Canceled, want: false},
+		{err: errors.New("unknown"), want: false},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%T-%v", test.err, test.err), func(t *testing.T) {
+			if got := isDeterministicSealCandidateError(test.err); got != test.want {
+				t.Fatalf("classification = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func nextSealTestCandidates(open map[abi.SectorNumber]bool, failed map[abi.SectorNumber]struct{}, limit int) []abi.SectorNumber {
+	available := make([]abi.SectorNumber, 0, len(open))
+	for sector := range open {
+		if _, excluded := failed[sector]; excluded {
+			continue
+		}
+		available = append(available, sector)
+	}
+	sort.Slice(available, func(i, j int) bool { return available[i] < available[j] })
+	return available[:min(len(available), limit)]
+}

--- a/market/storageingest/deal_ingest_integration_test.go
+++ b/market/storageingest/deal_ingest_integration_test.go
@@ -219,6 +219,49 @@ func TestStorageTransferDBSnapMovesAtomically(t *testing.T) {
 	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSnapInitialSector, 1, spID, sector)
 }
 
+func TestStorageTransferDBLateFailureRollsBackWholeBatch(t *testing.T) {
+	db, _ := storageTransferITestDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	const spID = int64(3103)
+	if _, err := db.Exec(ctx, `INSERT INTO sectors_meta (sp_id, sector_num) VALUES ($1, 1), ($1, 2)`, spID); err != nil {
+		t.Fatal(err)
+	}
+	insertStorageTransferOpenSectors(t, ctx, db, spID, 1, 2, true)
+	// This is valid fixture SQL but invalid Snap candidate data. The existing
+	// transfer function raises P0001 for the second sector, after the first
+	// sector's initial-piece INSERT and open-piece DELETE have executed.
+	if _, err := db.Exec(ctx, `UPDATE open_sector_pieces SET f05_deal_id = 1
+		WHERE sp_id = $1 AND sector_number = 2`, spID); err != nil {
+		t.Fatal(err)
+	}
+	params := sealBatchParams{
+		spID:                 spID,
+		proof:                int64(abi.RegisteredUpdateProof_StackedDrg2KiBV1),
+		sectorSize:           storageTransferITestSectorSize,
+		isSnap:               true,
+		maxWaitBefore:        time.Now().Add(-24 * time.Hour),
+		sealBeforeChainEpoch: 0,
+	}
+	if _, err := sealReadyBatch(ctx, db, params, nil, sealBatchSize); err == nil || !isDeterministicSealCandidateError(err) {
+		t.Fatalf("expected candidate-specific transfer failure, got %v", err)
+	}
+	for _, sector := range []int64{1, 2} {
+		assertStorageTransferITestCount(t, ctx, db, storageTransferCountOpenSector, 1, spID, sector)
+		assertStorageTransferITestCount(t, ctx, db, storageTransferCountSnapPipelineSector, 0, spID, sector)
+		assertStorageTransferITestCount(t, ctx, db, storageTransferCountSnapInitialSector, 0, spID, sector)
+	}
+	if err := drainSealProviders(ctx, db, []sealBatchParams{params}); err == nil {
+		t.Fatal("expected the retained invalid candidate to be reported")
+	}
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountOpenSector, 0, spID, 1)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSnapPipelineSector, 1, spID, 1)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSnapInitialSector, 1, spID, 1)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountOpenSector, 1, spID, 2)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSnapPipelineSector, 0, spID, 2)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSnapInitialSector, 0, spID, 2)
+}
+
 func insertStorageTransferOpenSectors(t *testing.T, ctx context.Context, db *harmonydb.DB, spID int64, first, count int, isSnap bool) {
 	t.Helper()
 	committed, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {

--- a/market/storageingest/deal_ingest_integration_test.go
+++ b/market/storageingest/deal_ingest_integration_test.go
@@ -1,0 +1,481 @@
+//go:build integration
+
+package storageingest
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+)
+
+const (
+	storageTransferITestOptInEnv    = "CURIO_STORAGE_TRANSFER_ITEST"
+	storageTransferITestHostEnv     = "CURIO_STORAGE_TRANSFER_ITEST_HOST"
+	storageTransferITestPortEnv     = "CURIO_STORAGE_TRANSFER_ITEST_PORT"
+	storageTransferITestDBEnv       = "CURIO_STORAGE_TRANSFER_ITEST_DATABASE"
+	storageTransferITestUserEnv     = "CURIO_STORAGE_TRANSFER_ITEST_USERNAME"
+	storageTransferITestPasswordEnv = "CURIO_STORAGE_TRANSFER_ITEST_PASSWORD"
+	storageTransferITestSectorSize  = int64(2 << 10)
+)
+
+// storageTransferITestDB connects only after explicit opt-in and only to an
+// explicit literal loopback target. It deliberately constructs Config
+// directly instead of inheriting Curio's normal database environment or the
+// defaults in DefaultItestOptions. ReadOnly suppresses migration replay; it
+// does not prevent test transactions after the connection is established.
+func storageTransferITestDB(t *testing.T) (*harmonydb.DB, harmonydb.Config) {
+	t.Helper()
+	if os.Getenv(storageTransferITestOptInEnv) != "1" {
+		t.Skipf("set %s=1 and all dedicated target variables to run", storageTransferITestOptInEnv)
+	}
+
+	host := requireStorageTransferITestEnv(t, storageTransferITestHostEnv)
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		t.Fatalf("%s must be a literal loopback IP address, got %q", storageTransferITestHostEnv, host)
+	}
+	port := requireStorageTransferITestEnv(t, storageTransferITestPortEnv)
+	parsedPort, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || parsedPort == 0 {
+		t.Fatalf("%s must be a valid nonzero TCP port, got %q", storageTransferITestPortEnv, port)
+	}
+
+	id := harmonydb.ITestNewID()
+	cfg := harmonydb.Config{
+		Hosts:           []string{host},
+		Port:            port,
+		Database:        requireStorageTransferITestEnv(t, storageTransferITestDBEnv),
+		Username:        requireStorageTransferITestEnv(t, storageTransferITestUserEnv),
+		Password:        requireStorageTransferITestEnv(t, storageTransferITestPasswordEnv),
+		LoadBalance:     false,
+		ReadOnly:        true,
+		SSLMode:         "disable",
+		ApplicationName: "curio-storage-transfer-itest",
+		ITestID:         id,
+		UseTemplate:     false,
+	}
+	db, err := harmonydb.NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("opening isolated storage-transfer test schema: %v", err)
+	}
+	t.Cleanup(db.ITestDeleteAll)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := db.Exec(ctx, storageTransferITestSchema); err != nil {
+		t.Fatalf("creating focused storage-transfer fixture: %v", err)
+	}
+
+	var version, displayedIsolation string
+	if err := db.QueryRow(ctx, `SELECT version()`).Scan(&version); err != nil {
+		t.Fatalf("reading database version: %v", err)
+	}
+	if err := db.QueryRow(ctx, `SHOW transaction_isolation`).Scan(&displayedIsolation); err != nil {
+		t.Fatalf("reading displayed transaction isolation: %v", err)
+	}
+	t.Logf("database version=%q; SQL displayed transaction_isolation=%q; effective Yugabyte isolation=UNVERIFIED (server flags were not inspected)", version, displayedIsolation)
+
+	peerCfg := cfg
+	peerCfg.ITestID = ""
+	peerCfg.Schema = "itest_" + string(id)
+	peerCfg.ApplicationName = "curio-storage-transfer-itest-peer"
+	return db, peerCfg
+}
+
+func requireStorageTransferITestEnv(t *testing.T, name string) string {
+	t.Helper()
+	value, ok := os.LookupEnv(name)
+	if !ok || value == "" {
+		t.Fatalf("%s must be set explicitly", name)
+	}
+	return value
+}
+
+func TestStorageTransferDBConcurrentHandlesMoveEachSectorOnce(t *testing.T) {
+	db, peerCfg := storageTransferITestDB(t)
+	peerDB, err := harmonydb.NewFromConfig(peerCfg)
+	if err != nil {
+		t.Fatalf("opening independent storage-transfer database handle: %v", err)
+	}
+	// HarmonyDB does not expose a non-destructive Close method. The owner
+	// handle drops the isolated schema; the peer is scoped to this short-lived
+	// opt-in test process and is never pointed at a non-loopback target.
+	dbs := []*harmonydb.DB{db, peerDB}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	const (
+		spID  = int64(3100)
+		total = 2*sealBatchSize + 1
+	)
+	insertStorageTransferOpenSectors(t, ctx, db, spID, 1, total, false)
+
+	params := sealBatchParams{
+		spID:                 spID,
+		proof:                int64(abi.RegisteredSealProof_StackedDrg2KiBV1_1),
+		sectorSize:           storageTransferITestSectorSize,
+		maxWaitBefore:        time.Now().Add(-24 * time.Hour),
+		sealBeforeChainEpoch: 0,
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, len(dbs))
+	var wg sync.WaitGroup
+	for _, transactionDB := range dbs {
+		wg.Add(1)
+		go func(transactionDB *harmonydb.DB) {
+			defer wg.Done()
+			<-start
+			errs <- drainSealProviders(ctx, transactionDB, []sealBatchParams{params})
+		}(transactionDB)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountOpen, 0, spID)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSDRPipeline, total, spID)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSDRInitial, total, spID)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountDuplicateSDRInitial, 0, spID)
+}
+
+func TestStorageTransferDBInconsistentPipelineRollsBackAndContinues(t *testing.T) {
+	db, _ := storageTransferITestDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	const (
+		spID         = int64(3101)
+		poisonSector = int64(1)
+		validSector  = int64(2)
+	)
+	insertStorageTransferOpenSectors(t, ctx, db, spID, 1, 2, false)
+	if _, err := db.Exec(ctx, `INSERT INTO sectors_sdr_pipeline
+		(sp_id, sector_number, reg_seal_proof) VALUES ($1, $2, $3)`,
+		spID, poisonSector, abi.RegisteredSealProof_StackedDrg2KiBV1_1); err != nil {
+		t.Fatal(err)
+	}
+
+	err := drainSealProviders(ctx, db, []sealBatchParams{{
+		spID:                 spID,
+		proof:                int64(abi.RegisteredSealProof_StackedDrg2KiBV1_1),
+		sectorSize:           storageTransferITestSectorSize,
+		maxWaitBefore:        time.Now().Add(-24 * time.Hour),
+		sealBeforeChainEpoch: 0,
+	}})
+	if err == nil {
+		t.Fatal("expected existing-pipeline inconsistency")
+	}
+
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountOpenSector, 1, spID, poisonSector)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSDRPipelineSector, 1, spID, poisonSector)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSDRInitialSector, 0, spID, poisonSector)
+
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountOpenSector, 0, spID, validSector)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSDRPipelineSector, 1, spID, validSector)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSDRInitialSector, 1, spID, validSector)
+}
+
+func TestStorageTransferDBSnapMovesAtomically(t *testing.T) {
+	db, _ := storageTransferITestDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	const (
+		spID   = int64(3102)
+		sector = int64(11)
+	)
+	if _, err := db.Exec(ctx, `INSERT INTO sectors_meta (sp_id, sector_num) VALUES ($1, $2)`, spID, sector); err != nil {
+		t.Fatal(err)
+	}
+	insertStorageTransferOpenSectors(t, ctx, db, spID, int(sector), 1, true)
+
+	err := drainSealProviders(ctx, db, []sealBatchParams{{
+		spID:                 spID,
+		proof:                int64(abi.RegisteredUpdateProof_StackedDrg2KiBV1),
+		sectorSize:           storageTransferITestSectorSize,
+		isSnap:               true,
+		maxWaitBefore:        time.Now().Add(-24 * time.Hour),
+		sealBeforeChainEpoch: 0,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountOpenSector, 0, spID, sector)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSnapPipelineSector, 1, spID, sector)
+	assertStorageTransferITestCount(t, ctx, db, storageTransferCountSnapInitialSector, 1, spID, sector)
+}
+
+func insertStorageTransferOpenSectors(t *testing.T, ctx context.Context, db *harmonydb.DB, spID int64, first, count int, isSnap bool) {
+	t.Helper()
+	committed, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		for sector := first; sector < first+count; sector++ {
+			if _, err := tx.Exec(`INSERT INTO open_sector_pieces (
+				sp_id, sector_number, piece_index, piece_cid, piece_size,
+				data_url, data_raw_size, data_delete_on_finalize, is_snap
+			) VALUES ($1, $2, 0, $3, $4, $5, 2032, FALSE, $6)`,
+				spID, sector, fmt.Sprintf("itest-piece-%d", sector), storageTransferITestSectorSize,
+				fmt.Sprintf("pieceref:%d", sector), isSnap); err != nil {
+				return false, err
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !committed {
+		t.Fatal("open-sector fixture transaction did not commit")
+	}
+}
+
+type storageTransferCountQuery int
+
+const (
+	storageTransferCountOpen storageTransferCountQuery = iota
+	storageTransferCountOpenSector
+	storageTransferCountSDRPipeline
+	storageTransferCountSDRPipelineSector
+	storageTransferCountSDRInitial
+	storageTransferCountSDRInitialSector
+	storageTransferCountDuplicateSDRInitial
+	storageTransferCountSnapPipelineSector
+	storageTransferCountSnapInitialSector
+)
+
+func assertStorageTransferITestCount(t *testing.T, ctx context.Context, db *harmonydb.DB, query storageTransferCountQuery, want int, args ...any) {
+	t.Helper()
+	var got int
+	var err error
+	switch query {
+	case storageTransferCountOpen:
+		err = db.QueryRow(ctx, `SELECT COUNT(*) FROM open_sector_pieces WHERE sp_id = $1`, args...).Scan(&got)
+	case storageTransferCountOpenSector:
+		err = db.QueryRow(ctx, `SELECT COUNT(*) FROM open_sector_pieces WHERE sp_id = $1 AND sector_number = $2`, args...).Scan(&got)
+	case storageTransferCountSDRPipeline:
+		err = db.QueryRow(ctx, `SELECT COUNT(*) FROM sectors_sdr_pipeline WHERE sp_id = $1`, args...).Scan(&got)
+	case storageTransferCountSDRPipelineSector:
+		err = db.QueryRow(ctx, `SELECT COUNT(*) FROM sectors_sdr_pipeline WHERE sp_id = $1 AND sector_number = $2`, args...).Scan(&got)
+	case storageTransferCountSDRInitial:
+		err = db.QueryRow(ctx, `SELECT COUNT(*) FROM sectors_sdr_initial_pieces WHERE sp_id = $1`, args...).Scan(&got)
+	case storageTransferCountSDRInitialSector:
+		err = db.QueryRow(ctx, `SELECT COUNT(*) FROM sectors_sdr_initial_pieces WHERE sp_id = $1 AND sector_number = $2`, args...).Scan(&got)
+	case storageTransferCountDuplicateSDRInitial:
+		err = db.QueryRow(ctx, `SELECT COUNT(*) FROM (
+			SELECT sector_number FROM sectors_sdr_initial_pieces
+			WHERE sp_id = $1 GROUP BY sector_number HAVING COUNT(*) <> 1
+		) duplicated`, args...).Scan(&got)
+	case storageTransferCountSnapPipelineSector:
+		err = db.QueryRow(ctx, `SELECT COUNT(*) FROM sectors_snap_pipeline WHERE sp_id = $1 AND sector_number = $2`, args...).Scan(&got)
+	case storageTransferCountSnapInitialSector:
+		err = db.QueryRow(ctx, `SELECT COUNT(*) FROM sectors_snap_initial_pieces WHERE sp_id = $1 AND sector_number = $2`, args...).Scan(&got)
+	default:
+		t.Fatalf("unknown storage-transfer count query %d", query)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("count query %d = %d, want %d", query, got, want)
+	}
+}
+
+const storageTransferITestSchema = `
+CREATE TABLE sectors_allocated_numbers (
+    sp_id BIGINT NOT NULL PRIMARY KEY,
+    allocated JSONB NOT NULL
+);
+
+CREATE TABLE sectors_sdr_pipeline (
+    sp_id BIGINT NOT NULL,
+    sector_number BIGINT NOT NULL,
+    reg_seal_proof INT NOT NULL,
+    PRIMARY KEY (sp_id, sector_number)
+);
+
+CREATE TABLE sectors_sdr_initial_pieces (
+    sp_id BIGINT NOT NULL,
+    sector_number BIGINT NOT NULL,
+    piece_index BIGINT NOT NULL,
+    piece_cid TEXT NOT NULL,
+    piece_size BIGINT NOT NULL,
+    data_url TEXT NOT NULL,
+    data_headers JSONB NOT NULL DEFAULT '{}',
+    data_raw_size BIGINT NOT NULL,
+    data_delete_on_finalize BOOL NOT NULL,
+    f05_publish_cid TEXT,
+    f05_deal_id BIGINT,
+    f05_deal_proposal JSONB,
+    f05_deal_start_epoch BIGINT,
+    f05_deal_end_epoch BIGINT,
+    direct_start_epoch BIGINT,
+    direct_end_epoch BIGINT,
+    direct_piece_activation_manifest JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (sp_id, sector_number, piece_index),
+    FOREIGN KEY (sp_id, sector_number)
+        REFERENCES sectors_sdr_pipeline (sp_id, sector_number) ON DELETE CASCADE
+);
+
+CREATE TABLE sectors_meta (
+    sp_id BIGINT NOT NULL,
+    sector_num BIGINT NOT NULL,
+    PRIMARY KEY (sp_id, sector_num)
+);
+
+CREATE TABLE sectors_snap_pipeline (
+    sp_id BIGINT NOT NULL,
+    sector_number BIGINT NOT NULL,
+    upgrade_proof INT NOT NULL,
+    PRIMARY KEY (sp_id, sector_number),
+    FOREIGN KEY (sp_id, sector_number)
+        REFERENCES sectors_meta (sp_id, sector_num)
+);
+
+CREATE TABLE sectors_snap_initial_pieces (
+    sp_id BIGINT NOT NULL,
+    sector_number BIGINT NOT NULL,
+    piece_index BIGINT NOT NULL,
+    piece_cid TEXT NOT NULL,
+    piece_size BIGINT NOT NULL,
+    data_url TEXT NOT NULL,
+    data_headers JSONB NOT NULL DEFAULT '{}',
+    data_raw_size BIGINT NOT NULL,
+    data_delete_on_finalize BOOL NOT NULL,
+    direct_start_epoch BIGINT,
+    direct_end_epoch BIGINT,
+    direct_piece_activation_manifest JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (sp_id, sector_number, piece_index),
+    FOREIGN KEY (sp_id, sector_number)
+        REFERENCES sectors_snap_pipeline (sp_id, sector_number) ON DELETE CASCADE
+);
+
+CREATE TABLE open_sector_pieces (
+    sp_id BIGINT NOT NULL,
+    sector_number BIGINT NOT NULL,
+    piece_index BIGINT NOT NULL,
+    piece_cid TEXT NOT NULL,
+    piece_size BIGINT NOT NULL,
+    data_url TEXT NOT NULL,
+    data_headers JSONB NOT NULL DEFAULT '{}',
+    data_raw_size BIGINT NOT NULL,
+    data_delete_on_finalize BOOL NOT NULL,
+    f05_publish_cid TEXT,
+    f05_deal_id BIGINT,
+    f05_deal_proposal JSONB,
+    f05_deal_start_epoch BIGINT,
+    f05_deal_end_epoch BIGINT,
+    direct_start_epoch BIGINT,
+    direct_end_epoch BIGINT,
+    direct_piece_activation_manifest JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    is_snap BOOL NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (sp_id, sector_number, piece_index)
+);
+
+CREATE OR REPLACE FUNCTION transfer_and_delete_sorted_open_piece(v_sp_id BIGINT, v_sector_number BIGINT)
+RETURNS VOID AS $$
+DECLARE
+    sorted_piece RECORD;
+    new_index INT := 0;
+BEGIN
+    FOR sorted_piece IN
+        SELECT piece_cid, piece_size, data_url, data_headers, data_raw_size,
+               data_delete_on_finalize, f05_publish_cid, f05_deal_id,
+               f05_deal_proposal, f05_deal_start_epoch, f05_deal_end_epoch,
+               direct_start_epoch, direct_end_epoch,
+               direct_piece_activation_manifest, created_at
+        FROM open_sector_pieces
+        WHERE sp_id = v_sp_id AND sector_number = v_sector_number
+        ORDER BY piece_size DESC
+    LOOP
+        INSERT INTO sectors_sdr_initial_pieces (
+            sp_id, sector_number, piece_index, piece_cid, piece_size,
+            data_url, data_headers, data_raw_size, data_delete_on_finalize,
+            f05_publish_cid, f05_deal_id, f05_deal_proposal,
+            f05_deal_start_epoch, f05_deal_end_epoch, direct_start_epoch,
+            direct_end_epoch, direct_piece_activation_manifest, created_at
+        ) VALUES (
+            v_sp_id, v_sector_number, new_index, sorted_piece.piece_cid,
+            sorted_piece.piece_size, sorted_piece.data_url,
+            sorted_piece.data_headers, sorted_piece.data_raw_size,
+            sorted_piece.data_delete_on_finalize, sorted_piece.f05_publish_cid,
+            sorted_piece.f05_deal_id, sorted_piece.f05_deal_proposal,
+            sorted_piece.f05_deal_start_epoch, sorted_piece.f05_deal_end_epoch,
+            sorted_piece.direct_start_epoch, sorted_piece.direct_end_epoch,
+            sorted_piece.direct_piece_activation_manifest, sorted_piece.created_at
+        );
+        new_index := new_index + 1;
+    END LOOP;
+
+    IF FOUND THEN
+        DELETE FROM open_sector_pieces
+        WHERE sp_id = v_sp_id AND sector_number = v_sector_number;
+    ELSE
+        RAISE EXCEPTION 'No open pieces for provider % and sector %', v_sp_id, v_sector_number;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION transfer_and_delete_sorted_open_piece_snap(v_sp_id BIGINT, v_sector_number BIGINT)
+RETURNS VOID AS $$
+DECLARE
+    sorted_piece RECORD;
+    new_index INT := 0;
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM open_sector_pieces
+        WHERE sp_id = v_sp_id AND sector_number = v_sector_number
+          AND f05_deal_id IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION 'Snap transfer cannot contain an F05 deal';
+    END IF;
+
+    FOR sorted_piece IN
+        SELECT piece_cid, piece_size, data_url, data_headers, data_raw_size,
+               data_delete_on_finalize, direct_start_epoch, direct_end_epoch,
+               direct_piece_activation_manifest, created_at
+        FROM open_sector_pieces
+        WHERE sp_id = v_sp_id AND sector_number = v_sector_number
+        ORDER BY piece_size DESC
+    LOOP
+        INSERT INTO sectors_snap_initial_pieces (
+            sp_id, sector_number, piece_index, piece_cid, piece_size,
+            data_url, data_headers, data_raw_size, data_delete_on_finalize,
+            direct_start_epoch, direct_end_epoch,
+            direct_piece_activation_manifest, created_at
+        ) VALUES (
+            v_sp_id, v_sector_number, new_index, sorted_piece.piece_cid,
+            sorted_piece.piece_size, sorted_piece.data_url,
+            sorted_piece.data_headers, sorted_piece.data_raw_size,
+            sorted_piece.data_delete_on_finalize, sorted_piece.direct_start_epoch,
+            sorted_piece.direct_end_epoch,
+            sorted_piece.direct_piece_activation_manifest, sorted_piece.created_at
+        );
+        new_index := new_index + 1;
+    END LOOP;
+
+    IF FOUND THEN
+        DELETE FROM open_sector_pieces
+        WHERE sp_id = v_sp_id AND sector_number = v_sector_number;
+    ELSE
+        RAISE EXCEPTION 'No open pieces for provider % and sector %', v_sp_id, v_sector_number;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+`

--- a/market/storageingest/deal_ingest_seal.go
+++ b/market/storageingest/deal_ingest_seal.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -39,6 +40,11 @@ var log = logging.Logger("storage-ingest")
 type Ingester interface {
 	AllocatePieceToSector(ctx context.Context, tx *harmonydb.Tx, maddr address.Address, piece lpiece.PieceDealInfo, rawSize int64, source url.URL, header http.Header) (*abi.SectorNumber, *abi.RegisteredSealProof, error)
 	GetExpectedSealDuration() abi.ChainEpoch
+}
+
+type WakingIngester interface {
+	Ingester
+	Wake()
 }
 
 type PieceIngesterApi interface {
@@ -88,6 +94,8 @@ type PieceIngester struct {
 	minerDetails         map[int64]*mdetails
 	maxWaitTime          *config.Dynamic[time.Duration]
 	expectedSealDuration abi.ChainEpoch
+	sealWake             chan struct{}
+	sealMu               sync.Mutex
 }
 
 type verifiedDeal struct {
@@ -152,6 +160,7 @@ func NewPieceIngester(ctx context.Context, db *harmonydb.DB, api PieceIngesterAp
 		minerDetails:         minerDetails,
 		idToAddr:             idToAddr,
 		expectedSealDuration: abi.ChainEpoch(int64(expectedEpochs)),
+		sealWake:             newSealWake(),
 	}
 
 	go pi.start()
@@ -163,86 +172,41 @@ func (p *PieceIngester) start() {
 	ticker := time.NewTicker(loopFrequency)
 	defer ticker.Stop()
 
-	for {
-		select {
-		case <-p.ctx.Done():
-			return
-		case <-ticker.C:
-			err := p.Seal()
-			if err != nil {
-				log.Error(err)
-			}
-		}
-	}
+	runSealLoop(p.ctx, ticker.C, p.sealWake, p.Seal, func(err error) {
+		log.Errorw("storage ingest seal pass failed", "error", err)
+	})
 }
 
 func (p *PieceIngester) Seal() error {
+	p.sealMu.Lock()
+	defer p.sealMu.Unlock()
+
 	head, err := p.api.ChainHead(p.ctx)
 	if err != nil {
 		return xerrors.Errorf("getting chain head: %w", err)
 	}
 
-	shouldSeal := func(sector *openSector) bool {
-		// Start sealing a sector if
-		// 1. If sector is full
-		// 2. We have been waiting for MaxWaitDuration
-		// 3. StartEpoch is currentEpoch + expectedSealDuration
-		if sector.currentSize == abi.PaddedPieceSize(p.minerDetails[int64(sector.miner)].sectorSize) {
-			log.Debugf("start sealing sector %d of miner %s: %s", sector.number, p.idToAddr[sector.miner].String(), "sector full")
-			return true
-		}
-		if time.Since(*sector.openedAt) > p.maxWaitTime.Get() {
-			log.Debugf("start sealing sector %d of miner %s: %s", sector.number, p.idToAddr[sector.miner].String(), "MaxWaitTime reached")
-			return true
-		}
-		if sector.earliestStartEpoch < head.Height()+p.expectedSealDuration {
-			log.Debugf("start sealing sector %d of miner %s: %s", sector.number, p.idToAddr[sector.miner].String(), "earliest start epoch")
-			return true
-		}
-		return false
+	minerIDs := sortedProviderIDs(p.minerDetails)
+	maxWaitBefore := time.Now().Add(-p.maxWaitTime.Get())
+	params := make([]sealBatchParams, 0, len(minerIDs))
+	for _, mid := range minerIDs {
+		params = append(params, sealBatchParams{
+			spID:                 mid,
+			proof:                int64(p.minerDetails[mid].sealProof),
+			sectorSize:           int64(p.minerDetails[mid].sectorSize),
+			maxWaitBefore:        maxWaitBefore,
+			sealBeforeChainEpoch: head.Height() + p.expectedSealDuration,
+		})
 	}
 
-	comm, err := p.db.BeginTransaction(p.ctx, func(tx *harmonydb.Tx) (commit bool, err error) {
-		for _, mid := range p.addToID {
-			openSectors, err := p.getOpenSectors(tx, mid)
-			if err != nil {
-				return false, err
-			}
+	return drainSealProviders(p.ctx, p.db, params)
+}
 
-			for _, sector := range openSectors {
-				if shouldSeal(sector) {
-					// Start sealing the sector
-					cn, err := tx.Exec(`INSERT INTO sectors_sdr_pipeline (sp_id, sector_number, reg_seal_proof) VALUES ($1, $2, $3);`, mid, sector.number, p.minerDetails[mid].sealProof)
-
-					if err != nil {
-						return false, xerrors.Errorf("adding sector to pipeline: %w", err)
-					}
-
-					if cn != 1 {
-						return false, xerrors.Errorf("adding sector to pipeline: incorrect number of rows returned")
-					}
-
-					_, err = tx.Exec("SELECT transfer_and_delete_sorted_open_piece($1, $2)", mid, sector.number)
-					if err != nil {
-						return false, xerrors.Errorf("adding sector to pipeline: %w", err)
-					}
-				}
-
-			}
-
-		}
-		return true, nil
-	}, harmonydb.OptionRetry())
-
-	if err != nil {
-		return xerrors.Errorf("start sealing sector: %w", err)
+func (p *PieceIngester) Wake() {
+	if p == nil || p.sealWake == nil {
+		return
 	}
-
-	if !comm {
-		return xerrors.Errorf("start sealing sector: commit failed")
-	}
-
-	return nil
+	wakeSealLoop(p.sealWake)
 }
 
 func (p *PieceIngester) AllocatePieceToSector(ctx context.Context, tx *harmonydb.Tx, maddr address.Address, piece lpiece.PieceDealInfo, rawSize int64, source url.URL, header http.Header) (*abi.SectorNumber, *abi.RegisteredSealProof, error) {
@@ -313,6 +277,9 @@ func (p *PieceIngester) AllocatePieceToSector(ctx context.Context, tx *harmonydb
 	mid, ok := p.addToID[maddr]
 	if !ok {
 		return nil, nil, xerrors.Errorf("miner not found")
+	}
+	if err := seal.LockSectorState(ctx, tx, mid); err != nil {
+		return nil, nil, err
 	}
 
 	// Try to allocate the piece to an open sector

--- a/market/storageingest/deal_ingest_snap.go
+++ b/market/storageingest/deal_ingest_snap.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"golang.org/x/xerrors"
@@ -23,6 +24,7 @@ import (
 	"github.com/filecoin-project/curio/build"
 	"github.com/filecoin-project/curio/deps/config"
 	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/tasks/seal"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/market"
@@ -49,6 +51,8 @@ type PieceIngesterSnap struct {
 	minerDetails         map[int64]*mdetails
 	maxWaitTime          *config.Dynamic[time.Duration]
 	expectedSnapDuration abi.ChainEpoch
+	sealWake             chan struct{}
+	sealMu               sync.Mutex
 }
 
 func NewPieceIngesterSnap(ctx context.Context, db *harmonydb.DB, api PieceIngesterApi, miners []address.Address, cfg *config.CurioConfig) (*PieceIngesterSnap, error) {
@@ -107,6 +111,7 @@ func NewPieceIngesterSnap(ctx context.Context, db *harmonydb.DB, api PieceIngest
 		minerDetails:         minerDetails,
 		idToAddr:             idToAddr,
 		expectedSnapDuration: abi.ChainEpoch(int64(expectedEpochs)),
+		sealWake:             newSealWake(),
 	}
 
 	go pi.start()
@@ -118,87 +123,42 @@ func (p *PieceIngesterSnap) start() {
 	ticker := time.NewTicker(loopFrequency)
 	defer ticker.Stop()
 
-	for {
-		select {
-		case <-p.ctx.Done():
-			return
-		case <-ticker.C:
-			err := p.Seal()
-			if err != nil {
-				log.Error(err)
-			}
-		}
-	}
+	runSealLoop(p.ctx, ticker.C, p.sealWake, p.Seal, func(err error) {
+		log.Errorw("snap storage ingest seal pass failed", "error", err)
+	})
 }
 
 func (p *PieceIngesterSnap) Seal() error {
+	p.sealMu.Lock()
+	defer p.sealMu.Unlock()
+
 	head, err := p.api.ChainHead(p.ctx)
 	if err != nil {
 		return xerrors.Errorf("getting chain head: %w", err)
 	}
 
-	shouldSeal := func(sector *openSector) bool {
-		// Start sealing a sector if
-		// 1. If sector is full
-		// 2. We have been waiting for MaxWaitDuration
-		// 3. StartEpoch is currentEpoch + expectedSealDuration
-		if sector.currentSize == abi.PaddedPieceSize(p.minerDetails[int64(sector.miner)].sectorSize) {
-			log.Debugf("start sealing sector %d of miner %s: %s", sector.number, p.idToAddr[sector.miner].String(), "sector full")
-			return true
-		}
-		if time.Since(*sector.openedAt) > p.maxWaitTime.Get() {
-			log.Debugf("start sealing sector %d of miner %s: %s", sector.number, p.idToAddr[sector.miner].String(), "MaxWaitTime reached")
-			return true
-		}
-		if sector.earliestStartEpoch < head.Height()+p.expectedSnapDuration {
-			log.Debugf("start sealing sector %d of miner %s: %s", sector.number, p.idToAddr[sector.miner].String(), "earliest start epoch")
-			return true
-		}
-
-		log.Debugw("not starting to seal sector", "sector", sector.number, "miner", p.idToAddr[sector.miner].String(), "csize", sector.currentSize, "open", time.Since(*sector.openedAt), "toStart", sector.earliestStartEpoch-(head.Height()+p.expectedSnapDuration))
-		return false
+	minerIDs := sortedProviderIDs(p.minerDetails)
+	maxWaitBefore := time.Now().Add(-p.maxWaitTime.Get())
+	params := make([]sealBatchParams, 0, len(minerIDs))
+	for _, mid := range minerIDs {
+		params = append(params, sealBatchParams{
+			spID:                 mid,
+			proof:                int64(p.minerDetails[mid].updateProof),
+			sectorSize:           int64(p.minerDetails[mid].sectorSize),
+			isSnap:               true,
+			maxWaitBefore:        maxWaitBefore,
+			sealBeforeChainEpoch: head.Height() + p.expectedSnapDuration,
+		})
 	}
 
-	comm, err := p.db.BeginTransaction(p.ctx, func(tx *harmonydb.Tx) (commit bool, err error) {
-		for _, mid := range p.addToID {
-			openSectors, err := p.getOpenSectors(tx, mid)
-			if err != nil {
-				return false, err
-			}
+	return drainSealProviders(p.ctx, p.db, params)
+}
 
-			for _, sector := range openSectors {
-				if shouldSeal(sector) {
-					// Start sealing the sector
-					cn, err := tx.Exec(`INSERT INTO sectors_snap_pipeline (sp_id, sector_number, upgrade_proof) VALUES ($1, $2, $3);`, mid, sector.number, p.minerDetails[mid].updateProof)
-
-					if err != nil {
-						return false, xerrors.Errorf("adding sector to pipeline: %w", err)
-					}
-
-					if cn != 1 {
-						return false, xerrors.Errorf("adding sector to pipeline: incorrect number of rows returned")
-					}
-
-					_, err = tx.Exec("SELECT transfer_and_delete_sorted_open_piece_snap($1, $2)", mid, sector.number)
-					if err != nil {
-						return false, xerrors.Errorf("adding sector to pipeline: %w", err)
-					}
-				}
-
-			}
-		}
-		return true, nil
-	}, harmonydb.OptionRetry())
-
-	if err != nil {
-		return xerrors.Errorf("start sealing sector: %w", err)
+func (p *PieceIngesterSnap) Wake() {
+	if p == nil || p.sealWake == nil {
+		return
 	}
-
-	if !comm {
-		return xerrors.Errorf("start sealing sector: commit failed")
-	}
-
-	return nil
+	wakeSealLoop(p.sealWake)
 }
 
 func (p *PieceIngesterSnap) AllocatePieceToSector(ctx context.Context, tx *harmonydb.Tx, maddr address.Address, piece lpiece.PieceDealInfo, rawSize int64, source url.URL, header http.Header) (*abi.SectorNumber, *abi.RegisteredSealProof, error) {
@@ -302,6 +262,14 @@ func (p *PieceIngesterSnap) AllocatePieceToSector(ctx context.Context, tx *harmo
 	propJson, err = json.Marshal(piece.PieceActivationManifest)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("json.Marshal(piece.PieceActivationManifest): %w", err)
+	}
+
+	mid, ok := p.addToID[maddr]
+	if !ok {
+		return nil, nil, xerrors.Errorf("miner not found")
+	}
+	if err := seal.LockSectorState(ctx, tx, mid); err != nil {
+		return nil, nil, err
 	}
 
 	// Try to allocate the piece to an open sector

--- a/market/storageingest/deal_ingest_wake.go
+++ b/market/storageingest/deal_ingest_wake.go
@@ -1,0 +1,47 @@
+package storageingest
+
+import (
+	"context"
+	"sort"
+	"time"
+)
+
+func newSealWake() chan struct{} {
+	wake := make(chan struct{}, 1)
+	wakeSealLoop(wake)
+	return wake
+}
+
+func wakeSealLoop(wake chan<- struct{}) {
+	select {
+	case wake <- struct{}{}:
+	default:
+	}
+}
+
+func runSealLoop(ctx context.Context, ticks <-chan time.Time, wake <-chan struct{}, seal func() error, onError func(error)) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticks:
+		case <-wake:
+		}
+
+		if ctx.Err() != nil {
+			return
+		}
+		if err := seal(); err != nil {
+			onError(err)
+		}
+	}
+}
+
+func sortedProviderIDs(details map[int64]*mdetails) []int64 {
+	providers := make([]int64, 0, len(details))
+	for spID := range details {
+		providers = append(providers, spID)
+	}
+	sort.Slice(providers, func(i, j int) bool { return providers[i] < providers[j] })
+	return providers
+}

--- a/market/storageingest/deal_ingest_wake_test.go
+++ b/market/storageingest/deal_ingest_wake_test.go
@@ -1,0 +1,179 @@
+package storageingest
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestNewSealWakeRequestsStartupDrain(t *testing.T) {
+	wake := newSealWake()
+	select {
+	case <-wake:
+	default:
+		t.Fatal("startup drain was not requested")
+	}
+	select {
+	case <-wake:
+		t.Fatal("more than one startup drain was requested")
+	default:
+	}
+}
+
+func TestSealLoopDoesNotRunQueuedWakeAfterCancellation(t *testing.T) {
+	for range 100 {
+		ctx, cancel := context.WithCancel(context.Background())
+		wake := make(chan struct{}, 1)
+		wake <- struct{}{}
+		cancel()
+
+		calls := 0
+		runSealLoop(ctx, make(chan time.Time), wake, func() error {
+			calls++
+			return nil
+		}, func(err error) {
+			t.Errorf("unexpected seal error: %v", err)
+		})
+		if calls != 0 {
+			t.Fatalf("seal calls after cancellation = %d, want 0", calls)
+		}
+	}
+}
+
+func TestSealWakeCoalescesAndDoesNotOverlap(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ticks := make(chan time.Time)
+	wake := make(chan struct{}, 1)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	secondDone := make(chan struct{})
+	loopDone := make(chan struct{})
+
+	var calls atomic.Int32
+	var active atomic.Int32
+	var maxActive atomic.Int32
+	go func() {
+		defer close(loopDone)
+		runSealLoop(ctx, ticks, wake, func() error {
+			call := calls.Add(1)
+			current := active.Add(1)
+			for {
+				previous := maxActive.Load()
+				if current <= previous || maxActive.CompareAndSwap(previous, current) {
+					break
+				}
+			}
+			defer active.Add(-1)
+
+			switch call {
+			case 1:
+				close(started)
+				<-release
+			case 2:
+				close(secondDone)
+			}
+			return nil
+		}, func(err error) {
+			t.Errorf("unexpected seal error: %v", err)
+		})
+	}()
+
+	wakeSealLoop(wake)
+	waitForSealTestSignal(t, started, "first seal pass")
+	for range 100 {
+		wakeSealLoop(wake)
+	}
+	close(release)
+	waitForSealTestSignal(t, secondDone, "coalesced seal pass")
+	cancel()
+	waitForSealTestSignal(t, loopDone, "seal loop shutdown")
+
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("seal calls = %d, want 2", got)
+	}
+	if got := maxActive.Load(); got != 1 {
+		t.Fatalf("maximum concurrent seal calls = %d, want 1", got)
+	}
+}
+
+func TestSealLoopKeepsTickerFallback(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ticks := make(chan time.Time, 1)
+	wake := make(chan struct{}, 1)
+	called := make(chan struct{})
+	go runSealLoop(ctx, ticks, wake, func() error {
+		close(called)
+		return nil
+	}, func(err error) {
+		t.Errorf("unexpected seal error: %v", err)
+	})
+
+	ticks <- time.Now()
+	waitForSealTestSignal(t, called, "ticker seal pass")
+}
+
+func TestPieceIngesterWakeIsNonBlocking(t *testing.T) {
+	p := &PieceIngester{sealWake: make(chan struct{}, 1)}
+	for range 100 {
+		p.Wake()
+	}
+
+	select {
+	case <-p.sealWake:
+	default:
+		t.Fatal("Wake did not queue a seal pass")
+	}
+	select {
+	case <-p.sealWake:
+		t.Fatal("Wake queued more than one seal pass")
+	default:
+	}
+}
+
+func TestPieceIngesterSnapWakeIsNonBlocking(t *testing.T) {
+	p := &PieceIngesterSnap{sealWake: make(chan struct{}, 1)}
+	for range 100 {
+		p.Wake()
+	}
+
+	select {
+	case <-p.sealWake:
+	default:
+		t.Fatal("Wake did not queue a seal pass")
+	}
+	select {
+	case <-p.sealWake:
+		t.Fatal("Wake queued more than one seal pass")
+	default:
+	}
+}
+
+func TestSortedProviderIDsUsesStableLockOrder(t *testing.T) {
+	details := map[int64]*mdetails{
+		1003: {},
+		1001: {},
+		1002: {},
+	}
+
+	got := sortedProviderIDs(details)
+	want := []int64{1001, 1002, 1003}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("provider order = %v, want %v", got, want)
+		}
+	}
+}
+
+func waitForSealTestSignal(t *testing.T, signal <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}

--- a/market/storageingest/seal_now.go
+++ b/market/storageingest/seal_now.go
@@ -10,6 +10,7 @@ import (
 	"github.com/filecoin-project/go-state-types/network"
 
 	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/tasks/seal"
 
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
@@ -45,6 +46,10 @@ func SealNow(ctx context.Context, node SealNowNodeApi, db *harmonydb.DB, act add
 	}
 
 	comm, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (commit bool, err error) {
+		if err := seal.LockSectorState(ctx, tx, int64(mid)); err != nil {
+			return false, err
+		}
+
 		// Get current open sector pieces from DB
 		var pieces []struct {
 			Sector abi.SectorNumber    `db:"sector_number"`
@@ -71,8 +76,14 @@ func SealNow(ctx context.Context, node SealNowNodeApi, db *harmonydb.DB, act add
 		if len(pieces) < 1 {
 			return false, xerrors.Errorf("sector %d is not waiting to be sealed", sector)
 		}
+		isSnap := pieces[0].IsSnap
+		for _, piece := range pieces[1:] {
+			if piece.IsSnap != isSnap {
+				return false, xerrors.Errorf("sector %d contains mixed normal and snap open pieces", sector)
+			}
+		}
 
-		if pieces[0].IsSnap {
+		if isSnap {
 			// Upgrade
 			upt, err := spt.RegisteredUpdateProof()
 			if err != nil {

--- a/tasks/seal/sector_num_alloc.go
+++ b/tasks/seal/sector_num_alloc.go
@@ -19,15 +19,56 @@ type AllocAPI interface {
 	StateMinerAllocated(context.Context, address.Address, types.TipSetKey) (*bitfield.BitField, error)
 }
 
+const lockSectorStateSQL = `INSERT INTO sectors_allocated_numbers (sp_id, allocated)
+	VALUES ($1, '[0]'::jsonb)
+	ON CONFLICT (sp_id) DO UPDATE
+	SET allocated = sectors_allocated_numbers.allocated
+	RETURNING sp_id`
+
+// LockSectorState serializes transactions which allocate sector numbers or
+// mutate open-sector state for one storage provider. The self-assignment in
+// the conflict branch preserves the allocation bitfield while establishing a
+// transaction-scoped write-conflict point, including when the row is created
+// concurrently for the first time.
+func LockSectorState(ctx context.Context, tx *harmonydb.Tx, spID int64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	var lockedSPID int64
+	err := tx.QueryRow(lockSectorStateSQL, spID).Scan(&lockedSPID)
+	if err != nil {
+		return xerrors.Errorf("locking sector state for provider %d: %w", spID, err)
+	}
+	if lockedSPID != spID {
+		return xerrors.Errorf("locked sector state for provider %d, expected %d", lockedSPID, spID)
+	}
+
+	return nil
+}
+
 func AllocateSectorNumbers(ctx context.Context, a AllocAPI, tx *harmonydb.Tx, maddr address.Address, count int) ([]abi.SectorNumber, error) {
 	chainAlloc, err := a.StateMinerAllocated(ctx, maddr, types.EmptyTSK)
 	if err != nil {
 		return nil, xerrors.Errorf("getting on-chain allocated sector numbers: %w", err)
 	}
 
+	return AllocateSectorNumbersFromChain(ctx, tx, maddr, chainAlloc, count)
+}
+
+// AllocateSectorNumbersFromChain allocates sector numbers using an already
+// fetched view of the provider's on-chain allocations. Callers which allocate
+// for multiple providers can fetch chain state before acquiring provider
+// locks, then acquire those locks in a stable order.
+func AllocateSectorNumbersFromChain(ctx context.Context, tx *harmonydb.Tx, maddr address.Address, chainAlloc *bitfield.BitField, count int) ([]abi.SectorNumber, error) {
 	mid, err := address.IDFromAddress(maddr)
 	if err != nil {
 		return nil, xerrors.Errorf("getting miner id: %w", err)
+	}
+	spID := int64(mid)
+
+	if err := LockSectorState(ctx, tx, spID); err != nil {
+		return nil, err
 	}
 
 	var res []abi.SectorNumber
@@ -36,16 +77,9 @@ func AllocateSectorNumbers(ctx context.Context, a AllocAPI, tx *harmonydb.Tx, ma
 	var dbAllocated bitfield.BitField
 	var rawJson []byte
 
-	err = tx.QueryRow("SELECT COALESCE(allocated, '[0]') from sectors_allocated_numbers sa FULL OUTER JOIN (SELECT 1) AS d ON FALSE WHERE sp_id = $1 OR sp_id IS NULL ORDER BY sp_id LIMIT 1", mid).Scan(&rawJson)
+	err = tx.QueryRow("SELECT allocated FROM sectors_allocated_numbers WHERE sp_id = $1", spID).Scan(&rawJson)
 	if err != nil {
 		return res, xerrors.Errorf("querying allocated sector numbers: %w", err)
-	}
-
-	if rawJson != nil {
-		err = dbAllocated.UnmarshalJSON(rawJson)
-		if err != nil {
-			return res, xerrors.Errorf("unmarshaling allocated sector numbers: %w", err)
-		}
 	}
 
 	if err := dbAllocated.UnmarshalJSON(rawJson); err != nil {
@@ -95,9 +129,12 @@ func AllocateSectorNumbers(ctx context.Context, a AllocAPI, tx *harmonydb.Tx, ma
 		return res, xerrors.Errorf("marshaling allocated sector numbers: %w", err)
 	}
 
-	_, err = tx.Exec("INSERT INTO sectors_allocated_numbers(sp_id, allocated) VALUES($1, $2) ON CONFLICT(sp_id) DO UPDATE SET allocated = $2", mid, rawJson)
+	n, err := tx.Exec("UPDATE sectors_allocated_numbers SET allocated = $2 WHERE sp_id = $1", spID, rawJson)
 	if err != nil {
 		return res, xerrors.Errorf("persisting allocated sector numbers: %w", err)
+	}
+	if n != 1 {
+		return res, xerrors.Errorf("persisting allocated sector numbers: updated %d rows", n)
 	}
 
 	return res, nil

--- a/tasks/seal/sector_num_alloc_integration_test.go
+++ b/tasks/seal/sector_num_alloc_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -178,4 +179,134 @@ func requireSectorAllocationITestEnv(t *testing.T, name string) string {
 		t.Fatalf("%s must be set explicitly when %s=1", name, sectorAllocationITestOptIn)
 	}
 	return value
+}
+
+// The held transaction deliberately establishes the ordering. Unlike a
+// simultaneous start, linked PostgreSQL blocking proves the real allocator
+// reached the provider write-conflict point before the holder committed.
+func TestSectorStateDBLockBlocksAllocatorUntilCommit(t *testing.T) {
+	dbs := newSectorAllocationIntegrationDBs(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var version string
+	if err := dbs[0].QueryRow(ctx, `SELECT version()`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.ToLower(version), "yugabyte") {
+		t.Skip("linked PostgreSQL lock observation is not a Yugabyte observer")
+	}
+	maddr, err := address.NewIDAddress(1100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type outcome struct {
+		committed bool
+		sectors   []abi.SectorNumber
+		err       error
+	}
+	held := make(chan int, 1)
+	entered := make(chan int, 1)
+	release := make(chan struct{})
+	results := make(chan outcome, 2)
+	var releaseOnce sync.Once
+	var participants sync.WaitGroup
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	defer func() {
+		unblock()
+		cancel()
+		participants.Wait()
+	}()
+	participants.Add(1)
+	go func() {
+		defer participants.Done()
+		var sectors []abi.SectorNumber
+		committed, err := dbs[0].BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+			var err error
+			sectors, err = AllocateSectorNumbers(ctx, emptySectorAllocationAPI{}, tx, maddr, 1)
+			if err != nil {
+				return false, err
+			}
+			var pid int
+			if err := tx.QueryRow(`SELECT pg_backend_pid()`).Scan(&pid); err != nil {
+				return false, err
+			}
+			held <- pid
+			select {
+			case <-release:
+				return true, nil
+			case <-ctx.Done():
+				return false, ctx.Err()
+			}
+		})
+		results <- outcome{committed, sectors, err}
+	}()
+	var holderPID int
+	select {
+	case holderPID = <-held:
+	case result := <-results:
+		t.Fatalf("holder exited before lock: %+v", result)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	participants.Add(1)
+	go func() {
+		defer participants.Done()
+		var sectors []abi.SectorNumber
+		committed, err := dbs[1].BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+			var pid int
+			if err := tx.QueryRow(`SELECT pg_backend_pid()`).Scan(&pid); err != nil {
+				return false, err
+			}
+			entered <- pid
+			var err error
+			sectors, err = AllocateSectorNumbers(ctx, emptySectorAllocationAPI{}, tx, maddr, 1)
+			return err == nil, err
+		})
+		results <- outcome{committed, sectors, err}
+	}()
+	var waiterPID int
+	select {
+	case waiterPID = <-entered:
+	case result := <-results:
+		t.Fatalf("contender exited before allocator: %+v", result)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	observation, stopObservation := context.WithTimeout(ctx, 3*time.Second)
+	defer stopObservation()
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		var blocked bool
+		if err := dbs[0].QueryRow(observation, `SELECT $1::int = ANY(pg_blocking_pids($2::int))`, holderPID, waiterPID).Scan(&blocked); err != nil {
+			t.Fatalf("contention not established: %v", err)
+		}
+		if blocked {
+			t.Logf("observed allocator pid=%d blocked by provider-lock holder pid=%d before release", waiterPID, holderPID)
+			break
+		}
+		select {
+		case result := <-results:
+			t.Fatalf("contender completed while provider lock was held: %+v", result)
+		case <-observation.Done():
+			t.Fatal("contention not established before observation deadline")
+		case <-tick.C:
+		}
+	}
+	unblock()
+	seen := make(map[abi.SectorNumber]bool)
+	for range 2 {
+		select {
+		case result := <-results:
+			if result.err != nil || !result.committed || len(result.sectors) != 1 {
+				t.Fatalf("allocation outcome: %+v", result)
+			}
+			seen[result.sectors[0]] = true
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		}
+	}
+	if len(seen) != 2 {
+		t.Fatalf("distinct committed sectors=%v, want two", seen)
+	}
 }

--- a/tasks/seal/sector_num_alloc_integration_test.go
+++ b/tasks/seal/sector_num_alloc_integration_test.go
@@ -1,0 +1,181 @@
+//go:build integration
+
+package seal
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-bitfield"
+	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+const (
+	sectorAllocationITestOptIn    = "CURIO_SECTOR_ALLOC_ITEST"
+	sectorAllocationITestHost     = "CURIO_SECTOR_ALLOC_ITEST_HOST"
+	sectorAllocationITestPort     = "CURIO_SECTOR_ALLOC_ITEST_PORT"
+	sectorAllocationITestDatabase = "CURIO_SECTOR_ALLOC_ITEST_DATABASE"
+	sectorAllocationITestUser     = "CURIO_SECTOR_ALLOC_ITEST_USER"
+	sectorAllocationITestPassword = "CURIO_SECTOR_ALLOC_ITEST_PASSWORD"
+)
+
+// TestAllocateSectorNumbersConcurrentFirstUse exercises the production
+// transaction and allocator against two concurrent transactions. It is
+// intentionally opt-in and requires an explicit loopback target; normal test
+// runs cannot inherit Curio's database connection settings.
+func TestAllocateSectorNumbersConcurrentFirstUse(t *testing.T) {
+	dbs := newSectorAllocationIntegrationDBs(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	maddr, err := address.NewIDAddress(1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 2
+	start := make(chan struct{})
+	results := make(chan abi.SectorNumber, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for _, db := range dbs {
+		wg.Add(1)
+		go func(db *harmonydb.DB) {
+			defer wg.Done()
+			<-start
+
+			var allocated []abi.SectorNumber
+			committed, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+				var allocErr error
+				allocated, allocErr = AllocateSectorNumbers(ctx, emptySectorAllocationAPI{}, tx, maddr, 1)
+				return allocErr == nil, allocErr
+			}, harmonydb.OptionRetry())
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !committed || len(allocated) != 1 {
+				errs <- fmt.Errorf("allocation committed=%t count=%d", committed, len(allocated))
+				return
+			}
+			results <- allocated[0]
+		}(db)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+	close(results)
+	for err := range errs {
+		t.Fatal(err)
+	}
+
+	seen := make(map[abi.SectorNumber]struct{}, workers)
+	for sector := range results {
+		seen[sector] = struct{}{}
+	}
+	if len(seen) != workers {
+		t.Fatalf("allocated sector numbers = %v, want %d distinct numbers", seen, workers)
+	}
+}
+
+type emptySectorAllocationAPI struct{}
+
+func (emptySectorAllocationAPI) StateMinerAllocated(context.Context, address.Address, types.TipSetKey) (*bitfield.BitField, error) {
+	empty := bitfield.New()
+	return &empty, nil
+}
+
+func newSectorAllocationIntegrationDBs(t *testing.T) [2]*harmonydb.DB {
+	t.Helper()
+	if os.Getenv(sectorAllocationITestOptIn) != "1" {
+		t.Skipf("set %s=1 and the dedicated target variables to run", sectorAllocationITestOptIn)
+	}
+
+	host := requireSectorAllocationITestEnv(t, sectorAllocationITestHost)
+	port := requireSectorAllocationITestEnv(t, sectorAllocationITestPort)
+	database := requireSectorAllocationITestEnv(t, sectorAllocationITestDatabase)
+	username := requireSectorAllocationITestEnv(t, sectorAllocationITestUser)
+
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		t.Fatalf("%s must be a literal loopback IP address, got %q", sectorAllocationITestHost, host)
+	}
+	if ip.To4() == nil {
+		host = "[" + ip.String() + "]"
+	} else {
+		host = ip.String()
+	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil || portNumber < 1 || portNumber > 65535 {
+		t.Fatalf("%s must be a valid TCP port, got %q", sectorAllocationITestPort, port)
+	}
+
+	itestID := harmonydb.ITestNewID()
+	cfg := harmonydb.Config{
+		Hosts:           []string{host},
+		Port:            port,
+		Database:        database,
+		Username:        username,
+		Password:        os.Getenv(sectorAllocationITestPassword),
+		LoadBalance:     false,
+		ReadOnly:        true,
+		UseTemplate:     false,
+		ITestID:         itestID,
+		ApplicationName: "curio-sector-allocation-itest",
+	}
+	first, err := harmonydb.NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("opening first handle to isolated sector-allocation test schema: %v", err)
+	}
+	t.Cleanup(first.ITestDeleteAll)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := first.Exec(ctx, `CREATE TABLE sectors_allocated_numbers (
+		sp_id BIGINT NOT NULL PRIMARY KEY,
+		allocated JSONB NOT NULL
+	)`); err != nil {
+		t.Fatalf("creating sector-allocation fixture: %v", err)
+	}
+
+	peerCfg := cfg
+	peerCfg.ITestID = ""
+	peerCfg.Schema = "itest_" + string(itestID)
+	peerCfg.ApplicationName = "curio-sector-allocation-itest-peer"
+	second, err := harmonydb.NewFromConfig(peerCfg)
+	if err != nil {
+		t.Fatalf("opening second handle to isolated sector-allocation test schema: %v", err)
+	}
+
+	var version, isolation string
+	if err := first.QueryRow(ctx, `SELECT version()`).Scan(&version); err != nil {
+		t.Fatalf("reading database version: %v", err)
+	}
+	if err := first.QueryRow(ctx, `SHOW transaction_isolation`).Scan(&isolation); err != nil {
+		t.Fatalf("reading requested transaction isolation: %v", err)
+	}
+	t.Logf("database_version=%q requested_transaction_isolation=%q effective_yugabyte_isolation=UNVERIFIED", version, isolation)
+
+	return [2]*harmonydb.DB{first, second}
+}
+
+func requireSectorAllocationITestEnv(t *testing.T, name string) string {
+	t.Helper()
+	value := os.Getenv(name)
+	if value == "" {
+		t.Fatalf("%s must be set explicitly when %s=1", name, sectorAllocationITestOptIn)
+	}
+	return value
+}

--- a/tasks/seal/sector_num_alloc_test.go
+++ b/tasks/seal/sector_num_alloc_test.go
@@ -1,0 +1,34 @@
+package seal
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSectorStateLockUsesPreservingWriteConflict(t *testing.T) {
+	required := []string{
+		"ON CONFLICT (sp_id) DO UPDATE",
+		"SET allocated = sectors_allocated_numbers.allocated",
+		"RETURNING sp_id",
+	}
+	for _, fragment := range required {
+		if !strings.Contains(lockSectorStateSQL, fragment) {
+			t.Fatalf("sector state lock SQL is missing %q", fragment)
+		}
+	}
+	if strings.Contains(lockSectorStateSQL, "SET allocated = EXCLUDED.allocated") {
+		t.Fatal("sector state lock must not reset an existing allocation bitfield")
+	}
+}
+
+func TestSectorStateLockHonorsCanceledContextBeforeQuery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := LockSectorState(ctx, nil, 1000)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("lock error = %v, want context cancellation", err)
+	}
+}

--- a/tasks/sealsupra/task_supraseal.go
+++ b/tasks/sealsupra/task_supraseal.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -571,6 +572,66 @@ type sectorClaim struct {
 	TaskIDSDR    sql.NullInt64 `db:"task_id_sdr"`
 }
 
+type ccSchedule struct {
+	SpID         int64 `db:"sp_id"`
+	ToSeal       int64 `db:"to_seal"`
+	Weight       int64 `db:"weight"`
+	DurationDays int64 `db:"duration_days"`
+}
+
+type ccAllocation struct {
+	schedule       ccSchedule
+	count          int64
+	miner          address.Address
+	chainAllocated *bitfield.BitField
+}
+
+// planCCAllocations preserves the scheduler's existing weighted allocation
+// and remainder behavior while making the selected providers known before
+// any provider lock is acquired.
+func planCCAllocations(schedules []ccSchedule, toSeal int64) []ccAllocation {
+	var totalWeight int64
+	for _, schedule := range schedules {
+		totalWeight += schedule.Weight
+	}
+
+	remainingToSeal := toSeal
+	allocations := make([]ccAllocation, 0, len(schedules))
+	for i, schedule := range schedules {
+		if remainingToSeal <= 0 {
+			break
+		}
+
+		var sectorsForSP int64
+		if i == len(schedules)-1 {
+			sectorsForSP = remainingToSeal
+		} else {
+			sectorsForSP = min(min((toSeal*schedule.Weight)/totalWeight, schedule.ToSeal), remainingToSeal)
+		}
+
+		if sectorsForSP == 0 {
+			continue
+		}
+
+		allocations = append(allocations, ccAllocation{
+			schedule: schedule,
+			count:    sectorsForSP,
+		})
+		remainingToSeal -= sectorsForSP
+	}
+
+	return allocations
+}
+
+func ccProviderLockOrder(allocations []ccAllocation) []int64 {
+	providers := make([]int64, 0, len(allocations))
+	for _, allocation := range allocations {
+		providers = append(providers, allocation.schedule.SpID)
+	}
+	sort.Slice(providers, func(i, j int) bool { return providers[i] < providers[j] })
+	return providers
+}
+
 func (s *SupraSeal) schedule(taskFunc harmonytask.AddTaskFunc) error {
 	if s.slots.Available() == 0 {
 		return nil
@@ -632,12 +693,7 @@ func (s *SupraSeal) schedule(taskFunc harmonytask.AddTaskFunc) error {
 }
 
 func (s *SupraSeal) claimsFromCCScheduler(tx *harmonydb.Tx, toSeal int64) ([]sectorClaim, error) {
-	var enabledSchedules []struct {
-		SpID         int64 `db:"sp_id"`
-		ToSeal       int64 `db:"to_seal"`
-		Weight       int64 `db:"weight"`
-		DurationDays int64 `db:"duration_days"`
-	}
+	var enabledSchedules []ccSchedule
 
 	err := tx.Select(&enabledSchedules, `SELECT sp_id, to_seal, weight, duration_days FROM sectors_cc_scheduler WHERE enabled = TRUE AND weight > 0 ORDER BY weight DESC`)
 	if err != nil {
@@ -659,36 +715,39 @@ func (s *SupraSeal) claimsFromCCScheduler(tx *harmonydb.Tx, toSeal int64) ([]sec
 		return nil, nil
 	}
 
-	// Calculate proportional allocation based on weights
-	var outClaims []sectorClaim
-	remainingToSeal := toSeal
+	allocations := planCCAllocations(enabledSchedules, toSeal)
 
-	for i, schedule := range enabledSchedules {
-		if remainingToSeal <= 0 {
-			break
-		}
-
-		// Calculate how many sectors this SP should get based on weight
-		var sectorsForSP int64
-		if i == len(enabledSchedules)-1 {
-			// Last SP gets the remaining sectors
-			sectorsForSP = remainingToSeal
-		} else {
-			// Proportional allocation based on weight
-			sectorsForSP = min(min((toSeal*schedule.Weight)/totalWeight, schedule.ToSeal), remainingToSeal)
-		}
-
-		if sectorsForSP == 0 {
-			continue
-		}
-
-		// Allocate sector numbers for this SP
-		maddr, err := address.NewIDAddress(uint64(schedule.SpID))
+	// Fetch chain state before acquiring any provider lock. Once the first
+	// provider is locked, this transaction performs database work only.
+	for i := range allocations {
+		maddr, err := address.NewIDAddress(uint64(allocations[i].schedule.SpID))
 		if err != nil {
-			return nil, xerrors.Errorf("getting miner address for %d: %w", schedule.SpID, err)
+			return nil, xerrors.Errorf("getting miner address for %d: %w", allocations[i].schedule.SpID, err)
 		}
 
-		sectorNumbers, err := seal.AllocateSectorNumbers(context.Background(), s.api, tx, maddr, int(sectorsForSP))
+		chainAllocated, err := s.api.StateMinerAllocated(context.Background(), maddr, types.EmptyTSK)
+		if err != nil {
+			return nil, xerrors.Errorf("getting on-chain allocated sector numbers for %d: %w", allocations[i].schedule.SpID, err)
+		}
+		allocations[i].miner = maddr
+		allocations[i].chainAllocated = chainAllocated
+	}
+
+	// A SupraSeal task may allocate for several providers in one transaction.
+	// Acquire the selected providers' locks in ascending order to avoid a
+	// cross-provider lock-order cycle, then return to the existing weighted
+	// scheduling order.
+	for _, spID := range ccProviderLockOrder(allocations) {
+		if err := seal.LockSectorState(context.Background(), tx, spID); err != nil {
+			return nil, err
+		}
+	}
+
+	var outClaims []sectorClaim
+	for _, allocation := range allocations {
+		schedule := allocation.schedule
+
+		sectorNumbers, err := seal.AllocateSectorNumbersFromChain(context.Background(), tx, allocation.miner, allocation.chainAllocated, int(allocation.count))
 		if err != nil {
 			return nil, xerrors.Errorf("allocating sector numbers for %d: %w", schedule.SpID, err)
 		}
@@ -720,13 +779,12 @@ func (s *SupraSeal) claimsFromCCScheduler(tx *harmonydb.Tx, toSeal int64) ([]sec
 		}
 
 		// Update the to_seal count for this SP
-		_, err = tx.Exec(`UPDATE sectors_cc_scheduler SET to_seal = to_seal - $1 WHERE sp_id = $2`, sectorsForSP, schedule.SpID)
+		_, err = tx.Exec(`UPDATE sectors_cc_scheduler SET to_seal = to_seal - $1 WHERE sp_id = $2`, allocation.count, schedule.SpID)
 		if err != nil {
 			return nil, xerrors.Errorf("updating to_seal for SP %d: %w", schedule.SpID, err)
 		}
 
-		remainingToSeal -= sectorsForSP
-		log.Debugw("allocated sectors from CC scheduler", "sp_id", schedule.SpID, "count", sectorsForSP, "remaining", remainingToSeal, "totalWeight", totalWeight, "totalToSeal", totalToSeal)
+		log.Debugw("allocated sectors from CC scheduler", "sp_id", schedule.SpID, "count", allocation.count, "totalWeight", totalWeight, "totalToSeal", totalToSeal)
 	}
 
 	if len(outClaims) != int(toSeal) {

--- a/tasks/sealsupra/task_supraseal_test.go
+++ b/tasks/sealsupra/task_supraseal_test.go
@@ -1,0 +1,61 @@
+package sealsupra
+
+import "testing"
+
+func TestPlanCCAllocationsPreservesExistingRemainderBehavior(t *testing.T) {
+	schedules := []ccSchedule{
+		{SpID: 1001, ToSeal: 10, Weight: 1},
+		{SpID: 1002, ToSeal: 10, Weight: 1},
+		{SpID: 1003, ToSeal: 1, Weight: 1},
+	}
+
+	allocations := planCCAllocations(schedules, 2)
+	if len(allocations) != 1 {
+		t.Fatalf("allocation count = %d, want 1", len(allocations))
+	}
+	if allocations[0].schedule.SpID != 1003 || allocations[0].count != 2 {
+		t.Fatalf("allocation = provider %d count %d, want provider 1003 count 2", allocations[0].schedule.SpID, allocations[0].count)
+	}
+}
+
+func TestPlanCCAllocationsPreservesWeightedCounts(t *testing.T) {
+	schedules := []ccSchedule{
+		{SpID: 1003, ToSeal: 20, Weight: 3},
+		{SpID: 1001, ToSeal: 20, Weight: 2},
+		{SpID: 1002, ToSeal: 20, Weight: 1},
+	}
+
+	allocations := planCCAllocations(schedules, 10)
+	wantProviders := []int64{1003, 1001, 1002}
+	wantCounts := []int64{5, 3, 2}
+	if len(allocations) != len(wantProviders) {
+		t.Fatalf("allocation count = %d, want %d", len(allocations), len(wantProviders))
+	}
+	for i := range allocations {
+		if allocations[i].schedule.SpID != wantProviders[i] || allocations[i].count != wantCounts[i] {
+			t.Fatalf("allocation %d = provider %d count %d, want provider %d count %d", i, allocations[i].schedule.SpID, allocations[i].count, wantProviders[i], wantCounts[i])
+		}
+	}
+}
+
+func TestCCProviderLockOrderIsStableAndDoesNotChangeScheduleOrder(t *testing.T) {
+	allocations := []ccAllocation{
+		{schedule: ccSchedule{SpID: 1003}, count: 5},
+		{schedule: ccSchedule{SpID: 1001}, count: 3},
+		{schedule: ccSchedule{SpID: 1002}, count: 2},
+	}
+
+	got := ccProviderLockOrder(allocations)
+	want := []int64{1001, 1002, 1003}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("lock order = %v, want %v", got, want)
+		}
+	}
+
+	for i, wantProvider := range []int64{1003, 1001, 1002} {
+		if allocations[i].schedule.SpID != wantProvider {
+			t.Fatalf("scheduling order changed to %v", allocations)
+		}
+	}
+}

--- a/tasks/storage-market/storage_market.go
+++ b/tasks/storage-market/storage_market.go
@@ -72,7 +72,7 @@ type storageMarketAPI interface {
 type CurioStorageDealMarket struct {
 	cfg         *config.CurioConfig
 	db          *harmonydb.DB
-	pin         storageingest.Ingester
+	pin         storageingest.WakingIngester
 	miners      *config.Dynamic[[]address.Address]
 	api         storageMarketAPI
 	MK12Handler *mk12.MK12
@@ -1042,6 +1042,7 @@ func (d *CurioStorageDealMarket) ingestDeal(ctx context.Context, deal MK12Pipeli
 		return xerrors.Errorf("UUID: %s: failed to commit transaction: %w", deal.UUID, err)
 	}
 
+	d.pin.Wake()
 	log.Infof("Added deal %s to sector %d", deal.UUID, *sector)
 	return nil
 }

--- a/tasks/storage-market/storage_market_test.go
+++ b/tasks/storage-market/storage_market_test.go
@@ -45,6 +45,8 @@ func (e *expiryTestIngester) GetExpectedSealDuration() abi.ChainEpoch {
 	return e.expectedSealDuration
 }
 
+func (e *expiryTestIngester) Wake() {}
+
 func TestIntegration_CheckExpiry(t *testing.T) {
 	ctx := context.Background()
 	db, err := harmonydb.NewFromConfigWithITestID(t)


### PR DESCRIPTION
# storageingest: bound and serialize ready-sector transfers

Ready-sector transfer currently scans and moves an unbounded provider set in one transaction without sharing a serialization point with open-sector allocation.

This change:

- transfers at most 64 eligible sectors per transaction, preserving full-sector, maximum-wait and deadline eligibility for both SDR and Snap;
- continues in fair provider rounds and keeps the ten-second fallback poll plus coalesced wakeups;
- uses a preserving write to `sectors_allocated_numbers` for first-use allocation, open-sector mutation, manual seal-now and transfer;
- acquires multiple SupraSeal provider locks in ascending provider order, without changing weighted counts, remainder behavior or proof selection;
- keeps pipeline creation, initial-piece transfer and open-piece deletion atomic, retains inconsistent rows as evidence, and isolates only deterministic candidate errors rather than retrying every sector during a database outage.

The 64-sector quantum is not a sealing WIP cap. Participating writers must use the same locking contract; older binaries or direct SQL bypasses are outside this guarantee. Existing chain reads inside some single-provider allocation transactions can extend lock duration. CC quota/remainder correction is a separate change and is not included here.

## Validation

- Database-free normal/race tests: `market/storageingest`, `tasks/seal`, `tasks/sealsupra`, `tasks/storage-market`; exact unsafe upstream fallback-DB tests excluded by name.
- Exact `cgo,fvm,nosupraseal,integration` vet/lint and test-binary compilation: PASS.
- Disposable PostgreSQL 16.15, reported Read Committed: actual first-use allocator, two-handle 129-sector drain, inconsistent-state preservation/continuation, Snap transfer and late-transfer rollback: PASS.
- Deterministically held provider transaction: linked `pg_blocking_pids` observation established that the actual allocator waited before holder release; both committed distinct sector numbers. This added test also passed with the race detector.
- The late Snap failure test verifies the entire failed batch rolled back, then only the valid candidate moves during bounded fallback; race PASS.
- Historical operator-reported YugabyteDB 2025.2.2.2-b11 RC/wait-queue allocation/transfer execution is separate evidence. Current-source Yugabyte execution: NOT RUN. PostgreSQL-specific observation is not presented as a Yugabyte observer.

No schema, public configuration, scheduling threshold, deal schedule or chain-message behavior change is introduced. Current normal production sealing is compatibility evidence, not deliberate contention/failure-path proof.
