### PR TITLE
indexing: wait for sector offsets before assigning tasks

### DIFF
--- a/documentation/en/market-2.0/indexing-offset-sql-tests.md
+++ b/documentation/en/market-2.0/indexing-offset-sql-tests.md
@@ -1,8 +1,11 @@
 # Indexing Offset Readiness: Operator SQL Verification
 
 This follow-up adds executable SQL assertions to the existing NULL-offset
-readiness fix. PostgreSQL and YugabyteDB execution remains **NOT RUN** until
-an operator runs these tests in a separately authorized disposable database.
+readiness fix. PostgreSQL 16.15 execution passed at follow-up `6dace4e4`
+and current-upstream extraction `ac6bf2dc`, including all six MK12/MK20
+baseline subtests and the candidate-side negative controls described below.
+YugabyteDB execution remains **NOT RUN**. Future execution requires a
+separately authorized disposable database.
 No production target, API, task engine, payload processing, or recovery is used.
 
 ## Statements and Coverage
@@ -135,8 +138,12 @@ at the same commit. Do not edit the review branch or any deployed checkout.
 5. Repeat steps 1–4 for `indexingMK20AssignSQL` and the `MK20` subtest only.
 
 Do not commit/push either mutation or disable the safety guard. This negative
-control has been prepared, **not executed** here. It is different evidence
-from the earlier database-free SQL-shape mutation.
+control was executed on disposable PostgreSQL 16.15 for both MK12 and MK20:
+each candidate-side mutation produced the expected one-versus-zero affected-row
+assertion failure, and the restored baseline passed. Neither mutation was
+committed. This is SQL row-effect evidence, distinct from the earlier
+database-free SQL-shape mutation; it is not Yugabyte execution or proof of an
+impossible interleaving within the single atomic assignment statement.
 
 The previously reported ownerless Indexing canary task was resolved by
 uncordoning workers; it did not reproduce this NULL-offset bug. Existing

