### PR TITLE
web: expose bounded Cluster Tasks snapshots and current-attempt runtime

### DIFF
--- a/documentation/en/developer/cluster-task-monitoring.md
+++ b/documentation/en/developer/cluster-task-monitoring.md
@@ -7,7 +7,10 @@ older migrations remain unknown. No historical task rows are backfilled.
 
 `ClusterTaskSummaryLimited` provides a bounded snapshot (at most 500 rows),
 filtering before selection, running/pending counts, a database observation time,
-and nullable ages. The generic view orders each section by ownership/posting age
+and nullable ages. Owned rows display current-attempt Took, with an explicit
+awaiting-start/unknown state; Pending rows display posted-based Waiting. See
+[current-attempt monitoring](task-attempt-monitoring.md) for worker instrumentation,
+mixed-version compatibility and failure behavior. The generic view orders each section by ownership/posting age
 then task ID, without a task-type priority policy. Pending rows can use whatever
 capacity remains after running rows. Controls can reduce that preview to zero.
 The row bound is not a bound on database scan cost.
@@ -28,5 +31,6 @@ unknown ages and filter-mismatch notices survive ordinary refreshes. Site-specif
 task priorities and shorter preview defaults are not part of this generic policy.
 
 Database-free Go and JavaScript tests exercise response orchestration, null-time
-provenance, provider batching, request lifecycle and display clocks. SQL-shape
+provenance, provider batching, request lifecycle and display clocks. Opt-in SQL
+tests execute the actual snapshot query and migration/attempt adapters. SQL-shape
 assertions are not PostgreSQL/Yugabyte execution or browser layout validation.

--- a/documentation/en/developer/cluster-task-monitoring.md
+++ b/documentation/en/developer/cluster-task-monitoring.md
@@ -1,0 +1,32 @@
+# Cluster task monitoring
+
+`ClusterTaskSummary` retains its legacy response fields and update-time-based
+`SincePosted` meaning. Its additive ownership age is not execution runtime.
+The ownership timestamp has explicit claim provenance; timestamps inherited from
+older migrations remain unknown. No historical task rows are backfilled.
+
+`ClusterTaskSummaryLimited` provides a bounded snapshot (at most 500 rows),
+filtering before selection, running/pending counts, a database observation time,
+and nullable ages. The generic view orders each section by ownership/posting age
+then task ID, without a task-type priority policy. Pending rows can use whatever
+capacity remains after running rows. Controls can reduce that preview to zero.
+The row bound is not a bound on database scan cost.
+
+Provider enrichment is batched by task type, and the additive `SpIDs`/`Miners`
+arrays preserve all distinct providers. Legacy singular fields are retained;
+they are only one representative when a task spans several providers. Failed
+enrichment is partial metadata, not failure of the successfully observed tasks.
+
+The view polls five seconds after request settlement, cancels hidden/disconnected
+requests, and rejects obsolete responses. A single monotonic display clock may
+estimate ages between confirmed snapshots. Pause, failure, and hidden views
+freeze those estimates; resume requires a successful fresh response before
+interpolation restarts. Server values can decrease on a new observation.
+
+Grouping is consecutive and preserves server order. Controls, retained snapshots,
+unknown ages and filter-mismatch notices survive ordinary refreshes. Site-specific
+task priorities and shorter preview defaults are not part of this generic policy.
+
+Database-free Go and JavaScript tests exercise response orchestration, null-time
+provenance, provider batching, request lifecycle and display clocks. SQL-shape
+assertions are not PostgreSQL/Yugabyte execution or browser layout validation.

--- a/documentation/en/developer/task-attempt-monitoring.md
+++ b/documentation/en/developer/task-attempt-monitoring.md
@@ -1,0 +1,82 @@
+# Current-attempt task monitoring
+
+Cluster Tasks separates owned work from a bounded Pending preview. Owned rows
+display **Took**, measured from the current task's `Do` entry; Pending rows retain
+posted-based **Waiting**. Ownership alone is not proof of execution: a prepared
+or newly claimed task displays `awaiting-start` and a dash. Missing provenance or
+a future timestamp displays unknown. Existing API ownership-age fields and old
+History records are unchanged.
+
+The runner creates a fresh task/owner/attempt identity after acceptance and
+ownership acquisition, before storage acquisition. This includes same-owner
+recovery. Immediately before `Do`, it captures the worker clock once and shares
+that instant with the asynchronous live timestamp write and the new History
+record. This measures the task body, not native FFI/kernel execution. The earlier
+run-registry timestamp still governs preemption. Pre-entry failures do not claim
+that a task body ran.
+
+## Execution and database effects
+
+Preparation and failure-release each have one five-second batch budget. A failed
+preparation is **not dispatched**: the existing task/owner CAS releases ownership
+for later scheduling. This is a real scheduler readiness change, including for
+time-sensitive tasks, not a claim of zero execution-path overhead. The engine's
+resource/acceptance/early-skip checks still run first; no storage is held while
+preparing. A database outage may delay admission or leave ownership for recovery
+if its bounded release also fails. It never fabricates a successful task.
+
+The start writer requires the exact task, owner and attempt token, a NULL start,
+and prepared provenance. A delayed prior attempt cannot replace a newer start.
+It has a five-second context and is canceled and joined when `Do` returns or
+panics. A panic inside the asynchronous writer is contained and logged separately
+instead of escaping the task runner's panic boundary. Timestamp write failure
+leaves live timing unconfirmed, but does not
+change the task's execution result. Per accepted task, telemetry adds one
+preparation UPDATE, one asynchronous conditional start UPDATE and one bounded
+writer goroutine. A short task may finish before its timestamp persists; History
+still uses its captured entry. There is no new scheduler, timer RPC or global lock.
+
+The exact existing migrations `20260909-task-ownership-age.sql` and
+`20260909-task-attempt-start.sql` are reused without renaming, backfill or a second
+writer/trigger. The latter adds nullable fields and clears them on ownership
+change/release. Reapplication preserves existing starts and one trigger. Upgrading
+an already instrumented schema does not reinterpret timestamps. Downgrading to
+older workers leaves the additive columns unused; there is no destructive SQL
+rollback or historical rewrite. Mixed-version old workers do not report Do entry;
+in particular an old same-owner recovery without an ownership write cannot be
+recognized as a new attempt. Roll out compatible workers before relying on timing.
+
+Worker/database clocks must be synchronized. Future starts are rejected, but a
+past clock skew cannot be detected from these fields. A server snapshot anchors
+monotonic local interpolation; pause, hidden/disconnected views or refresh failure
+freeze that estimate. A new snapshot/attempt may reduce Took. Display ticks neither
+reorder rows nor issue per-second RPCs. Both duration columns use text-start
+alignment. Neutral generic defaults remain a 500-row maximum, 500 pending preview
+limit and consecutive coalescing enabled; presentation preferences are not worker
+scheduling priority.
+
+## Verification
+
+Database-free tests exercise the actual preparation/entry helpers, scheduler
+prepare-failure boundary, writer cancellation/join, response conversion and UI
+clock/polling logic. SQL tests use the production HarmonyDB adapter and snapshot
+source, plus the actual migration files, under the `integration` build tag:
+
+```sh
+go test -tags=cgo,fvm,nosupraseal,integration -count=1 -timeout=2m \
+  ./harmony/harmonytask ./web/api/webrpc \
+  -run 'TestTaskAttemptSQL|TestClusterTaskSnapshotSQL'
+```
+
+They require `CURIO_TASK_ATTEMPT_ITEST=1` and dedicated suffixes `_HOST`, `_PORT`,
+`_DATABASE`, `_USER`, optionally `_PASSWORD`. HOST must be a literal loopback IP;
+ordinary Curio/libpq defaults are not accepted. Each test owns a random schema.
+The SQL tests cover fresh/upgrade migration, stale identities, same-owner recovery,
+reassignment, existing starts, FK ownership release, rollback, actual Do entry and
+bounded snapshot rows including NULL provenance. Sequential independent-handle
+stale-writer checks prove conditional row effects, not simultaneous lock contention.
+The bounded query's counts can examine more rows than its returned-row limit.
+
+Current disposable PostgreSQL execution and browser evidence belong to the review
+validation report. Yugabyte execution is separate evidence; compilation or static
+SQL checks are never equivalent to an executed database test.

--- a/harmony/harmonydb/sql/20260909-task-attempt-start.sql
+++ b/harmony/harmonydb/sql/20260909-task-attempt-start.sql
@@ -1,0 +1,29 @@
+ALTER TABLE harmony_task ADD COLUMN IF NOT EXISTS attempt_started_at TIMESTAMPTZ;
+ALTER TABLE harmony_task ADD COLUMN IF NOT EXISTS attempt_id TEXT;
+ALTER TABLE harmony_task ADD COLUMN IF NOT EXISTS attempt_start_source TEXT;
+
+COMMENT ON COLUMN harmony_task.attempt_started_at IS 'Current Do-entry timestamp shared with new History records; NULL when not confirmed. Never backfilled.';
+
+CREATE OR REPLACE FUNCTION harmony_task_clear_attempt_start()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        NEW.attempt_started_at := NULL;
+        NEW.attempt_id := NULL;
+        NEW.attempt_start_source := 'claimed';
+    ELSIF NEW.owner_id IS NULL OR NEW.owner_id IS DISTINCT FROM OLD.owner_id THEN
+        NEW.attempt_started_at := NULL;
+        NEW.attempt_id := NULL;
+        NEW.attempt_start_source := 'claimed';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS harmony_task_clear_attempt_start_trigger ON harmony_task;
+CREATE TRIGGER harmony_task_clear_attempt_start_trigger
+    BEFORE INSERT OR UPDATE OF owner_id ON harmony_task
+    FOR EACH ROW EXECUTE FUNCTION harmony_task_clear_attempt_start();
+
+-- No historical row or timestamp is backfilled. A new same-owner recovery gets
+-- a fresh identity from the runner before any new Do invocation.

--- a/harmony/harmonydb/sql/20260909-task-ownership-age.sql
+++ b/harmony/harmonydb/sql/20260909-task-ownership-age.sql
@@ -1,0 +1,30 @@
+ALTER TABLE harmony_task ADD COLUMN IF NOT EXISTS work_start TIMESTAMPTZ;
+ALTER TABLE harmony_task ADD COLUMN IF NOT EXISTS work_start_source TEXT;
+
+COMMENT ON COLUMN harmony_task.work_start IS 'Current ownership timestamp, not task execution start; trusted only with work_start_source.';
+COMMENT ON COLUMN harmony_task.work_start_source IS 'claim for newly observed ownership; NULL means unknown legacy/migration provenance.';
+
+CREATE OR REPLACE FUNCTION harmony_task_sync_work_start()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.owner_id IS NULL THEN
+        NEW.work_start := NULL;
+        NEW.work_start_source := NULL;
+    ELSIF TG_OP = 'INSERT' THEN
+        NEW.work_start := CURRENT_TIMESTAMP;
+        NEW.work_start_source := 'claim';
+    ELSIF NEW.owner_id IS DISTINCT FROM OLD.owner_id THEN
+        NEW.work_start := CURRENT_TIMESTAMP;
+        NEW.work_start_source := 'claim';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS harmony_task_sync_work_start_trigger ON harmony_task;
+CREATE TRIGGER harmony_task_sync_work_start_trigger
+    BEFORE INSERT OR UPDATE OF owner_id ON harmony_task
+    FOR EACH ROW EXECUTE FUNCTION harmony_task_sync_work_start();
+
+-- Existing ownership timestamps may have been backfilled or recorded by older
+-- binaries. Do not invent provenance or rewrite existing task/history rows.

--- a/harmony/harmonytask/attempt_start.go
+++ b/harmony/harmonytask/attempt_start.go
@@ -1,0 +1,115 @@
+package harmonytask
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+)
+
+const PREPARE_TASK_ATTEMPT = `UPDATE harmony_task
+SET attempt_id=$1, attempt_started_at=NULL, attempt_start_source='prepared'
+WHERE id=$2 AND owner_id=$3`
+
+const RECORD_TASK_ATTEMPT_START = `UPDATE harmony_task
+SET attempt_started_at=$1, attempt_start_source='do_entry'
+WHERE id=$2 AND owner_id=$3 AND attempt_id=$4
+  AND attempt_started_at IS NULL AND attempt_start_source='prepared'`
+
+type taskAttemptStore interface {
+	prepare(context.Context, TaskID, string) error
+	record(context.Context, TaskID, string, time.Time) (bool, error)
+	releaseUnstarted(context.Context, TaskID) error
+}
+
+type harmonyTaskAttemptStore struct {
+	db    *harmonydb.DB
+	owner int
+}
+
+func (s harmonyTaskAttemptStore) prepare(ctx context.Context, id TaskID, token string) error {
+	n, err := s.db.Exec(ctx, PREPARE_TASK_ATTEMPT, token, id, s.owner)
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return fmt.Errorf("attempt preparation affected %d task rows", n)
+	}
+	return nil
+}
+
+func (s harmonyTaskAttemptStore) record(ctx context.Context, id TaskID, token string, start time.Time) (bool, error) {
+	n, err := s.db.Exec(ctx, RECORD_TASK_ATTEMPT_START, start.UTC(), id, s.owner, token)
+	return n == 1, err
+}
+
+func (s harmonyTaskAttemptStore) releaseUnstarted(ctx context.Context, id TaskID) error {
+	_, err := s.db.Exec(ctx, `UPDATE harmony_task SET owner_id=NULL WHERE id=$1 AND owner_id=$2`, id, s.owner)
+	return err
+}
+
+func prepareTaskAttempts(ctx context.Context, store taskAttemptStore, ids []TaskID) ([]TaskID, map[TaskID]string) {
+	prepareCtx, stopPrepare := context.WithTimeout(ctx, 5*time.Second)
+	defer stopPrepare()
+	prepared := make([]TaskID, 0, len(ids))
+	tokens := make(map[TaskID]string, len(ids))
+	failed := make([]TaskID, 0)
+	for _, id := range ids {
+		token := uuid.NewString()
+		if err := store.prepare(prepareCtx, id, token); err != nil {
+			log.Errorw("Could not prepare task attempt telemetry", "id", id, "error", err)
+			failed = append(failed, id)
+			continue
+		}
+		prepared = append(prepared, id)
+		tokens[id] = token
+	}
+	// A single bounded release budget remains usable even if preparation timed
+	// out. This uses the existing ownership CAS, never task deletion.
+	releaseCtx, stopRelease := context.WithTimeout(context.Background(), 5*time.Second)
+	defer stopRelease()
+	for _, id := range failed {
+		if err := store.releaseUnstarted(releaseCtx, id); err != nil {
+			log.Errorw("Could not release unstarted task", "id", id, "error", err)
+		}
+	}
+	return prepared, tokens
+}
+
+// runWithAttemptStart has one final entry gate. The optional hook commits a
+// start reservation; after it succeeds there is no second cancellation exit
+// before Do. Timestamp persistence runs concurrently so DB latency is not
+// counted as pre-execution time. The bounded writer is joined even on panic.
+func runWithAttemptStart(ctx context.Context, store taskAttemptStore, id TaskID, token string,
+	beforeStart func(context.Context) error, now func() time.Time, onStart func(time.Time), do func() (bool, error),
+) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if beforeStart != nil {
+		if err := beforeStart(ctx); err != nil {
+			return false, err
+		}
+	}
+	started := now()
+	onStart(started)
+	writeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		defer func() {
+			if failure := recover(); failure != nil {
+				log.Errorw("Task execution start writer panicked; telemetry is unconfirmed", "id", id, "panic", failure)
+			}
+		}()
+		ok, err := store.record(writeCtx, id, token, started)
+		if err != nil || !ok {
+			log.Warnw("Task execution start is unconfirmed", "id", id, "recorded", ok, "error", err)
+		}
+	}()
+	defer func() { cancel(); <-finished }()
+	return do()
+}

--- a/harmony/harmonytask/attempt_start_integration_test.go
+++ b/harmony/harmonytask/attempt_start_integration_test.go
@@ -1,0 +1,194 @@
+//go:build integration && !skiff
+
+package harmonytask
+
+import (
+	"context"
+	"database/sql"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yugabyte/pgx/v5"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+)
+
+// No regular Curio/libpq defaults are used. Each invocation owns one fresh
+// HarmonyDB test namespace and only drops that namespace during cleanup.
+func attemptSQLFixture(t *testing.T) (context.Context, *harmonydb.DB, *harmonydb.DB, *pgx.Conn) {
+	t.Helper()
+	if os.Getenv("CURIO_TASK_ATTEMPT_ITEST") != "1" {
+		t.Skip("requires explicit CURIO_TASK_ATTEMPT_ITEST=1 and a disposable loopback target")
+	}
+	const prefix = "CURIO_TASK_ATTEMPT_ITEST_"
+	host, port := os.Getenv(prefix+"HOST"), os.Getenv(prefix+"PORT")
+	address := net.ParseIP(host)
+	require.True(t, address != nil && address.IsLoopback(), "HOST must be a literal loopback IP")
+	n, err := strconv.ParseUint(port, 10, 16)
+	require.NoError(t, err)
+	require.NotZero(t, n)
+	database, user := os.Getenv(prefix+"DATABASE"), os.Getenv(prefix+"USER")
+	require.NotEmpty(t, strings.TrimSpace(database))
+	require.NotEmpty(t, strings.TrimSpace(user))
+	opts := harmonydb.ItestOptions{Hosts: []string{host}, Port: port, Database: database,
+		Username: user, Password: os.Getenv(prefix + "PASSWORD"), ITestID: harmonydb.ITestNewID()}
+	cfg := opts.HarmonyConfig()
+	cfg.ReadOnly, cfg.LoadBalance = true, false
+	cfg.ApplicationName = "curio-attempt-itest"
+	first, err := harmonydb.NewFromConfig(cfg)
+	require.NoError(t, err)
+	t.Cleanup(first.ITestDeleteAll)
+	second, err := harmonydb.NewFromConfig(cfg)
+	require.NoError(t, err)
+	t.Cleanup(second.ITestDeleteAll)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	pcfg, err := pgx.ParseConfig("postgresql://placeholder@127.0.0.1/placeholder?sslmode=disable&load_balance=false")
+	require.NoError(t, err)
+	pcfg.Host, pcfg.Port, pcfg.Database, pcfg.User, pcfg.Password = host, uint16(n), database, user, opts.Password
+	pcfg.Fallbacks, pcfg.ConnectTimeout = nil, 5*time.Second
+	pcfg.RuntimeParams = map[string]string{"search_path": "itest_" + string(opts.ITestID), "statement_timeout": "5000", "lock_timeout": "2000"}
+	conn, err := pgx.ConnectConfig(ctx, pcfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		closeCtx, stop := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stop()
+		require.NoError(t, conn.Close(closeCtx))
+	})
+	applyAttemptMigration(t, ctx, conn, "20230719-harmony.sql")
+	_, err = first.Exec(ctx, `INSERT INTO harmony_machines (id,host_and_port,cpu,ram,gpu) VALUES (101,'worker-a.example:12300',8,1024,0),(102,'worker-b.example:12300',8,1024,0)`)
+	require.NoError(t, err)
+	var version, isolation string
+	require.NoError(t, conn.QueryRow(ctx, `SELECT version()`).Scan(&version))
+	require.NoError(t, conn.QueryRow(ctx, `SHOW transaction_isolation`).Scan(&isolation))
+	t.Logf("database=%s requested isolation=driver default; SQL transaction_isolation=%s; Yugabyte effective isolation=UNVERIFIED", version, isolation)
+	return ctx, first, second, conn
+}
+
+func applyAttemptMigration(t *testing.T, ctx context.Context, conn *pgx.Conn, name string) {
+	t.Helper()
+	_, source, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	contents, err := os.ReadFile(filepath.Join(filepath.Dir(source), "..", "harmonydb", "sql", name))
+	require.NoError(t, err)
+	_, err = conn.Exec(ctx, string(contents))
+	require.NoError(t, err)
+}
+
+func TestTaskAttemptSQLMigrationAndIdentity(t *testing.T) {
+	ctx, db, other, conn := attemptSQLFixture(t)
+	_, err := db.Exec(ctx, `INSERT INTO harmony_task (id,posted_time,owner_id,added_by,name) VALUES (1,CURRENT_TIMESTAMP-INTERVAL '3 hours',101,101,'Synthetic'),(2,CURRENT_TIMESTAMP,NULL,101,'Synthetic')`)
+	require.NoError(t, err)
+	applyAttemptMigration(t, ctx, conn, "20260909-task-ownership-age.sql")
+	applyAttemptMigration(t, ctx, conn, "20260909-task-attempt-start.sql")
+	var start sql.NullTime
+	var token, source sql.NullString
+	read := func(id int) {
+		t.Helper()
+		require.NoError(t, db.QueryRow(ctx, `SELECT attempt_started_at,attempt_id,attempt_start_source FROM harmony_task WHERE id=$1`, id).Scan(&start, &token, &source))
+	}
+	read(1)
+	require.False(t, start.Valid || token.Valid || source.Valid, "upgrade must not backfill execution provenance")
+	first := harmonyTaskAttemptStore{db: db, owner: 101}
+	delayed := harmonyTaskAttemptStore{db: other, owner: 101}
+	ids, tokens := prepareTaskAttempts(ctx, first, []TaskID{1})
+	require.Equal(t, []TaskID{1}, ids)
+	old := tokens[1]
+	entry := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	ok, err := first.record(ctx, 1, old, entry)
+	require.NoError(t, err)
+	require.True(t, ok)
+	read(1)
+	require.True(t, start.Time.Equal(entry))
+	require.Equal(t, "do_entry", source.String)
+	// Reapplying the exact migration models the existing personal schema upgrade.
+	applyAttemptMigration(t, ctx, conn, "20260909-task-attempt-start.sql")
+	read(1)
+	require.True(t, start.Time.Equal(entry))
+	var triggerCount int
+	require.NoError(t, conn.QueryRow(ctx, `SELECT count(*) FROM pg_trigger WHERE tgrelid='harmony_task'::regclass AND tgname='harmony_task_clear_attempt_start_trigger'`).Scan(&triggerCount))
+	require.Equal(t, 1, triggerCount)
+	_, next := prepareTaskAttempts(ctx, first, []TaskID{1})
+	require.NotEqual(t, old, next[1], "same-owner recovery must replace attempt identity")
+	ok, err = delayed.record(ctx, 1, old, entry)
+	require.NoError(t, err)
+	require.False(t, ok, "independent delayed writer must not populate the next attempt")
+	read(1)
+	require.False(t, start.Valid)
+	require.Equal(t, "prepared", source.String)
+	ok, err = first.record(ctx, 1, next[1], entry.Add(time.Minute))
+	require.NoError(t, err)
+	require.True(t, ok)
+	ok, err = delayed.record(ctx, 1, next[1], entry)
+	require.NoError(t, err)
+	require.False(t, ok, "already populated starts are immutable")
+	_, err = db.Exec(ctx, `UPDATE harmony_task SET owner_id=102 WHERE id=1`)
+	require.NoError(t, err)
+	read(1)
+	require.False(t, start.Valid || token.Valid)
+	require.Equal(t, "claimed", source.String)
+	require.Error(t, first.prepare(ctx, 1, "stale-owner"))
+	ok, err = delayed.record(ctx, 1, next[1], entry)
+	require.NoError(t, err)
+	require.False(t, ok)
+	read(2)
+	require.False(t, start.Valid || token.Valid, "unrelated pending row changed")
+	_, err = db.Exec(ctx, `INSERT INTO harmony_task (id,posted_time,owner_id,added_by,name,attempt_id,attempt_started_at,attempt_start_source) VALUES (3,CURRENT_TIMESTAMP,101,101,'Synthetic','invented',CURRENT_TIMESTAMP,'do_entry')`)
+	require.NoError(t, err)
+	read(3)
+	require.False(t, start.Valid || token.Valid, "fresh inserts cannot invent an executed attempt")
+	require.Equal(t, "claimed", source.String)
+	_, err = db.Exec(ctx, `DELETE FROM harmony_machines WHERE id=102`)
+	require.NoError(t, err)
+	read(1)
+	require.False(t, start.Valid || token.Valid, "FK ownership release must clear telemetry")
+}
+
+func TestTaskAttemptSQLDoEntryAndRollback(t *testing.T) {
+	ctx, db, _, conn := attemptSQLFixture(t)
+	applyAttemptMigration(t, ctx, conn, "20260909-task-ownership-age.sql")
+	applyAttemptMigration(t, ctx, conn, "20260909-task-attempt-start.sql")
+	_, err := db.Exec(ctx, `INSERT INTO harmony_task (id,posted_time,owner_id,added_by,name) VALUES (1,CURRENT_TIMESTAMP-INTERVAL '3 hours',101,101,'Synthetic')`)
+	require.NoError(t, err)
+	store := harmonyTaskAttemptStore{db: db, owner: 101}
+	_, tokens := prepareTaskAttempts(ctx, store, []TaskID{1})
+	entry := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	var history time.Time
+	done, err := runWithAttemptStart(ctx, store, 1, tokens[1], nil, func() time.Time { return entry }, func(start time.Time) { history = start }, func() (bool, error) {
+		// Observe the actual asynchronous adapter write before completing the
+		// synthetic body. This is bounded polling, not contention evidence.
+		for {
+			var recorded sql.NullTime
+			if err := db.QueryRow(ctx, `SELECT attempt_started_at FROM harmony_task WHERE id=1`).Scan(&recorded); err != nil {
+				return false, err
+			}
+			if recorded.Valid {
+				return recorded.Time.Equal(entry), nil
+			}
+			select {
+			case <-ctx.Done():
+				return false, ctx.Err()
+			case <-time.After(time.Millisecond):
+			}
+		}
+	})
+	require.NoError(t, err)
+	require.True(t, done)
+	require.True(t, history.Equal(entry), "live and new History starts must share the same instant")
+	committed, err := db.BeginTransaction(ctx, func(tx *harmonydb.Tx) (bool, error) {
+		_, err := tx.Exec(PREPARE_TASK_ATTEMPT, "rolled-back", 1, 101)
+		return false, err
+	})
+	require.NoError(t, err)
+	require.False(t, committed)
+	var stored string
+	require.NoError(t, db.QueryRow(ctx, `SELECT attempt_id FROM harmony_task WHERE id=1`).Scan(&stored))
+	require.Equal(t, tokens[1], stored)
+}

