### PR TITLE
market: account for preceding pieces in MK20 sector offsets

### DIFF
--- a/tasks/storage-market/mk20.go
+++ b/tasks/storage-market/mk20.go
@@ -842,17 +842,32 @@ func (d *CurioStorageDealMarket) createCommPMk20Piece(ctx context.Context, piece
 	return nil
 }
 
+type mk20SectorPiece struct {
+	CID   string              `db:"piece_cid"`
+	Size  abi.PaddedPieceSize `db:"piece_size"`
+	Index int64               `db:"piece_index"`
+}
+
+func findMK20PieceOffset(pieces []mk20SectorPiece, pieceCID string, pieceSize abi.PaddedPieceSize) (abi.PaddedPieceSize, bool) {
+	var offset abi.UnpaddedPieceSize
+
+	for _, piece := range pieces {
+		_, padLength := proofs.GetRequiredPadding(offset.Padded(), piece.Size)
+		offset += padLength.Unpadded()
+		if piece.CID == pieceCID && piece.Size == pieceSize {
+			return offset.Padded(), true
+		}
+		offset += piece.Size.Unpadded()
+	}
+
+	return 0, false
+}
+
 func (d *CurioStorageDealMarket) addDealOffset(ctx context.Context, piece MK20PipelinePiece) error {
 	// Get the deal offset if sector has started sealing
 	if piece.Sector.Valid && piece.RegSealProof.Valid && !piece.SectorOffset.Valid {
 		_, err := d.db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (commit bool, err error) {
-			type pieces struct {
-				Cid   string              `db:"piece_cid"`
-				Size  abi.PaddedPieceSize `db:"piece_size"`
-				Index int64               `db:"piece_index"`
-			}
-
-			var pieceList []pieces
+			var pieceList []mk20SectorPiece
 			err = tx.Select(&pieceList, `SELECT piece_cid, piece_size, piece_index
 												FROM sectors_sdr_initial_pieces
 												WHERE sp_id = $1 AND sector_number = $2
@@ -873,25 +888,19 @@ func (d *CurioStorageDealMarket) addDealOffset(ctx context.Context, piece MK20Pi
 				return false, nil
 			}
 
-			var offset abi.UnpaddedPieceSize
-
-			for _, p := range pieceList {
-				_, padLength := proofs.GetRequiredPadding(offset.Padded(), p.Size)
-				offset += padLength.Unpadded()
-				if p.Cid == piece.PieceCID && p.Size == abi.PaddedPieceSize(piece.PieceSize) {
-					n, err := tx.Exec(`UPDATE market_mk20_pipeline SET sector_offset = $1 WHERE id = $2 AND sector = $3 AND sector_offset IS NULL`, offset.Padded(), piece.ID, piece.Sector.Int64)
-					if err != nil {
-						return false, xerrors.Errorf("updating deal offset: %w", err)
-					}
-					if n != 1 {
-						return false, xerrors.Errorf("expected to update 1 deal, updated %d", n)
-					}
-					offset += p.Size.Unpadded()
-					return true, nil
-				}
-
+			offset, found := findMK20PieceOffset(pieceList, piece.PieceCID, abi.PaddedPieceSize(piece.PieceSize))
+			if !found {
+				return false, xerrors.Errorf("failed to find deal offset for piece %s", piece.PieceCID)
 			}
-			return false, xerrors.Errorf("failed to find deal offset for piece %s", piece.PieceCID)
+
+			n, err := tx.Exec(`UPDATE market_mk20_pipeline SET sector_offset = $1 WHERE id = $2 AND sector = $3 AND sector_offset IS NULL`, offset, piece.ID, piece.Sector.Int64)
+			if err != nil {
+				return false, xerrors.Errorf("updating deal offset: %w", err)
+			}
+			if n != 1 {
+				return false, xerrors.Errorf("expected to update 1 deal, updated %d", n)
+			}
+			return true, nil
 		}, harmonydb.OptionRetry())
 		if err != nil {
 			return xerrors.Errorf("failed to get deal offset: %w", err)

--- a/tasks/storage-market/mk20_offset_test.go
+++ b/tasks/storage-market/mk20_offset_test.go
@@ -1,0 +1,175 @@
+package storage_market
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	commcid "github.com/filecoin-project/go-fil-commcid"
+	"github.com/filecoin-project/go-state-types/abi"
+)
+
+func TestFindMK20PieceOffsetLayouts(t *testing.T) {
+	pieceCIDs := []string{
+		syntheticPieceCID(t, 1),
+		syntheticPieceCID(t, 2),
+		syntheticPieceCID(t, 3),
+	}
+
+	tests := []struct {
+		name    string
+		sizes   []abi.PaddedPieceSize
+		offsets []abi.PaddedPieceSize
+	}{
+		{
+			name:    "single piece",
+			sizes:   []abi.PaddedPieceSize{512},
+			offsets: []abi.PaddedPieceSize{0},
+		},
+		{
+			name:    "distinct descending sizes",
+			sizes:   []abi.PaddedPieceSize{512, 256, 128},
+			offsets: []abi.PaddedPieceSize{0, 512, 768},
+		},
+		{
+			name:    "equal sizes with distinct CIDs",
+			sizes:   []abi.PaddedPieceSize{256, 256, 256},
+			offsets: []abi.PaddedPieceSize{0, 256, 512},
+		},
+		{
+			// This deliberately exercises arithmetic alignment; it does not model
+			// the normal transfer function's piece ordering.
+			name:    "arithmetic alignment fixture",
+			sizes:   []abi.PaddedPieceSize{128, 256, 128},
+			offsets: []abi.PaddedPieceSize{0, 256, 512},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pieces := make([]mk20SectorPiece, len(test.sizes))
+			for index, size := range test.sizes {
+				pieces[index] = mk20SectorPiece{
+					CID:   pieceCIDs[index],
+					Size:  size,
+					Index: int64(index),
+				}
+			}
+			original := append([]mk20SectorPiece(nil), pieces...)
+
+			for index, piece := range pieces {
+				offset, found := findMK20PieceOffset(pieces, piece.CID, piece.Size)
+				require.True(t, found)
+				require.Equal(t, test.offsets[index], offset)
+			}
+
+			require.Equal(t, original, pieces, "offset calculation must not mutate or reorder its input")
+		})
+	}
+}
+
+func TestFindMK20PieceOffsetMatchesCIDAndSize(t *testing.T) {
+	sharedCID := syntheticPieceCID(t, 4)
+	pieces := []mk20SectorPiece{
+		{CID: sharedCID, Size: 128, Index: 0},
+		{CID: sharedCID, Size: 256, Index: 1},
+	}
+
+	offset, found := findMK20PieceOffset(pieces, sharedCID, 256)
+	require.True(t, found)
+	require.Equal(t, abi.PaddedPieceSize(256), offset)
+
+	_, found = findMK20PieceOffset(pieces, syntheticPieceCID(t, 5), 256)
+	require.False(t, found, "matching size without matching CID must not succeed")
+
+	_, found = findMK20PieceOffset(pieces, sharedCID, 512)
+	require.False(t, found, "matching CID without matching size must not succeed")
+}
+
+func TestFindMK20PieceOffsetMissingAndEmpty(t *testing.T) {
+	pieceCID := syntheticPieceCID(t, 6)
+	pieces := []mk20SectorPiece{{CID: pieceCID, Size: 128, Index: 0}}
+
+	offset, found := findMK20PieceOffset(pieces, syntheticPieceCID(t, 7), 128)
+	require.False(t, found)
+	require.Zero(t, offset, "a missing target must not be reported as a successful zero offset")
+
+	offset, found = findMK20PieceOffset(nil, pieceCID, 128)
+	require.False(t, found)
+	require.Zero(t, offset)
+}
+
+func TestAddDealOffsetUsesTestedCalculation(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	mk20File := filepath.Join(filepath.Dir(testFile), "mk20.go")
+	parsed, err := parser.ParseFile(token.NewFileSet(), mk20File, nil, 0)
+	require.NoError(t, err)
+
+	var addDealOffset *ast.FuncDecl
+	for _, declaration := range parsed.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if ok && function.Name.Name == "addDealOffset" {
+			addDealOffset = function
+			break
+		}
+	}
+	require.NotNil(t, addDealOffset)
+
+	helperCalls := 0
+	paddingCalls := 0
+	orderedPieceQuery := false
+	offsetUpdateCalls := 0
+	offsetUpdateUsesHelperResult := false
+	ast.Inspect(addDealOffset.Body, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		for _, argument := range call.Args {
+			literal, ok := argument.(*ast.BasicLit)
+			if ok && strings.Contains(literal.Value, "ORDER BY piece_index ASC") {
+				orderedPieceQuery = true
+			}
+		}
+		if function, ok := call.Fun.(*ast.Ident); ok && function.Name == "findMK20PieceOffset" {
+			helperCalls++
+		}
+		if selector, ok := call.Fun.(*ast.SelectorExpr); ok {
+			if selector.Sel.Name == "GetRequiredPadding" {
+				paddingCalls++
+			}
+			if selector.Sel.Name == "Exec" && len(call.Args) > 1 {
+				query, ok := call.Args[0].(*ast.BasicLit)
+				if ok && strings.Contains(query.Value, "SET sector_offset = $1") {
+					offsetUpdateCalls++
+					argument, ok := call.Args[1].(*ast.Ident)
+					offsetUpdateUsesHelperResult = ok && argument.Name == "offset"
+				}
+			}
+		}
+		return true
+	})
+
+	require.Equal(t, 1, helperCalls, "addDealOffset must use the tested offset calculation")
+	require.Zero(t, paddingCalls, "addDealOffset must not retain a separate padding loop")
+	require.True(t, orderedPieceQuery, "addDealOffset must preserve authoritative piece_index order")
+	require.Equal(t, 1, offsetUpdateCalls, "addDealOffset must retain one conditional offset update")
+	require.True(t, offsetUpdateUsesHelperResult, "addDealOffset must persist the tested helper result")
+}
+
+func syntheticPieceCID(t *testing.T, marker byte) string {
+	t.Helper()
+
+	pieceCID, err := commcid.PieceCommitmentV1ToCID(bytes.Repeat([]byte{marker}, 32))
+	require.NoError(t, err)
+	return pieceCID.String()
+}


### PR DESCRIPTION
## Summary

Correct MK20 sector-offset accumulation for a target preceded by other pieces. The old loop advances past a piece only inside the matching branch, immediately before returning, so preceding nonmatching pieces do not contribute to the offset. A first/single-piece fixture can mask this bug.

The production `addDealOffset` path now uses a small private calculation helper that applies existing padding, returns the matching piece's aligned start, and advances past every nonmatching predecessor. It preserves authoritative `piece_index` order, padded/unpadded units, CID-and-size matching and first-match behavior, the existing transaction/NULL-only update, and empty/not-found handling. The MK12 path is unchanged.

No retained-metadata fallback, stored-offset repair, assignment, scheduling or completion-policy change is included. This patch has no dependency on another proposed patch.

## Validation

Validated on upstream base `86e95967cd602dbf8db5ea538abe986c3968e2e3`, topic `7aa54787d6042d20d76e2b9c4100c8ef1e5c1b64`, with Go 1.26.1:

```sh
go test -p=2 -tags=cgo,fvm,nosupraseal -count=1 -timeout=3m \
  -skip '^(TestIntegration_CheckExpiry|TestIntegration_FailMK20DealBeforeSector)$' ./tasks/storage-market
go test -race -p=2 -tags=cgo,fvm,nosupraseal -count=1 -timeout=3m \
  -skip '^(TestIntegration_CheckExpiry|TestIntegration_FailMK20DealBeforeSector)$' ./tasks/storage-market
go vet -p=2 -tags=cgo,fvm,nosupraseal ./tasks/storage-market
```

All passed in a sanitized, database-free environment; the two excluded pre-existing integration tests can use fallback database settings and are unrelated to the arithmetic.

The executable production-helper tests cover first/single-piece zero; `[512,256,128]` offsets `[0,512,768]`; equal-size distinct pieces; an arithmetic alignment fixture `[128,256,128]`; CID-and-size matching; missing/empty lists; and input preservation. A source-level call-site regression protects the helper's use by `addDealOffset`.

In a throwaway negative control, removing predecessor accumulation made the later-piece assertion fail (`expected 512, actual 0`); restoring the implementation passed. This is executable arithmetic evidence, not a compilation failure or a database model. PostgreSQL/Yugabyte execution is not claimed or required to establish this pure calculation. Existing non-NULL offsets and post-GC discovery remain outside scope.