--- a/documentation/en/market-2.0/indexing-offset-sql-tests.md
+++ b/documentation/en/market-2.0/indexing-offset-sql-tests.md
@@ -1,0 +1,144 @@
+# Indexing Offset Readiness: Operator SQL Verification
+
+This follow-up adds executable SQL assertions to the existing NULL-offset
+readiness fix. PostgreSQL and YugabyteDB execution remains **NOT RUN** until
+an operator runs these tests in a separately authorized disposable database.
+No production target, API, task engine, payload processing, or recovery is used.
+
+## Statements and Coverage
+
+`tasks/indexing/task_indexing_offset_integration_test.go` executes the exact
+`indexingMK12AssignSQL` and `indexingMK20AssignSQL` constants consumed by
+`IndexingTask.schedule`. Candidate selection and conditional assignment are
+one atomic CTE-plus-UPDATE, not copied queries or a second eligibility model.
+The fixture supplies only task-row creation and commit/rollback plumbing via
+the repository-pinned pgx driver. It does not execute Harmony's full task adder,
+retry runner, or scheduler loop. Existing database-free tests verify that the
+production scheduler uses these constants.
+
+Each of these tests has `MK12` and `MK20` subtests:
+
+- `TestIndexingOffsetSQLReadiness`: an older otherwise-ready NULL offset,
+  later zero and positive offsets, and older assigned/indexed/completed/
+  unsealed/missing-readiness-time exclusions. The zero-offset row requests
+  metadata-only processing; the positive row requests physical indexing.
+  Snapshots verify that only the selected task-ID field changes, including
+  preservation of another eligible provider/deal and, for MK20, another
+  aggregate index with the same deal ID. The other market table is untouched.
+- `TestIndexingOffsetSQLAllNullThenReady`: no assignment or retained new task
+  for an all-NULL set. A fixture-owned producer transition supplies offset zero
+  to the later row; a new scheduling statement can then assign it while the
+  older NULL row remains untouched.
+- `TestIndexingOffsetSQLAssignmentRollback`: rolling back a successful SQL
+  assignment also rolls back its newly created task; a later commit succeeds,
+  and subsequent scheduling cannot overwrite that existing assignment.
+
+The conditional UPDATE's prerequisites execute in every operation. There is
+no application callback between its CTE and UPDATE in which to inject a stale
+candidate. These tests do not invent such an interleaving or claim independent
+cross-connection proof of the outer recheck. Its presence remains separately
+protected by the existing SQL-shape regression. Concurrent-writer/isolation
+behavior is not established by these single-connection row-effect tests.
+
+Normally completed fixtures have both `complete=true` and `indexed=true`.
+The existing scheduler excludes them via `indexed`; neither statement adds a
+new `complete` predicate. This work does not invent a contract for contradictory
+historical stage flags or clear existing task IDs. Metadata-only assignment is
+tested, but actual metadata insertion/completion in `Do` is outside this fixture.
+
+## Schema and Safety Boundary
+
+The focused projection follows `20240731-market-migration.sql` (MK12) and
+`20250505-market-mk20.sql` (MK20), checked against subsequent migrations. It
+retains the unique non-NULL MK12 UUID, MK20 `(id, aggr_index)` primary key,
+provider types, nullable BIGINT offsets/task IDs, TIMESTAMPTZ readiness time,
+and relevant stage/indexing flags. Neither task-ID column has a foreign key
+to `harmony_task`. The minimal task table retains its SERIAL identity and
+VARCHAR(16) name from `20230719-harmony.sql`; unused payload and engine fields
+are not a substitute for full task-engine integration. No historical migration
+replay or production schema change is performed.
+
+The file requires build tags `integration && !skiff` **and** explicit
+`CURIO_INDEXING_OFFSET_ITEST=1` before opening a connection. Supply all of:
+
+- `CURIO_INDEXING_OFFSET_ITEST_HOST`: literal loopback IP, e.g. `127.0.0.1`
+  or `::1`; not a hostname, host list, remote address, or implicit default.
+- `CURIO_INDEXING_OFFSET_ITEST_PORT`: explicit integer in 1–65535.
+- `CURIO_INDEXING_OFFSET_ITEST_DATABASE`: dedicated disposable database.
+- `CURIO_INDEXING_OFFSET_ITEST_USER`: dedicated user allowed to create an
+  isolated schema in that database.
+- Optional `CURIO_INDEXING_OFFSET_ITEST_PASSWORD`, supplied only through the
+  operator's existing secret environment, never a URI, command argument or log.
+
+Start with normal Curio/HarmonyDB/libpq connection variables and other
+integration opt-ins removed, then supply only this dedicated target. The
+fixture overwrites target/runtime parameters, removes fallback hosts, and
+explicitly disables load balancing. Each subtest creates a random owned
+schema; cleanup drops only that schema. Connection timeout is five seconds,
+statement timeout five seconds, lock timeout two seconds, subtest context
+30 seconds, and cleanup/close contexts five seconds each. Cleanup follows
+transaction rollback; no participant goroutines or server processes are started.
+If the test process is forcibly killed, normal deferred cleanup is not assured;
+do not broaden cleanup to other namespaces.
+
+Logs record server version, default and transaction-reported isolation. Driver
+default isolation is requested. For YugabyteDB 2025.2.2.2-b11, the operator must
+record effective RC and wait-queue settings from the disposable server's own
+configuration independently of `SHOW transaction_isolation`; otherwise effective
+isolation stays **UNVERIFIED**. No remote flag query is part of this test.
+
+## Compile and Operator Execution
+
+Use the existing pinned Go/FFI toolchain and local OpenCL build environment.
+No server installation/startup or connection command is needed for compilation:
+
+```sh
+go list -tags=cgo,fvm,nosupraseal,integration \
+  -f '{{.TestGoFiles}}' ./tasks/indexing
+go test -c -tags=cgo,fvm,nosupraseal,integration \
+  -o /tmp/curio-indexing-offset-sql.test ./tasks/indexing
+```
+
+Verify that `task_indexing_offset_integration_test.go` is selected. Normal
+`cgo,fvm,nosupraseal` tests exclude that file. Compiling it is not executing it;
+running without opt-in skips before any connection.
+
+Only the separately authorized operator, after supplying the dedicated target,
+runs the following once per disposable PostgreSQL/Yugabyte instance:
+
+```sh
+CURIO_INDEXING_OFFSET_ITEST=1 /tmp/curio-indexing-offset-sql.test \
+  -test.v -test.count=1 -test.timeout=5m \
+  -test.run='^TestIndexingOffsetSQL(Readiness|AllNullThenReady|AssignmentRollback)$'
+```
+
+Expect all six market subtests to pass. Record the exact tested commit, version,
+isolation evidence and results separately for each database. A compile, skip,
+or static SQL assertion is not a database PASS.
+
+## Operator-Only Negative Control
+
+After the baseline SQL run passes, use a separate disposable source worktree
+at the same commit. Do not edit the review branch or any deployed checkout.
+
+1. In `task_indexing.go`, temporarily remove **only** the candidate clause
+   `AND sector_offset IS NOT NULL` inside `indexingMK12AssignSQL`. Retain the
+   outer `AND p.sector_offset IS NOT NULL` and all other SQL unchanged.
+2. Recompile the integration binary from this mutated worktree, then execute
+   only `^TestIndexingOffsetSQLReadiness$/^MK12$` with the same explicit opt-in,
+   dedicated disposable target, count=1 and five-minute test timeout.
+3. Require an executable assertion failure: expected one affected row, actual
+   zero. The older NULL row wins the candidate LIMIT but is rejected by the
+   outer guard, so the later ready zero-offset row is not assigned. A compile,
+   setup, connection or timeout failure is **not** this negative-control result.
+4. Restore that one mutation, rebuild, and rerun the same SQL subtest to PASS.
+5. Repeat steps 1–4 for `indexingMK20AssignSQL` and the `MK20` subtest only.
+
+Do not commit/push either mutation or disable the safety guard. This negative
+control has been prepared, **not executed** here. It is different evidence
+from the earlier database-free SQL-shape mutation.
+
+The previously reported ownerless Indexing canary task was resolved by
+uncordoning workers; it did not reproduce this NULL-offset bug. Existing
+assigned tasks, exhausted retries, post-GC offset discovery, stored schedules,
+and completion recovery remain outside this fix and this verification task.