--- a/harmony/harmonytask/attempt_start_test.go
+++ b/harmony/harmonytask/attempt_start_test.go
@@ -1,0 +1,262 @@
+package harmonytask
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/curio/harmony/harmonytask/internal/acceptcache"
+	"github.com/filecoin-project/curio/harmony/harmonytask/internal/runregistry"
+	"github.com/filecoin-project/curio/harmony/resources"
+	"github.com/filecoin-project/curio/harmony/taskhelp"
+)
+
+type memoryAttemptStore struct {
+	mu           sync.Mutex
+	tokens       map[TaskID]string
+	starts       map[TaskID]time.Time
+	released     []TaskID
+	prepareErr   error
+	recordErr    error
+	recordCalled chan struct{}
+	blockWriter  bool
+	panicWriter  bool
+	writerExited chan struct{}
+}
+
+func newMemoryAttemptStore() *memoryAttemptStore {
+	return &memoryAttemptStore{tokens: map[TaskID]string{}, starts: map[TaskID]time.Time{}, recordCalled: make(chan struct{}, 1), writerExited: make(chan struct{}, 1)}
+}
+func (s *memoryAttemptStore) prepare(ctx context.Context, id TaskID, token string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if s.prepareErr != nil {
+		return s.prepareErr
+	}
+	s.tokens[id] = token
+	delete(s.starts, id)
+	return nil
+}
+func (s *memoryAttemptStore) record(ctx context.Context, id TaskID, token string, start time.Time) (bool, error) {
+	defer func() { s.writerExited <- struct{}{} }()
+	if s.panicWriter {
+		panic("synthetic writer panic")
+	}
+	if s.blockWriter {
+		s.recordCalled <- struct{}{}
+		<-ctx.Done()
+		return false, ctx.Err()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer func() { s.recordCalled <- struct{}{} }()
+	if s.recordErr != nil {
+		return false, s.recordErr
+	}
+	if s.tokens[id] != token || !s.starts[id].IsZero() {
+		return false, nil
+	}
+	s.starts[id] = start
+	return true, nil
+}
+func (s *memoryAttemptStore) releaseUnstarted(_ context.Context, id TaskID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.released = append(s.released, id)
+	delete(s.tokens, id)
+	delete(s.starts, id)
+	return nil
+}
+
+func TestAttemptPreparationIsFreshOnSameOwnerRecovery(t *testing.T) {
+	s := newMemoryAttemptStore()
+	ids, first := prepareTaskAttempts(context.Background(), s, []TaskID{1})
+	if len(ids) != 1 || first[1] == "" {
+		t.Fatalf("first=%v", first)
+	}
+	s.starts[1] = time.Unix(10, 0)
+	_, second := prepareTaskAttempts(context.Background(), s, []TaskID{1})
+	if first[1] == second[1] || !s.starts[1].IsZero() {
+		t.Fatal("recovery retained the prior attempt")
+	}
+	if ok, err := s.record(context.Background(), 1, first[1], time.Unix(20, 0)); err != nil || ok {
+		t.Fatalf("stale token record=%v %v", ok, err)
+	}
+}
+
+func TestAttemptPreparationFailureReleasesWithoutStart(t *testing.T) {
+	for _, cancelled := range []bool{false, true} {
+		s := newMemoryAttemptStore()
+		ctx, cancel := context.WithCancel(context.Background())
+		if cancelled {
+			cancel()
+		} else {
+			s.prepareErr = errors.New("synthetic unavailable")
+		}
+		ids, tokens := prepareTaskAttempts(ctx, s, []TaskID{1, 2})
+		cancel()
+		if len(ids) != 0 || len(tokens) != 0 || len(s.released) != 2 || len(s.starts) != 0 {
+			t.Fatalf("ids=%v tokens=%v released=%v starts=%v", ids, tokens, s.released, s.starts)
+		}
+	}
+}
+
+func TestAttemptPreparationFailureDoesNotDispatchFromScheduler(t *testing.T) {
+	for _, source := range []string{workSourcePoller, workSourceRecover, workSourcePreempt} {
+		t.Run(source, func(t *testing.T) {
+			store := newMemoryAttemptStore()
+			store.prepareErr = errors.New("synthetic preparation failure")
+			h := &taskTypeHandler{
+				TaskInterface:   &stubAcceptTask{},
+				TaskTypeDetails: TaskTypeDetails{Name: "Synthetic", Max: taskhelp.Max(2), Cost: resources.Resources{Cpu: 1}},
+				TaskEngine:      &TaskEngine{cfg: taskEngineConfig{ctx: context.Background(), reg: &resources.Reg{Resources: resources.Resources{Cpu: 2}}}},
+				running:         runregistry.New(), accept: acceptcache.New(time.Hour), storageFailures: map[TaskID]time.Time{},
+			}
+			accepted := h.considerWorkWithOwnership(source, []task{{ID: 1}}, eventEmitter{},
+				func(ids []TaskID, _ int) ([]TaskID, error) { return ids, nil },
+				func([]TaskID) error { t.Fatal("unexpected storage ownership release"); return nil }, store)
+			if accepted || h.Max.Active() != 0 || len(store.released) != 1 || len(store.starts) != 0 {
+				t.Fatalf("accepted=%v active=%d released=%v starts=%v", accepted, h.Max.Active(), store.released, store.starts)
+			}
+		})
+	}
+}
+
+func TestAttemptStartUsesDoEntryForLiveAndHistory(t *testing.T) {
+	s := newMemoryAttemptStore()
+	_, tokens := prepareTaskAttempts(context.Background(), s, []TaskID{1})
+	claimed := time.Unix(100, 0)
+	entry := claimed.Add(10 * time.Minute)
+	historyStart := claimed
+	done, err := runWithAttemptStart(context.Background(), s, 1, tokens[1], nil, func() time.Time { return entry }, func(start time.Time) { historyStart = start }, func() (bool, error) {
+		if !historyStart.Equal(entry) {
+			t.Fatal("History still uses pre-entry start")
+		}
+		select {
+		case <-s.recordCalled:
+		case <-time.After(time.Second):
+			t.Fatal("writer not called")
+		}
+		return true, nil
+	})
+	if err != nil || !done || !s.starts[1].Equal(entry) || !historyStart.Equal(entry) {
+		t.Fatalf("done=%v err=%v live=%v history=%v", done, err, s.starts[1], historyStart)
+	}
+}
+
+func TestAttemptStartCancellationAndReservationFailure(t *testing.T) {
+	for _, cancelled := range []bool{true, false} {
+		s := newMemoryAttemptStore()
+		ctx, cancel := context.WithCancel(context.Background())
+		if cancelled {
+			cancel()
+		}
+		calls := 0
+		_, err := runWithAttemptStart(ctx, s, 1, "token", func(context.Context) error { return errors.New("reservation failed") }, time.Now, func(time.Time) { calls++ }, func() (bool, error) { calls++; return true, nil })
+		cancel()
+		if err == nil || calls != 0 {
+			t.Fatalf("err=%v calls=%d", err, calls)
+		}
+		select {
+		case <-s.recordCalled:
+			t.Fatal("unstarted attempt written")
+		default:
+		}
+	}
+}
+
+func TestAttemptStartHasNoCancellationGapAfterReservation(t *testing.T) {
+	s := newMemoryAttemptStore()
+	_, tokens := prepareTaskAttempts(context.Background(), s, []TaskID{1})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	entered := false
+	done, err := runWithAttemptStart(ctx, s, 1, tokens[1], func(context.Context) error { cancel(); return nil }, time.Now, func(time.Time) {}, func() (bool, error) { entered = true; return true, nil })
+	if !done || err != nil || !entered {
+		t.Fatalf("committed reservation did not enter Do: %v %v", done, err)
+	}
+}
+
+func TestAttemptExecutionFailureDoesNotEraseStart(t *testing.T) {
+	s := newMemoryAttemptStore()
+	_, tokens := prepareTaskAttempts(context.Background(), s, []TaskID{1})
+	entry := time.Unix(100, 0)
+	_, err := runWithAttemptStart(context.Background(), s, 1, tokens[1], nil, func() time.Time { return entry }, func(time.Time) {}, func() (bool, error) { <-s.recordCalled; return false, errors.New("task failed") })
+	if err == nil || !s.starts[1].Equal(entry) {
+		t.Fatalf("failed attempt lost start: %v %v", s.starts, err)
+	}
+}
+
+func TestAttemptTelemetryErrorDoesNotFabricateSuccess(t *testing.T) {
+	s := newMemoryAttemptStore()
+	s.recordErr = errors.New("synthetic write failure")
+	_, tokens := prepareTaskAttempts(context.Background(), s, []TaskID{1})
+	done, err := runWithAttemptStart(context.Background(), s, 1, tokens[1], nil, time.Now, func(time.Time) {}, func() (bool, error) { <-s.recordCalled; return true, nil })
+	if !done || err != nil || len(s.starts) != 0 {
+		t.Fatalf("execution=%v %v telemetry=%v", done, err, s.starts)
+	}
+}
+
+func TestAttemptWriterJoinedOnPanic(t *testing.T) {
+	s := newMemoryAttemptStore()
+	s.blockWriter = true
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		defer func() { _ = recover() }()
+		_, _ = runWithAttemptStart(context.Background(), s, 1, "token", nil, time.Now, func(time.Time) {}, func() (bool, error) { <-s.recordCalled; panic("synthetic panic") })
+	}()
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("writer not canceled/joined")
+	}
+	select {
+	case <-s.writerExited:
+	default:
+		t.Fatal("participant survived wrapper")
+	}
+}
+
+func TestAttemptWriterPanicDoesNotEscapeTelemetry(t *testing.T) {
+	s := newMemoryAttemptStore()
+	s.panicWriter = true
+	done, err := runWithAttemptStart(context.Background(), s, 1, "token", nil, time.Now, func(time.Time) {}, func() (bool, error) {
+		select {
+		case <-s.writerExited:
+		case <-time.After(time.Second):
+			t.Fatal("writer did not exit")
+		}
+		return true, nil
+	})
+	if !done || err != nil || len(s.starts) != 0 {
+		t.Fatalf("execution=%v %v telemetry=%v", done, err, s.starts)
+	}
+}
+
+func TestAttemptProductionCallSiteAndSQLGuard(t *testing.T) {
+	data, err := os.ReadFile("task_type_handler.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(data)
+	prepare, storage, entry := strings.Index(source, "prepareTaskAttempts("), strings.Index(source, "h.Cost.Claim("), strings.Index(source, "runWithAttemptStart(")
+	if prepare < 0 || prepare >= storage || storage >= entry || !strings.Contains(source, "workStart = start") {
+		t.Fatal("production does not use the checked attempt boundary")
+	}
+	for _, s := range []string{"owner_id=$3", "attempt_id=$4", "attempt_started_at IS NULL", "attempt_start_source='prepared'"} {
+		if !strings.Contains(RECORD_TASK_ATTEMPT_START, s) {
+			t.Fatalf("missing CAS %s", s)
+		}
+	}
+	if strings.Contains(PREPARE_TASK_ATTEMPT, "work_start=") {
+		t.Fatal("ownership/history semantics conflated")
+	}
+}

--- a/harmony/harmonytask/task_spid.go
+++ b/harmony/harmonytask/task_spid.go
@@ -1,0 +1,7 @@
+package harmonytask
+
+// TaskSPID associates one task with a provider; a task may have several.
+type TaskSPID struct {
+	TaskID int64 `db:"task_id"`
+	SPID   int64 `db:"sp_id"`
+}

--- a/harmony/harmonytask/task_type_handler.go
+++ b/harmony/harmonytask/task_type_handler.go
@@ -99,6 +99,17 @@ const (
 // availability, but that's safe — resources can only increase, never
 // invalidating a "fits" decision made moments earlier.
 func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter eventEmitter) (workAccepted bool) {
+	return h.considerWorkWithOwnership(from, tasks, eventEmitter, h.claimTaskOwnership, h.releaseTaskOwnership)
+}
+
+// The ownership callbacks keep failure paths testable without changing the
+// production SQL or requiring a live database for admission lifecycle tests.
+func (h *taskTypeHandler) considerWorkWithOwnership(from string, tasks []task, eventEmitter eventEmitter,
+	claim func([]TaskID, int) ([]TaskID, error), release func([]TaskID) error, attemptStores ...taskAttemptStore) (workAccepted bool) {
+	var attemptStore taskAttemptStore
+	if len(attemptStores) > 0 {
+		attemptStore = attemptStores[0]
+	}
 	if len(tasks) == 0 {
 		return true
 	}
@@ -161,23 +172,7 @@ func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter e
 	tIDs = reorderTaskIDsByPostedOrder(tasks, tIDs)
 
 	if from != workSourceRecover {
-		var tasksAccepted []TaskID
-		err := h.TaskEngine.cfg.db.Select(h.TaskEngine.cfg.ctx, &tasksAccepted, `
-		WITH candidates AS (
-			SELECT t.id
-			FROM harmony_task t
-			JOIN unnest($2::bigint[]) AS x(id) ON x.id = t.id
-			WHERE t.owner_id IS NULL
-			ORDER BY array_position($2, t.id::bigint)
-			LIMIT $3
-			FOR UPDATE SKIP LOCKED
-		)
-		UPDATE harmony_task t
-		SET owner_id = $1
-		FROM candidates c
-		WHERE t.id = c.id
-		RETURNING t.id;`, h.TaskEngine.cfg.ownerID, tIDs, maxAcceptable)
-
+		tasksAccepted, err := claim(tIDs, maxAcceptable)
 		if err != nil {
 			log.Error(err)
 			return false
@@ -196,6 +191,14 @@ func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter e
 			h.accept.Add(toInt64s(remainder))
 			tIDs = tasksAccepted
 		}
+	}
+
+	if attemptStore == nil {
+		attemptStore = harmonyTaskAttemptStore{db: h.TaskEngine.cfg.db, owner: int(h.TaskEngine.cfg.ownerID)}
+	}
+	tIDs, attemptTokens := prepareTaskAttempts(h.TaskEngine.cfg.ctx, attemptStore, tIDs)
+	if len(tIDs) == 0 {
+		return false
 	}
 
 	releaseStorage := make([]func(), len(tIDs))
@@ -221,7 +224,7 @@ func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter e
 		if len(failedTIDs) > 0 {
 			tIDs = goodTIDs
 			log.Errorw("did not accept task", "task_ids", failedTIDs, "reason", "storage claim failed", "name", h.Name)
-			_, err := h.TaskEngine.cfg.db.Exec(h.TaskEngine.cfg.ctx, `UPDATE harmony_task SET owner_id = NULL WHERE id = ANY($1)`, failedTIDs)
+			err := release(failedTIDs)
 			if err != nil {
 				log.Errorw("Could not reset failed tasks", "error", err)
 			}
@@ -324,34 +327,38 @@ func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter e
 
 			defer taskCancel()
 
-			done, doErr = h.Do(taskCtx, tID, func() bool {
-				if taskCtx.Err() != nil {
-					return false
-				}
-				if taskhelp.IsBackgroundTask(h.Name) || h.CanYield {
-					if h.TaskEngine.atomics.yieldBackground.Load() {
-						log.Infow("yielding background task", "name", h.Name, "id", tID)
+			done, doErr = runWithAttemptStart(taskCtx, attemptStore, tID, attemptTokens[tID], nil, time.Now, func(start time.Time) {
+				workStart = start
+			}, func() (bool, error) {
+				return h.Do(taskCtx, tID, func() bool {
+					if taskCtx.Err() != nil {
 						return false
 					}
-				}
-				// Uninterruptible work (e.g. Send*) calls stillOwned before
-				// taking a per-sender lock. During shutdown drain, fail that
-				// check so hundreds of waiters can exit without starting a new
-				// critical section; in-flight holders do not call stillOwned
-				// and are waited on via Active() in GracefullyTerminate.
-				if h.Uninterruptible && h.TaskEngine.atomics.draining.Load() {
-					log.Infow("yielding uninterruptible task during shutdown drain", "name", h.Name, "id", tID)
-					return false
-				}
+					if taskhelp.IsBackgroundTask(h.Name) || h.CanYield {
+						if h.TaskEngine.atomics.yieldBackground.Load() {
+							log.Infow("yielding background task", "name", h.Name, "id", tID)
+							return false
+						}
+					}
+					// Uninterruptible work (e.g. Send*) calls stillOwned before
+					// taking a per-sender lock. During shutdown drain, fail that
+					// check so hundreds of waiters can exit without starting a new
+					// critical section; in-flight holders do not call stillOwned
+					// and are waited on via Active() in GracefullyTerminate.
+					if h.Uninterruptible && h.TaskEngine.atomics.draining.Load() {
+						log.Infow("yielding uninterruptible task during shutdown drain", "name", h.Name, "id", tID)
+						return false
+					}
 
-				var owner int
-				err := h.TaskEngine.cfg.db.QueryRow(taskCtx,
-					`SELECT owner_id FROM harmony_task WHERE id=$1`, tID).Scan(&owner)
-				if err != nil {
-					log.Error("Cannot determine ownership: ", err)
-					return false
-				}
-				return owner == h.TaskEngine.cfg.ownerID
+					var owner int
+					err := h.TaskEngine.cfg.db.QueryRow(taskCtx,
+						`SELECT owner_id FROM harmony_task WHERE id=$1`, tID).Scan(&owner)
+					if err != nil {
+						log.Error("Cannot determine ownership: ", err)
+						return false
+					}
+					return owner == h.TaskEngine.cfg.ownerID
+				})
 			})
 			if doErr != nil {
 				log.Errorw("Do() returned error", "type", h.Name, "id", strconv.Itoa(int(tID)), "error", doErr)
@@ -360,6 +367,31 @@ func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter e
 		i++
 	}
 	return true
+}
+
+func (h *taskTypeHandler) claimTaskOwnership(ids []TaskID, maxAcceptable int) ([]TaskID, error) {
+	var accepted []TaskID
+	err := h.TaskEngine.cfg.db.Select(h.TaskEngine.cfg.ctx, &accepted, `
+		WITH candidates AS (
+			SELECT t.id
+			FROM harmony_task t
+			JOIN unnest($2::bigint[]) AS x(id) ON x.id = t.id
+			WHERE t.owner_id IS NULL
+			ORDER BY array_position($2, t.id::bigint)
+			LIMIT $3
+			FOR UPDATE SKIP LOCKED
+		)
+		UPDATE harmony_task t
+		SET owner_id = $1
+		FROM candidates c
+		WHERE t.id = c.id
+		RETURNING t.id;`, h.TaskEngine.cfg.ownerID, ids, maxAcceptable)
+	return accepted, err
+}
+
+func (h *taskTypeHandler) releaseTaskOwnership(ids []TaskID) error {
+	_, err := h.TaskEngine.cfg.db.Exec(h.TaskEngine.cfg.ctx, `UPDATE harmony_task SET owner_id = NULL WHERE id = ANY($1)`, ids)
+	return err
 }
 
 // emitRetryTask re-adds a failed or preempted task to the scheduler after

--- a/tasks/f3/f3_task.go
+++ b/tasks/f3/f3_task.go
@@ -24,6 +24,12 @@ import (
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 
+func (f *F3Task) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id, sp_id FROM f3_tasks WHERE task_id = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 const (
 	// ParticipationCheckProgressMaxAttempts defines the maximum number of failed attempts
 	// before we abandon the current lease and restart the participation process.

--- a/tasks/indexing/task_indexing.go
+++ b/tasks/indexing/task_indexing.go
@@ -35,6 +35,14 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
+func (i *IndexingTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT indexing_task_id AS task_id, sp_id FROM market_mk12_deal_pipeline WHERE indexing_task_id = ANY($1::BIGINT[])
+		UNION ALL
+		SELECT indexing_task_id AS task_id, sp_id FROM market_mk20_pipeline WHERE indexing_task_id = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type IndexingTask struct {
 	db                *harmonydb.DB
 	indexStore        *indexstore.IndexStore

--- a/tasks/indexing/task_ipni.go
+++ b/tasks/indexing/task_ipni.go
@@ -39,6 +39,12 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
+func (I *IPNITask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id, sp_id FROM ipni_task WHERE task_id = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type IPNITask struct {
 	db  *harmonydb.DB
 	cfg *config.CurioConfig

--- a/tasks/seal/task_finalize.go
+++ b/tasks/seal/task_finalize.go
@@ -21,6 +21,12 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
+func (f *FinalizeTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_finalize AS task_id, sp_id FROM sectors_sdr_pipeline WHERE task_id_finalize = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type FinalizeTask struct {
 	max int
 	sp  *SealPoller

--- a/tasks/seal/task_movestorage.go
+++ b/tasks/seal/task_movestorage.go
@@ -22,6 +22,12 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
+func (m *MoveStorageTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_move_storage AS task_id, sp_id FROM sectors_sdr_pipeline WHERE task_id_move_storage = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type MoveStorageTask struct {
 	sp *SealPoller
 	sc *ffi2.SealCalls

--- a/tasks/seal/task_porep.go
+++ b/tasks/seal/task_porep.go
@@ -26,6 +26,12 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
+func (p *PoRepTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_porep AS task_id, sp_id FROM sectors_sdr_pipeline WHERE task_id_porep = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type PoRepAPI interface {
 	ChainHead(context.Context) (*types.TipSet, error)
 	StateGetRandomnessFromBeacon(context.Context, crypto.DomainSeparationTag, abi.ChainEpoch, []byte, types.TipSetKey) (abi.Randomness, error)

--- a/tasks/seal/task_sdr.go
+++ b/tasks/seal/task_sdr.go
@@ -30,6 +30,12 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
+func (s *SDRTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_sdr AS task_id, sp_id FROM sectors_sdr_pipeline WHERE task_id_sdr = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 var IsDevnet = build.BlockDelaySecs < 30
 
 func SetDevnet(value bool) {

--- a/tasks/seal/task_submit_commit.go
+++ b/tasks/seal/task_submit_commit.go
@@ -41,6 +41,12 @@ import (
 	"github.com/filecoin-project/lotus/storage/ctladdr"
 )
 
+func (s *SubmitCommitTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_commit_msg AS task_id, sp_id FROM sectors_sdr_pipeline WHERE task_id_commit_msg = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type SubmitCommitAPI interface {
 	ChainHead(context.Context) (*types.TipSet, error)
 	StateMinerInfo(context.Context, address.Address, types.TipSetKey) (api.MinerInfo, error)

--- a/tasks/seal/task_submit_precommit.go
+++ b/tasks/seal/task_submit_precommit.go
@@ -35,6 +35,12 @@ import (
 	"github.com/filecoin-project/lotus/storage/ctladdr"
 )
 
+func (s *SubmitPrecommitTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_precommit_msg AS task_id, sp_id FROM sectors_sdr_pipeline WHERE task_id_precommit_msg = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type SubmitPrecommitTaskApi interface {
 	ChainHead(context.Context) (*types.TipSet, error)
 	StateMinerPreCommitDepositForPower(context.Context, address.Address, miner.SectorPreCommitInfo, types.TipSetKey) (big.Int, error)

--- a/tasks/seal/task_synth_proofs.go
+++ b/tasks/seal/task_synth_proofs.go
@@ -23,6 +23,12 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
+func (s *SyntheticProofTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_synth AS task_id, sp_id FROM sectors_sdr_pipeline WHERE task_id_synth = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type SyntheticProofTask struct {
 	sp  *SealPoller
 	db  *harmonydb.DB

--- a/tasks/seal/task_treed.go
+++ b/tasks/seal/task_treed.go
@@ -20,6 +20,12 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
+func (t *TreeDTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_tree_d AS task_id, sp_id FROM sectors_sdr_pipeline WHERE task_id_tree_d = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type TreeDTask struct {
 	sp    *SealPoller
 	db    *harmonydb.DB

--- a/tasks/seal/task_treerc.go
+++ b/tasks/seal/task_treerc.go
@@ -22,6 +22,12 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
+func (t *TreeRCTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_tree_r AS task_id, sp_id FROM sectors_sdr_pipeline WHERE task_id_tree_r = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type TreeRCTask struct {
 	sp *SealPoller
 	db *harmonydb.DB

--- a/tasks/snap/task_encode.go
+++ b/tasks/snap/task_encode.go
@@ -27,6 +27,12 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
+func (e *EncodeTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_encode AS task_id, sp_id FROM sectors_snap_pipeline WHERE task_id_encode = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 const MinSnapSchedInterval = 10 * time.Second
 
 type EncodeTask struct {

--- a/tasks/snap/task_movestorage.go
+++ b/tasks/snap/task_movestorage.go
@@ -25,6 +25,12 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
+func (m *MoveStorageTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_move_storage AS task_id, sp_id FROM sectors_snap_pipeline WHERE task_id_move_storage = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type MoveStorageTask struct {
 	max int
 

--- a/tasks/snap/task_prove.go
+++ b/tasks/snap/task_prove.go
@@ -24,6 +24,12 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
+func (p *ProveTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_prove AS task_id, sp_id FROM sectors_snap_pipeline WHERE task_id_prove = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type ProveTask struct {
 	max                int
 	enableRemoteProofs bool

--- a/tasks/snap/task_submit.go
+++ b/tasks/snap/task_submit.go
@@ -44,6 +44,12 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
+func (s *SubmitTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_submit AS task_id, sp_id FROM sectors_snap_pipeline WHERE task_id_submit = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 var log = logging.Logger("update")
 
 var ImmutableSubmitGate = abi.ChainEpoch(2) // don't submit more than 2 minutes before the deadline becomes immutable

--- a/tasks/unseal/task_unseal_decode.go
+++ b/tasks/unseal/task_unseal_decode.go
@@ -23,6 +23,12 @@ import (
 	"github.com/filecoin-project/curio/tasks/tasknames"
 )
 
+func (t *TaskUnsealDecode) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_decode_sector AS task_id, sp_id FROM sectors_unseal_pipeline WHERE task_id_decode_sector = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 var log = logging.Logger("unseal")
 
 const MinSchedInterval = 120 * time.Second

--- a/tasks/unseal/task_unseal_sdr.go
+++ b/tasks/unseal/task_unseal_sdr.go
@@ -25,6 +25,12 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
+func (t *TaskUnsealSdr) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id_unseal_sdr AS task_id, sp_id FROM sectors_unseal_pipeline WHERE task_id_unseal_sdr = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 var isDevnet = build.BlockDelaySecs < 30
 
 type UnsealSDRApi interface {

--- a/tasks/window/compute_task.go
+++ b/tasks/window/compute_task.go
@@ -38,6 +38,12 @@ import (
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 
+func (t *WdPostTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id, sp_id FROM wdpost_partition_tasks WHERE task_id = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 var log = logging.Logger("curio/window")
 
 var EpochsPerDeadline = miner.WPoStProvingPeriod() / abi.ChainEpoch(miner.WPoStPeriodDeadlines)

--- a/tasks/window/recover_task.go
+++ b/tasks/window/recover_task.go
@@ -29,6 +29,12 @@ import (
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 
+func (w *WdPostRecoverDeclareTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id, sp_id FROM wdpost_recovery_tasks WHERE task_id = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type WdPostRecoverDeclareTask struct {
 	sender       *message.Sender
 	db           *harmonydb.DB

--- a/tasks/window/submit_task.go
+++ b/tasks/window/submit_task.go
@@ -27,6 +27,12 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
+func (w *WdPostSubmitTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT submit_task_id AS task_id, sp_id FROM wdpost_proofs WHERE submit_task_id = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 type WdPoStSubmitTaskApi interface {
 	ChainHead(context.Context) (*types.TipSet, error)
 

--- a/tasks/winning/winning_task.go
+++ b/tasks/winning/winning_task.go
@@ -48,6 +48,12 @@ import (
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
 
+func (t *WinPostTask) GetSpids(ctx context.Context, db *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	var spids []harmonytask.TaskSPID
+	err := db.Select(ctx, &spids, `SELECT task_id, sp_id FROM mining_tasks WHERE task_id = ANY($1::BIGINT[])`, taskIDs)
+	return spids, err
+}
+
 var log = logging.Logger("curio/winning")
 
 type WinPostTask struct {

--- a/web/api/webrpc/task_age.go
+++ b/web/api/webrpc/task_age.go
@@ -1,0 +1,15 @@
+package webrpc
+
+import (
+	"database/sql"
+	"time"
+)
+
+// knownTaskAge never substitutes queue age for missing or future timestamps.
+func knownTaskAge(observedAt time.Time, start sql.NullTime, source sql.NullString) *int64 {
+	if !start.Valid || !source.Valid || source.String != "claim" || start.Time.After(observedAt) {
+		return nil
+	}
+	age := int64(observedAt.Sub(start.Time) / time.Second)
+	return &age
+}

--- a/web/api/webrpc/task_age_test.go
+++ b/web/api/webrpc/task_age_test.go
@@ -1,0 +1,47 @@
+package webrpc
+
+import (
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOwnershipAgeProvenance(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name   string
+		start  sql.NullTime
+		source sql.NullString
+		known  bool
+	}{
+		{"known claim", sql.NullTime{Time: now.Add(-10 * time.Minute), Valid: true}, sql.NullString{String: "claim", Valid: true}, true},
+		{"missing", sql.NullTime{}, sql.NullString{}, false},
+		{"legacy backfill", sql.NullTime{Time: now.Add(-time.Hour), Valid: true}, sql.NullString{}, false},
+		{"unrecognized provenance", sql.NullTime{Time: now, Valid: true}, sql.NullString{String: "migration", Valid: true}, false},
+		{"future claim", sql.NullTime{Time: now.Add(time.Minute), Valid: true}, sql.NullString{String: "claim", Valid: true}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			age := knownTaskAge(now, tc.start, tc.source)
+			if (age != nil) != tc.known {
+				t.Fatalf("age=%v, known=%v", age, tc.known)
+			}
+			if tc.known && *age != 600 {
+				t.Fatalf("age=%d", *age)
+			}
+		})
+	}
+}
+
+func TestTaskSummaryLegacyFieldsRemain(t *testing.T) {
+	data, err := json.Marshal(TaskSummary{SincePosted: time.Unix(10, 0), SincePostedStr: "2m0s"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{`"SincePosted":`, `"SincePostedStr":"2m0s"`, `"OwnershipAgeSeconds":null`} {
+		if !strings.Contains(string(data), field) {
+			t.Fatalf("missing legacy/additive field %s in %s", field, data)
+		}
+	}
+}

--- a/web/api/webrpc/task_spids.go
+++ b/web/api/webrpc/task_spids.go
@@ -1,0 +1,24 @@
+package webrpc
+
+import (
+	"context"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+)
+
+const CLUSTER_TASK_SPID_BATCH_SIZE = 10_000
+
+type BatchSpidGetter interface {
+	GetSpids(context.Context, *harmonydb.DB, []int64) ([]harmonytask.TaskSPID, error)
+}
+
+func makeBatchTaskSPIDs(legacy map[string]SpidGetter) map[string]BatchSpidGetter {
+	batch := make(map[string]BatchSpidGetter)
+	for name, getter := range legacy {
+		if g, ok := getter.(BatchSpidGetter); ok {
+			batch[name] = g
+		}
+	}
+	return batch
+}

--- a/web/api/webrpc/task_spids_test.go
+++ b/web/api/webrpc/task_spids_test.go
@@ -1,0 +1,66 @@
+package webrpc
+
+import (
+	"context"
+	"database/sql"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+)
+
+type recordingSpidGetter struct {
+	calls   [][]int64
+	resolve func(int64) []int64
+}
+
+func (g *recordingSpidGetter) GetSpids(_ context.Context, _ *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	call := append([]int64(nil), taskIDs...)
+	g.calls = append(g.calls, call)
+
+	var result []harmonytask.TaskSPID
+	for _, taskID := range taskIDs {
+		for _, spid := range g.resolve(taskID) {
+			result = append(result, harmonytask.TaskSPID{TaskID: taskID, SPID: spid})
+		}
+	}
+	return result, nil
+}
+
+func TestLimitedTaskPreservesAllProviders(t *testing.T) {
+	rows := []clusterTaskSummaryLimitedRow{{ID: 1, Name: "synthetic"}}
+	g := &recordingSpidGetter{resolve: func(int64) []int64 { return []int64{1002, 1001, 1002} }}
+	spids, _, err := resolveLimitedTaskSPIDs(context.Background(), nil, rows, map[string]BatchSpidGetter{"synthetic": g})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(spids[1], []int64{1001, 1002}) {
+		t.Fatalf("providers=%v", spids)
+	}
+	if len(g.calls) != 1 {
+		t.Fatalf("calls=%v", g.calls)
+	}
+}
+
+func TestLimitedTaskIsolatesUnknownOwnershipAge(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+	owner := int64(7)
+	rows := []clusterTaskSummaryLimitedRow{
+		{ID: 1, Name: "task", State: "running", OwnerID: &owner, PostedTime: now.Add(-time.Hour)},
+		{ID: 2, Name: "task", State: "running", OwnerID: &owner, WorkStart: sql.NullTime{Time: now.Add(-time.Minute), Valid: true}, WorkStartSource: sql.NullString{String: "claim", Valid: true}},
+		{ID: 3, Name: "task", State: "running", OwnerID: &owner, WorkStart: sql.NullTime{Time: now.Add(-time.Minute), Valid: true}},
+		{ID: 4, Name: "task", State: "running", OwnerID: &owner, WorkStart: sql.NullTime{Time: now.Add(time.Minute), Valid: true}, WorkStartSource: sql.NullString{String: "claim", Valid: true}},
+	}
+	for _, row := range rows {
+		task := buildLimitedTaskSummary(row, now, nil)
+		if row.ID == 2 {
+			if task.AgeSeconds == nil || *task.AgeSeconds != 60 {
+				t.Fatalf("known row: %+v", task)
+			}
+		} else if task.AgeSeconds != nil {
+			t.Fatalf("unknown/future row: %+v", task)
+		}
+	}
+}

--- a/web/api/webrpc/task_took.go
+++ b/web/api/webrpc/task_took.go
@@ -1,0 +1,20 @@
+package webrpc
+
+import "time"
+
+func taskTookAge(row clusterTaskSummaryLimitedRow, observedAt time.Time) (*int64, string) {
+	if row.OwnerID == nil {
+		return nil, "pending"
+	}
+	if row.AttemptStartSource.Valid && (row.AttemptStartSource.String == "claimed" || row.AttemptStartSource.String == "prepared") {
+		return nil, "awaiting-start"
+	}
+	if !row.AttemptID.Valid || row.AttemptID.String == "" || !row.AttemptStartedAt.Valid || !row.AttemptStartSource.Valid || row.AttemptStartSource.String != "do_entry" {
+		return nil, "unknown"
+	}
+	if row.AttemptStartedAt.Time.After(observedAt) {
+		return nil, "future-start"
+	}
+	age := int64(observedAt.Sub(row.AttemptStartedAt.Time) / time.Second)
+	return &age, "running"
+}

--- a/web/api/webrpc/task_took_test.go
+++ b/web/api/webrpc/task_took_test.go
@@ -1,0 +1,69 @@
+package webrpc
+
+import (
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTaskTookCurrentAttemptOnly(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+	owner := int64(7)
+	base := clusterTaskSummaryLimitedRow{ID: 1, Name: "task", State: "running", OwnerID: &owner, PostedTime: now.Add(-3 * time.Hour), WorkStart: sql.NullTime{Time: now.Add(-2 * time.Hour), Valid: true}, WorkStartSource: sql.NullString{String: "claim", Valid: true}, AttemptID: sql.NullString{String: "new-attempt", Valid: true}, AttemptStartedAt: sql.NullTime{Time: now.Add(-10 * time.Minute), Valid: true}, AttemptStartSource: sql.NullString{String: "do_entry", Valid: true}}
+	for _, tc := range []struct {
+		name    string
+		change  func(*clusterTaskSummaryLimitedRow)
+		state   string
+		seconds int64
+		known   bool
+	}{
+		{"old posted fresh attempt", func(*clusterTaskSummaryLimitedRow) {}, "running", 600, true},
+		{"pending", func(r *clusterTaskSummaryLimitedRow) { r.OwnerID = nil; r.State = "pending" }, "pending", 0, false},
+		{"claimed before Do", func(r *clusterTaskSummaryLimitedRow) {
+			r.AttemptStartedAt = sql.NullTime{}
+			r.AttemptStartSource = sql.NullString{String: "claimed", Valid: true}
+		}, "awaiting-start", 0, false},
+		{"prepared not started", func(r *clusterTaskSummaryLimitedRow) {
+			r.AttemptStartedAt = sql.NullTime{}
+			r.AttemptStartSource.String = "prepared"
+		}, "awaiting-start", 0, false},
+		{"missing start", func(r *clusterTaskSummaryLimitedRow) { r.AttemptStartedAt = sql.NullTime{} }, "unknown", 0, false},
+		{"legacy backfill", func(r *clusterTaskSummaryLimitedRow) { r.AttemptStartSource = sql.NullString{} }, "unknown", 0, false},
+		{"migration provenance", func(r *clusterTaskSummaryLimitedRow) { r.AttemptStartSource.String = "migration" }, "unknown", 0, false},
+		{"missing identity", func(r *clusterTaskSummaryLimitedRow) { r.AttemptID = sql.NullString{} }, "unknown", 0, false},
+		{"future clock", func(r *clusterTaskSummaryLimitedRow) { r.AttemptStartedAt.Time = now.Add(time.Minute) }, "future-start", 0, false},
+		{"same owner recovered", func(r *clusterTaskSummaryLimitedRow) {
+			r.AttemptID.String = "restart"
+			r.AttemptStartedAt.Time = now.Add(-time.Second)
+		}, "running", 1, true},
+		{"owner changed", func(r *clusterTaskSummaryLimitedRow) {
+			other := int64(8)
+			r.OwnerID = &other
+			r.AttemptID.String = "new-owner"
+			r.AttemptStartedAt.Time = now.Add(-2 * time.Second)
+		}, "running", 2, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			row := base
+			tc.change(&row)
+			got := buildLimitedTaskSummary(row, now, nil)
+			if got.TookState != tc.state || (got.TookSeconds != nil) != tc.known {
+				t.Fatalf("got=%+v", got)
+			}
+			if tc.known && *got.TookSeconds != tc.seconds {
+				t.Fatalf("seconds=%d", *got.TookSeconds)
+			}
+		})
+	}
+	encoded, err := json.Marshal(buildLimitedTaskSummary(base, now, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{`"AgeSeconds":7200`, `"TookSeconds":600`, `"AttemptID":"new-attempt"`} {
+		if !strings.Contains(string(encoded), field) {
+			t.Fatalf("compatibility field %s missing from %s", field, encoded)
+		}
+	}
+}

--- a/web/api/webrpc/tasks.go
+++ b/web/api/webrpc/tasks.go
@@ -2,6 +2,7 @@ package webrpc
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strconv"
 	"time"
@@ -26,12 +27,21 @@ type TaskSummary struct {
 	SincePostedStr string `db:"-"`
 
 	Miner string
+
+	// Ownership age is additive telemetry, not execution runtime. Legacy fields
+	// above intentionally retain their existing update_time-based meaning.
+	OwnershipAgeSeconds  *int64         `db:"-"`
+	OwnershipStartSource string         `db:"-"`
+	WorkStart            sql.NullTime   `db:"work_start" json:"-"`
+	WorkStartSource      sql.NullString `db:"work_start_source" json:"-"`
+	ObservedAt           time.Time      `db:"observed_at"`
 }
 
 func (a *WebRPC) ClusterTaskSummary(ctx context.Context) ([]TaskSummary, error) {
 	var ts = []TaskSummary{}
 	err := a.Deps.DB.Select(ctx, &ts, `SELECT 
-		t.id as id, t.name as name, t.update_time as since_posted, t.owner_id as owner_id, hm.host_and_port as owner
+		t.id as id, t.name as name, t.update_time as since_posted, t.owner_id as owner_id, hm.host_and_port as owner,
+		t.work_start, t.work_start_source, statement_timestamp() AS observed_at
 	FROM harmony_task t LEFT JOIN harmony_machines hm ON hm.id = t.owner_id 
 	ORDER BY
 	    CASE WHEN t.owner_id IS NULL THEN 1 ELSE 0 END, t.update_time ASC`)
@@ -42,6 +52,13 @@ func (a *WebRPC) ClusterTaskSummary(ctx context.Context) ([]TaskSummary, error) 
 	// Populate MinerID
 	for i := range ts {
 		ts[i].SincePostedStr = time.Since(ts[i].SincePosted).Truncate(time.Second).String()
+		if ts[i].OwnerID != nil {
+			ts[i].OwnershipAgeSeconds = knownTaskAge(ts[i].ObservedAt, ts[i].WorkStart, ts[i].WorkStartSource)
+			ts[i].OwnershipStartSource = "unknown"
+			if ts[i].OwnershipAgeSeconds != nil {
+				ts[i].OwnershipStartSource = "claim"
+			}
+		}
 
 		if v, ok := a.TaskSPIDs[ts[i].Name]; ok {
 			ts[i].SpID = v.GetSpid(a.Deps.DB, ts[i].ID)

--- a/web/api/webrpc/tasks_limited.go
+++ b/web/api/webrpc/tasks_limited.go
@@ -1,0 +1,472 @@
+package webrpc
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/filecoin-project/go-address"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+)
+
+const (
+	CLUSTER_TASK_SUMMARY_DEFAULT_MAX_TASKS   = 500
+	CLUSTER_TASK_SUMMARY_DEFAULT_MAX_PENDING = 500
+	CLUSTER_TASK_SUMMARY_MAX_TASKS           = 500
+)
+
+type ClusterTaskSummaryLimitedRequest struct {
+	MaxTasks          *int
+	MaxPending        *int
+	IncludeBackground bool
+	TaskName          *string
+}
+
+type ClusterTaskSummaryApplied struct {
+	MaxTasks          int
+	MaxPending        int
+	IncludeBackground bool
+	TaskName          *string
+}
+
+type ClusterTaskSummaryWarning struct {
+	Code     string
+	Message  string
+	TaskName string
+}
+
+type ClusterTaskTypeCount struct {
+	Name    string
+	Running int64
+	Pending int64
+	Total   int64
+}
+
+type ClusterTaskSummaryLimitedTask struct {
+	ID                   int64
+	Name                 string
+	SpID                 string
+	SpIDs                []string
+	Miners               []string
+	OwnershipStartSource string
+	Miner                string
+	State                string
+	AgeSeconds           *int64
+	Owner                *string
+	OwnerID              *int64
+}
+
+type ClusterTaskSummaryLimitedResponse struct {
+	Running            []ClusterTaskSummaryLimitedTask
+	Pending            []ClusterTaskSummaryLimitedTask
+	Applied            ClusterTaskSummaryApplied
+	RunningTotal       int64
+	PendingTotal       int64
+	TotalsAvailable    bool
+	ObservedAt         time.Time
+	TaskTypes          []ClusterTaskTypeCount
+	TaskTypesAvailable bool
+	Partial            bool
+	Warnings           []ClusterTaskSummaryWarning
+}
+
+type clusterTaskSummaryLimitedRow struct {
+	ID              int64
+	Name            string
+	PostedTime      time.Time
+	WorkStart       sql.NullTime
+	WorkStartSource sql.NullString
+	Owner           *string
+	OwnerID         *int64
+	State           string
+}
+
+type clusterTaskSummarySnapshot struct {
+	Rows         []clusterTaskSummaryLimitedRow
+	RunningTotal int64
+	PendingTotal int64
+	ObservedAt   time.Time
+}
+
+type clusterTaskSummarySource interface {
+	LoadSnapshot(context.Context, ClusterTaskSummaryApplied) (clusterTaskSummarySnapshot, error)
+	LoadTaskTypes(context.Context, bool) ([]ClusterTaskTypeCount, error)
+}
+
+type harmonyClusterTaskSummarySource struct {
+	db *harmonydb.DB
+}
+
+type clusterTaskSummaryDBRow struct {
+	ID              sql.NullInt64  `db:"id"`
+	Name            sql.NullString `db:"name"`
+	PostedTime      sql.NullTime   `db:"posted_time"`
+	WorkStart       sql.NullTime   `db:"work_start"`
+	WorkStartSource sql.NullString `db:"work_start_source"`
+	Owner           sql.NullString `db:"owner"`
+	OwnerID         sql.NullInt64  `db:"owner_id"`
+	State           sql.NullString `db:"state"`
+	RunningTotal    int64          `db:"running_total"`
+	PendingTotal    int64          `db:"pending_total"`
+	ObservedAt      time.Time      `db:"observed_at"`
+}
+
+const clusterTaskSummaryLimitedQuery = `
+WITH matching AS (
+	SELECT
+		t.id,
+		t.name,
+		t.posted_time,
+		t.work_start,
+		t.work_start_source,
+		t.owner_id
+	FROM harmony_task t
+	WHERE ($1::BOOLEAN OR t.name NOT LIKE 'bg:%')
+		AND ($2::TEXT IS NULL OR t.name = $2)
+),
+matching_counts AS (
+	SELECT
+		COUNT(*) FILTER (WHERE owner_id IS NOT NULL) AS running_total,
+		COUNT(*) FILTER (WHERE owner_id IS NULL) AS pending_total
+	FROM matching
+),
+running AS (
+	SELECT *, 'running'::TEXT AS state, 0::BIGINT AS section_order
+	FROM matching
+	WHERE owner_id IS NOT NULL
+	ORDER BY work_start ASC NULLS FIRST, id ASC
+	LIMIT $3
+),
+remaining AS (
+	SELECT GREATEST($3::BIGINT - COUNT(*)::BIGINT, 0::BIGINT) AS pending_slots
+	FROM running
+),
+pending AS (
+	SELECT *, 'pending'::TEXT AS state, 1::BIGINT AS section_order
+	FROM matching
+	WHERE owner_id IS NULL
+	ORDER BY posted_time ASC, id ASC
+	LIMIT (SELECT LEAST($4::BIGINT, pending_slots) FROM remaining)
+),
+selected AS (
+	SELECT * FROM running
+	UNION ALL
+	SELECT * FROM pending
+),
+observed AS (
+	SELECT statement_timestamp() AS observed_at
+)
+SELECT
+	s.id,
+	s.name,
+	s.posted_time,
+	s.work_start,
+	s.work_start_source,
+	hm.host_and_port AS owner,
+	s.owner_id,
+	s.state,
+	c.running_total,
+	c.pending_total,
+	o.observed_at
+FROM matching_counts c
+CROSS JOIN observed o
+LEFT JOIN selected s ON TRUE
+LEFT JOIN harmony_machines hm ON hm.id = s.owner_id
+ORDER BY
+	s.section_order ASC NULLS LAST,
+	CASE WHEN s.section_order = 0 THEN s.work_start ELSE s.posted_time END ASC NULLS FIRST,
+	s.id ASC`
+
+func (s harmonyClusterTaskSummarySource) LoadSnapshot(ctx context.Context, applied ClusterTaskSummaryApplied) (clusterTaskSummarySnapshot, error) {
+	var rows []clusterTaskSummaryDBRow
+	err := s.db.Select(ctx, &rows, clusterTaskSummaryLimitedQuery, clusterTaskSummaryLimitedQueryArgs(applied)...)
+	if err != nil {
+		return clusterTaskSummarySnapshot{}, err
+	}
+	if len(rows) == 0 {
+		return clusterTaskSummarySnapshot{}, fmt.Errorf("cluster task summary query returned no metadata row")
+	}
+
+	snapshot := clusterTaskSummarySnapshot{
+		Rows:         make([]clusterTaskSummaryLimitedRow, 0, len(rows)),
+		RunningTotal: rows[0].RunningTotal,
+		PendingTotal: rows[0].PendingTotal,
+		ObservedAt:   rows[0].ObservedAt,
+	}
+	for _, row := range rows {
+		if !row.ID.Valid {
+			continue
+		}
+		if !row.Name.Valid || !row.PostedTime.Valid || !row.State.Valid {
+			return clusterTaskSummarySnapshot{}, fmt.Errorf("cluster task summary row %d is missing required data", row.ID.Int64)
+		}
+
+		var owner *string
+		if row.Owner.Valid {
+			value := row.Owner.String
+			owner = &value
+		}
+		var ownerID *int64
+		if row.OwnerID.Valid {
+			value := row.OwnerID.Int64
+			ownerID = &value
+		}
+
+		snapshot.Rows = append(snapshot.Rows, clusterTaskSummaryLimitedRow{
+			ID:              row.ID.Int64,
+			Name:            row.Name.String,
+			PostedTime:      row.PostedTime.Time,
+			WorkStart:       row.WorkStart,
+			WorkStartSource: row.WorkStartSource,
+			Owner:           owner,
+			OwnerID:         ownerID,
+			State:           row.State.String,
+		})
+	}
+
+	return snapshot, nil
+}
+
+func clusterTaskSummaryLimitedQueryArgs(applied ClusterTaskSummaryApplied) []any {
+	var taskName any
+	if applied.TaskName != nil {
+		taskName = *applied.TaskName
+	}
+	return []any{
+		applied.IncludeBackground,
+		taskName,
+		applied.MaxTasks,
+		applied.MaxPending,
+	}
+}
+
+func (s harmonyClusterTaskSummarySource) LoadTaskTypes(ctx context.Context, includeBackground bool) ([]ClusterTaskTypeCount, error) {
+	var taskTypes []ClusterTaskTypeCount
+	err := s.db.Select(ctx, &taskTypes, `
+		SELECT
+			name,
+			COUNT(*) FILTER (WHERE owner_id IS NOT NULL) AS running,
+			COUNT(*) FILTER (WHERE owner_id IS NULL) AS pending,
+			COUNT(*) AS total
+		FROM harmony_task
+		WHERE ($1::BOOLEAN OR name NOT LIKE 'bg:%')
+		GROUP BY name
+		ORDER BY name ASC`, includeBackground)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(taskTypes, func(i, j int) bool {
+		return taskTypes[i].Name < taskTypes[j].Name
+	})
+	return taskTypes, nil
+}
+
+func normalizeClusterTaskSummaryRequest(request ClusterTaskSummaryLimitedRequest) ClusterTaskSummaryApplied {
+	maxTasks := CLUSTER_TASK_SUMMARY_DEFAULT_MAX_TASKS
+	if request.MaxTasks != nil {
+		maxTasks = min(max(*request.MaxTasks, 1), CLUSTER_TASK_SUMMARY_MAX_TASKS)
+	}
+
+	maxPending := CLUSTER_TASK_SUMMARY_DEFAULT_MAX_PENDING
+	if request.MaxPending != nil {
+		maxPending = max(*request.MaxPending, 0)
+	}
+	maxPending = min(maxPending, maxTasks)
+
+	var taskName *string
+	if request.TaskName != nil {
+		value := *request.TaskName
+		taskName = &value
+	}
+
+	return ClusterTaskSummaryApplied{
+		MaxTasks:          maxTasks,
+		MaxPending:        maxPending,
+		IncludeBackground: request.IncludeBackground,
+		TaskName:          taskName,
+	}
+}
+
+func clusterTaskContextError(ctx context.Context, err error) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	return nil
+}
+
+func resolveLimitedTaskSPIDs(ctx context.Context, db *harmonydb.DB, rows []clusterTaskSummaryLimitedRow, getters map[string]BatchSpidGetter) (map[int64][]int64, []ClusterTaskSummaryWarning, error) {
+	taskIDsByName := make(map[string][]int64)
+	taskNames := make([]string, 0)
+	for _, row := range rows {
+		if _, ok := getters[row.Name]; !ok {
+			continue
+		}
+		if _, ok := taskIDsByName[row.Name]; !ok {
+			taskNames = append(taskNames, row.Name)
+		}
+		taskIDsByName[row.Name] = append(taskIDsByName[row.Name], row.ID)
+	}
+
+	spids := make(map[int64][]int64)
+	warnings := make([]ClusterTaskSummaryWarning, 0)
+	sort.Strings(taskNames)
+	for _, name := range taskNames {
+		ids := taskIDsByName[name]
+		for start := 0; start < len(ids); start += CLUSTER_TASK_SPID_BATCH_SIZE {
+			end := min(start+CLUSTER_TASK_SPID_BATCH_SIZE, len(ids))
+			batchIDs := ids[start:end]
+			allowedIDs := make(map[int64]struct{}, len(batchIDs))
+			for _, taskID := range batchIDs {
+				allowedIDs[taskID] = struct{}{}
+			}
+
+			resolved, err := getters[name].GetSpids(ctx, db, batchIDs)
+			if err != nil {
+				if cancellationErr := clusterTaskContextError(ctx, err); cancellationErr != nil {
+					return nil, nil, cancellationErr
+				}
+				log.Warnw("cluster task SpID enrichment failed", "task_type", name, "task_count", end-start, "error", err)
+				warnings = append(warnings, ClusterTaskSummaryWarning{
+					Code:     "spid_enrichment_failed",
+					Message:  fmt.Sprintf("Provider IDs are unavailable for %s tasks in this snapshot.", name),
+					TaskName: name,
+				})
+				break
+			}
+
+			for _, resolvedTask := range resolved {
+				if _, ok := allowedIDs[resolvedTask.TaskID]; !ok {
+					continue
+				}
+				if !slices.Contains(spids[resolvedTask.TaskID], resolvedTask.SPID) {
+					spids[resolvedTask.TaskID] = append(spids[resolvedTask.TaskID], resolvedTask.SPID)
+				}
+			}
+		}
+	}
+
+	for _, ids := range spids {
+		slices.Sort(ids)
+	}
+	return spids, warnings, nil
+}
+
+func clusterTaskAgeSeconds(observedAt, startedAt time.Time) int64 {
+	age := observedAt.Sub(startedAt)
+	if age < 0 {
+		return 0
+	}
+	return int64(age / time.Second)
+}
+
+func buildLimitedTaskSummary(row clusterTaskSummaryLimitedRow, observedAt time.Time, spids map[int64][]int64) ClusterTaskSummaryLimitedTask {
+	task := ClusterTaskSummaryLimitedTask{
+		ID:      row.ID,
+		Name:    row.Name,
+		State:   row.State,
+		Owner:   row.Owner,
+		OwnerID: row.OwnerID,
+	}
+
+	if row.State == "pending" {
+		ageSeconds := clusterTaskAgeSeconds(observedAt, row.PostedTime)
+		task.AgeSeconds = &ageSeconds
+	} else {
+		task.AgeSeconds = knownTaskAge(observedAt, row.WorkStart, row.WorkStartSource)
+		task.OwnershipStartSource = "unknown"
+		if task.AgeSeconds != nil {
+			task.OwnershipStartSource = "claim"
+		}
+	}
+
+	for _, spid := range spids[row.ID] {
+		task.SpIDs = append(task.SpIDs, strconv.FormatInt(spid, 10))
+		if spid > 0 {
+			if miner, err := address.NewIDAddress(uint64(spid)); err == nil {
+				task.Miners = append(task.Miners, miner.String())
+			}
+		}
+	}
+	if len(task.SpIDs) > 0 {
+		task.SpID = task.SpIDs[0]
+	}
+	if len(task.Miners) > 0 {
+		task.Miner = task.Miners[0]
+	}
+
+	return task
+}
+
+func buildClusterTaskSummaryLimited(ctx context.Context, request ClusterTaskSummaryLimitedRequest, source clusterTaskSummarySource, db *harmonydb.DB, getters map[string]BatchSpidGetter) (ClusterTaskSummaryLimitedResponse, error) {
+	applied := normalizeClusterTaskSummaryRequest(request)
+	snapshot, err := source.LoadSnapshot(ctx, applied)
+	if err != nil {
+		return ClusterTaskSummaryLimitedResponse{}, fmt.Errorf("loading cluster task snapshot: %w", err)
+	}
+
+	spids, warnings, err := resolveLimitedTaskSPIDs(ctx, db, snapshot.Rows, getters)
+	if err != nil {
+		return ClusterTaskSummaryLimitedResponse{}, err
+	}
+
+	response := ClusterTaskSummaryLimitedResponse{
+		Running:         make([]ClusterTaskSummaryLimitedTask, 0),
+		Pending:         make([]ClusterTaskSummaryLimitedTask, 0),
+		Applied:         applied,
+		RunningTotal:    snapshot.RunningTotal,
+		PendingTotal:    snapshot.PendingTotal,
+		TotalsAvailable: true,
+		ObservedAt:      snapshot.ObservedAt,
+		TaskTypes:       make([]ClusterTaskTypeCount, 0),
+		Warnings:        warnings,
+		Partial:         len(warnings) > 0,
+	}
+	for _, row := range snapshot.Rows {
+		task := buildLimitedTaskSummary(row, snapshot.ObservedAt, spids)
+		if row.State == "running" {
+			response.Running = append(response.Running, task)
+		} else {
+			response.Pending = append(response.Pending, task)
+		}
+	}
+
+	taskTypes, err := source.LoadTaskTypes(ctx, applied.IncludeBackground)
+	if err != nil {
+		if cancellationErr := clusterTaskContextError(ctx, err); cancellationErr != nil {
+			return ClusterTaskSummaryLimitedResponse{}, cancellationErr
+		}
+		log.Warnw("cluster task type summary failed", "error", err)
+		response.Warnings = append(response.Warnings, ClusterTaskSummaryWarning{
+			Code:    "task_types_unavailable",
+			Message: "Task type choices are unavailable for this snapshot.",
+		})
+		response.Partial = true
+	} else {
+		if taskTypes == nil {
+			taskTypes = make([]ClusterTaskTypeCount, 0)
+		}
+		response.TaskTypes = taskTypes
+		response.TaskTypesAvailable = true
+	}
+
+	return response, nil
+}
+
+func (a *WebRPC) ClusterTaskSummaryLimited(ctx context.Context, request ClusterTaskSummaryLimitedRequest) (ClusterTaskSummaryLimitedResponse, error) {
+	return buildClusterTaskSummaryLimited(
+		ctx,
+		request,
+		harmonyClusterTaskSummarySource{db: a.Deps.DB},
+		a.Deps.DB,
+		makeBatchTaskSPIDs(a.TaskSPIDs),
+	)
+}

--- a/web/api/webrpc/tasks_limited.go
+++ b/web/api/webrpc/tasks_limited.go
@@ -58,6 +58,9 @@ type ClusterTaskSummaryLimitedTask struct {
 	Miner                string
 	State                string
 	AgeSeconds           *int64
+	TookSeconds          *int64
+	TookState            string
+	AttemptID            *string
 	Owner                *string
 	OwnerID              *int64
 }
@@ -77,14 +80,17 @@ type ClusterTaskSummaryLimitedResponse struct {
 }
 
 type clusterTaskSummaryLimitedRow struct {
-	ID              int64
-	Name            string
-	PostedTime      time.Time
-	WorkStart       sql.NullTime
-	WorkStartSource sql.NullString
-	Owner           *string
-	OwnerID         *int64
-	State           string
+	ID                 int64
+	Name               string
+	PostedTime         time.Time
+	WorkStart          sql.NullTime
+	WorkStartSource    sql.NullString
+	AttemptStartedAt   sql.NullTime
+	AttemptID          sql.NullString
+	AttemptStartSource sql.NullString
+	Owner              *string
+	OwnerID            *int64
+	State              string
 }
 
 type clusterTaskSummarySnapshot struct {
@@ -104,17 +110,20 @@ type harmonyClusterTaskSummarySource struct {
 }
 
 type clusterTaskSummaryDBRow struct {
-	ID              sql.NullInt64  `db:"id"`
-	Name            sql.NullString `db:"name"`
-	PostedTime      sql.NullTime   `db:"posted_time"`
-	WorkStart       sql.NullTime   `db:"work_start"`
-	WorkStartSource sql.NullString `db:"work_start_source"`
-	Owner           sql.NullString `db:"owner"`
-	OwnerID         sql.NullInt64  `db:"owner_id"`
-	State           sql.NullString `db:"state"`
-	RunningTotal    int64          `db:"running_total"`
-	PendingTotal    int64          `db:"pending_total"`
-	ObservedAt      time.Time      `db:"observed_at"`
+	ID                 sql.NullInt64  `db:"id"`
+	Name               sql.NullString `db:"name"`
+	PostedTime         sql.NullTime   `db:"posted_time"`
+	WorkStart          sql.NullTime   `db:"work_start"`
+	WorkStartSource    sql.NullString `db:"work_start_source"`
+	AttemptStartedAt   sql.NullTime   `db:"attempt_started_at"`
+	AttemptID          sql.NullString `db:"attempt_id"`
+	AttemptStartSource sql.NullString `db:"attempt_start_source"`
+	Owner              sql.NullString `db:"owner"`
+	OwnerID            sql.NullInt64  `db:"owner_id"`
+	State              sql.NullString `db:"state"`
+	RunningTotal       int64          `db:"running_total"`
+	PendingTotal       int64          `db:"pending_total"`
+	ObservedAt         time.Time      `db:"observed_at"`
 }
 
 const clusterTaskSummaryLimitedQuery = `
@@ -125,6 +134,9 @@ WITH matching AS (
 		t.posted_time,
 		t.work_start,
 		t.work_start_source,
+		t.attempt_started_at,
+		t.attempt_id,
+		t.attempt_start_source,
 		t.owner_id
 	FROM harmony_task t
 	WHERE ($1::BOOLEAN OR t.name NOT LIKE 'bg:%')
@@ -168,6 +180,9 @@ SELECT
 	s.posted_time,
 	s.work_start,
 	s.work_start_source,
+	s.attempt_started_at,
+	s.attempt_id,
+	s.attempt_start_source,
 	hm.host_and_port AS owner,
 	s.owner_id,
 	s.state,
@@ -219,14 +234,17 @@ func (s harmonyClusterTaskSummarySource) LoadSnapshot(ctx context.Context, appli
 		}
 
 		snapshot.Rows = append(snapshot.Rows, clusterTaskSummaryLimitedRow{
-			ID:              row.ID.Int64,
-			Name:            row.Name.String,
-			PostedTime:      row.PostedTime.Time,
-			WorkStart:       row.WorkStart,
-			WorkStartSource: row.WorkStartSource,
-			Owner:           owner,
-			OwnerID:         ownerID,
-			State:           row.State.String,
+			ID:                 row.ID.Int64,
+			Name:               row.Name.String,
+			PostedTime:         row.PostedTime.Time,
+			WorkStart:          row.WorkStart,
+			WorkStartSource:    row.WorkStartSource,
+			AttemptStartedAt:   row.AttemptStartedAt,
+			AttemptID:          row.AttemptID,
+			AttemptStartSource: row.AttemptStartSource,
+			Owner:              owner,
+			OwnerID:            ownerID,
+			State:              row.State.String,
 		})
 	}
 
@@ -386,6 +404,12 @@ func buildLimitedTaskSummary(row clusterTaskSummaryLimitedRow, observedAt time.T
 		if task.AgeSeconds != nil {
 			task.OwnershipStartSource = "claim"
 		}
+	}
+
+	task.TookSeconds, task.TookState = taskTookAge(row, observedAt)
+	if row.AttemptID.Valid {
+		id := row.AttemptID.String
+		task.AttemptID = &id
 	}
 
 	for _, spid := range spids[row.ID] {

--- a/web/api/webrpc/tasks_limited_integration_test.go
+++ b/web/api/webrpc/tasks_limited_integration_test.go
@@ -1,0 +1,105 @@
+//go:build integration && !skiff
+
+package webrpc
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yugabyte/pgx/v5"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+)
+
+func TestClusterTaskSnapshotSQL(t *testing.T) {
+	if os.Getenv("CURIO_TASK_ATTEMPT_ITEST") != "1" {
+		t.Skip("requires explicit CURIO_TASK_ATTEMPT_ITEST=1 and a disposable loopback target")
+	}
+	const prefix = "CURIO_TASK_ATTEMPT_ITEST_"
+	host, port := os.Getenv(prefix+"HOST"), os.Getenv(prefix+"PORT")
+	address := net.ParseIP(host)
+	require.True(t, address != nil && address.IsLoopback(), "HOST must be a literal loopback IP")
+	n, err := strconv.ParseUint(port, 10, 16)
+	require.NoError(t, err)
+	require.NotZero(t, n)
+	database, user := os.Getenv(prefix+"DATABASE"), os.Getenv(prefix+"USER")
+	require.NotEmpty(t, strings.TrimSpace(database))
+	require.NotEmpty(t, strings.TrimSpace(user))
+	opts := harmonydb.ItestOptions{Hosts: []string{host}, Port: port, Database: database, Username: user,
+		Password: os.Getenv(prefix + "PASSWORD"), ITestID: harmonydb.ITestNewID()}
+	cfg := opts.HarmonyConfig()
+	cfg.ReadOnly, cfg.LoadBalance = true, false
+	db, err := harmonydb.NewFromConfig(cfg)
+	require.NoError(t, err)
+	t.Cleanup(db.ITestDeleteAll)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	pcfg, err := pgx.ParseConfig("postgresql://placeholder@127.0.0.1/placeholder?sslmode=disable&load_balance=false")
+	require.NoError(t, err)
+	pcfg.Host, pcfg.Port, pcfg.Database, pcfg.User, pcfg.Password = host, uint16(n), database, user, opts.Password
+	pcfg.Fallbacks, pcfg.ConnectTimeout = nil, 5*time.Second
+	pcfg.RuntimeParams = map[string]string{"search_path": "itest_" + string(opts.ITestID), "statement_timeout": "5000", "lock_timeout": "2000"}
+	conn, err := pgx.ConnectConfig(ctx, pcfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		closeCtx, stop := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stop()
+		require.NoError(t, conn.Close(closeCtx))
+	})
+	_, path, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	for _, name := range []string{"20230719-harmony.sql", "20260909-task-ownership-age.sql", "20260909-task-attempt-start.sql"} {
+		contents, err := os.ReadFile(filepath.Join(filepath.Dir(path), "..", "..", "..", "harmony", "harmonydb", "sql", name))
+		require.NoError(t, err)
+		_, err = conn.Exec(ctx, string(contents))
+		require.NoError(t, err)
+	}
+	_, err = db.Exec(ctx, `INSERT INTO harmony_machines (id,host_and_port,cpu,ram,gpu) VALUES (101,'worker.example:12300',8,1024,0)`)
+	require.NoError(t, err)
+	_, err = db.Exec(ctx, `INSERT INTO harmony_task (id,posted_time,owner_id,added_by,name)
+SELECT n, CURRENT_TIMESTAMP-INTERVAL '3 hours', CASE WHEN n<=3 THEN 101 ELSE NULL END,101,'Synthetic' FROM generate_series(1,503) n`)
+	require.NoError(t, err)
+	_, err = db.Exec(ctx, `UPDATE harmony_task SET attempt_id='current',attempt_started_at=CURRENT_TIMESTAMP-INTERVAL '10 minutes',attempt_start_source='do_entry' WHERE id=1`)
+	require.NoError(t, err)
+	_, err = db.Exec(ctx, `UPDATE harmony_task SET attempt_start_source=NULL WHERE id=3`)
+	require.NoError(t, err)
+	source := harmonyClusterTaskSummarySource{db: db}
+	applied := ClusterTaskSummaryApplied{MaxTasks: 5, MaxPending: 2}
+	started := time.Now()
+	snapshot, err := source.LoadSnapshot(ctx, applied)
+	require.NoError(t, err)
+	t.Logf("bounded snapshot wall=%s returned=%d running_total=%d pending_total=%d; row limit is not a scanned-row bound", time.Since(started), len(snapshot.Rows), snapshot.RunningTotal, snapshot.PendingTotal)
+	require.Len(t, snapshot.Rows, 5)
+	require.Equal(t, int64(3), snapshot.RunningTotal)
+	require.Equal(t, int64(500), snapshot.PendingTotal)
+	for i, expected := range []string{"running", "awaiting-start", "unknown", "pending", "pending"} {
+		row := buildLimitedTaskSummary(snapshot.Rows[i], snapshot.ObservedAt, nil)
+		require.Equal(t, expected, row.TookState)
+		if i == 0 {
+			require.NotNil(t, row.TookSeconds)
+			require.InDelta(t, 600, *row.TookSeconds, 3)
+		} else {
+			require.Nil(t, row.TookSeconds)
+		}
+	}
+	types, err := source.LoadTaskTypes(ctx, false)
+	require.NoError(t, err)
+	require.Len(t, types, 1)
+	rows, err := conn.Query(ctx, "EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) "+clusterTaskSummaryLimitedQuery, clusterTaskSummaryLimitedQueryArgs(applied)...)
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		t.Log(line)
+	}
+	require.NoError(t, rows.Err())
+}

--- a/web/api/webrpc/tasks_limited_test.go
+++ b/web/api/webrpc/tasks_limited_test.go
@@ -1,0 +1,500 @@
+package webrpc
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/curio/harmony/harmonydb"
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+	"github.com/filecoin-project/curio/tasks/tasknames"
+)
+
+type memoryClusterTaskSummarySource struct {
+	rows         []clusterTaskSummaryLimitedRow
+	observedAt   time.Time
+	snapshotErr  error
+	taskTypesErr error
+	applied      []ClusterTaskSummaryApplied
+	typeIncludes []bool
+}
+
+func (m *memoryClusterTaskSummarySource) LoadSnapshot(ctx context.Context, applied ClusterTaskSummaryApplied) (clusterTaskSummarySnapshot, error) {
+	if err := ctx.Err(); err != nil {
+		return clusterTaskSummarySnapshot{}, err
+	}
+	m.applied = append(m.applied, applied)
+	if m.snapshotErr != nil {
+		return clusterTaskSummarySnapshot{}, m.snapshotErr
+	}
+
+	var running, pending []clusterTaskSummaryLimitedRow
+	for _, row := range m.rows {
+		if !applied.IncludeBackground && strings.HasPrefix(row.Name, "bg:") {
+			continue
+		}
+		if applied.TaskName != nil && row.Name != *applied.TaskName {
+			continue
+		}
+
+		if row.OwnerID != nil {
+			row.State = "running"
+			running = append(running, row)
+		} else {
+			row.State = "pending"
+			pending = append(pending, row)
+		}
+	}
+
+	sort.Slice(running, func(i, j int) bool {
+		left, right := running[i], running[j]
+		if left.WorkStart.Valid != right.WorkStart.Valid {
+			return !left.WorkStart.Valid
+		}
+		if left.WorkStart.Valid && !left.WorkStart.Time.Equal(right.WorkStart.Time) {
+			return left.WorkStart.Time.Before(right.WorkStart.Time)
+		}
+		return left.ID < right.ID
+	})
+	sort.Slice(pending, func(i, j int) bool {
+		left, right := pending[i], pending[j]
+		if !left.PostedTime.Equal(right.PostedTime) {
+			return left.PostedTime.Before(right.PostedTime)
+		}
+		return left.ID < right.ID
+	})
+
+	runningTotal, pendingTotal := len(running), len(pending)
+	running = running[:min(len(running), applied.MaxTasks)]
+	pendingLimit := min(applied.MaxPending, applied.MaxTasks-len(running))
+	pending = pending[:min(len(pending), pendingLimit)]
+	selected := append(append([]clusterTaskSummaryLimitedRow{}, running...), pending...)
+	return clusterTaskSummarySnapshot{
+		Rows:         selected,
+		RunningTotal: int64(runningTotal),
+		PendingTotal: int64(pendingTotal),
+		ObservedAt:   m.observedAt,
+	}, nil
+}
+
+func (m *memoryClusterTaskSummarySource) LoadTaskTypes(ctx context.Context, includeBackground bool) ([]ClusterTaskTypeCount, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	m.typeIncludes = append(m.typeIncludes, includeBackground)
+	if m.taskTypesErr != nil {
+		return nil, m.taskTypesErr
+	}
+
+	byName := map[string]*ClusterTaskTypeCount{}
+	for _, row := range m.rows {
+		if !includeBackground && strings.HasPrefix(row.Name, "bg:") {
+			continue
+		}
+		count, ok := byName[row.Name]
+		if !ok {
+			count = &ClusterTaskTypeCount{Name: row.Name}
+			byName[row.Name] = count
+		}
+		if row.OwnerID != nil {
+			count.Running++
+		} else {
+			count.Pending++
+		}
+		count.Total++
+	}
+
+	taskTypes := make([]ClusterTaskTypeCount, 0, len(byName))
+	for _, count := range byName {
+		taskTypes = append(taskTypes, *count)
+	}
+	sort.Slice(taskTypes, func(i, j int) bool { return taskTypes[i].Name < taskTypes[j].Name })
+	return taskTypes, nil
+}
+
+type failingSpidGetter struct {
+	err   error
+	calls [][]int64
+}
+
+func (f *failingSpidGetter) GetSpids(_ context.Context, _ *harmonydb.DB, taskIDs []int64) ([]harmonytask.TaskSPID, error) {
+	f.calls = append(f.calls, append([]int64(nil), taskIDs...))
+	return nil, f.err
+}
+
+type fixedSpidGetter struct {
+	resolved []harmonytask.TaskSPID
+}
+
+func (f fixedSpidGetter) GetSpids(_ context.Context, _ *harmonydb.DB, _ []int64) ([]harmonytask.TaskSPID, error) {
+	return f.resolved, nil
+}
+
+func clusterTaskTestInt(value int) *int {
+	return &value
+}
+
+func TestNormalizeClusterTaskSummaryRequest(t *testing.T) {
+	empty := ""
+	tests := []struct {
+		name               string
+		request            ClusterTaskSummaryLimitedRequest
+		wantMaxTasks       int
+		wantMaxPending     int
+		wantTaskName       *string
+		wantIncludeBacklog bool
+	}{
+		{name: "omitted defaults", wantMaxTasks: 500, wantMaxPending: 500},
+		{name: "explicit zero tasks clamps to one", request: ClusterTaskSummaryLimitedRequest{MaxTasks: clusterTaskTestInt(0)}, wantMaxTasks: 1, wantMaxPending: 1},
+		{name: "tasks above hard cap", request: ClusterTaskSummaryLimitedRequest{MaxTasks: clusterTaskTestInt(10_000)}, wantMaxTasks: 500, wantMaxPending: 500},
+		{name: "explicit zero pending", request: ClusterTaskSummaryLimitedRequest{MaxPending: clusterTaskTestInt(0)}, wantMaxTasks: 500, wantMaxPending: 0},
+		{name: "negative pending", request: ClusterTaskSummaryLimitedRequest{MaxPending: clusterTaskTestInt(-5)}, wantMaxTasks: 500, wantMaxPending: 0},
+		{name: "pending constrained by tasks", request: ClusterTaskSummaryLimitedRequest{MaxTasks: clusterTaskTestInt(20), MaxPending: clusterTaskTestInt(100)}, wantMaxTasks: 20, wantMaxPending: 20},
+		{name: "empty exact task name retained", request: ClusterTaskSummaryLimitedRequest{TaskName: &empty}, wantMaxTasks: 500, wantMaxPending: 500, wantTaskName: &empty},
+		{name: "background retained", request: ClusterTaskSummaryLimitedRequest{IncludeBackground: true}, wantMaxTasks: 500, wantMaxPending: 500, wantIncludeBacklog: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := normalizeClusterTaskSummaryRequest(test.request)
+			if got.MaxTasks != test.wantMaxTasks || got.MaxPending != test.wantMaxPending {
+				t.Fatalf("limits = %d/%d, want %d/%d", got.MaxTasks, got.MaxPending, test.wantMaxTasks, test.wantMaxPending)
+			}
+			if got.IncludeBackground != test.wantIncludeBacklog {
+				t.Fatalf("IncludeBackground = %v, want %v", got.IncludeBackground, test.wantIncludeBacklog)
+			}
+			if (got.TaskName == nil) != (test.wantTaskName == nil) {
+				t.Fatalf("TaskName = %v, want %v", got.TaskName, test.wantTaskName)
+			}
+			if got.TaskName != nil && *got.TaskName != *test.wantTaskName {
+				t.Fatalf("TaskName = %q, want %q", *got.TaskName, *test.wantTaskName)
+			}
+		})
+	}
+}
+
+func TestClusterTaskSummaryRequestRejectsMalformedLimits(t *testing.T) {
+	var request ClusterTaskSummaryLimitedRequest
+	err := json.Unmarshal([]byte(`{"MaxTasks":"500"}`), &request)
+	if err == nil || !strings.Contains(err.Error(), "cannot unmarshal string") {
+		t.Fatalf("unexpected malformed request error: %v", err)
+	}
+}
+
+func TestClusterTaskSummaryLimitedQueryIsBoundedAndParameterized(t *testing.T) {
+	for _, fragment := range []string{
+		"WHERE ($1::BOOLEAN OR t.name NOT LIKE 'bg:%')",
+		"AND ($2::TEXT IS NULL OR t.name = $2)",
+		"LIMIT $3",
+		"LEAST($4::BIGINT, pending_slots)",
+		"LEFT JOIN selected s ON TRUE",
+	} {
+		if !strings.Contains(clusterTaskSummaryLimitedQuery, fragment) {
+			t.Fatalf("limited query is missing %q", fragment)
+		}
+	}
+
+	name := tasknames.SDR
+	applied := ClusterTaskSummaryApplied{MaxTasks: 123, MaxPending: 12, IncludeBackground: true, TaskName: &name}
+	args := clusterTaskSummaryLimitedQueryArgs(applied)
+	if len(args) != 4 || args[0] != true || args[1] != name || args[2] != 123 || args[3] != 12 {
+		t.Fatalf("unexpected query args: %#v", args)
+	}
+}
+
+func TestClusterTaskSummaryLimitedSelectionRules(t *testing.T) {
+	observedAt := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	ownerID := int64(9)
+	rows := []clusterTaskSummaryLimitedRow{
+		{ID: 10, Name: tasknames.StorePiece, PostedTime: observedAt.Add(-24 * time.Hour), WorkStart: sql.NullTime{Time: observedAt.Add(-10 * time.Hour), Valid: true}, OwnerID: &ownerID},
+		{ID: 5, Name: tasknames.SDR, PostedTime: observedAt.Add(-time.Hour), WorkStart: sql.NullTime{Time: observedAt.Add(-time.Minute), Valid: true}, OwnerID: &ownerID},
+		{ID: 4, Name: tasknames.TreeRC, PostedTime: observedAt.Add(-time.Hour), OwnerID: &ownerID},
+		{ID: 3, Name: tasknames.PoRep, PostedTime: observedAt.Add(-time.Hour), WorkStart: sql.NullTime{Time: observedAt.Add(-2 * time.Hour), Valid: true}, OwnerID: &ownerID},
+		{ID: 2, Name: tasknames.PoRep, PostedTime: observedAt.Add(-time.Hour), WorkStart: sql.NullTime{Time: observedAt.Add(-2 * time.Hour), Valid: true}, OwnerID: &ownerID},
+		{ID: 1, Name: tasknames.StorePiece, PostedTime: observedAt.Add(-48 * time.Hour)},
+	}
+	source := &memoryClusterTaskSummarySource{rows: rows, observedAt: observedAt}
+
+	response, err := buildClusterTaskSummaryLimited(context.Background(), ClusterTaskSummaryLimitedRequest{}, source, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantRunning := []int64{4, 10, 2, 3, 5}
+	for i, id := range wantRunning {
+		if response.Running[i].ID != id {
+			t.Fatalf("running[%d] = %d, want %d", i, response.Running[i].ID, id)
+		}
+	}
+	if response.Running[0].AgeSeconds != nil {
+		t.Fatal("unknown running start unexpectedly acquired an age")
+	}
+	if response.Pending[0].ID != 1 {
+		t.Fatalf("pending ID = %d, want 1", response.Pending[0].ID)
+	}
+	if response.Pending[0].AgeSeconds == nil || *response.Pending[0].AgeSeconds != int64((48*time.Hour)/time.Second) {
+		t.Fatalf("pending age = %v", response.Pending[0].AgeSeconds)
+	}
+	if len(response.Running)+len(response.Pending) > response.Applied.MaxTasks {
+		t.Fatalf("response exceeded hard cap: %d", len(response.Running)+len(response.Pending))
+	}
+}
+
+func TestClusterTaskSummaryLimitedAlwaysReservesCapacityForRunning(t *testing.T) {
+	observedAt := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	ownerID := int64(1)
+	source := &memoryClusterTaskSummarySource{
+		observedAt: observedAt,
+		rows: []clusterTaskSummaryLimitedRow{
+			{ID: 1, Name: tasknames.StorePiece, WorkStart: sql.NullTime{Time: observedAt.Add(-time.Minute), Valid: true}, OwnerID: &ownerID},
+			{ID: 2, Name: tasknames.SDR, PostedTime: observedAt.Add(-365 * 24 * time.Hour)},
+		},
+	}
+	maxTasks, maxPending := 1, 1
+
+	response, err := buildClusterTaskSummaryLimited(context.Background(), ClusterTaskSummaryLimitedRequest{MaxTasks: &maxTasks, MaxPending: &maxPending}, source, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Running) != 1 || response.Running[0].ID != 1 || len(response.Pending) != 0 {
+		t.Fatalf("running did not retain the only slot: running=%+v pending=%+v", response.Running, response.Pending)
+	}
+	if response.PendingTotal != 1 {
+		t.Fatalf("PendingTotal = %d, want 1", response.PendingTotal)
+	}
+}
+
+func TestClusterTaskSummaryLimitedPendingPreviewExamples(t *testing.T) {
+	observedAt := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		running     int
+		pending     int
+		request     ClusterTaskSummaryLimitedRequest
+		wantRunning int
+		wantPending int
+	}{
+		{name: "20 plus 30", running: 20, pending: 40_000, request: ClusterTaskSummaryLimitedRequest{MaxPending: clusterTaskTestInt(30)}, wantRunning: 20, wantPending: 30},
+		{name: "480 plus 20", running: 480, pending: 40_000, wantRunning: 480, wantPending: 20},
+		{name: "500 plus zero", running: 600, pending: 40_000, wantRunning: 500, wantPending: 0},
+		{name: "explicit zero pending", running: 20, pending: 40_000, request: ClusterTaskSummaryLimitedRequest{MaxPending: clusterTaskTestInt(0)}, wantRunning: 20, wantPending: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ownerID := int64(1)
+			rows := make([]clusterTaskSummaryLimitedRow, 0, test.running+test.pending)
+			for i := 0; i < test.running; i++ {
+				rows = append(rows, clusterTaskSummaryLimitedRow{ID: int64(i + 1), Name: tasknames.SDR, WorkStart: sql.NullTime{Time: observedAt.Add(-time.Minute), Valid: true}, OwnerID: &ownerID})
+			}
+			for i := 0; i < test.pending; i++ {
+				rows = append(rows, clusterTaskSummaryLimitedRow{ID: int64(test.running + i + 1), Name: tasknames.SDR, PostedTime: observedAt.Add(-time.Hour)})
+			}
+			source := &memoryClusterTaskSummarySource{rows: rows, observedAt: observedAt}
+
+			response, err := buildClusterTaskSummaryLimited(context.Background(), test.request, source, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(response.Running) != test.wantRunning || len(response.Pending) != test.wantPending {
+				t.Fatalf("shown = %d/%d, want %d/%d", len(response.Running), len(response.Pending), test.wantRunning, test.wantPending)
+			}
+			if response.RunningTotal != int64(test.running) || response.PendingTotal != int64(test.pending) {
+				t.Fatalf("totals = %d/%d, want %d/%d", response.RunningTotal, response.PendingTotal, test.running, test.pending)
+			}
+		})
+	}
+}
+
+func TestClusterTaskSummaryLimitedFiltersBeforeLimits(t *testing.T) {
+	observedAt := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	ownerID := int64(1)
+	rows := make([]clusterTaskSummaryLimitedRow, 0, 602)
+	for i := 0; i < 600; i++ {
+		rows = append(rows, clusterTaskSummaryLimitedRow{ID: int64(i + 1), Name: "bg:Hidden", WorkStart: sql.NullTime{Time: observedAt.Add(-time.Hour), Valid: true}, OwnerID: &ownerID})
+	}
+	rows = append(rows,
+		clusterTaskSummaryLimitedRow{ID: 1001, Name: tasknames.StorePiece, WorkStart: sql.NullTime{Time: observedAt.Add(-time.Minute), Valid: true}, OwnerID: &ownerID},
+		clusterTaskSummaryLimitedRow{ID: 1002, Name: tasknames.SDR, WorkStart: sql.NullTime{Time: observedAt.Add(-time.Minute), Valid: true}, OwnerID: &ownerID},
+	)
+	source := &memoryClusterTaskSummarySource{rows: rows, observedAt: observedAt}
+	maxTasks := 1
+	taskName := tasknames.StorePiece
+	getter := &recordingSpidGetter{resolve: func(int64) []int64 { return []int64{1234} }}
+
+	response, err := buildClusterTaskSummaryLimited(
+		context.Background(),
+		ClusterTaskSummaryLimitedRequest{MaxTasks: &maxTasks, TaskName: &taskName},
+		source,
+		nil,
+		map[string]BatchSpidGetter{tasknames.StorePiece: getter},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Running) != 1 || response.Running[0].ID != 1001 || response.RunningTotal != 1 {
+		t.Fatalf("filtered response = %+v, total %d", response.Running, response.RunningTotal)
+	}
+	if !response.TaskTypesAvailable || slices.ContainsFunc(response.TaskTypes, func(count ClusterTaskTypeCount) bool { return count.Name == "bg:Hidden" }) {
+		t.Fatalf("background type leaked into choices: %+v", response.TaskTypes)
+	}
+	if !slices.ContainsFunc(response.TaskTypes, func(count ClusterTaskTypeCount) bool { return count.Name == tasknames.SDR }) {
+		t.Fatalf("outside-subset task type missing: %+v", response.TaskTypes)
+	}
+	if len(getter.calls) != 1 || !slices.Equal(getter.calls[0], []int64{1001}) {
+		t.Fatalf("enriched IDs = %v, want [1001]", getter.calls)
+	}
+}
+
+func TestClusterTaskSummaryLimitedEnrichesOnlySelectedRows(t *testing.T) {
+	observedAt := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	ownerID := int64(1)
+	rows := make([]clusterTaskSummaryLimitedRow, 0, 40_020)
+	for i := 0; i < 20; i++ {
+		rows = append(rows, clusterTaskSummaryLimitedRow{ID: int64(i + 1), Name: tasknames.SDR, WorkStart: sql.NullTime{Time: observedAt.Add(-time.Minute), Valid: true}, OwnerID: &ownerID})
+	}
+	for i := 0; i < 40_000; i++ {
+		rows = append(rows, clusterTaskSummaryLimitedRow{ID: int64(i + 21), Name: tasknames.SDR, PostedTime: observedAt.Add(-time.Hour)})
+	}
+	source := &memoryClusterTaskSummarySource{rows: rows, observedAt: observedAt}
+	getter := &recordingSpidGetter{resolve: func(taskID int64) []int64 { return []int64{taskID + 1000} }}
+
+	response, err := buildClusterTaskSummaryLimited(context.Background(), ClusterTaskSummaryLimitedRequest{MaxPending: clusterTaskTestInt(30)}, source, nil, map[string]BatchSpidGetter{tasknames.SDR: getter})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Running) != 20 || len(response.Pending) != 30 {
+		t.Fatalf("selected = %d/%d, want 20/30", len(response.Running), len(response.Pending))
+	}
+	if len(getter.calls) != 1 || len(getter.calls[0]) != 50 {
+		t.Fatalf("enrichment calls = %d with %d IDs", len(getter.calls), len(getter.calls[0]))
+	}
+}
+
+func TestClusterTaskSummaryLimitedPartialEnrichment(t *testing.T) {
+	observedAt := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	ownerID := int64(1)
+	source := &memoryClusterTaskSummarySource{
+		observedAt: observedAt,
+		rows: []clusterTaskSummaryLimitedRow{
+			{ID: 1, Name: tasknames.SDR, WorkStart: sql.NullTime{Time: observedAt.Add(-time.Hour), Valid: true}, OwnerID: &ownerID},
+			{ID: 2, Name: tasknames.TreeD, WorkStart: sql.NullTime{Time: observedAt.Add(-time.Minute), Valid: true}, OwnerID: &ownerID},
+			{ID: 3, Name: "NoSpid", WorkStart: sql.NullTime{Time: observedAt.Add(-time.Minute), Valid: true}, OwnerID: &ownerID},
+		},
+	}
+	failing := &failingSpidGetter{err: errors.New("database unavailable")}
+	success := &recordingSpidGetter{resolve: func(int64) []int64 { return []int64{1234} }}
+
+	response, err := buildClusterTaskSummaryLimited(context.Background(), ClusterTaskSummaryLimitedRequest{}, source, nil, map[string]BatchSpidGetter{
+		tasknames.SDR:   failing,
+		tasknames.TreeD: success,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !response.Partial || len(response.Warnings) != 1 || response.Warnings[0].Code != "spid_enrichment_failed" {
+		t.Fatalf("partial warnings = %+v", response.Warnings)
+	}
+	if response.Running[0].SpID != "" || response.Running[1].SpID != "1234" || response.Running[2].SpID != "" {
+		t.Fatalf("unexpected enrichment: %+v", response.Running)
+	}
+}
+
+func TestResolveLimitedTaskSPIDsRejectsResultFromAnotherTaskType(t *testing.T) {
+	rows := []clusterTaskSummaryLimitedRow{
+		{ID: 1, Name: tasknames.SDR},
+		{ID: 2, Name: tasknames.TreeD},
+	}
+	getter := fixedSpidGetter{resolved: []harmonytask.TaskSPID{
+		{TaskID: 1, SPID: 1001},
+		{TaskID: 2, SPID: 2002},
+	}}
+
+	spids, warnings, err := resolveLimitedTaskSPIDs(
+		context.Background(),
+		nil,
+		rows,
+		map[string]BatchSpidGetter{tasknames.SDR: getter},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %+v, want none", warnings)
+	}
+	if !slices.Equal(spids[1], []int64{1001}) {
+		t.Fatalf("SpID for requested SDR task = %v, want 1001", spids[1])
+	}
+	if spid, ok := spids[2]; ok {
+		t.Fatalf("SDR getter attached SpID %v to selected TreeD task", spid)
+	}
+}
+
+func TestClusterTaskSummaryLimitedCancellationAndSnapshotFailures(t *testing.T) {
+	observedAt := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	ownerID := int64(1)
+	row := clusterTaskSummaryLimitedRow{ID: 1, Name: tasknames.SDR, WorkStart: sql.NullTime{Time: observedAt, Valid: true}, OwnerID: &ownerID}
+
+	t.Run("snapshot failure", func(t *testing.T) {
+		source := &memoryClusterTaskSummarySource{snapshotErr: errors.New("snapshot failed")}
+		if _, err := buildClusterTaskSummaryLimited(context.Background(), ClusterTaskSummaryLimitedRequest{}, source, nil, nil); err == nil {
+			t.Fatal("expected snapshot error")
+		}
+	})
+
+	t.Run("enrichment cancellation", func(t *testing.T) {
+		source := &memoryClusterTaskSummarySource{rows: []clusterTaskSummaryLimitedRow{row}, observedAt: observedAt}
+		getter := &failingSpidGetter{err: context.Canceled}
+		if _, err := buildClusterTaskSummaryLimited(context.Background(), ClusterTaskSummaryLimitedRequest{}, source, nil, map[string]BatchSpidGetter{tasknames.SDR: getter}); !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context cancellation", err)
+		}
+	})
+
+	t.Run("task type failure is partial", func(t *testing.T) {
+		source := &memoryClusterTaskSummarySource{rows: []clusterTaskSummaryLimitedRow{row}, observedAt: observedAt, taskTypesErr: errors.New("count failed")}
+		response, err := buildClusterTaskSummaryLimited(context.Background(), ClusterTaskSummaryLimitedRequest{}, source, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !response.Partial || response.TaskTypesAvailable || len(response.Warnings) != 1 || response.Warnings[0].Code != "task_types_unavailable" {
+			t.Fatalf("unexpected partial response: %+v", response)
+		}
+	})
+
+	t.Run("task type cancellation is fatal", func(t *testing.T) {
+		source := &memoryClusterTaskSummarySource{rows: []clusterTaskSummaryLimitedRow{row}, observedAt: observedAt, taskTypesErr: context.DeadlineExceeded}
+		if _, err := buildClusterTaskSummaryLimited(context.Background(), ClusterTaskSummaryLimitedRequest{}, source, nil, nil); !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("error = %v, want context deadline", err)
+		}
+	})
+}
+
+func TestBuildLimitedTaskSummaryDoesNotFallbackForUnknownRuntime(t *testing.T) {
+	observedAt := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	ownerID := int64(1)
+	row := clusterTaskSummaryLimitedRow{
+		ID:         1,
+		Name:       tasknames.SDR,
+		PostedTime: observedAt.Add(-24 * time.Hour),
+		OwnerID:    &ownerID,
+		State:      "running",
+	}
+
+	task := buildLimitedTaskSummary(row, observedAt, nil)
+	if task.AgeSeconds != nil {
+		t.Fatalf("unknown runtime fell back to posted time: %d", *task.AgeSeconds)
+	}
+}
+
+func TestClusterTaskAgeSecondsClampsFutureTimestamp(t *testing.T) {
+	now := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	if got := clusterTaskAgeSeconds(now, now.Add(time.Minute)); got != 0 {
+		t.Fatalf("future age = %d, want 0", got)
+	}
+}

--- a/web/static/cluster-tasks-age.mjs
+++ b/web/static/cluster-tasks-age.mjs
@@ -1,0 +1,13 @@
+import {interpolateClusterTaskAgeSeconds as interpolate} from './cluster-tasks-model.mjs';
+
+export function clusterTaskAge(entry, clock) {
+  const pending = entry.OwnerID === null || entry.OwnerID === undefined;
+  if (pending) {
+    const age = interpolate(entry.AgeSeconds, clock);
+    return {seconds: age, text: age === null ? 'unknown' : null, title: 'Waiting since posting; this task has not started.'};
+  }
+  const age = entry.TookState === 'running' ? interpolate(entry.TookSeconds, clock) : null;
+  if (age !== null) return {seconds:age, text:null, title:'Took since entry into the current task Do attempt; the same start is used by new History records.'};
+  if (entry.TookState === 'awaiting-start') return {seconds:null, text:'—', title:'No current attempt execution start has been confirmed; ownership alone is not execution.'};
+  return {seconds:null, text:'unknown', title:entry.TookState === 'future-start' ? 'The recorded start is ahead of the server snapshot; check clock synchronization.' : 'The current attempt start is unknown. Posted, claim and migration times are not used as Took.'};
+}

--- a/web/static/cluster-tasks-controller.mjs
+++ b/web/static/cluster-tasks-controller.mjs
@@ -1,0 +1,289 @@
+export const CLUSTER_TASK_SETTLE_MS = 5000;
+export const CLUSTER_TASK_TIMEOUT_MS = 15000;
+export const CLUSTER_TASK_FRESHNESS_TICK_MS = 1000;
+
+export class ClusterTaskFreshnessTicker {
+  constructor({
+    onTick,
+    tickMs = CLUSTER_TASK_FRESHNESS_TICK_MS,
+    nowFn = Date.now,
+    setTimeoutFn = globalThis.setTimeout.bind(globalThis),
+    clearTimeoutFn = globalThis.clearTimeout.bind(globalThis),
+  }) {
+    if (typeof onTick !== 'function') {
+      throw new TypeError('onTick must be a function');
+    }
+
+    this.onTick = onTick;
+    this.tickMs = tickMs;
+    this.nowFn = nowFn;
+    this.setTimeoutFn = setTimeoutFn;
+    this.clearTimeoutFn = clearTimeoutFn;
+    this.active = false;
+    this.timer = null;
+  }
+
+  start() {
+    if (this.active) {
+      return false;
+    }
+
+    this.active = true;
+    this.onTick(this.nowFn());
+    this.schedule();
+    return true;
+  }
+
+  stop() {
+    this.active = false;
+    if (this.timer !== null) {
+      this.clearTimeoutFn(this.timer);
+      this.timer = null;
+    }
+  }
+
+  schedule() {
+    this.timer = this.setTimeoutFn(() => {
+      this.timer = null;
+      if (!this.active) {
+        return;
+      }
+      this.onTick(this.nowFn());
+      this.schedule();
+    }, this.tickMs);
+  }
+}
+
+function timeoutError(timeoutMs) {
+  const error = new Error(`Cluster task refresh timed out after ${timeoutMs / 1000}s`);
+  error.name = 'TimeoutError';
+  return error;
+}
+
+function cancellationError() {
+  const error = new Error('Cluster task refresh canceled');
+  error.name = 'AbortError';
+  return error;
+}
+
+export class ClusterTaskPollController {
+  constructor({
+    request,
+    onStart = () => {},
+    onSuccess = () => {},
+    onError = () => {},
+    settleMs = CLUSTER_TASK_SETTLE_MS,
+    timeoutMs = CLUSTER_TASK_TIMEOUT_MS,
+    setTimeoutFn = globalThis.setTimeout.bind(globalThis),
+    clearTimeoutFn = globalThis.clearTimeout.bind(globalThis),
+  }) {
+    if (typeof request !== 'function') {
+      throw new TypeError('request must be a function');
+    }
+
+    this.request = request;
+    this.onStart = onStart;
+    this.onSuccess = onSuccess;
+    this.onError = onError;
+    this.settleMs = settleMs;
+    this.timeoutMs = timeoutMs;
+    this.setTimeoutFn = setTimeoutFn;
+    this.clearTimeoutFn = clearTimeoutFn;
+
+    this.mounted = false;
+    this.viewVisible = false;
+    this.documentVisible = true;
+    this.paused = false;
+
+    this.generation = 0;
+    this.currentRun = null;
+    this.settleTimer = null;
+    this.pendingImmediate = false;
+  }
+
+  get active() {
+    return this.mounted && this.viewVisible && this.documentVisible && !this.paused;
+  }
+
+  get running() {
+    return this.currentRun !== null;
+  }
+
+  setActivity(activity = {}) {
+    const wasActive = this.active;
+
+    for (const field of ['mounted', 'viewVisible', 'documentVisible', 'paused']) {
+      if (Object.hasOwn(activity, field)) {
+        this[field] = Boolean(activity[field]);
+      }
+    }
+
+    if (!this.active) {
+      this.stopActiveWork();
+      return;
+    }
+
+    if (!wasActive) {
+      this.refreshNow();
+    }
+  }
+
+  refreshNow() {
+    if (!this.active) {
+      return false;
+    }
+
+    this.clearSettleTimer();
+    this.pendingImmediate = true;
+
+    if (this.currentRun) {
+      this.invalidateCurrentRun();
+    } else {
+      this.startPendingRun();
+    }
+
+    return true;
+  }
+
+  stopActiveWork() {
+    this.pendingImmediate = false;
+    this.clearSettleTimer();
+    this.generation += 1;
+
+    if (!this.currentRun) {
+      return;
+    }
+
+    this.currentRun.invalidated = true;
+    this.clearRunTimeout(this.currentRun);
+    this.currentRun.controller.abort();
+    this.currentRun.interrupt(cancellationError());
+  }
+
+  invalidateCurrentRun() {
+    const run = this.currentRun;
+    if (!run || run.invalidated) {
+      return;
+    }
+
+    run.invalidated = true;
+    this.generation += 1;
+    this.clearRunTimeout(run);
+    run.controller.abort();
+    run.interrupt(cancellationError());
+  }
+
+  startPendingRun() {
+    if (!this.active || this.currentRun || !this.pendingImmediate) {
+      return;
+    }
+
+    this.pendingImmediate = false;
+    let rejectInterrupt;
+    const interruptPromise = new Promise((_, reject) => {
+      rejectInterrupt = reject;
+    });
+    const run = {
+      controller: new AbortController(),
+      generation: ++this.generation,
+      invalidated: false,
+      timedOut: false,
+      timeoutTimer: null,
+      interruptPromise,
+      interrupt: (error) => {
+        if (rejectInterrupt === null) {
+          return;
+        }
+        const reject = rejectInterrupt;
+        rejectInterrupt = null;
+        reject(error);
+      },
+    };
+
+    this.currentRun = run;
+    run.timeoutTimer = this.setTimeoutFn(() => {
+      if (this.currentRun !== run || run.invalidated) {
+        return;
+      }
+      run.timedOut = true;
+      run.controller.abort();
+      run.interrupt(timeoutError(this.timeoutMs));
+    }, this.timeoutMs);
+
+    run.promise = this.executeRun(run);
+  }
+
+  canCommit(run) {
+    return this.currentRun === run &&
+      run.generation === this.generation &&
+      !run.invalidated &&
+      this.active;
+  }
+
+  async executeRun(run) {
+    try {
+      this.onStart();
+      const requestPromise = this.request(run.controller.signal);
+      const result = await Promise.race([requestPromise, run.interruptPromise]);
+      if (!this.canCommit(run)) {
+        return;
+      }
+      if (run.timedOut) {
+        this.onError(timeoutError(this.timeoutMs), {timedOut: true});
+      } else {
+        this.onSuccess(result);
+      }
+    } catch (error) {
+      if (!this.canCommit(run)) {
+        return;
+      }
+      if (run.timedOut) {
+        this.onError(timeoutError(this.timeoutMs), {timedOut: true});
+      } else if (!run.controller.signal.aborted) {
+        this.onError(error, {timedOut: false});
+      }
+    } finally {
+      this.clearRunTimeout(run);
+      if (this.currentRun !== run) {
+        return;
+      }
+
+      this.currentRun = null;
+      if (!this.active) {
+        return;
+      }
+
+      if (this.pendingImmediate) {
+        this.startPendingRun();
+      } else {
+        this.scheduleNextRun();
+      }
+    }
+  }
+
+  scheduleNextRun() {
+    this.clearSettleTimer();
+    this.settleTimer = this.setTimeoutFn(() => {
+      this.settleTimer = null;
+      if (!this.active || this.currentRun) {
+        return;
+      }
+      this.pendingImmediate = true;
+      this.startPendingRun();
+    }, this.settleMs);
+  }
+
+  clearRunTimeout(run) {
+    if (run.timeoutTimer !== null) {
+      this.clearTimeoutFn(run.timeoutTimer);
+      run.timeoutTimer = null;
+    }
+  }
+
+  clearSettleTimer() {
+    if (this.settleTimer !== null) {
+      this.clearTimeoutFn(this.settleTimer);
+      this.settleTimer = null;
+    }
+  }
+}

--- a/web/static/cluster-tasks-grouping.mjs
+++ b/web/static/cluster-tasks-grouping.mjs
@@ -1,0 +1,24 @@
+export function groupConsecutiveTasks(data) {
+  const groups = [];
+  let currentGroup = [];
+  let currentKey = null;
+
+  for (const entry of data) {
+    const key = JSON.stringify([entry.State, entry.SpIDs || entry.SpID, entry.Name, entry.OwnerID]);
+    if (key !== currentKey) {
+      if (currentGroup.length > 0) {
+        groups.push(currentGroup);
+      }
+      currentGroup = [entry];
+      currentKey = key;
+    } else {
+      currentGroup.push(entry);
+    }
+  }
+
+  if (currentGroup.length > 0) {
+    groups.push(currentGroup);
+  }
+
+  return groups;
+}

--- a/web/static/cluster-tasks-model.mjs
+++ b/web/static/cluster-tasks-model.mjs
@@ -11,7 +11,7 @@ export const CLUSTER_TASK_DEFAULTS = Object.freeze({
 export const CLUSTER_TASK_ORDER_POLICY =
   'Current ownership age first; task ID breaks ties';
 export const RUNNING_AGE_TOOLTIP =
-  'Ownership age starts when the current owner claimed the task; it is not execution runtime.';
+  'Took starts at entry into the current task Do attempt, matching new History records; not at claim or FFI entry.';
 export const PENDING_AGE_TOOLTIP =
   'Waiting time starts when the task was posted.';
 export const UNKNOWN_RUNNING_AGE_TOOLTIP =
@@ -373,7 +373,7 @@ export function buildClusterTaskSections(response, coalesceEntries) {
     {
       key: 'running',
       title: 'Running',
-      ageLabel: 'Owned',
+      ageLabel: 'Took',
       ageTooltip: `${RUNNING_AGE_TOOLTIP} ${INTERPOLATED_AGE_TOOLTIP}`,
       entries: normalized.Running,
       groups: groupsFor(normalized.Running, coalesceEntries),

--- a/web/static/cluster-tasks-model.mjs
+++ b/web/static/cluster-tasks-model.mjs
@@ -1,0 +1,392 @@
+import {groupConsecutiveTasks} from './cluster-tasks-grouping.mjs';
+
+export const CLUSTER_TASK_DEFAULTS = Object.freeze({
+  maxTasks: 500,
+  maxPending: 500,
+  includeBackground: false,
+  taskName: '',
+  coalesceEntries: true,
+});
+
+export const CLUSTER_TASK_ORDER_POLICY =
+  'Current ownership age first; task ID breaks ties';
+export const RUNNING_AGE_TOOLTIP =
+  'Ownership age starts when the current owner claimed the task; it is not execution runtime.';
+export const PENDING_AGE_TOOLTIP =
+  'Waiting time starts when the task was posted.';
+export const UNKNOWN_RUNNING_AGE_TOOLTIP =
+  'Ownership age is unknown because the timestamp or its provenance is unavailable.';
+export const INTERPOLATED_AGE_TOOLTIP =
+  'Between successful refreshes, displayed time is estimated locally from the last task snapshot.';
+
+export function parseBoundedInteger(value, min, max) {
+  const text = String(value).trim();
+  if (!/^-?\d+$/.test(text)) {
+    return null;
+  }
+
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed)) {
+    return null;
+  }
+  return Math.min(max, Math.max(min, parsed));
+}
+
+export function buildClusterTaskRequest(controls) {
+  return {
+    MaxTasks: controls.maxTasks,
+    MaxPending: controls.maxPending,
+    IncludeBackground: controls.includeBackground,
+    TaskName: controls.taskName || null,
+  };
+}
+
+export function formatTaskAgeSeconds(value) {
+  if (!Number.isFinite(value) || value < 0) {
+    return 'unknown';
+  }
+
+  let seconds = Math.floor(value);
+  const hours = Math.floor(seconds / 3600);
+  seconds %= 3600;
+  const minutes = Math.floor(seconds / 60);
+  seconds %= 60;
+
+  if (hours > 0) {
+    return `${hours}h${minutes}m${seconds}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+export function createClusterTaskDisplayClock() {
+  return {
+    anchorMonotonic: null,
+    elapsedSeconds: 0,
+    interpolating: false,
+  };
+}
+
+export function resetClusterTaskDisplayClock(monotonicNow) {
+  if (!Number.isFinite(monotonicNow)) {
+    return createClusterTaskDisplayClock();
+  }
+  return {
+    anchorMonotonic: monotonicNow,
+    elapsedSeconds: 0,
+    interpolating: true,
+  };
+}
+
+export function advanceClusterTaskDisplayClock(clock, monotonicNow) {
+  if (
+    !clock?.interpolating ||
+    !Number.isFinite(clock.anchorMonotonic) ||
+    !Number.isFinite(monotonicNow)
+  ) {
+    return clock;
+  }
+
+  const elapsedSeconds = Math.max(
+      clock.elapsedSeconds,
+      Math.floor(Math.max(0, monotonicNow - clock.anchorMonotonic) / 1000),
+  );
+  return elapsedSeconds === clock.elapsedSeconds
+    ? clock
+    : {...clock, elapsedSeconds};
+}
+
+export function freezeClusterTaskDisplayClock(clock) {
+  if (!clock?.interpolating) {
+    return clock;
+  }
+  return {...clock, interpolating: false};
+}
+
+export function interpolateClusterTaskAgeSeconds(ageSeconds, clock) {
+  if (!Number.isFinite(ageSeconds) || ageSeconds < 0) {
+    return null;
+  }
+  const elapsedSeconds = Number.isSafeInteger(clock?.elapsedSeconds) &&
+    clock.elapsedSeconds >= 0
+    ? clock.elapsedSeconds
+    : 0;
+  return Math.floor(ageSeconds) + elapsedSeconds;
+}
+
+export function formatClusterTaskFreshness(now, updatedAt) {
+  if (!Number.isFinite(now) || !Number.isFinite(updatedAt)) {
+    return '';
+  }
+
+  const elapsedSeconds = Math.max(0, Math.floor((now - updatedAt) / 1000));
+  return elapsedSeconds === 0
+    ? 'just now'
+    : `${formatTaskAgeSeconds(elapsedSeconds)} ago`;
+}
+
+export function buildClusterTaskLastSuccessPresentation({
+  paused,
+  now,
+  lastSuccessAt,
+}) {
+  if (!Number.isFinite(lastSuccessAt)) {
+    return {
+      text: paused ? 'No successful snapshot is available yet.' : '',
+      title: '',
+    };
+  }
+
+  const absolute = new Date(lastSuccessAt).toLocaleString();
+  if (paused) {
+    return {
+      text: `Last successful update: ${absolute}`,
+      title: absolute,
+    };
+  }
+
+  const relative = formatClusterTaskFreshness(now, lastSuccessAt);
+  return {
+    text: relative ? `Last successful update: ${relative}` : '',
+    title: absolute,
+  };
+}
+
+export function formatClusterTaskSectionSummary(shown, total, totalsAvailable) {
+  return totalsAvailable
+    ? `${shown} of ${total}`
+    : `${shown} shown; total unavailable`;
+}
+
+export function clusterTaskSectionEmptyMessage(sectionKey, value) {
+  const response = normalizeClusterTaskResponse(value);
+  const entries = sectionKey === 'pending' ? response.Pending : response.Running;
+  if (sectionKey === 'pending' && response.Applied.MaxPending === 0) {
+    return 'Pending preview is disabled.';
+  }
+  if (entries.length > 0) {
+    return '';
+  }
+  if (!response.TotalsAvailable) {
+    return `No ${sectionKey} rows displayed; total unavailable.`;
+  }
+
+  const total = sectionKey === 'pending'
+    ? response.PendingTotal
+    : response.RunningTotal;
+  if (total === 0) {
+    return `No ${sectionKey} tasks match the applied snapshot filters.`;
+  }
+  if (
+    sectionKey === 'pending' &&
+    response.Running.length >= response.Applied.MaxTasks
+  ) {
+    return 'Pending preview is omitted because running tasks use the display limit.';
+  }
+  return `No ${sectionKey} rows displayed for this snapshot.`;
+}
+
+function normalizeTaskName(value) {
+  return typeof value === 'string' && value.length > 0 ? value : '';
+}
+
+function normalizeQueryControls(value) {
+  const controls = value && typeof value === 'object' ? value : {};
+  return {
+    MaxTasks: controls.MaxTasks ?? controls.maxTasks,
+    MaxPending: controls.MaxPending ?? controls.maxPending,
+    IncludeBackground: Boolean(
+        controls.IncludeBackground ?? controls.includeBackground,
+    ),
+    TaskName: normalizeTaskName(controls.TaskName ?? controls.taskName),
+  };
+}
+
+export function clusterTaskControlsMatchApplied(controls, applied) {
+  const selected = normalizeQueryControls(controls);
+  const snapshot = normalizeQueryControls(applied);
+  return selected.MaxTasks === snapshot.MaxTasks &&
+    selected.MaxPending === snapshot.MaxPending &&
+    selected.IncludeBackground === snapshot.IncludeBackground &&
+    selected.TaskName === snapshot.TaskName;
+}
+
+export function formatClusterTaskControls(value) {
+  const controls = normalizeQueryControls(value);
+  const taskScope = controls.TaskName ? `${controls.TaskName} tasks` : 'All tasks';
+  const background = controls.IncludeBackground
+    ? 'background included'
+    : 'background hidden';
+  return `${taskScope}; ${background}; max ${controls.MaxTasks}; ` +
+    `pending preview ${controls.MaxPending}`;
+}
+
+export function clusterTaskSnapshotMismatchMessage({
+  controls,
+  response,
+  refreshing,
+  failed,
+  paused,
+}) {
+  if (!response?.Applied || clusterTaskControlsMatchApplied(controls, response.Applied)) {
+    return '';
+  }
+
+  const snapshot = formatClusterTaskControls(response.Applied);
+  const selected = formatClusterTaskControls(controls);
+  let explanation = 'The selected controls have not been applied yet';
+  if (paused) {
+    explanation = 'The selected controls have not been applied while updates are paused';
+  } else if (failed) {
+    explanation = 'The selected controls were not applied because the refresh failed';
+  } else if (refreshing) {
+    explanation = 'The selected controls have not been applied yet';
+  }
+
+  return `Showing the last snapshot for ${snapshot}. ${explanation}: ${selected}.`;
+}
+
+export function shouldRunClusterTaskFreshness({
+  isConnected,
+  viewVisible,
+  documentVisible,
+  paused,
+  hasSuccessfulLoad,
+}) {
+  return isConnected && viewVisible && documentVisible && !paused && hasSuccessfulLoad;
+}
+
+export function buildClusterTaskTypeOptions(selectedTaskName, taskTypes) {
+  const available = Array.isArray(taskTypes) ? taskTypes : [];
+  const seen = new Set();
+  const options = [];
+
+  if (selectedTaskName && !available.some((entry) => entry?.Name === selectedTaskName)) {
+    options.push({Name: selectedTaskName});
+    seen.add(selectedTaskName);
+  }
+
+  for (const taskType of available) {
+    if (taskType && typeof taskType.Name === 'string' && !seen.has(taskType.Name)) {
+      options.push(taskType);
+      seen.add(taskType.Name);
+    }
+  }
+  return options;
+}
+
+function nonNegativeInteger(value, fallback = 0) {
+  return Number.isSafeInteger(value) && value >= 0 ? value : fallback;
+}
+
+export function normalizeClusterTaskResponse(value) {
+  const response = value && typeof value === 'object' ? value : {};
+  const applied = response.Applied && typeof response.Applied === 'object'
+    ? response.Applied
+    : {};
+
+  return {
+    Running: Array.isArray(response.Running) ? response.Running : [],
+    Pending: Array.isArray(response.Pending) ? response.Pending : [],
+    Applied: {
+      MaxTasks: nonNegativeInteger(applied.MaxTasks, CLUSTER_TASK_DEFAULTS.maxTasks),
+      MaxPending: nonNegativeInteger(applied.MaxPending, CLUSTER_TASK_DEFAULTS.maxPending),
+      IncludeBackground: Boolean(applied.IncludeBackground),
+      TaskName: typeof applied.TaskName === 'string' ? applied.TaskName : '',
+    },
+    RunningTotal: nonNegativeInteger(response.RunningTotal),
+    PendingTotal: nonNegativeInteger(response.PendingTotal),
+    TotalsAvailable: Boolean(response.TotalsAvailable),
+    Partial: Boolean(response.Partial),
+    ObservedAt: typeof response.ObservedAt === 'string' ? response.ObservedAt : '',
+    TaskTypes: Array.isArray(response.TaskTypes)
+      ? response.TaskTypes.filter((entry) => entry && typeof entry.Name === 'string')
+      : [],
+    TaskTypesAvailable: Boolean(response.TaskTypesAvailable),
+    Warnings: Array.isArray(response.Warnings)
+      ? response.Warnings.filter((entry) => entry && typeof entry.Message === 'string')
+      : [],
+  };
+}
+
+export function createClusterTaskViewState() {
+  return {
+    response: null,
+    hasSuccessfulLoad: false,
+    refreshing: false,
+    stale: false,
+    error: '',
+    lastSuccessAt: null,
+  };
+}
+
+export function beginClusterTaskRefresh(state) {
+  return {
+    ...state,
+    refreshing: true,
+    error: '',
+  };
+}
+
+export function completeClusterTaskRefresh(state, value, completedAt) {
+  return {
+    ...state,
+    response: normalizeClusterTaskResponse(value),
+    hasSuccessfulLoad: true,
+    refreshing: false,
+    stale: false,
+    error: '',
+    lastSuccessAt: completedAt,
+  };
+}
+
+export function failClusterTaskRefresh(state, error) {
+  return {
+    ...state,
+    refreshing: false,
+    stale: state.hasSuccessfulLoad,
+    error: error?.message || String(error || 'Cluster task refresh failed'),
+  };
+}
+
+export function cancelClusterTaskRefresh(state) {
+  if (!state.refreshing) {
+    return state;
+  }
+  return {
+    ...state,
+    refreshing: false,
+  };
+}
+
+function groupsFor(entries, coalesceEntries) {
+  return coalesceEntries
+    ? groupConsecutiveTasks(entries)
+    : entries.map((entry) => [entry]);
+}
+
+export function buildClusterTaskSections(response, coalesceEntries) {
+  const normalized = normalizeClusterTaskResponse(response);
+  return [
+    {
+      key: 'running',
+      title: 'Running',
+      ageLabel: 'Owned',
+      ageTooltip: `${RUNNING_AGE_TOOLTIP} ${INTERPOLATED_AGE_TOOLTIP}`,
+      entries: normalized.Running,
+      groups: groupsFor(normalized.Running, coalesceEntries),
+      total: normalized.RunningTotal,
+    },
+    {
+      key: 'pending',
+      title: 'Pending preview',
+      ageLabel: 'Waiting',
+      ageTooltip: `${PENDING_AGE_TOOLTIP} ${INTERPOLATED_AGE_TOOLTIP}`,
+      entries: normalized.Pending,
+      groups: groupsFor(normalized.Pending, coalesceEntries),
+      total: normalized.PendingTotal,
+    },
+  ];
+}

--- a/web/static/cluster-tasks.mjs
+++ b/web/static/cluster-tasks.mjs
@@ -1,4 +1,5 @@
 import {LitElement, html, css} from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
+import {clusterTaskAge} from './cluster-tasks-age.mjs';
 import {RPCCallHTTP} from '/lib/jsonrpc.mjs';
 import {
   ClusterTaskFreshnessTicker,
@@ -23,11 +24,9 @@ import {
   freezeClusterTaskDisplayClock,
   formatClusterTaskSectionSummary,
   formatTaskAgeSeconds,
-  interpolateClusterTaskAgeSeconds,
   parseBoundedInteger,
   resetClusterTaskDisplayClock,
   shouldRunClusterTaskFreshness,
-  UNKNOWN_RUNNING_AGE_TOOLTIP,
 } from '/cluster-tasks-model.mjs';
 
 class ClusterTasks extends LitElement {
@@ -248,7 +247,7 @@ class ClusterTasks extends LitElement {
       }
 
       .age-column {
-        text-align: right;
+        text-align: start;
         font-variant-numeric: tabular-nums;
       }
 
@@ -775,16 +774,13 @@ class ClusterTasks extends LitElement {
 
   renderRow(entry) {
     const hasOwner = entry.OwnerID !== null && entry.OwnerID !== undefined;
-    const state = entry.State || (hasOwner ? 'running' : 'pending');
+    const state = hasOwner && entry.TookState === 'awaiting-start'
+      ? 'awaiting-start'
+      : entry.State || (hasOwner ? 'running' : 'pending');
     const miner = entry.Miners?.length ? entry.Miners.join(', ') : entry.SpID ? entry.Miner : 'n/a';
-    const age = formatTaskAgeSeconds(
-        interpolateClusterTaskAgeSeconds(entry.AgeSeconds, this.displayClock),
-    );
-    const ageTitle = age === 'unknown'
-      ? state === 'running'
-        ? UNKNOWN_RUNNING_AGE_TOOLTIP
-        : 'Waiting time is unavailable.'
-      : age;
+    const ageValue = clusterTaskAge(entry, this.displayClock);
+    const age = ageValue.text ?? formatTaskAgeSeconds(ageValue.seconds);
+    const ageTitle = ageValue.title;
     return html`
       <tr>
         <td title=${miner}>${miner}</td>

--- a/web/static/cluster-tasks.mjs
+++ b/web/static/cluster-tasks.mjs
@@ -1,20 +1,205 @@
 import {LitElement, html, css} from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
-import RPCCall from '/lib/jsonrpc.mjs';
-import { pollRPC } from '/lib/poll.mjs';
+import {RPCCallHTTP} from '/lib/jsonrpc.mjs';
+import {
+  ClusterTaskFreshnessTicker,
+  ClusterTaskPollController,
+} from '/cluster-tasks-controller.mjs';
+import {
+  CLUSTER_TASK_DEFAULTS,
+  CLUSTER_TASK_ORDER_POLICY,
+  advanceClusterTaskDisplayClock,
+  beginClusterTaskRefresh,
+  buildClusterTaskLastSuccessPresentation,
+  buildClusterTaskRequest,
+  buildClusterTaskSections,
+  buildClusterTaskTypeOptions,
+  cancelClusterTaskRefresh,
+  clusterTaskSectionEmptyMessage,
+  clusterTaskSnapshotMismatchMessage,
+  completeClusterTaskRefresh,
+  createClusterTaskDisplayClock,
+  createClusterTaskViewState,
+  failClusterTaskRefresh,
+  freezeClusterTaskDisplayClock,
+  formatClusterTaskSectionSummary,
+  formatTaskAgeSeconds,
+  interpolateClusterTaskAgeSeconds,
+  parseBoundedInteger,
+  resetClusterTaskDisplayClock,
+  shouldRunClusterTaskFreshness,
+  UNKNOWN_RUNNING_AGE_TOOLTIP,
+} from '/cluster-tasks-model.mjs';
 
 class ClusterTasks extends LitElement {
   static get properties() {
     return {
-      data: { type: Array },
-      showBackgroundTasks: { type: Boolean },
-      coalesceEntries: { type: Boolean },
+      viewState: {type: Object},
+      maxTasks: {type: Number},
+      maxPending: {type: Number},
+      maxTasksDraft: {type: String},
+      maxPendingDraft: {type: String},
+      maxTasksError: {type: String},
+      maxPendingError: {type: String},
+      includeBackground: {type: Boolean},
+      taskName: {type: String},
+      coalesceEntries: {type: Boolean},
+      paused: {type: Boolean},
+      viewVisible: {type: Boolean},
+      freshnessNow: {type: Number},
+      displayClock: {type: Object},
     };
   }
 
   static get styles() {
     return css`
+      :host {
+        display: block;
+      }
+
+      .controls {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: flex-end;
+        gap: var(--space-3, 12px);
+        margin-bottom: var(--space-3, 12px);
+      }
+
+      .control {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1, 4px);
+        min-width: 7rem;
+      }
+
+      .control > label,
+      .check-control {
+        color: var(--color-text-secondary, #8b949e);
+        font-size: 11px;
+        font-weight: 500;
+      }
+
+      .control input[type='number'] {
+        width: 7rem;
+      }
+
+      .control select {
+        min-width: 11rem;
+        max-width: 18rem;
+      }
+
+      .check-control {
+        display: flex;
+        align-items: center;
+        gap: var(--space-1, 4px);
+        min-height: 31px;
+        white-space: nowrap;
+      }
+
+      .control-error {
+        max-width: 12rem;
+        color: var(--color-danger-fg, #f85149);
+        font-size: 11px;
+      }
+
+      .actions {
+        display: flex;
+        gap: var(--space-2, 8px);
+      }
+
+      .status-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--space-2, 8px);
+        min-height: 24px;
+        margin-bottom: var(--space-2, 8px);
+        color: var(--color-text-secondary, #8b949e);
+        font-size: 12px;
+      }
+
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 5.75rem;
+        padding: 2px 8px;
+        border-radius: var(--radius-md, 6px);
+        font-weight: 600;
+      }
+
+      .status-pill.fresh {
+        color: var(--color-success-fg, #3fb950);
+        background: var(--color-success-muted, rgba(63, 185, 80, 0.15));
+      }
+
+      .status-pill.loading {
+        color: var(--color-info-fg, #58a6ff);
+        background: var(--color-info-muted, rgba(88, 166, 255, 0.15));
+      }
+
+      .status-pill.stale,
+      .status-pill.paused {
+        color: var(--color-warning-fg, #d29922);
+        background: var(--color-warning-muted, rgba(210, 153, 34, 0.15));
+      }
+
+      .status-pill.failed {
+        color: var(--color-danger-fg, #f85149);
+        background: var(--color-danger-muted, rgba(248, 81, 73, 0.15));
+      }
+
+      .policy {
+        margin: 0 0 var(--space-3, 12px);
+        color: var(--color-text-secondary, #8b949e);
+        font-size: 12px;
+      }
+
+      .task-section {
+        margin-top: var(--space-4, 16px);
+      }
+
+      .section-heading {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--space-2, 8px);
+        margin-bottom: var(--space-2, 8px);
+      }
+
+      .section-heading h3 {
+        margin: 0;
+        color: var(--color-text-primary, #e6edf3);
+        font-size: 14px;
+      }
+
+      .section-summary,
+      .empty-state {
+        color: var(--color-text-secondary, #8b949e);
+        font-size: 12px;
+      }
+
+      .empty-state {
+        padding: var(--space-3, 12px);
+        border: 1px dashed var(--color-border-default, #30363d);
+        border-radius: var(--radius-md, 6px);
+      }
+
+      .table-wrap {
+        max-width: 100%;
+        overflow-x: auto;
+      }
+
+      table {
+        width: 100%;
+        min-width: 36rem;
+        table-layout: fixed;
+      }
+
       th,
       td {
+        padding-right: 0.375rem;
+        padding-left: 0.375rem;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -22,153 +207,646 @@ class ClusterTasks extends LitElement {
 
       th:nth-child(1),
       td:nth-child(1) {
-        width: 8ch;
-      }
-      th:nth-child(2),
-      td:nth-child(2) {
-        width: 16ch;
-      }
-      th:nth-child(3),
-      td:nth-child(3) {
         width: 10ch;
-      }
-      th:nth-child(4),
-      td:nth-child(4) {
-        width: 10ch;
-      }
-      th:nth-child(5),
-      td:nth-child(5) {
-        min-width: 20ch;
       }
 
-      /* Row used to coalesce runs of similar tasks */
+      th:nth-child(2),
+      td:nth-child(2) {
+        width: 14ch;
+        max-width: 18ch;
+      }
+
+      th:nth-child(3),
+      td:nth-child(3) {
+        width: 9ch;
+      }
+
+      th:nth-child(4),
+      td:nth-child(4) {
+        width: 9ch;
+      }
+
+      th:nth-child(5),
+      td:nth-child(5) {
+        width: 10ch;
+      }
+
+      th:nth-child(6),
+      td:nth-child(6) {
+        width: 23ch;
+        min-width: 23ch;
+        max-width: none;
+      }
+
+      td:nth-child(6) {
+        overflow: visible;
+        text-overflow: clip;
+      }
+
+      td:nth-child(6) > a {
+        white-space: nowrap;
+      }
+
+      .age-column {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+      }
+
       .similar-row > td {
-        background: var(--color-form-group-2);
+        background: var(--color-form-group-2, #21262d);
         line-height: 1.2em;
         text-align: center;
         font-style: italic;
+      }
+
+      .message {
+        margin-bottom: var(--space-3, 12px);
+      }
+
+      .warnings {
+        margin: 0;
+        padding-left: var(--space-5, 20px);
       }
     `;
   }
 
   constructor() {
     super();
-    this.data = [];
-    this.showBackgroundTasks = false;
-    this.coalesceEntries = true; // Default-enabled coalesce checkbox
-    pollRPC(async () => {
-      this.data = (await RPCCall('ClusterTaskSummary')) || [];
-    }, 1000);
+    this.viewState = createClusterTaskViewState();
+    this.maxTasks = CLUSTER_TASK_DEFAULTS.maxTasks;
+    this.maxPending = CLUSTER_TASK_DEFAULTS.maxPending;
+    this.maxTasksDraft = String(this.maxTasks);
+    this.maxPendingDraft = String(this.maxPending);
+    this.maxTasksError = '';
+    this.maxPendingError = '';
+    this.includeBackground = CLUSTER_TASK_DEFAULTS.includeBackground;
+    this.taskName = CLUSTER_TASK_DEFAULTS.taskName;
+    this.coalesceEntries = CLUSTER_TASK_DEFAULTS.coalesceEntries;
+    this.paused = false;
+    this.viewVisible = false;
+    this.freshnessNow = Date.now();
+    this.displayClock = createClusterTaskDisplayClock();
+    this.monotonicNow = () => performance.now();
+
+    this.drawer = null;
+    this.drawerObserver = null;
+    this.resizeObserver = null;
+    this.handleDocumentVisibility = () => this.syncActivity();
+    this.handleWindowResize = () => this.syncActivity();
+
+    this.pollController = new ClusterTaskPollController({
+      request: (signal) => RPCCallHTTP(
+          'ClusterTaskSummaryLimited',
+          [buildClusterTaskRequest(this.currentControls())],
+          {signal},
+      ),
+      onStart: () => {
+        this.viewState = beginClusterTaskRefresh(this.viewState);
+      },
+      onSuccess: (response) => {
+        const completedAt = Date.now();
+        this.viewState = completeClusterTaskRefresh(this.viewState, response, completedAt);
+        this.displayClock = resetClusterTaskDisplayClock(this.monotonicNow());
+        this.applyServerLimits(this.viewState.response.Applied);
+        this.freshnessNow = completedAt;
+        this.syncFreshnessTicker();
+      },
+      onError: (error) => {
+        this.freezeDisplayClock();
+        this.viewState = failClusterTaskRefresh(this.viewState, error);
+      },
+    });
+    this.freshnessTicker = new ClusterTaskFreshnessTicker({
+      onTick: (now) => {
+        this.freshnessNow = now;
+        this.displayClock = advanceClusterTaskDisplayClock(
+            this.displayClock,
+            this.monotonicNow(),
+        );
+      },
+    });
   }
 
-  toggleShowBackgroundTasks(e) {
-    this.showBackgroundTasks = e.target.checked;
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener('visibilitychange', this.handleDocumentVisibility);
+    window.addEventListener('resize', this.handleWindowResize, {passive: true});
+    this.pollController.setActivity({
+      mounted: true,
+      documentVisible: !document.hidden,
+      paused: this.paused,
+    });
+
+    this.updateComplete.then(() => {
+      if (this.isConnected) {
+        this.observeVisibility();
+      }
+    });
   }
 
-  toggleCoalesceEntries(e) {
-    this.coalesceEntries = e.target.checked;
+  disconnectedCallback() {
+    document.removeEventListener('visibilitychange', this.handleDocumentVisibility);
+    window.removeEventListener('resize', this.handleWindowResize);
+    this.disconnectVisibilityObservers();
+    this.freezeDisplayClock();
+    this.freshnessTicker.stop();
+    this.pollController.setActivity({mounted: false, viewVisible: false});
+    this.viewState = cancelClusterTaskRefresh(this.viewState);
+    super.disconnectedCallback();
   }
 
-  /**
-   * Group consecutive entries that share the same SpID, task name, and OwnerID.
-   * Returns an array of groups, where each group is an array of entries.
-   */
-  groupData(data) {
-    const groups = [];
-    let currentGroup = [];
-    let currentKey = null;
+  updated(changedProperties) {
+    if (!changedProperties.has('taskName') && !changedProperties.has('viewState')) {
+      return;
+    }
 
-    for (const entry of data) {
-      // The grouping key is the triplet: [SpID, Name, OwnerID]
-      const key = JSON.stringify([entry.SpID, entry.Name, entry.OwnerID]);
-      if (key !== currentKey) {
-        if (currentGroup.length > 0) {
-          groups.push(currentGroup);
-        }
-        currentGroup = [entry];
-        currentKey = key;
-      } else {
-        currentGroup.push(entry);
+    const select = this.renderRoot.querySelector('#task-type');
+    if (select && select.value !== this.taskName) {
+      select.value = this.taskName;
+    }
+  }
+
+  currentControls() {
+    return {
+      maxTasks: this.maxTasks,
+      maxPending: this.maxPending,
+      includeBackground: this.includeBackground,
+      taskName: this.taskName,
+    };
+  }
+
+  applyServerLimits(applied) {
+    const maxTasksDraftWasCommitted = this.maxTasksDraft === String(this.maxTasks);
+    const maxPendingDraftWasCommitted = this.maxPendingDraft === String(this.maxPending);
+
+    this.maxTasks = applied.MaxTasks;
+    this.maxPending = applied.MaxPending;
+    if (maxTasksDraftWasCommitted) {
+      this.maxTasksDraft = String(applied.MaxTasks);
+      this.maxTasksError = '';
+    }
+    if (maxPendingDraftWasCommitted) {
+      this.maxPendingDraft = String(applied.MaxPending);
+      this.maxPendingError = '';
+    }
+  }
+
+  observeVisibility() {
+    this.disconnectVisibilityObservers();
+    this.drawer = this.closest('ui-drawer');
+
+    if (this.drawer && 'MutationObserver' in window) {
+      this.drawerObserver = new MutationObserver(() => this.syncActivity());
+      this.drawerObserver.observe(this.drawer, {
+        attributes: true,
+        attributeFilter: ['isopen', 'class', 'hidden', 'style'],
+      });
+    }
+
+    if ('ResizeObserver' in window) {
+      this.resizeObserver = new ResizeObserver(() => this.syncActivity());
+      this.resizeObserver.observe(this);
+      if (this.drawer) {
+        this.resizeObserver.observe(this.drawer);
       }
     }
-    // Push the last group
-    if (currentGroup.length > 0) {
-      groups.push(currentGroup);
-    }
 
-    return groups;
+    this.syncActivity();
   }
 
-  /**
-   * Renders table rows for a group of entries.
-   * If coalesce mode is off or a group has <= 3 entries, render all rows.
-   * Otherwise, render the first, a "similar tasks" row, then the last.
-   */
+  disconnectVisibilityObservers() {
+    this.drawerObserver?.disconnect();
+    this.resizeObserver?.disconnect();
+    this.drawerObserver = null;
+    this.resizeObserver = null;
+    this.drawer = null;
+  }
+
+  isActuallyVisible() {
+    if (!this.isConnected || this.hidden) {
+      return false;
+    }
+
+    const drawer = this.drawer || this.closest('ui-drawer');
+    if (drawer?.isOpen === false) {
+      return false;
+    }
+    return this.getClientRects().length > 0;
+  }
+
+  syncActivity() {
+    const viewVisible = this.isActuallyVisible();
+    this.viewVisible = viewVisible;
+    this.pollController.setActivity({
+      mounted: this.isConnected,
+      viewVisible,
+      documentVisible: !document.hidden,
+      paused: this.paused,
+    });
+
+    if (!this.pollController.active) {
+      this.freezeDisplayClock();
+      this.viewState = cancelClusterTaskRefresh(this.viewState);
+    }
+    this.syncFreshnessTicker();
+  }
+
+  freezeDisplayClock() {
+    this.displayClock = freezeClusterTaskDisplayClock(this.displayClock);
+  }
+
+  syncFreshnessTicker() {
+    const shouldTick = shouldRunClusterTaskFreshness({
+      isConnected: this.isConnected,
+      viewVisible: this.viewVisible,
+      documentVisible: !document.hidden,
+      paused: this.paused,
+      hasSuccessfulLoad: this.viewState.hasSuccessfulLoad,
+    });
+    if (shouldTick) {
+      this.freshnessTicker.start();
+    } else {
+      this.freshnessTicker.stop();
+    }
+  }
+
+  refreshNow() {
+    if (!this.maxTasksError && !this.maxPendingError) {
+      this.pollController.refreshNow();
+    }
+  }
+
+  togglePause() {
+    this.paused = !this.paused;
+    this.syncActivity();
+  }
+
+  handleTaskNameChange(event) {
+    const taskName = event.target.value;
+    if (taskName === this.taskName) {
+      return;
+    }
+    this.taskName = taskName;
+    this.pollController.refreshNow();
+  }
+
+  handleBackgroundChange(event) {
+    this.includeBackground = event.target.checked;
+    this.pollController.refreshNow();
+  }
+
+  handleCoalesceChange(event) {
+    this.coalesceEntries = event.target.checked;
+  }
+
+  handleMaxTasksInput(event) {
+    this.maxTasksDraft = event.target.value;
+    this.maxTasksError = '';
+  }
+
+  handleMaxPendingInput(event) {
+    this.maxPendingDraft = event.target.value;
+    this.maxPendingError = '';
+  }
+
+  commitMaxTasks() {
+    const value = parseBoundedInteger(this.maxTasksDraft, 1, 500);
+    if (value === null) {
+      this.maxTasksError = 'Enter a whole number from 1 to 500.';
+      return;
+    }
+
+    let changed = value !== this.maxTasks;
+    this.maxTasks = value;
+    this.maxTasksDraft = String(value);
+    this.maxTasksError = '';
+
+    if (this.maxPending > value) {
+      this.maxPending = value;
+      this.maxPendingDraft = String(value);
+      this.maxPendingError = '';
+      changed = true;
+    }
+
+    if (changed) {
+      this.pollController.refreshNow();
+    }
+  }
+
+  commitMaxPending() {
+    const value = parseBoundedInteger(this.maxPendingDraft, 0, this.maxTasks);
+    if (value === null) {
+      this.maxPendingError = `Enter a whole number from 0 to ${this.maxTasks}.`;
+      return;
+    }
+
+    const changed = value !== this.maxPending;
+    this.maxPending = value;
+    this.maxPendingDraft = String(value);
+    this.maxPendingError = '';
+    if (changed) {
+      this.pollController.refreshNow();
+    }
+  }
+
+  handleMaxTasksKeyDown(event) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      this.commitMaxTasks();
+    }
+  }
+
+  handleMaxPendingKeyDown(event) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      this.commitMaxPending();
+    }
+  }
+
+  taskTypeOptions() {
+    return buildClusterTaskTypeOptions(
+        this.taskName,
+        this.viewState.response?.TaskTypes,
+    );
+  }
+
+  formatTimestamp(value) {
+    if (!value) {
+      return '';
+    }
+    const timestamp = new Date(value);
+    return Number.isNaN(timestamp.getTime()) ? String(value) : timestamp.toLocaleTimeString();
+  }
+
+  renderStatus() {
+    const state = this.viewState;
+    let label = 'Waiting to load';
+    let tone = 'loading';
+
+    if (this.paused) {
+      label = 'Paused';
+      tone = 'paused';
+    } else if (state.refreshing && !state.hasSuccessfulLoad) {
+      label = 'Loading';
+    } else if (state.stale) {
+      label = 'Stale';
+      tone = 'stale';
+    } else if (state.hasSuccessfulLoad && state.response?.Partial && !state.refreshing) {
+      label = 'Partial';
+      tone = 'stale';
+    } else if (state.error && !state.hasSuccessfulLoad) {
+      label = 'Refresh failed';
+      tone = 'failed';
+    } else if (state.refreshing) {
+      label = 'Refreshing';
+    } else if (state.hasSuccessfulLoad) {
+      label = 'Fresh';
+      tone = 'fresh';
+    }
+
+    const observedAt = this.formatTimestamp(state.response?.ObservedAt);
+    const lastSuccess = buildClusterTaskLastSuccessPresentation({
+      paused: this.paused,
+      now: this.freshnessNow,
+      lastSuccessAt: state.lastSuccessAt,
+    });
+    return html`
+      <div class="status-row" role="status" aria-live="polite">
+        <span class="status-pill ${tone}">${label}</span>
+        ${lastSuccess.text ? html`
+          <span title=${lastSuccess.title}>${lastSuccess.text}</span>
+        ` : ''}
+        ${observedAt ? html`<span>Snapshot observed: ${observedAt}</span>` : ''}
+      </div>
+    `;
+  }
+
+  renderMessages() {
+    const state = this.viewState;
+    const warnings = state.response?.Warnings || [];
+    const snapshotMismatch = clusterTaskSnapshotMismatchMessage({
+      controls: this.currentControls(),
+      response: state.response,
+      refreshing: state.refreshing,
+      failed: Boolean(state.error),
+      paused: this.paused,
+    });
+    return html`
+      ${snapshotMismatch ? html`
+        <div class="alert alert-warning message" role="status">
+          ${snapshotMismatch}
+        </div>
+      ` : ''}
+      ${state.error ? html`
+        <div class="alert ${state.hasSuccessfulLoad ? 'alert-warning' : 'alert-danger'} message" role="alert">
+          ${state.hasSuccessfulLoad
+            ? `Refresh failed; showing the last successful snapshot. ${state.error}`
+            : `Unable to load Cluster Tasks. ${state.error}`}
+        </div>
+      ` : ''}
+      ${warnings.length > 0 ? html`
+        <div class="alert alert-warning message" role="status">
+          <ul class="warnings">
+            ${warnings.map((warning) => html`
+              <li>
+                ${warning.TaskName ? `${warning.TaskName}: ` : ''}${warning.Message}
+                ${warning.Code ? html` <span title="Warning code">(${warning.Code})</span>` : ''}
+              </li>
+            `)}
+          </ul>
+        </div>
+      ` : ''}
+    `;
+  }
+
+  renderControls() {
+    const taskTypes = this.taskTypeOptions();
+    const controlsInvalid = Boolean(this.maxTasksError || this.maxPendingError);
+    return html`
+      <div class="controls">
+        <div class="control">
+          <label for="task-type">Task type</label>
+          <select
+            id="task-type"
+            class="form-select form-select-sm"
+            .value=${this.taskName}
+            @change=${this.handleTaskNameChange}
+          >
+            <option value="">All</option>
+            ${taskTypes.map((taskType) => html`
+              <option value=${taskType.Name}>${taskType.Name}</option>
+            `)}
+          </select>
+        </div>
+
+        <div class="control">
+          <label for="max-tasks">Max displayed tasks</label>
+          <input
+            id="max-tasks"
+            class="form-control form-control-sm"
+            type="number"
+            min="1"
+            max="500"
+            step="1"
+            .value=${this.maxTasksDraft}
+            aria-invalid=${this.maxTasksError ? 'true' : 'false'}
+            @input=${this.handleMaxTasksInput}
+            @change=${this.commitMaxTasks}
+            @keydown=${this.handleMaxTasksKeyDown}
+          />
+          ${this.maxTasksError ? html`<span class="control-error">${this.maxTasksError}</span>` : ''}
+        </div>
+
+        <div class="control">
+          <label for="max-pending">Pending preview</label>
+          <input
+            id="max-pending"
+            class="form-control form-control-sm"
+            type="number"
+            min="0"
+            max=${this.maxTasks}
+            step="1"
+            .value=${this.maxPendingDraft}
+            aria-invalid=${this.maxPendingError ? 'true' : 'false'}
+            @input=${this.handleMaxPendingInput}
+            @change=${this.commitMaxPending}
+            @keydown=${this.handleMaxPendingKeyDown}
+          />
+          ${this.maxPendingError ? html`<span class="control-error">${this.maxPendingError}</span>` : ''}
+        </div>
+
+        <label class="check-control">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            .checked=${this.includeBackground}
+            @change=${this.handleBackgroundChange}
+          />
+          Show background tasks
+        </label>
+
+        <label class="check-control">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            .checked=${this.coalesceEntries}
+            @change=${this.handleCoalesceChange}
+          />
+          Coalesce Entries
+        </label>
+
+        <div class="actions">
+          <button
+            type="button"
+            class="btn btn-secondary btn-sm"
+            ?disabled=${this.paused || controlsInvalid}
+            @click=${this.refreshNow}
+          >
+            Refresh now
+          </button>
+          <button
+            type="button"
+            class="btn btn-secondary btn-sm"
+            @click=${this.togglePause}
+          >
+            ${this.paused ? 'Resume' : 'Pause'}
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
   renderTableRows(entries) {
-    if (!this.coalesceEntries || entries.length <= 3) {
+    if (entries.length <= 3) {
       return entries.map((entry) => this.renderRow(entry));
     }
 
     const firstEntry = entries[0];
     const lastEntry = entries[entries.length - 1];
     const middleCount = entries.length - 2;
-
     return html`
       ${this.renderRow(firstEntry)}
       <tr class="similar-row">
-        <td colspan="5">${middleCount} similar tasks</td>
+        <td colspan="6">${middleCount} similar tasks</td>
       </tr>
       ${this.renderRow(lastEntry)}
     `;
   }
 
   renderRow(entry) {
+    const hasOwner = entry.OwnerID !== null && entry.OwnerID !== undefined;
+    const state = entry.State || (hasOwner ? 'running' : 'pending');
+    const miner = entry.Miners?.length ? entry.Miners.join(', ') : entry.SpID ? entry.Miner : 'n/a';
+    const age = formatTaskAgeSeconds(
+        interpolateClusterTaskAgeSeconds(entry.AgeSeconds, this.displayClock),
+    );
+    const ageTitle = age === 'unknown'
+      ? state === 'running'
+        ? UNKNOWN_RUNNING_AGE_TOOLTIP
+        : 'Waiting time is unavailable.'
+      : age;
     return html`
       <tr>
-        <td>${entry.SpID ? entry.Miner : 'n/a'}</td>
-        <td>${entry.Name}</td>
+        <td title=${miner}>${miner}</td>
+        <td title=${entry.Name}>${entry.Name}</td>
         <td><a href="/pages/task/id/?id=${entry.ID}">${entry.ID}</a></td>
-        <td>${entry.SincePostedStr}</td>
-        <td>
-          ${entry.OwnerID
-              ? html`<a href="/pages/node_info/?id=${entry.OwnerID}">${entry.Owner}</a>`
-              : ''}
+        <td>${state}</td>
+        <td class="age-column" title=${ageTitle}>${age}</td>
+        <td title=${entry.Owner || ''}>
+          ${hasOwner
+            ? html`<a href="/pages/node_info/?id=${entry.OwnerID}">${entry.Owner}</a>`
+            : ''}
         </td>
       </tr>
     `;
   }
 
-  render() {
-    // First, filter out background tasks if needed
-    const filtered = this.data.filter(
-        (entry) => this.showBackgroundTasks || !entry.Name.startsWith('bg:')
+  sectionSummary(section, response) {
+    return formatClusterTaskSectionSummary(
+        section.entries.length,
+        section.total,
+        response.TotalsAvailable,
     );
+  }
 
-    let sortedOrOriginal = filtered;
+  renderSection(section, response) {
+    const emptyMessage = clusterTaskSectionEmptyMessage(section.key, response);
+    return html`
+      <section class="task-section" aria-labelledby="cluster-tasks-${section.key}">
+        <div class="section-heading">
+          <h3 id="cluster-tasks-${section.key}">${section.title}</h3>
+          <span class="section-summary">${this.sectionSummary(section, response)}</span>
+        </div>
+        ${emptyMessage ? html`
+          <div class="empty-state">${emptyMessage}</div>
+        ` : html`
+          <div class="table-wrap">
+            <table class="table table-dark">
+              <thead>
+                <tr>
+                  <th>SpID</th>
+                  <th>Task</th>
+                  <th>ID</th>
+                  <th>State</th>
+                  <th class="age-column" title=${section.ageTooltip}>${section.ageLabel}</th>
+                  <th>Owner</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${section.groups.map((group) => this.renderTableRows(group))}
+              </tbody>
+            </table>
+          </div>
+        `}
+      </section>
+    `;
+  }
 
-    // In coalesced mode, we sort by [Name -> SpID -> OwnerID]
-    // Otherwise, leave data in its default order (e.g., posted time).
-    if (this.coalesceEntries) {
-      sortedOrOriginal = [...filtered].sort((a, b) => {
-        const nameCmp = a.Name.localeCompare(b.Name);
-        if (nameCmp !== 0) return nameCmp;
-        // If SpID is numeric, do numeric sort, else compare as strings
-        const spA = typeof a.SpID === 'number' ? a.SpID : Number.parseInt(a.SpID, 10) || a.SpID;
-        const spB = typeof b.SpID === 'number' ? b.SpID : Number.parseInt(b.SpID, 10) || b.SpID;
-        const spCmp = spA > spB ? 1 : spA < spB ? -1 : 0;
-        if (spCmp !== 0) return spCmp;
-        // Compare OwnerIDs (if numeric, do numeric compare; fallback to string)
-        const ownerA = typeof a.OwnerID === 'number' ? a.OwnerID : Number.parseInt(a.OwnerID, 10) || a.OwnerID || '';
-        const ownerB = typeof b.OwnerID === 'number' ? b.OwnerID : Number.parseInt(b.OwnerID, 10) || b.OwnerID || '';
-        const ownerCmp = ownerA > ownerB ? 1 : ownerA < ownerB ? -1 : 0;
-        return ownerCmp;
-      });
-    }
-
-    // If coalescing, group them, otherwise each entry is its own group
-    const grouped = this.coalesceEntries
-        ? this.groupData(sortedOrOriginal)
-        : sortedOrOriginal.map((e) => [e]);
+  render() {
+    const response = this.viewState.response;
+    const sections = response
+      ? buildClusterTaskSections(response, this.coalesceEntries)
+      : [];
 
     return html`
       <link rel="stylesheet" href="/ux/vendor/bootstrap.min.css">
@@ -178,40 +856,16 @@ class ClusterTasks extends LitElement {
         onload="document.body.style.visibility = 'initial'"
       />
 
-      <!-- Toggle for showing background tasks -->
-      <label>
-        <input
-          type="checkbox"
-          @change=${this.toggleShowBackgroundTasks}
-          ?checked=${this.showBackgroundTasks}
-        />
-        Show background tasks
-      </label>
+      ${this.renderControls()}
+      ${this.renderStatus()}
+      <p class="policy">${CLUSTER_TASK_ORDER_POLICY}</p>
+      ${this.renderMessages()}
 
-      <!-- Toggle for coalescing entries -->
-      <label style="margin-left: 1em;">
-        <input
-          type="checkbox"
-          @change=${this.toggleCoalesceEntries}
-          ?checked=${this.coalesceEntries}
-        />
-        Coalesce Entries
-      </label>
-
-      <table class="table table-dark mt-3">
-        <thead>
-          <tr>
-            <th>SpID</th>
-            <th style="min-width: 128px">Task</th>
-            <th>ID</th>
-            <th>Posted</th>
-            <th>Owner</th>
-          </tr>
-        </thead>
-        <tbody>
-          ${grouped.map((group) => this.renderTableRows(group))}
-        </tbody>
-      </table>
+      ${!this.viewState.hasSuccessfulLoad && this.viewState.refreshing ? html`
+        <div class="empty-state" role="status">Loading Cluster Tasks…</div>
+      ` : !this.viewState.hasSuccessfulLoad && this.viewState.error ? html`
+        <div class="empty-state">No task snapshot is available yet. Refresh will retry automatically.</div>
+      ` : sections.map((section) => this.renderSection(section, response))}
     `;
   }
 }

--- a/web/test/cluster-tasks-callsite.test.mjs
+++ b/web/test/cluster-tasks-callsite.test.mjs
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+
+test('production component uses the bounded controller and display clock', () => {
+  const source = readFileSync(new URL('../static/cluster-tasks.mjs', import.meta.url), 'utf8');
+  for (const token of ['new ClusterTaskPollController(', "'ClusterTaskSummaryLimited'", 'new ClusterTaskFreshnessTicker(', 'resetClusterTaskDisplayClock(this.monotonicNow())', 'freezeClusterTaskDisplayClock(this.displayClock)', 'interpolateClusterTaskAgeSeconds(']) {
+    assert.ok(source.includes(token), `production component missing ${token}`);
+  }
+  assert.ok(!source.includes("RPCCall('ClusterTaskSummary')"));
+});

--- a/web/test/cluster-tasks-callsite.test.mjs
+++ b/web/test/cluster-tasks-callsite.test.mjs
@@ -4,7 +4,7 @@ import {readFileSync} from 'node:fs';
 
 test('production component uses the bounded controller and display clock', () => {
   const source = readFileSync(new URL('../static/cluster-tasks.mjs', import.meta.url), 'utf8');
-  for (const token of ['new ClusterTaskPollController(', "'ClusterTaskSummaryLimited'", 'new ClusterTaskFreshnessTicker(', 'resetClusterTaskDisplayClock(this.monotonicNow())', 'freezeClusterTaskDisplayClock(this.displayClock)', 'interpolateClusterTaskAgeSeconds(']) {
+  for (const token of ['new ClusterTaskPollController(', "'ClusterTaskSummaryLimited'", 'new ClusterTaskFreshnessTicker(', 'resetClusterTaskDisplayClock(this.monotonicNow())', 'freezeClusterTaskDisplayClock(this.displayClock)', 'clusterTaskAge(']) {
     assert.ok(source.includes(token), `production component missing ${token}`);
   }
   assert.ok(!source.includes("RPCCall('ClusterTaskSummary')"));

--- a/web/test/cluster-tasks-controller.test.mjs
+++ b/web/test/cluster-tasks-controller.test.mjs
@@ -1,0 +1,375 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CLUSTER_TASK_FRESHNESS_TICK_MS,
+  CLUSTER_TASK_SETTLE_MS,
+  CLUSTER_TASK_TIMEOUT_MS,
+  ClusterTaskFreshnessTicker,
+  ClusterTaskPollController,
+} from '../static/cluster-tasks-controller.mjs';
+import {
+  advanceClusterTaskDisplayClock,
+  freezeClusterTaskDisplayClock,
+  resetClusterTaskDisplayClock,
+} from '../static/cluster-tasks-model.mjs';
+
+class FakeClock {
+  constructor() {
+    this.now = 0;
+    this.nextID = 1;
+    this.timers = new Map();
+  }
+
+  setTimeout(callback, delay) {
+    const id = this.nextID++;
+    this.timers.set(id, {callback, at: this.now + delay});
+    return id;
+  }
+
+  clearTimeout(id) {
+    this.timers.delete(id);
+  }
+
+  advance(duration) {
+    const target = this.now + duration;
+    while (true) {
+      const next = [...this.timers.entries()]
+          .filter(([, timer]) => timer.at <= target)
+          .sort((left, right) => left[1].at - right[1].at || left[0] - right[0])[0];
+      if (!next) {
+        break;
+      }
+
+      const [id, timer] = next;
+      this.timers.delete(id);
+      this.now = timer.at;
+      timer.callback();
+    }
+    this.now = target;
+  }
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {promise, resolve, reject};
+}
+
+function abortError() {
+  const error = new Error('aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function requestHarness({honorAbort = true} = {}) {
+  const calls = [];
+  return {
+    calls,
+    request(signal) {
+      const pending = deferred();
+      const call = {signal, ...pending};
+      calls.push(call);
+      if (honorAbort) {
+        signal.addEventListener('abort', () => pending.reject(abortError()), {once: true});
+      }
+      return pending.promise;
+    },
+  };
+}
+
+async function flushPromises() {
+  for (let index = 0; index < 5; index++) {
+    await Promise.resolve();
+  }
+}
+
+function makeController({clock, harness, successes = [], errors = []}) {
+  return new ClusterTaskPollController({
+    request: (signal) => harness.request(signal),
+    onSuccess: (value) => successes.push(value),
+    onError: (error) => errors.push(error),
+    setTimeoutFn: (callback, delay) => clock.setTimeout(callback, delay),
+    clearTimeoutFn: (id) => clock.clearTimeout(id),
+  });
+}
+
+function activate(controller) {
+  controller.setActivity({
+    mounted: true,
+    viewVisible: true,
+    documentVisible: true,
+    paused: false,
+  });
+}
+
+test('freshness ticker starts once, advances, and cleans up', () => {
+  const clock = new FakeClock();
+  const ticks = [];
+  const ticker = new ClusterTaskFreshnessTicker({
+    onTick: (now) => ticks.push(now),
+    nowFn: () => clock.now,
+    setTimeoutFn: (callback, delay) => clock.setTimeout(callback, delay),
+    clearTimeoutFn: (id) => clock.clearTimeout(id),
+  });
+
+  assert.equal(ticker.start(), true);
+  assert.equal(ticker.start(), false);
+  assert.deepEqual(ticks, [0]);
+  assert.equal(clock.timers.size, 1);
+
+  clock.advance(CLUSTER_TASK_FRESHNESS_TICK_MS);
+  assert.deepEqual(ticks, [0, CLUSTER_TASK_FRESHNESS_TICK_MS]);
+  assert.equal(clock.timers.size, 1);
+
+  ticker.stop();
+  assert.equal(clock.timers.size, 0);
+  clock.advance(CLUSTER_TASK_FRESHNESS_TICK_MS * 2);
+  assert.deepEqual(ticks, [0, CLUSTER_TASK_FRESHNESS_TICK_MS]);
+
+  assert.equal(ticker.start(), true);
+  assert.deepEqual(ticks, [0, CLUSTER_TASK_FRESHNESS_TICK_MS, clock.now]);
+  ticker.stop();
+});
+
+test('display-clock ticks do not issue monitoring requests', async () => {
+  const clock = new FakeClock();
+  const harness = requestHarness();
+  const controller = makeController({clock, harness});
+  let displayClock = resetClusterTaskDisplayClock(clock.now);
+  const ticker = new ClusterTaskFreshnessTicker({
+    onTick: () => {
+      displayClock = advanceClusterTaskDisplayClock(displayClock, clock.now);
+    },
+    nowFn: () => clock.now,
+    setTimeoutFn: (callback, delay) => clock.setTimeout(callback, delay),
+    clearTimeoutFn: (id) => clock.clearTimeout(id),
+  });
+
+  activate(controller);
+  ticker.start();
+  assert.equal(harness.calls.length, 1);
+
+  clock.advance(CLUSTER_TASK_FRESHNESS_TICK_MS * 4);
+  assert.equal(displayClock.elapsedSeconds, 4);
+  assert.equal(harness.calls.length, 1, 'display updates must not trigger RPCs');
+
+  ticker.stop();
+  controller.setActivity({mounted: false});
+  await flushPromises();
+});
+
+test('inactive controllers do not issue requests', () => {
+  const clock = new FakeClock();
+  const harness = requestHarness();
+  const controller = makeController({clock, harness});
+
+  controller.setActivity({mounted: true, documentVisible: true});
+  controller.refreshNow();
+  clock.advance(CLUSTER_TASK_SETTLE_MS * 2);
+
+  assert.equal(harness.calls.length, 0);
+});
+
+test('polling starts once, never overlaps, and waits 5s after settlement', async () => {
+  const clock = new FakeClock();
+  const harness = requestHarness();
+  const successes = [];
+  const controller = makeController({clock, harness, successes});
+
+  activate(controller);
+  controller.setActivity({viewVisible: true});
+  assert.equal(harness.calls.length, 1);
+
+  clock.advance(CLUSTER_TASK_SETTLE_MS * 2);
+  assert.equal(harness.calls.length, 1, 'an unresolved request must not overlap another');
+
+  harness.calls[0].resolve('first');
+  await flushPromises();
+  assert.deepEqual(successes, ['first']);
+
+  clock.advance(CLUSTER_TASK_SETTLE_MS - 1);
+  assert.equal(harness.calls.length, 1);
+  clock.advance(1);
+  assert.equal(harness.calls.length, 2);
+
+  controller.setActivity({mounted: false});
+  await flushPromises();
+});
+
+test('manual refresh replaces one running request without fan-out', async () => {
+  const clock = new FakeClock();
+  const harness = requestHarness({honorAbort: false});
+  const successes = [];
+  const controller = makeController({clock, harness, successes});
+
+  activate(controller);
+  controller.refreshNow();
+  controller.refreshNow();
+  assert.equal(harness.calls.length, 1);
+  assert.equal(harness.calls[0].signal.aborted, true);
+
+  await flushPromises();
+  assert.equal(harness.calls.length, 2);
+  assert.deepEqual(successes, [], 'the invalidated generation must not commit');
+
+  harness.calls[1].resolve('current');
+  await flushPromises();
+  assert.deepEqual(successes, ['current']);
+
+  harness.calls[0].resolve('obsolete');
+  await flushPromises();
+  assert.deepEqual(successes, ['current']);
+
+  controller.setActivity({mounted: false});
+});
+
+test('disconnect, close, document hiding, and pause abort and resume once', async (t) => {
+  const cases = [
+    {name: 'disconnect', stop: {mounted: false}, resume: {mounted: true}},
+    {name: 'drawer close', stop: {viewVisible: false}, resume: {viewVisible: true}},
+    {name: 'document hidden', stop: {documentVisible: false}, resume: {documentVisible: true}},
+    {name: 'pause', stop: {paused: true}, resume: {paused: false}},
+  ];
+
+  for (const testCase of cases) {
+    await t.test(testCase.name, async () => {
+      const clock = new FakeClock();
+      const harness = requestHarness();
+      const controller = makeController({clock, harness});
+
+      activate(controller);
+      assert.equal(harness.calls.length, 1);
+      controller.setActivity(testCase.stop);
+      assert.equal(harness.calls[0].signal.aborted, true);
+
+      controller.setActivity(testCase.resume);
+      await flushPromises();
+      assert.equal(harness.calls.length, 2, 'resume must issue exactly one immediate request');
+
+      controller.setActivity({mounted: false});
+      await flushPromises();
+      clock.advance(CLUSTER_TASK_SETTLE_MS * 2);
+      assert.equal(harness.calls.length, 2, 'inactive controllers must not reschedule');
+    });
+  }
+});
+
+test('a stale completion after close and reopen cannot overwrite new data', async () => {
+  const clock = new FakeClock();
+  const harness = requestHarness({honorAbort: false});
+  const successes = [];
+  const controller = makeController({clock, harness, successes});
+
+  activate(controller);
+  controller.setActivity({viewVisible: false});
+  controller.setActivity({viewVisible: true});
+  await flushPromises();
+
+  assert.equal(harness.calls.length, 2);
+  assert.deepEqual(successes, []);
+  harness.calls[1].resolve('fresh');
+  await flushPromises();
+  assert.deepEqual(successes, ['fresh']);
+
+  harness.calls[0].resolve('stale');
+  await flushPromises();
+  assert.deepEqual(successes, ['fresh']);
+
+  controller.setActivity({mounted: false});
+});
+
+test('request timeout settles at 15s and retries even when transport abort lags', async () => {
+  const clock = new FakeClock();
+  const harness = requestHarness({honorAbort: false});
+  const errors = [];
+  const controller = makeController({clock, harness, errors});
+
+  activate(controller);
+  clock.advance(CLUSTER_TASK_TIMEOUT_MS - 1);
+  assert.equal(harness.calls[0].signal.aborted, false);
+  clock.advance(1);
+  assert.equal(harness.calls[0].signal.aborted, true);
+  await flushPromises();
+
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].name, 'TimeoutError');
+  clock.advance(CLUSTER_TASK_SETTLE_MS - 1);
+  assert.equal(harness.calls.length, 1);
+  clock.advance(1);
+  assert.equal(harness.calls.length, 2);
+
+  harness.calls[0].resolve('late');
+  await flushPromises();
+  assert.equal(errors.length, 1, 'late completion must not alter timeout state');
+
+  controller.setActivity({mounted: false});
+  await flushPromises();
+});
+
+test('timeout freezes display ages while the shared ticker can update freshness', async () => {
+  const clock = new FakeClock();
+  const harness = requestHarness({honorAbort: false});
+  const errors = [];
+  let freshnessTicks = 0;
+  let displayClock = resetClusterTaskDisplayClock(clock.now);
+  const ticker = new ClusterTaskFreshnessTicker({
+    onTick: () => {
+      freshnessTicks += 1;
+      displayClock = advanceClusterTaskDisplayClock(displayClock, clock.now);
+    },
+    nowFn: () => clock.now,
+    setTimeoutFn: (callback, delay) => clock.setTimeout(callback, delay),
+    clearTimeoutFn: (id) => clock.clearTimeout(id),
+  });
+  const controller = new ClusterTaskPollController({
+    request: (signal) => harness.request(signal),
+    onError: (error) => {
+      errors.push(error);
+      displayClock = freezeClusterTaskDisplayClock(displayClock);
+    },
+    setTimeoutFn: (callback, delay) => clock.setTimeout(callback, delay),
+    clearTimeoutFn: (id) => clock.clearTimeout(id),
+  });
+
+  activate(controller);
+  ticker.start();
+  clock.advance(CLUSTER_TASK_TIMEOUT_MS);
+  await flushPromises();
+
+  assert.equal(errors[0].name, 'TimeoutError');
+  const frozenAge = displayClock.elapsedSeconds;
+  const ticksAtFailure = freshnessTicks;
+  clock.advance(CLUSTER_TASK_FRESHNESS_TICK_MS * 2);
+  assert.equal(displayClock.elapsedSeconds, frozenAge);
+  assert.ok(freshnessTicks > ticksAtFailure, 'freshness may keep updating while stale');
+
+  ticker.stop();
+  controller.setActivity({mounted: false});
+  await flushPromises();
+});
+
+test('ordinary request failures retry 5s after settlement', async () => {
+  const clock = new FakeClock();
+  const harness = requestHarness();
+  const errors = [];
+  const controller = makeController({clock, harness, errors});
+
+  activate(controller);
+  harness.calls[0].reject(new Error('offline'));
+  await flushPromises();
+
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].message, 'offline');
+  clock.advance(CLUSTER_TASK_SETTLE_MS - 1);
+  assert.equal(harness.calls.length, 1);
+  clock.advance(1);
+  assert.equal(harness.calls.length, 2);
+
+  controller.setActivity({mounted: false});
+  await flushPromises();
+});

--- a/web/test/cluster-tasks-display-clock.test.mjs
+++ b/web/test/cluster-tasks-display-clock.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  advanceClusterTaskDisplayClock,
+  beginClusterTaskRefresh,
+  buildClusterTaskSections,
+  completeClusterTaskRefresh,
+  createClusterTaskDisplayClock,
+  createClusterTaskViewState,
+  failClusterTaskRefresh,
+  formatClusterTaskFreshness,
+  freezeClusterTaskDisplayClock,
+  interpolateClusterTaskAgeSeconds,
+  resetClusterTaskDisplayClock,
+} from '../static/cluster-tasks-model.mjs';
+
+test('display ages derive whole seconds from one monotonic receipt anchor', () => {
+  let clock = resetClusterTaskDisplayClock(10_000);
+  const baselineAge = 90;
+
+  clock = advanceClusterTaskDisplayClock(clock, 10_999);
+  assert.equal(interpolateClusterTaskAgeSeconds(baselineAge, clock), 90);
+
+  clock = advanceClusterTaskDisplayClock(clock, 11_001);
+  assert.equal(interpolateClusterTaskAgeSeconds(baselineAge, clock), 91);
+
+  clock = advanceClusterTaskDisplayClock(clock, 13_900);
+  assert.equal(interpolateClusterTaskAgeSeconds(baselineAge, clock), 93);
+
+  for (const repeatedCallback of [13_901, 13_999, 14_001]) {
+    clock = advanceClusterTaskDisplayClock(clock, repeatedCallback);
+  }
+  assert.equal(clock.elapsedSeconds, 4, 'callback frequency must not accumulate drift');
+  assert.equal(interpolateClusterTaskAgeSeconds(baselineAge, clock), 94);
+});
+
+test('unknown ages stay unknown and server/client wall clocks do not affect interpolation', () => {
+  let clock = resetClusterTaskDisplayClock(500);
+  clock = advanceClusterTaskDisplayClock(clock, 2_750);
+
+  for (const unavailable of [null, undefined, Number.NaN, -1]) {
+    assert.equal(interpolateClusterTaskAgeSeconds(unavailable, clock), null);
+  }
+
+  const snapshotsWithOppositeWallClockSkew = [
+    {ObservedAt: '1970-01-01T00:00:00Z', AgeSeconds: 12},
+    {ObservedAt: '2099-01-01T00:00:00Z', AgeSeconds: 12},
+  ];
+  assert.deepEqual(
+      snapshotsWithOppositeWallClockSkew.map((entry) =>
+        interpolateClusterTaskAgeSeconds(entry.AgeSeconds, clock)),
+      [14, 14],
+  );
+});
+
+test('pause or failure freezes the last displayed age until a new snapshot', () => {
+  let clock = resetClusterTaskDisplayClock(1_000);
+  clock = advanceClusterTaskDisplayClock(clock, 3_100);
+  const displayedBeforeFreeze = interpolateClusterTaskAgeSeconds(20, clock);
+
+  clock = freezeClusterTaskDisplayClock(clock);
+  assert.equal(interpolateClusterTaskAgeSeconds(20, clock), displayedBeforeFreeze);
+
+  clock = advanceClusterTaskDisplayClock(clock, 100_000);
+  assert.equal(
+      interpolateClusterTaskAgeSeconds(20, clock),
+      displayedBeforeFreeze,
+      'inactive time must not be extrapolated before a fresh response',
+  );
+
+  let viewState = completeClusterTaskRefresh(
+      createClusterTaskViewState(),
+      {Running: [{ID: 9, AgeSeconds: 20}]},
+      1_000,
+  );
+  viewState = beginClusterTaskRefresh(viewState);
+  viewState = failClusterTaskRefresh(viewState, new Error('timeout'));
+  assert.equal(viewState.stale, true);
+  assert.equal(formatClusterTaskFreshness(11_000, viewState.lastSuccessAt), '10s ago');
+  assert.equal(interpolateClusterTaskAgeSeconds(20, clock), displayedBeforeFreeze);
+});
+
+test('a successful snapshot resets the baseline and accepts a lower runtime', () => {
+  const previousTask = {ID: 44, OwnerID: 7, AgeSeconds: 100};
+  let clock = resetClusterTaskDisplayClock(1_000);
+  clock = advanceClusterTaskDisplayClock(clock, 5_100);
+  assert.equal(interpolateClusterTaskAgeSeconds(previousTask.AgeSeconds, clock), 104);
+
+  const restartedTask = {...previousTask, AgeSeconds: 3};
+  clock = resetClusterTaskDisplayClock(10_000);
+  assert.equal(
+      interpolateClusterTaskAgeSeconds(restartedTask.AgeSeconds, clock),
+      3,
+      'the new server value is authoritative even for the same task and owner',
+  );
+
+  clock = advanceClusterTaskDisplayClock(clock, 11_050);
+  assert.equal(interpolateClusterTaskAgeSeconds(restartedTask.AgeSeconds, clock), 4);
+});
+
+test('a successful partial-enrichment snapshot still advances task ages', () => {
+  const state = completeClusterTaskRefresh(createClusterTaskViewState(), {
+    Running: [{ID: 4, AgeSeconds: 7}],
+    Partial: true,
+    Warnings: [{Code: 'spid', Message: 'SpID unavailable'}],
+  }, 1_000);
+  let clock = resetClusterTaskDisplayClock(20_000);
+  clock = advanceClusterTaskDisplayClock(clock, 22_100);
+
+  assert.equal(state.response.Partial, true);
+  assert.equal(
+      interpolateClusterTaskAgeSeconds(state.response.Running[0].AgeSeconds, clock),
+      9,
+  );
+});
+
+test('display-clock updates do not mutate or reorder snapshot rows', () => {
+  const response = {
+    Running: [
+      {ID: 8, AgeSeconds: 80},
+      {ID: 3, AgeSeconds: 20},
+    ],
+    Pending: [
+      {ID: 12, AgeSeconds: 60},
+      {ID: 4, AgeSeconds: 10},
+    ],
+  };
+  const original = structuredClone(response);
+  const before = buildClusterTaskSections(response, false)
+      .flatMap((section) => section.entries.map((entry) => entry.ID));
+
+  let clock = createClusterTaskDisplayClock();
+  clock = resetClusterTaskDisplayClock(50);
+  clock = advanceClusterTaskDisplayClock(clock, 8_050);
+  response.Running.map((entry) => interpolateClusterTaskAgeSeconds(entry.AgeSeconds, clock));
+  response.Pending.map((entry) => interpolateClusterTaskAgeSeconds(entry.AgeSeconds, clock));
+
+  const after = buildClusterTaskSections(response, false)
+      .flatMap((section) => section.entries.map((entry) => entry.ID));
+  assert.deepEqual(after, before);
+  assert.deepEqual(response, original);
+});

--- a/web/test/cluster-tasks-grouping.test.mjs
+++ b/web/test/cluster-tasks-grouping.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {groupConsecutiveTasks} from '../static/cluster-tasks-grouping.mjs';
+
+test('coalescing preserves chronological order and only groups consecutive tasks', () => {
+  const tasks = [
+    {ID: 1, State: 'pending', SpID: '1000', Name: 'SDR', OwnerID: null, Age: '27m'},
+    {ID: 2, State: 'pending', SpID: '1000', Name: 'SDR', OwnerID: null, Age: '26m'},
+    {ID: 3, State: 'running', SpID: '1000', Name: 'SDR', OwnerID: '7', Age: '25m'},
+    {ID: 4, State: 'pending', SpID: '1000', Name: 'SDR', OwnerID: null, Age: '24m'},
+    {ID: 5, State: 'pending', SpID: '1000', Name: 'SDR', OwnerID: null, Age: '23m'},
+  ];
+
+  const groups = groupConsecutiveTasks(tasks);
+
+  assert.deepEqual(groups.map((group) => group.map((task) => task.ID)), [[1, 2], [3], [4, 5]]);
+  assert.deepEqual(groups.flat(), tasks);
+});
+
+test('coalescing handles empty and single-entry input', () => {
+  assert.deepEqual(groupConsecutiveTasks([]), []);
+
+  const task = {ID: 1, SpID: '', Name: 'bg:Example', OwnerID: null};
+  assert.deepEqual(groupConsecutiveTasks([task]), [[task]]);
+});
+
+test('all grouping identity fields form group boundaries', () => {
+  const tasks = [
+    {ID: 1, State: 'pending', SpID: '1000', Name: 'SDR', OwnerID: null},
+    {ID: 2, State: 'pending', SpID: '1001', Name: 'SDR', OwnerID: null},
+    {ID: 3, State: 'pending', SpID: '1001', Name: 'TreeD', OwnerID: null},
+    {ID: 4, State: 'running', SpID: '1001', Name: 'TreeD', OwnerID: null},
+    {ID: 5, State: 'running', SpID: '1001', Name: 'TreeD', OwnerID: '7'},
+  ];
+
+  assert.deepEqual(
+      groupConsecutiveTasks(tasks).map((group) => group.map((task) => task.ID)),
+      [[1], [2], [3], [4], [5]],
+  );
+});

--- a/web/test/cluster-tasks-model.test.mjs
+++ b/web/test/cluster-tasks-model.test.mjs
@@ -388,9 +388,9 @@ test('sections are Running then Pending and coalesce only inside each section', 
   const coalesced = buildClusterTaskSections(response, true);
   assert.deepEqual(coalesced[0].groups.map((group) => group.map((entry) => entry.ID)), [[1, 2]]);
   assert.deepEqual(coalesced[1].groups.map((group) => group.map((entry) => entry.ID)), [[3, 4]]);
-  assert.equal(coalesced[0].ageLabel, 'Owned');
+  assert.equal(coalesced[0].ageLabel, 'Took');
   assert.equal(coalesced[1].ageLabel, 'Waiting');
-  assert.match(RUNNING_AGE_TOOLTIP, /ownership|Ownership/);
+  assert.match(RUNNING_AGE_TOOLTIP, /Do attempt/);
   assert.match(PENDING_AGE_TOOLTIP, /posted/);
   assert.equal(
       CLUSTER_TASK_ORDER_POLICY,

--- a/web/test/cluster-tasks-model.test.mjs
+++ b/web/test/cluster-tasks-model.test.mjs
@@ -1,0 +1,417 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CLUSTER_TASK_DEFAULTS,
+  CLUSTER_TASK_ORDER_POLICY,
+  PENDING_AGE_TOOLTIP,
+  RUNNING_AGE_TOOLTIP,
+  UNKNOWN_RUNNING_AGE_TOOLTIP,
+  beginClusterTaskRefresh,
+  buildClusterTaskLastSuccessPresentation,
+  buildClusterTaskRequest,
+  buildClusterTaskSections,
+  buildClusterTaskTypeOptions,
+  clusterTaskControlsMatchApplied,
+  clusterTaskSectionEmptyMessage,
+  clusterTaskSnapshotMismatchMessage,
+  completeClusterTaskRefresh,
+  createClusterTaskViewState,
+  failClusterTaskRefresh,
+  formatClusterTaskFreshness,
+  formatClusterTaskSectionSummary,
+  formatTaskAgeSeconds,
+  normalizeClusterTaskResponse,
+  parseBoundedInteger,
+  shouldRunClusterTaskFreshness,
+} from '../static/cluster-tasks-model.mjs';
+
+test('controls use bounded defaults and the limited-RPC request shape', () => {
+  assert.deepEqual(CLUSTER_TASK_DEFAULTS, {
+    maxTasks: 500,
+    maxPending: 500,
+    includeBackground: false,
+    taskName: '',
+    coalesceEntries: true,
+  });
+
+  assert.deepEqual(buildClusterTaskRequest(CLUSTER_TASK_DEFAULTS), {
+    MaxTasks: 500,
+    MaxPending: 500,
+    IncludeBackground: false,
+    TaskName: null,
+  });
+  assert.equal(buildClusterTaskRequest({
+    ...CLUSTER_TASK_DEFAULTS,
+    taskName: 'SDR',
+  }).TaskName, 'SDR');
+  assert.deepEqual(buildClusterTaskRequest({
+    maxTasks: 17,
+    maxPending: 0,
+    includeBackground: true,
+    taskName: 'TreeRC',
+  }), {
+    MaxTasks: 17,
+    MaxPending: 0,
+    IncludeBackground: true,
+    TaskName: 'TreeRC',
+  });
+
+  assert.equal(parseBoundedInteger('1', 1, 500), 1);
+  assert.equal(parseBoundedInteger('500', 1, 500), 500);
+  assert.equal(parseBoundedInteger('0', 0, 500), 0);
+  assert.equal(parseBoundedInteger('', 1, 500), null);
+  assert.equal(parseBoundedInteger('1.5', 1, 500), null);
+  assert.equal(parseBoundedInteger('0', 1, 500), 1);
+  assert.equal(parseBoundedInteger('501', 1, 500), 500);
+  assert.equal(parseBoundedInteger('-1', 0, 30), 0);
+});
+
+test('task ages preserve second precision and distinguish unknown runtime', () => {
+  assert.equal(formatTaskAgeSeconds(0), '0s');
+  assert.equal(formatTaskAgeSeconds(42), '42s');
+  assert.equal(formatTaskAgeSeconds(5 * 60 + 1), '5m1s');
+  assert.equal(formatTaskAgeSeconds(18 * 60 + 39), '18m39s');
+  assert.equal(formatTaskAgeSeconds(25 * 60 * 60 + 61), '25h1m1s');
+  assert.equal(formatTaskAgeSeconds(null), 'unknown');
+  assert.equal(formatTaskAgeSeconds(undefined), 'unknown');
+  assert.equal(formatTaskAgeSeconds(-1), 'unknown');
+  assert.match(UNKNOWN_RUNNING_AGE_TOOLTIP, /ownership|Ownership/);
+});
+
+test('freshness is relative to the last successful client update', () => {
+  assert.equal(formatClusterTaskFreshness(10_000, 10_000), 'just now');
+  assert.equal(formatClusterTaskFreshness(15_001, 10_000), '5s ago');
+  assert.equal(formatClusterTaskFreshness(80_000, 10_000), '1m10s ago');
+  assert.equal(formatClusterTaskFreshness(9_000, 10_000), 'just now');
+  assert.equal(formatClusterTaskFreshness(Date.now(), null), '');
+});
+
+test('paused freshness uses an absolute date and time instead of frozen relative text', () => {
+  const lastSuccessAt = Date.UTC(2026, 8, 5, 3, 4, 5);
+  const absolute = new Date(lastSuccessAt).toLocaleString();
+
+  assert.deepEqual(buildClusterTaskLastSuccessPresentation({
+    paused: true,
+    now: lastSuccessAt + 60_000,
+    lastSuccessAt,
+  }), {
+    text: `Last successful update: ${absolute}`,
+    title: absolute,
+  });
+  assert.doesNotMatch(buildClusterTaskLastSuccessPresentation({
+    paused: true,
+    now: lastSuccessAt + 60_000,
+    lastSuccessAt,
+  }).text, /ago/);
+  assert.deepEqual(buildClusterTaskLastSuccessPresentation({
+    paused: true,
+    now: lastSuccessAt,
+    lastSuccessAt: null,
+  }), {
+    text: 'No successful snapshot is available yet.',
+    title: '',
+  });
+  assert.equal(buildClusterTaskLastSuccessPresentation({
+    paused: false,
+    now: lastSuccessAt + 5_000,
+    lastSuccessAt,
+  }).text, 'Last successful update: 5s ago');
+});
+
+test('freshness ticks only for a loaded, active, unpaused view', () => {
+  const active = {
+    isConnected: true,
+    viewVisible: true,
+    documentVisible: true,
+    paused: false,
+    hasSuccessfulLoad: true,
+  };
+  assert.equal(shouldRunClusterTaskFreshness(active), true);
+
+  for (const field of ['isConnected', 'viewVisible', 'documentVisible', 'hasSuccessfulLoad']) {
+    assert.equal(shouldRunClusterTaskFreshness({...active, [field]: false}), false, field);
+  }
+  assert.equal(shouldRunClusterTaskFreshness({...active, paused: true}), false, 'paused');
+});
+
+test('section summaries expose shown and total counts', () => {
+  assert.equal(formatClusterTaskSectionSummary(12, 40_000, true), '12 of 40000');
+  assert.equal(
+      formatClusterTaskSectionSummary(12, 0, false),
+      '12 shown; total unavailable',
+  );
+});
+
+test('pending empty states distinguish capacity, filters, disabled previews, and unknown totals', () => {
+  const runningAtLimit = Array.from({length: 500}, (_, index) => ({ID: index + 1}));
+  const capacityResponse = normalizeClusterTaskResponse({
+    Running: runningAtLimit,
+    Pending: [],
+    Applied: {MaxTasks: 500, MaxPending: 30},
+    RunningTotal: 600,
+    PendingTotal: 40_000,
+    TotalsAvailable: true,
+  });
+  assert.equal(
+      clusterTaskSectionEmptyMessage('pending', capacityResponse),
+      'Pending preview is omitted because running tasks use the display limit.',
+  );
+  assert.equal(
+      formatClusterTaskSectionSummary(
+          capacityResponse.Pending.length,
+          capacityResponse.PendingTotal,
+          capacityResponse.TotalsAvailable,
+      ),
+      '0 of 40000',
+  );
+
+  assert.equal(clusterTaskSectionEmptyMessage('pending', {
+    Pending: [],
+    Applied: {MaxTasks: 500, MaxPending: 0},
+    PendingTotal: 40_000,
+    TotalsAvailable: true,
+  }), 'Pending preview is disabled.');
+  assert.equal(clusterTaskSectionEmptyMessage('pending', {
+    Pending: [],
+    Applied: {MaxTasks: 500, MaxPending: 30},
+    PendingTotal: 0,
+    TotalsAvailable: true,
+  }), 'No pending tasks match the applied snapshot filters.');
+  assert.equal(clusterTaskSectionEmptyMessage('pending', {
+    Pending: [],
+    Applied: {MaxTasks: 500, MaxPending: 30},
+    TotalsAvailable: false,
+  }), 'No pending rows displayed; total unavailable.');
+});
+
+test('snapshot mismatch compares every applied control and normalizes empty task names', () => {
+  const selected = {
+    maxTasks: 500,
+    maxPending: 30,
+    includeBackground: false,
+    taskName: '',
+  };
+  const applied = {
+    MaxTasks: 500,
+    MaxPending: 30,
+    IncludeBackground: false,
+    TaskName: null,
+  };
+  assert.equal(clusterTaskControlsMatchApplied(selected, applied), true);
+
+  for (const changed of [
+    {MaxTasks: 499},
+    {MaxPending: 29},
+    {IncludeBackground: true},
+    {TaskName: 'SDR'},
+  ]) {
+    assert.equal(
+        clusterTaskControlsMatchApplied(selected, {...applied, ...changed}),
+        false,
+        JSON.stringify(changed),
+    );
+  }
+});
+
+test('retained snapshots identify filters that have not been applied', () => {
+  const allTasksResponse = {
+    Running: [{ID: 1}],
+    Pending: [],
+    Applied: {
+      MaxTasks: 500,
+      MaxPending: 30,
+      IncludeBackground: false,
+      TaskName: '',
+    },
+  };
+  const selectedSDR = {
+    maxTasks: 500,
+    maxPending: 30,
+    includeBackground: false,
+    taskName: 'SDR',
+  };
+
+  let state = completeClusterTaskRefresh(
+      createClusterTaskViewState(),
+      allTasksResponse,
+      1000,
+  );
+  state = beginClusterTaskRefresh(state);
+  const refreshing = clusterTaskSnapshotMismatchMessage({
+    controls: selectedSDR,
+    response: state.response,
+    refreshing: state.refreshing,
+    failed: Boolean(state.error),
+    paused: false,
+  });
+  assert.match(refreshing, /last snapshot for All tasks/);
+  assert.match(refreshing, /selected controls have not been applied yet: SDR tasks/);
+
+  state = failClusterTaskRefresh(state, new Error('offline'));
+  const failed = clusterTaskSnapshotMismatchMessage({
+    controls: selectedSDR,
+    response: state.response,
+    refreshing: state.refreshing,
+    failed: Boolean(state.error),
+    paused: false,
+  });
+  assert.match(failed, /last snapshot for All tasks/);
+  assert.match(failed, /were not applied because the refresh failed: SDR tasks/);
+
+  const paused = clusterTaskSnapshotMismatchMessage({
+    controls: selectedSDR,
+    response: state.response,
+    refreshing: false,
+    failed: false,
+    paused: true,
+  });
+  assert.match(paused, /last snapshot for All tasks/);
+  assert.match(paused, /have not been applied while updates are paused: SDR tasks/);
+
+  state = completeClusterTaskRefresh(state, {
+    ...allTasksResponse,
+    Applied: {...allTasksResponse.Applied, TaskName: 'SDR'},
+  }, 2000);
+  assert.equal(clusterTaskSnapshotMismatchMessage({
+    controls: selectedSDR,
+    response: state.response,
+    refreshing: false,
+    failed: false,
+    paused: false,
+  }), '');
+});
+
+test('task-type options preserve an active filter while metadata changes', () => {
+  assert.deepEqual(buildClusterTaskTypeOptions('SDR', []), [{Name: 'SDR'}]);
+  assert.deepEqual(
+      buildClusterTaskTypeOptions('SDR', [
+        {Name: 'TreeD'},
+        {Name: 'SDR'},
+        {Name: 'TreeD'},
+      ]).map((entry) => entry.Name),
+      ['TreeD', 'SDR'],
+  );
+  assert.deepEqual(
+      buildClusterTaskTypeOptions('', [{Name: 'TreeD'}]),
+      [{Name: 'TreeD'}],
+  );
+});
+
+test('limited response normalization keeps server metadata and safe arrays', () => {
+  const normalized = normalizeClusterTaskResponse({
+    Running: null,
+    Pending: [{ID: 1}],
+    Applied: {
+      MaxTasks: 50,
+      MaxPending: 10,
+      IncludeBackground: true,
+      TaskName: 'SDR',
+    },
+    RunningTotal: 7,
+    PendingTotal: 100,
+    TotalsAvailable: true,
+    Partial: true,
+    ObservedAt: '2026-09-05T12:00:00Z',
+    TaskTypes: [{Name: 'SDR', Total: 107}, null, {Name: 12}],
+    TaskTypesAvailable: true,
+    Warnings: [{Code: 'partial', Message: 'Partial result'}, {Code: 'bad'}],
+  });
+
+  assert.deepEqual(normalized.Running, []);
+  assert.deepEqual(normalized.Pending, [{ID: 1}]);
+  assert.deepEqual(normalized.Applied, {
+    MaxTasks: 50,
+    MaxPending: 10,
+    IncludeBackground: true,
+    TaskName: 'SDR',
+  });
+  assert.equal(normalized.PendingTotal, 100);
+  assert.equal(normalized.TotalsAvailable, true);
+  assert.equal(normalized.Partial, true);
+  assert.deepEqual(normalized.TaskTypes, [{Name: 'SDR', Total: 107}]);
+  assert.deepEqual(normalized.Warnings, [{Code: 'partial', Message: 'Partial result'}]);
+});
+
+test('failed refresh preserves the last rows, ages, and last-success timestamp', () => {
+  const firstResponse = {
+    Running: [{ID: 1, State: 'running', AgeSeconds: 720}],
+    Pending: [{ID: 2, State: 'pending', AgeSeconds: 240}],
+  };
+
+  let state = createClusterTaskViewState();
+  state = beginClusterTaskRefresh(state);
+  state = completeClusterTaskRefresh(state, firstResponse, 1234);
+  const acceptedResponse = state.response;
+
+  state = beginClusterTaskRefresh(state);
+  state = failClusterTaskRefresh(state, new Error('database unavailable'));
+
+  assert.equal(state.response, acceptedResponse);
+  assert.equal(state.response.Running[0].AgeSeconds, 720);
+  assert.equal(state.response.Pending[0].AgeSeconds, 240);
+  assert.equal(state.lastSuccessAt, 1234);
+  assert.equal(state.hasSuccessfulLoad, true);
+  assert.equal(state.refreshing, false);
+  assert.equal(state.stale, true);
+  assert.equal(state.error, 'database unavailable');
+});
+
+test('first refresh failure remains a first-state error, not stale data', () => {
+  let state = createClusterTaskViewState();
+  state = beginClusterTaskRefresh(state);
+  state = failClusterTaskRefresh(state, new Error('offline'));
+
+  assert.equal(state.response, null);
+  assert.equal(state.hasSuccessfulLoad, false);
+  assert.equal(state.stale, false);
+  assert.equal(state.error, 'offline');
+});
+
+test('sections are Running then Pending and coalesce only inside each section', () => {
+  const response = {
+    Running: [
+      {ID: 1, State: 'running', SpID: '1000', Name: 'SDR', OwnerID: '7'},
+      {ID: 2, State: 'running', SpID: '1000', Name: 'SDR', OwnerID: '7'},
+    ],
+    Pending: [
+      {ID: 3, State: 'pending', SpID: '1000', Name: 'SDR', OwnerID: null},
+      {ID: 4, State: 'pending', SpID: '1000', Name: 'SDR', OwnerID: null},
+    ],
+  };
+
+  const expanded = buildClusterTaskSections(response, false);
+  assert.deepEqual(expanded.map((section) => section.key), ['running', 'pending']);
+  assert.deepEqual(expanded[0].groups.map((group) => group.map((entry) => entry.ID)), [[1], [2]]);
+  assert.deepEqual(expanded[1].groups.map((group) => group.map((entry) => entry.ID)), [[3], [4]]);
+
+  const coalesced = buildClusterTaskSections(response, true);
+  assert.deepEqual(coalesced[0].groups.map((group) => group.map((entry) => entry.ID)), [[1, 2]]);
+  assert.deepEqual(coalesced[1].groups.map((group) => group.map((entry) => entry.ID)), [[3, 4]]);
+  assert.equal(coalesced[0].ageLabel, 'Owned');
+  assert.equal(coalesced[1].ageLabel, 'Waiting');
+  assert.match(RUNNING_AGE_TOOLTIP, /ownership|Ownership/);
+  assert.match(PENDING_AGE_TOOLTIP, /posted/);
+  assert.equal(
+      CLUSTER_TASK_ORDER_POLICY,
+      'Current ownership age first; task ID breaks ties',
+  );
+});
+
+test('coalescing preserves the selected-record bound', () => {
+  const selected = Array.from({length: 500}, (_, index) => ({
+    ID: index + 1,
+    State: 'running',
+    SpID: '1000',
+    Name: 'SDR',
+    OwnerID: 7,
+  }));
+
+  const sections = buildClusterTaskSections({Running: selected, Pending: []}, true);
+  assert.equal(sections[0].groups.length, 1);
+  assert.equal(
+      sections[0].groups.reduce((count, group) => count + group.length, 0),
+      500,
+  );
+  assert.equal(sections[1].groups.length, 0);
+});

--- a/web/test/cluster-tasks-took.test.mjs
+++ b/web/test/cluster-tasks-took.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {clusterTaskAge} from '../static/cluster-tasks-age.mjs';
+import {resetClusterTaskDisplayClock, advanceClusterTaskDisplayClock, freezeClusterTaskDisplayClock} from '../static/cluster-tasks-model.mjs';
+
+test('Took uses only confirmed current-attempt seconds, never Posted or ownership age', () => {
+  const task={ID:1,OwnerID:7,AgeSeconds:10800,TookSeconds:600,TookState:'running',AttemptID:'one'};
+  const clock=advanceClusterTaskDisplayClock(resetClusterTaskDisplayClock(100),2600);
+  assert.equal(clusterTaskAge(task,clock).seconds,602);
+  for(const state of ['unknown','awaiting-start','future-start']) {
+    const value=clusterTaskAge({...task,TookState:state},clock);
+    assert.equal(value.seconds,null);
+    assert.ok(value.text==='unknown'||value.text==='—');
+  }
+  assert.equal(clusterTaskAge({...task,OwnerID:null},clock).seconds,10802);
+});
+
+test('new same-owner attempt replaces Took with a lower authoritative baseline', () => {
+  const old={ID:1,OwnerID:7,TookState:'running',TookSeconds:600,AttemptID:'old'};
+  const running=advanceClusterTaskDisplayClock(resetClusterTaskDisplayClock(100),2500);
+  const frozen=freezeClusterTaskDisplayClock(running);
+  assert.equal(clusterTaskAge(old,advanceClusterTaskDisplayClock(frozen,1e9)).seconds,602);
+  assert.equal(clusterTaskAge({...old,TookSeconds:1,AttemptID:'new'},resetClusterTaskDisplayClock(1e9)).seconds,1);
+});


### PR DESCRIPTION
## Summary

Cluster Tasks currently loads an unbounded list and mixes posting/ownership age
with work duration. This adds a bounded monitoring endpoint and a view that
separates current-attempt **Took** from pending **Waiting**.

- At most 500 selected rows, filtering before selection, truthful totals and
  batched multi-provider enrichment. Existing RPC fields keep their meanings.
- Explicit running, awaiting-start and unknown timing states. Confirmed Took
  shares the exact Do-entry timestamp used by new History records; no backfill.
- Task/owner/attempt CAS rejects delayed writes from prior attempts. Ownership
  transitions clear telemetry; same-owner recovery prepares a fresh token.
- Refresh/pause/filter/coalescing controls, bounded polling, stale response
  rejection and monotonic interpolation without per-second RPCs. Took and Waiting
  use start alignment, including unknown/dash values.

The many small task-file changes implement one batched provider-lookup interface;
they do not change task scheduling policy. This topic has no dependency on SDR
pacing, admission caps, offset recovery, or site-specific profiles.

## Execution and rollout boundary

This is more than a GUI-only change. Preparation adds one conditional UPDATE per
accepted task before storage acquisition. Failed preparation prevents dispatch
and attempts a bounded ownership release; preparation and release each have a
five-second batch budget, including for time-sensitive tasks. The Do-entry writer
adds one asynchronous conditional UPDATE and a bounded goroutine, canceled and
joined even when Do panics. Its own panic is contained. Failed telemetry does not
invent task success or a live timestamp.

The additive migrations preserve existing fields/history and never backfill
execution timestamps. Already instrumented schemas use the same migration names
and SQL, without duplicate triggers. Older workers cannot report Do entry, and
old same-owner recovery without an ownership write cannot be recognized as a new
attempt. Worker/database clocks must be synchronized. This is task-body time,
not an FFI benchmark. Database counts can scan beyond the selected-row limit.

## Validation

- Go normal/race tests for `harmony/harmonytask` and `web/api/webrpc`: PASS with
  `cgo,fvm,nosupraseal`; includes real scheduler preparation-failure and bounded
  writer cancellation/panic tests.
- Exact `integration`-tag vet/lint, import formatting and diff checks: PASS.
- 41 Node tests: PASS for request ordering, hidden/pause/failure/resume, stale
  clocks, retry timing and response shaping.
- Actual Chromium component/Shadow DOM at 642x500 and 1280x760, coalescing on/off:
  PASS. Synthetic data only; computed start alignment, duration/unknown/dash
  values and adjacent column bounds verified. Original right alignment fails
  the same assertion.
- Disposable PostgreSQL 16.15: `TestTaskAttemptSQLMigrationAndIdentity`,
  `TestTaskAttemptSQLDoEntryAndRollback` and `TestClusterTaskSnapshotSQL`: PASS.
  These execute actual migrations, HarmonyDB adapter and snapshot SQL. Replacing
  the token-CAS predicate makes the delayed-writer assertion fail; restored PASS.
- Yugabyte execution: NOT RUN. Independent-handle stale-writer checks establish
  conditional row effects, not simultaneous lock contention or serializability.

The SQL fixtures require explicit `CURIO_TASK_ATTEMPT_ITEST=1`, dedicated target
fields, literal loopback, disabled load balancing and isolated schema ownership.
No production database, service or worker was accessed for these tests.