--- a/tasks/indexing/task_indexing.go
+++ b/tasks/indexing/task_indexing.go
@@ -508,21 +508,14 @@ func (i *IndexingTask) TypeDetails() harmonytask.TaskTypeDetails {
 	}
 }
 
-func (i *IndexingTask) schedule(ctx context.Context, taskFunc harmonytask.AddTaskFunc) error {
-	// schedule submits
-	for {
-		stop := true
-		taskFunc(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
-			// Indexing job must be created for every deal to make sure piece details are inserted in DB
-			// even if we don't want to index it. If piece is not supposed to be indexed then it will handled
-			// by the Do()
-			n, err := tx.Exec(`WITH pending AS (
+const indexingMK12AssignSQL = `WITH pending AS (
 					SELECT uuid
 					FROM market_mk12_deal_pipeline
 					WHERE sealed = TRUE
 					  AND indexing_task_id IS NULL
 					  AND indexed = FALSE
 					  AND indexing_created_at IS NOT NULL
+					  AND sector_offset IS NOT NULL
 					ORDER BY indexing_created_at ASC
 					LIMIT 1
 				)
@@ -532,7 +525,39 @@ func (i *IndexingTask) schedule(ctx context.Context, taskFunc harmonytask.AddTas
 				WHERE p.uuid = pending.uuid
 				  AND p.sealed = TRUE
 				  AND p.indexing_task_id IS NULL
-				  AND p.indexed = FALSE`, id)
+				  AND p.indexed = FALSE
+				  AND p.sector_offset IS NOT NULL`
+
+const indexingMK20AssignSQL = `WITH pending AS (
+					SELECT id, aggr_index
+					FROM market_mk20_pipeline
+					WHERE sealed = TRUE
+					  AND indexing_task_id IS NULL
+					  AND indexed = FALSE
+					  AND indexing_created_at IS NOT NULL
+					  AND sector_offset IS NOT NULL
+					ORDER BY indexing_created_at ASC
+					LIMIT 1
+				)
+				UPDATE market_mk20_pipeline p
+				SET indexing_task_id = $1
+				FROM pending
+				WHERE p.id = pending.id
+				  AND p.aggr_index = pending.aggr_index
+				  AND p.sealed = TRUE
+				  AND p.indexing_task_id IS NULL
+				  AND p.indexed = FALSE
+				  AND p.sector_offset IS NOT NULL`
+
+func (i *IndexingTask) schedule(ctx context.Context, taskFunc harmonytask.AddTaskFunc) error {
+	// schedule submits
+	for {
+		stop := true
+		taskFunc(func(id harmonytask.TaskID, tx *harmonydb.Tx) (shouldCommit bool, seriousError error) {
+			// Indexing job must be created for every deal to make sure piece details are inserted in DB
+			// even if we don't want to index it. If piece is not supposed to be indexed then it will handled
+			// by the Do()
+			n, err := tx.Exec(indexingMK12AssignSQL, id)
 			if err != nil {
 				return false, xerrors.Errorf("updating mk12 indexing task id: %w", err)
 			}
@@ -544,24 +569,7 @@ func (i *IndexingTask) schedule(ctx context.Context, taskFunc harmonytask.AddTas
 				return true, nil
 			}
 
-			n, err = tx.Exec(`WITH pending AS (
-					SELECT id, aggr_index
-					FROM market_mk20_pipeline
-					WHERE sealed = TRUE
-					  AND indexing_task_id IS NULL
-					  AND indexed = FALSE
-					  AND indexing_created_at IS NOT NULL
-					ORDER BY indexing_created_at ASC
-					LIMIT 1
-				)
-				UPDATE market_mk20_pipeline p
-				SET indexing_task_id = $1
-				FROM pending
-				WHERE p.id = pending.id
-				  AND p.aggr_index = pending.aggr_index
-				  AND p.sealed = TRUE
-				  AND p.indexing_task_id IS NULL
-				  AND p.indexed = FALSE`, id)
+			n, err = tx.Exec(indexingMK20AssignSQL, id)
 			if err != nil {
 				return false, xerrors.Errorf("updating mk20 indexing task id: %w", err)
 			}

--- a/tasks/indexing/task_indexing_offset_integration_test.go
+++ b/tasks/indexing/task_indexing_offset_integration_test.go
@@ -1,0 +1,302 @@
+//go:build integration && !skiff
+
+package indexing
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/yugabyte/pgx/v5"
+)
+
+// The only connection entry point: no normal Curio/HarmonyDB/libpq target is
+// accepted. This fixture is local to indexing; it imports no other PR's tests.
+func newIndexingOffsetSQLFixture(t *testing.T) (context.Context, *pgx.Conn) {
+	t.Helper()
+	if os.Getenv("CURIO_INDEXING_OFFSET_ITEST") != "1" {
+		t.Skip("requires CURIO_INDEXING_OFFSET_ITEST=1 and an explicit disposable loopback target")
+	}
+	const prefix = "CURIO_INDEXING_OFFSET_ITEST_"
+	host, database, user := os.Getenv(prefix+"HOST"), os.Getenv(prefix+"DATABASE"), os.Getenv(prefix+"USER")
+	ip := net.ParseIP(host)
+	require.True(t, ip != nil && ip.IsLoopback(), "dedicated HOST must be a literal loopback IP")
+	port, err := strconv.ParseUint(os.Getenv(prefix+"PORT"), 10, 16)
+	require.NoError(t, err, "dedicated PORT must be explicitly supplied")
+	require.NotZero(t, port)
+	require.NotEmpty(t, strings.TrimSpace(database), "dedicated DATABASE required")
+	require.NotEmpty(t, strings.TrimSpace(user), "dedicated USER required")
+
+	cfg, err := pgx.ParseConfig("postgresql://placeholder@127.0.0.1/placeholder?sslmode=disable&load_balance=false")
+	require.NoError(t, err)
+	cfg.Host, cfg.Port, cfg.Database, cfg.User = host, uint16(port), database, user
+	cfg.Password = os.Getenv(prefix + "PASSWORD")
+	cfg.Fallbacks = nil
+	cfg.ConnectTimeout = 5 * time.Second
+	schema := "itest_indexing_offset_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	cfg.RuntimeParams = map[string]string{
+		"search_path": schema, "application_name": "curio-indexing-offset-itest",
+		"statement_timeout": "5000", "lock_timeout": "2000",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	conn, err := pgx.ConnectConfig(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		closeCtx, stop := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stop()
+		require.NoError(t, conn.Close(closeCtx))
+	})
+	_, err = conn.Exec(ctx, "CREATE SCHEMA "+pgx.Identifier{schema}.Sanitize())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupCtx, stop := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stop()
+		_, err := conn.Exec(cleanupCtx, "DROP SCHEMA "+pgx.Identifier{schema}.Sanitize()+" CASCADE")
+		require.NoError(t, err)
+	})
+	_, err = conn.Exec(ctx, indexingOffsetSQLSchema)
+	require.NoError(t, err)
+	var version, isolation string
+	require.NoError(t, conn.QueryRow(ctx, `SELECT version()`).Scan(&version))
+	require.NoError(t, conn.QueryRow(ctx, `SHOW default_transaction_isolation`).Scan(&isolation))
+	t.Logf("version=%s schema=%s requested isolation=driver default; SQL default=%s; effective Yugabyte isolation=UNVERIFIED", version, schema, isolation)
+	return ctx, conn
+}
+
+type indexingOffsetSQLRow struct {
+	ID            string
+	Provider      int64
+	Aggregate     int64
+	Offset        *int64
+	Created       *time.Time
+	Sealed        bool
+	Indexed       bool
+	Complete      bool
+	PhysicalIndex bool
+	Task          *int64
+}
+
+func indexingOffsetSQLRowFixture(number int) indexingOffsetSQLRow {
+	created := time.Date(2000, 1, 1, 0, number, 0, 0, time.UTC)
+	offset := int64(0)
+	return indexingOffsetSQLRow{ID: fmt.Sprintf("%026d", number), Provider: 1000,
+		Offset: &offset, Created: &created, Sealed: true}
+}
+
+func seedIndexingOffsetSQLRow(t *testing.T, ctx context.Context, conn *pgx.Conn, mk20 bool, row indexingOffsetSQLRow) {
+	t.Helper()
+	if mk20 {
+		_, err := conn.Exec(ctx, `INSERT INTO market_mk20_pipeline
+			(id, sp_id, aggr_index, sector_offset, indexing_created_at, sealed, indexed, complete, indexing, indexing_task_id)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`, row.ID, row.Provider, row.Aggregate,
+			row.Offset, row.Created, row.Sealed, row.Indexed, row.Complete, row.PhysicalIndex, row.Task)
+		require.NoError(t, err)
+	} else {
+		_, err := conn.Exec(ctx, `INSERT INTO market_mk12_deal_pipeline
+			(uuid, sp_id, sector_offset, indexing_created_at, sealed, indexed, complete, should_index, indexing_task_id)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`, row.ID, row.Provider,
+			row.Offset, row.Created, row.Sealed, row.Indexed, row.Complete, row.PhysicalIndex, row.Task)
+		require.NoError(t, err)
+	}
+}
+
+func indexingOffsetSQLSnapshot(t *testing.T, ctx context.Context, conn *pgx.Conn, mk20 bool) []indexingOffsetSQLRow {
+	t.Helper()
+	query := `SELECT uuid, sp_id, 0::bigint, sector_offset, indexing_created_at, sealed, indexed, complete, should_index, indexing_task_id
+		FROM market_mk12_deal_pipeline ORDER BY uuid`
+	if mk20 {
+		query = `SELECT id, sp_id, aggr_index, sector_offset, indexing_created_at, sealed, indexed, complete, indexing, indexing_task_id
+			FROM market_mk20_pipeline ORDER BY id, aggr_index`
+	}
+	rows, err := conn.Query(ctx, query)
+	require.NoError(t, err)
+	result, err := pgx.CollectRows(rows, pgx.RowToStructByPos[indexingOffsetSQLRow])
+	require.NoError(t, err)
+	return result
+}
+
+// Execute the exact combined candidate/conditional-assignment constant consumed
+// by IndexingTask.schedule. Only task creation/commit plumbing is test-owned;
+// this does not replace or reproduce the scheduler's selection algorithm.
+func assignIndexingOffsetSQL(t *testing.T, ctx context.Context, conn *pgx.Conn, mk20, rollback bool) (int64, int64) {
+	t.Helper()
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{})
+	require.NoError(t, err)
+	defer func() {
+		cleanupCtx, stop := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stop()
+		err := tx.Rollback(cleanupCtx)
+		if err != nil && err != pgx.ErrTxClosed {
+			t.Errorf("rollback: %v", err)
+		}
+	}()
+	var isolation string
+	require.NoError(t, tx.QueryRow(ctx, `SHOW transaction_isolation`).Scan(&isolation))
+	t.Logf("assignment SQL transaction_isolation=%s; effective Yugabyte isolation=UNVERIFIED", isolation)
+	var taskID int64
+	require.NoError(t, tx.QueryRow(ctx, `INSERT INTO harmony_task (name) VALUES ('Indexing') RETURNING id`).Scan(&taskID))
+	query := indexingMK12AssignSQL
+	if mk20 {
+		query = indexingMK20AssignSQL
+	}
+	tag, err := tx.Exec(ctx, query, taskID)
+	require.NoError(t, err)
+	n := tag.RowsAffected()
+	require.LessOrEqual(t, n, int64(1))
+	if n == 1 && !rollback {
+		require.NoError(t, tx.Commit(ctx))
+	}
+	return taskID, n
+}
+
+func requireIndexingOffsetSQLTaskCount(t *testing.T, ctx context.Context, conn *pgx.Conn, count int) {
+	t.Helper()
+	var got int
+	require.NoError(t, conn.QueryRow(ctx, `SELECT COUNT(*) FROM harmony_task`).Scan(&got))
+	require.Equal(t, count, got)
+}
+
+func TestIndexingOffsetSQLReadiness(t *testing.T) {
+	for _, market := range []string{"MK12", "MK20"} {
+		t.Run(market, func(t *testing.T) {
+			mk20 := market == "MK20"
+			ctx, conn := newIndexingOffsetSQLFixture(t)
+			older := indexingOffsetSQLRowFixture(1)
+			older.Offset = nil
+			zero := indexingOffsetSQLRowFixture(2) // Metadata-only: must still be assigned.
+			positive := indexingOffsetSQLRowFixture(3)
+			offset := int64(512)
+			positive.Offset, positive.PhysicalIndex = &offset, true
+			peer := indexingOffsetSQLRowFixture(4)
+			peer.Provider = 2000
+			if mk20 {
+				peer.ID, peer.Aggregate = zero.ID, 7
+			}
+			for _, row := range []indexingOffsetSQLRow{older, zero, positive, peer} {
+				seedIndexingOffsetSQLRow(t, ctx, conn, mk20, row)
+			}
+			for i, state := range []string{"assigned", "complete", "unsealed", "indexed", "no timestamp"} {
+				row := indexingOffsetSQLRowFixture(i + 10)
+				row.Created = older.Created // Older exclusions cannot consume LIMIT 1.
+				switch state {
+				case "assigned":
+					var task int64
+					require.NoError(t, conn.QueryRow(ctx, `INSERT INTO harmony_task (name) VALUES ('Indexing') RETURNING id`).Scan(&task))
+					row.Task = &task
+				case "complete":
+					row.Complete, row.Indexed = true, true
+				case "unsealed":
+					row.Sealed = false
+				case "indexed":
+					row.Indexed = true
+				case "no timestamp":
+					row.Created = nil
+				}
+				seedIndexingOffsetSQLRow(t, ctx, conn, mk20, row)
+			}
+			otherMarket := indexingOffsetSQLRowFixture(99)
+			seedIndexingOffsetSQLRow(t, ctx, conn, !mk20, otherMarket)
+			untouched := indexingOffsetSQLSnapshot(t, ctx, conn, !mk20)
+			for _, target := range []indexingOffsetSQLRow{zero, positive} {
+				want := indexingOffsetSQLSnapshot(t, ctx, conn, mk20)
+				taskID, n := assignIndexingOffsetSQL(t, ctx, conn, mk20, false)
+				require.EqualValues(t, 1, n, "older NULL row must not block the later eligible row")
+				for i := range want {
+					if want[i].ID == target.ID && want[i].Aggregate == target.Aggregate {
+						want[i].Task = &taskID
+					}
+				}
+				require.Equal(t, want, indexingOffsetSQLSnapshot(t, ctx, conn, mk20), "only the exact selected identity may change")
+				require.Equal(t, untouched, indexingOffsetSQLSnapshot(t, ctx, conn, !mk20))
+			}
+			requireIndexingOffsetSQLTaskCount(t, ctx, conn, 3) // Existing task plus two new assignments.
+		})
+	}
+}
+
+func TestIndexingOffsetSQLAllNullThenReady(t *testing.T) {
+	for _, market := range []string{"MK12", "MK20"} {
+		t.Run(market, func(t *testing.T) {
+			mk20 := market == "MK20"
+			ctx, conn := newIndexingOffsetSQLFixture(t)
+			for i := 1; i <= 2; i++ {
+				row := indexingOffsetSQLRowFixture(i)
+				row.Offset = nil
+				seedIndexingOffsetSQLRow(t, ctx, conn, mk20, row)
+			}
+			before := indexingOffsetSQLSnapshot(t, ctx, conn, mk20)
+			_, n := assignIndexingOffsetSQL(t, ctx, conn, mk20, false)
+			require.Zero(t, n)
+			require.Equal(t, before, indexingOffsetSQLSnapshot(t, ctx, conn, mk20))
+			requireIndexingOffsetSQLTaskCount(t, ctx, conn, 0)
+			// A later, separate scheduling statement observes producer progress.
+			id := indexingOffsetSQLRowFixture(2).ID
+			if mk20 {
+				_, err := conn.Exec(ctx, `UPDATE market_mk20_pipeline SET sector_offset = 0 WHERE id = $1 AND sp_id = 1000 AND aggr_index = 0`, id)
+				require.NoError(t, err)
+			} else {
+				_, err := conn.Exec(ctx, `UPDATE market_mk12_deal_pipeline SET sector_offset = 0 WHERE uuid = $1 AND sp_id = 1000`, id)
+				require.NoError(t, err)
+			}
+			task, n := assignIndexingOffsetSQL(t, ctx, conn, mk20, false)
+			require.EqualValues(t, 1, n)
+			after := indexingOffsetSQLSnapshot(t, ctx, conn, mk20)
+			require.Nil(t, after[0].Task)
+			require.Equal(t, &task, after[1].Task)
+			requireIndexingOffsetSQLTaskCount(t, ctx, conn, 1)
+		})
+	}
+}
+
+func TestIndexingOffsetSQLAssignmentRollback(t *testing.T) {
+	for _, market := range []string{"MK12", "MK20"} {
+		t.Run(market, func(t *testing.T) {
+			mk20 := market == "MK20"
+			ctx, conn := newIndexingOffsetSQLFixture(t)
+			seedIndexingOffsetSQLRow(t, ctx, conn, mk20, indexingOffsetSQLRowFixture(1))
+			before := indexingOffsetSQLSnapshot(t, ctx, conn, mk20)
+			_, n := assignIndexingOffsetSQL(t, ctx, conn, mk20, true)
+			require.EqualValues(t, 1, n)
+			require.Equal(t, before, indexingOffsetSQLSnapshot(t, ctx, conn, mk20))
+			requireIndexingOffsetSQLTaskCount(t, ctx, conn, 0)
+			_, n = assignIndexingOffsetSQL(t, ctx, conn, mk20, false)
+			require.EqualValues(t, 1, n)
+			assigned := indexingOffsetSQLSnapshot(t, ctx, conn, mk20)
+			_, n = assignIndexingOffsetSQL(t, ctx, conn, mk20, false)
+			require.Zero(t, n)
+			require.Equal(t, assigned, indexingOffsetSQLSnapshot(t, ctx, conn, mk20))
+			requireIndexingOffsetSQLTaskCount(t, ctx, conn, 1)
+		})
+	}
+}
+
+// Projection of 20240731-market-migration.sql and 20250505-market-mk20.sql:
+// actual identity constraints, nullable BIGINT offsets/task IDs, TIMESTAMPTZ
+// readiness time, and stage/metadata flags. Neither assignment column has an
+// FK to harmony_task. Unused payload fields and unrelated tables are omitted.
+// harmony_task's SERIAL identity/name types come from 20230719-harmony.sql;
+// the test owns minimal task-create/rollback plumbing, not a running engine.
+const indexingOffsetSQLSchema = `
+CREATE TABLE harmony_task (id SERIAL PRIMARY KEY NOT NULL, name VARCHAR(16) NOT NULL);
+CREATE TABLE market_mk12_deal_pipeline (
+    uuid TEXT NOT NULL UNIQUE, sp_id BIGINT NOT NULL,
+    sector_offset BIGINT DEFAULT NULL, indexing_created_at TIMESTAMPTZ,
+    sealed BOOLEAN DEFAULT FALSE, indexed BOOLEAN DEFAULT FALSE,
+    indexing_task_id BIGINT DEFAULT NULL, should_index BOOLEAN DEFAULT FALSE,
+    complete BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE TABLE market_mk20_pipeline (
+    id TEXT NOT NULL, aggr_index BIGINT DEFAULT 0, sp_id BIGINT NOT NULL,
+    sector_offset BIGINT DEFAULT NULL, indexing_created_at TIMESTAMPTZ DEFAULT NULL,
+    sealed BOOLEAN DEFAULT FALSE, indexed BOOLEAN DEFAULT FALSE,
+    indexing_task_id BIGINT DEFAULT NULL, indexing BOOLEAN NOT NULL,
+    complete BOOLEAN NOT NULL DEFAULT FALSE, PRIMARY KEY (id, aggr_index)
+);`

--- a/tasks/indexing/task_indexing_test.go
+++ b/tasks/indexing/task_indexing_test.go
@@ -1,0 +1,125 @@
+//go:build !skiff
+
+package indexing
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexingAssignmentSQLRequiresSectorOffset(t *testing.T) {
+	tests := []struct {
+		name              string
+		query             string
+		candidateIdentity string
+		updateIdentity    []string
+	}{
+		{
+			name:              "MK12",
+			query:             indexingMK12AssignSQL,
+			candidateIdentity: "select uuid from market_mk12_deal_pipeline",
+			updateIdentity: []string{
+				"p.uuid = pending.uuid",
+			},
+		},
+		{
+			name:              "MK20",
+			query:             indexingMK20AssignSQL,
+			candidateIdentity: "select id, aggr_index from market_mk20_pipeline",
+			updateIdentity: []string{
+				"p.id = pending.id",
+				"p.aggr_index = pending.aggr_index",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			query := normalizeIndexingSQL(test.query)
+			candidate, update, found := strings.Cut(query, " update ")
+			require.True(t, found, "assignment query must contain an UPDATE")
+
+			require.Contains(t, candidate, test.candidateIdentity)
+			require.Contains(t, candidate, "sector_offset is not null")
+			require.Less(t,
+				strings.Index(candidate, "sector_offset is not null"),
+				strings.Index(candidate, "order by indexing_created_at asc limit 1"),
+				"offset readiness must be applied before ordering and limiting candidates",
+			)
+			require.Contains(t, update, "p.sector_offset is not null")
+			require.Equal(t, 2, strings.Count(query, "sector_offset is not null"),
+				"both candidate selection and assignment must recheck offset readiness")
+
+			for _, predicate := range []string{
+				"sealed = true",
+				"indexing_task_id is null",
+				"indexed = false",
+			} {
+				require.Equal(t, 2, strings.Count(query, predicate),
+					"candidate selection and assignment must retain %q", predicate)
+			}
+			require.Equal(t, 1, strings.Count(query, "indexing_created_at is not null"))
+			require.Contains(t, query, "set indexing_task_id = $1")
+
+			for _, identity := range test.updateIdentity {
+				require.Contains(t, update, identity)
+			}
+
+			// A NULL check excludes unavailable offsets while allowing both zero and
+			// positive offsets. Indexing remains scheduled for metadata-only rows.
+			require.NotContains(t, query, "coalesce(sector_offset")
+			require.NotRegexp(t, `sector_offset\s*(?:=|<>|!=|<|>)\s*[-+]?\d`, query)
+			require.NotContains(t, query, "should_index = true")
+		})
+	}
+}
+
+func TestIndexingScheduleUsesGuardedAssignmentSQL(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	taskFile := filepath.Join(filepath.Dir(testFile), "task_indexing.go")
+	parsed, err := parser.ParseFile(token.NewFileSet(), taskFile, nil, 0)
+	require.NoError(t, err)
+
+	var schedule *ast.FuncDecl
+	for _, declaration := range parsed.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if ok && function.Name.Name == "schedule" {
+			schedule = function
+			break
+		}
+	}
+	require.NotNil(t, schedule, "IndexingTask.schedule must exist")
+
+	usedQueries := map[string]int{}
+	ast.Inspect(schedule.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != "Exec" {
+			return true
+		}
+		query, ok := call.Args[0].(*ast.Ident)
+		if ok {
+			usedQueries[query.Name]++
+		}
+		return true
+	})
+
+	require.Equal(t, 1, usedQueries["indexingMK12AssignSQL"])
+	require.Equal(t, 1, usedQueries["indexingMK20AssignSQL"])
+}
+
+func normalizeIndexingSQL(query string) string {
+	return strings.ToLower(strings.Join(strings.Fields(query), " "))
+}


### PR DESCRIPTION
## Summary

Require a non-NULL sector offset before assigning Indexing work for both MK12
and MK20. The producer can leave the offset unavailable while `IndexingTask.Do`
loads it into a non-nullable integer, so assignment must wait for this prerequisite.

Guard both the candidate CTE before ORDER BY/LIMIT and the conditional UPDATE.
This prevents an older unready row from hiding a later ready row and avoids
relying solely on advisory selection. Zero is a valid offset; it is not excluded
or substituted for NULL. Existing task/provider/deal/aggregate identities,
sealed/indexed/task conditions, ordering and cadence are unchanged.

Metadata-only/no-physical-indexing rows still receive their required metadata
processing. No offsets or completion markers are fabricated. Assigned/exhausted
tasks, retry limits and historical state are unchanged. Post-GC discovery and
recovery are separate work, not included here.

## Validation

On upstream `86e95967cd602dbf8db5ea538abe986c3968e2e3`, executable extracted
source `ac6bf2dc1d7d0c43cbbcd2009f40b00ce010ac0f` (later changes are docs only):

- `go test` and `go test -race -tags=cgo,fvm,nosupraseal -count=1
  -timeout=3m ./tasks/indexing`: PASS in a database-free environment.
- Exact integration-tag file selection/compilation, vet, pinned golangci-lint
  2.11.4, canonical fiximports and diff check: PASS.
- Disposable PostgreSQL 16.15, reported Read Committed, exact production SQL:
  `TestIndexingOffsetSQLReadiness`, `TestIndexingOffsetSQLAllNullThenReady`,
  `TestIndexingOffsetSQLAssignmentRollback`: all MK12/MK20 cases PASS.
  Tests cover NULL vs zero/positive, metadata-only rows, existing tasks,
  completed/not-ready rows, unrelated composite identities and rollback.
- In a throwaway checkout, removing only the candidate-side non-NULL predicate
  caused the later-ready-row assertion to fail for each market: expected one
  affected row, got zero. Both restored baselines passed. These are executable
  SQL row effects, not regex/model evidence or an invented interleaving inside
  one atomic statement.

The fixture is opt-in (`integration` tag plus dedicated target variables), uses
literal loopback, disabled load balancing, owned random schemas and finite
timeouts. Current-head Yugabyte execution is NOT RUN; another engine run is not
required before code review for this narrow predicate change given actual
PostgreSQL row effects, negative controls and unchanged query identity semantics.
Neither ongoing production sealing nor the earlier cordoned-worker canary
reproduced this NULL-offset bug.
