### PR TITLE
seal: add optional per-instance SDR start pacing

### DIFF
--- a/cmd/curio/tasks/tasks.go
+++ b/cmd/curio/tasks/tasks.go
@@ -613,6 +613,9 @@ func addSealingTasks(
 		sdrMax := taskhelp.Max(cfg.Subsystems.SealSDRMaxTasks)
 
 		sdrTask := seal.NewSDRTask(full, db, sp, slr, sdrMax, cfg.Subsystems.SealSDRMinTasks)
+		if err := sdrTask.ConfigureStartPacing(cfg.Subsystems.SealSDRMinStartInterval, cfg.Subsystems.SealSDRStartJitter, os.Getenv("CURIO_NODE_NAME"), machineHostPort); err != nil {
+			return nil, nil, sp, nil, nil, nil, nil, xerrors.Errorf("configuring SDR start pacing: %w", err)
+		}
 		keyTask := unseal.NewTaskUnsealSDR(slr, db, sdrMax, full)
 
 		activeTasks = append(activeTasks, sdrTask, keyTask)

--- a/deps/config/doc_gen.go
+++ b/deps/config/doc_gen.go
@@ -673,6 +673,23 @@ In lotus-miner this was run as part of PreCommit1. (Default: false)`,
 also be bounded by resources available on the machine. (Default: 0 - unlimited)`,
 		},
 		{
+			Name: "SealSDRMinStartInterval",
+			Type: "time.Duration",
+
+			Comment: `Minimum interval between SDR Do entries on this instance. Zero disables
+pacing. Negative values reject task construction. Requires restart.`,
+		},
+		{
+			Name: "SealSDRStartJitter",
+			Type: "bool",
+
+			Comment: `On first start or after a long idle, wait for a stable instance phase
+within SealSDRMinStartInterval. This is not a cluster-wide rate limit.
+Identity combines CURIO_NODE_NAME and the instance listen identity.
+Both must be nonempty when jitter and a positive interval are enabled.
+Disabled by default; interval zero preserves unpaced scheduling.`,
+		},
+		{
 			Name: "SealSDRMinTasks",
 			Type: "int",
 

--- a/deps/config/sdr_start_pacing_test.go
+++ b/deps/config/sdr_start_pacing_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSDRStartPacingDefaultsDisabled(t *testing.T) {
+	cfg := DefaultCurioConfig()
+	if cfg.Subsystems.SealSDRMinStartInterval != 0 || cfg.Subsystems.SealSDRStartJitter {
+		t.Fatal("SDR start pacing must remain disabled by default")
+	}
+}
+
+func TestSDRStartPacingLayerValues(t *testing.T) {
+	for _, interval := range []string{"0s", "1m30s", "43m45s", "25m20s"} {
+		cfg := DefaultCurioConfig()
+		layer := "[Subsystems]\nSealSDRMinStartInterval = \"" + interval + "\"\nSealSDRStartJitter = true\n"
+		if _, err := TransparentDecode(layer, cfg); err != nil {
+			t.Fatal(err)
+		}
+		want, err := time.ParseDuration(interval)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Subsystems.SealSDRMinStartInterval != want || !cfg.Subsystems.SealSDRStartJitter {
+			t.Fatalf("layer values changed: %+v", cfg.Subsystems)
+		}
+	}
+}

--- a/deps/config/types.go
+++ b/deps/config/types.go
@@ -276,6 +276,17 @@ type CurioSubsystemsConfig struct {
 	// also be bounded by resources available on the machine. (Default: 0 - unlimited)
 	SealSDRMaxTasks int
 
+	// Minimum interval between SDR Do entries on this instance. Zero disables
+	// pacing. Negative values reject task construction. Requires restart.
+	SealSDRMinStartInterval time.Duration
+
+	// On first start or after a long idle, wait for a stable instance phase
+	// within SealSDRMinStartInterval. This is not a cluster-wide rate limit.
+	// Identity combines CURIO_NODE_NAME and the instance listen identity.
+	// Both must be nonempty when jitter and a positive interval are enabled.
+	// Disabled by default; interval zero preserves unpaced scheduling.
+	SealSDRStartJitter bool
+
 	// The maximum amount of SDR tasks that need to be queued before the system will start accepting new tasks.
 	// The main purpose of this setting is to allow for enough tasks to accumulate for batch sealing. When batch sealing
 	// nodes are present in the cluster, this value should be set to batch_size+1 to allow for the batch sealing node to

--- a/documentation/en/configuration/default-curio-configuration.md
+++ b/documentation/en/configuration/default-curio-configuration.md
@@ -87,6 +87,21 @@ description: The default curio configuration
   # type: int
   #SealSDRMaxTasks = 0
 
+  # Minimum interval between SDR Do entries on this instance. Zero disables
+  # pacing. Negative values reject task construction. Requires restart.
+  #
+  # type: time.Duration
+  #SealSDRMinStartInterval = "0s"
+
+  # On first start or after a long idle, wait for a stable instance phase
+  # within SealSDRMinStartInterval. This is not a cluster-wide rate limit.
+  # Identity combines CURIO_NODE_NAME and the instance listen identity.
+  # Both must be nonempty when jitter and a positive interval are enabled.
+  # Disabled by default; interval zero preserves unpaced scheduling.
+  #
+  # type: bool
+  #SealSDRStartJitter = false
+
   # The maximum amount of SDR tasks that need to be queued before the system will start accepting new tasks.
   # The main purpose of this setting is to allow for enough tasks to accumulate for batch sealing. When batch sealing
   # nodes are present in the cluster, this value should be set to batch_size+1 to allow for the batch sealing node to

--- a/documentation/en/sdr-start-pacing.md
+++ b/documentation/en/sdr-start-pacing.md
@@ -1,0 +1,129 @@
+# Optional per-instance SDR start pacing
+
+Optional start pacing spreads SDR task entry on one process without changing
+ordinary resource checks, task concurrency limits, or database ownership.
+
+## Contract
+
+`Subsystems.SealSDRMinStartInterval` retains its duration key and zero default.
+Zero preserves the existing unpaced batch path, even when jitter is enabled.
+Negative intervals reject SDR task construction instead of becoming unlimited.
+`Subsystems.SealSDRStartJitter` retains its boolean key and false default.
+These fields are read when tasks are constructed; changing them requires restart.
+
+The paced unit is an **SDR task's entry into `Do` on one Curio process**, after
+ordinary scheduler eligibility, resource capacity, authoritative SQL ownership,
+and storage claim. It is not the start of the native SDR computation, which
+occurs later after task-local preparation. It is not a global rate limiter,
+sector quota, sealing concurrency limit, or substitute for database ownership.
+UnsealSDR and SupraSeal batch tasks are not changed. CPU accounting, FFI backend,
+existing minimum-queue and maximum-task settings remain independent.
+
+With a positive interval, at most one provisional start is reserved per instance.
+Reservation happens outside speculative/cached `CanAccept`; candidate checks do
+not consume the interval. Claim loss/error, storage failure, or cancellation
+before `Do` releases only that reservation's token. At `Do` entry the token is
+committed and the minimum interval begins. Task errors, panic, or retries after
+that entry do not refund it. Stale or repeated cancellation cannot clear another
+attempt's reservation. No lock is held for SQL, storage calls, task execution,
+logging, or waiting; no scheduler sleep is added.
+
+## Phase and lifecycle
+
+When jitter is enabled, a first start or a start after more than twice the
+interval of inactivity waits for the next stable phase in that interval. Phase
+is the existing SHA-256 construction, now keyed by `CURIO_NODE_NAME`, a separator,
+and the instance's advertised listen identity. Both inputs are required
+and distinguish instances sharing the same host or node name. Keep it stable
+across restarts. Changing this identity changes phase; hashes can still collide.
+Different phases do not guarantee collision-free starts across the cluster.
+
+Wall time selects the phase once. The resulting wait is latched and measured
+with process-local monotonic elapsed time. Repeated polls cannot keep moving
+the deadline; wall-clock jumps cannot extend that latched wait or bypass the
+minimum interval. Phase waiting holds neither task ownership nor storage.
+After phase expiry, insufficient resources or lost claims may delay actual
+start past the nominal phase; there is no catch-up burst.
+
+| Lifecycle | Behavior |
+| --- | --- |
+| First start, jitter off | Immediately eligible after ordinary prerequisites. |
+| First start, jitter on | Wait at most one interval for the stable phase. |
+| Continuous work / retry | Minimum interval measured from the previous `Do` entry. |
+| Long idle | Re-latch one phase wait; do not accumulate missed slots. |
+| Claim or storage failure | Cancel provisional reservation; no interval charge. |
+| Cancellation before `Do` | No interval charge; existing task retry semantics remain. |
+| Failure after `Do` starts | Keep interval charge, including pre-native-computation failures. |
+| Recovery after restart | Apply the same pacing hook. Existing recovery code disowns work it cannot currently accept, making it discoverable by normal scheduling; no separate bypass or sleep is added. |
+| Config change/restart | Construct a fresh pacer with the new interval and stable identity. In-memory previous-start history is not persisted. |
+| Graceful shutdown | Already dispatched task contexts retain the existing shutdown contract. No new starts are scheduled once the engine stops scheduling. |
+
+Restart resets the minimum-interval history. Jitter re-phases the first start but
+does not promise minimum spacing across two process lifetimes. Fleet-wide or
+durable pacing would require a different policy and is outside this topic.
+
+## Operational diagnostics
+
+The `cu/seal` logger emits these structured INFO events:
+
+- `SDR start pacing configured`: once on successful task configuration, including
+  disabled pacing. Fields include `pacing_enabled`, `min_start_interval`, the
+  configured `start_jitter` flag, `jitter_offset`, and `blocked_log_interval`.
+  A true jitter flag with a zero interval still means pacing is disabled.
+- `SDR start delayed`: the first refused reservation and at most once per minute
+  thereafter per pacer, shared across tasks and reasons. `reason` distinguishes
+  `min start interval`, `start jitter phase`, and `reservation pending`.
+  `remaining` is derived from monotonic elapsed time; `next_start_at` is its
+  wall-clock estimate at `observed_at`. For a pending reservation, claim/storage
+  preparation has no known completion deadline: both values are `unknown` and
+  `next_start_known` is false. `reservation_token` identifies that provisional
+  reservation, not a committed start. Suppressed reason changes do not reset
+  the one-minute log budget.
+- `SDR Do entry committed`: once for a successful start-token commit at the
+  existing scheduler entry hook, with `task`, `reservation_token`, `observed_at`,
+  and the next minimum-interval wait. No such event is emitted for `CanAccept`,
+  a provisional reservation, a stale token, or a cancelled entry. Later task
+  failure does not refund the interval or erase this event. This is not evidence
+  that native SDR computation or sealing has completed.
+
+Snapshots are copied under the pacer mutex; formatting and every logger call
+occur after unlocking. The separate diagnostic rate limiter also releases its
+mutex before logging. Reading/formatting a snapshot never latches a phase,
+reserves a token, or consumes an interval. It uses no new scheduler timer,
+background goroutine, persistence, or configuration setting.
+
+Rate limiting uses process-local elapsed time, not wall time. Wall-clock changes
+may change the displayed next-start estimate but cannot change admission. The
+estimate is not a promised dispatch time: resources, claims, later idle-phase
+selection, and scheduling can delay entry. A snapshot can become stale before
+the logger returns, and concurrent log lines need not arrive in event order;
+use `observed_at` and process-local tokens for interpretation. Tokens and log
+throttling reset on process restart. Diagnostics do not provide cluster-wide
+ordering or a distributed rate guarantee. No node name or listen address is
+included in the new events.
+
+## Evidence and limits
+
+Database-free tests execute the production pacer and scheduler reservation/run
+helpers with injected elapsed/wall clocks, cancellation, and a simultaneous
+reservation barrier. They include 43m45s and 25m20s as regression inputs, not
+defaults or recommendations. Tests guard against recursive logging mutexes
+and speculative `CanAccept` consumption: admission uses one locked state
+transition with diagnostic emission after unlocking.
+
+Diagnostic regressions additionally compare every admission-state field before
+and after repeated snapshots/formatting/logging, force concurrent refused starts,
+re-enter diagnostics from a log sink, and hold a sink at a barrier while verifying
+reservation cancellation and committed-interval enforcement can proceed. They
+check all three blocked reasons, monotonic log throttling across wall jumps,
+configuration fields, and committed-only entry events. These are executable
+database-free tests, not production-log or database validation.
+
+The actual scheduler admission body is also exercised with injected ownership
+outcomes and storage-claim failures: lost claims, claim errors, cancellation,
+storage errors, failed ownership release, and restart recovery all cancel the
+reservation without starting work. The production wrapper supplies its existing
+SQL methods; call-site assertions additionally protect reserve/claim/storage/Do
+ordering. These unit tests do not execute PostgreSQL/Yugabyte or prove distributed
+claim behavior. Real scheduler/database integration and role-specific native
+builds remain separate validation gates.

--- a/harmony/harmonytask/start_reservation.go
+++ b/harmony/harmonytask/start_reservation.go
@@ -1,0 +1,60 @@
+package harmonytask
+
+import "context"
+
+// taskStartReserver is optional. CanAccept may be cached or called speculatively;
+// this hook runs only after ordinary eligibility/resource checks, before claim.
+// A nil start/cancel pair preserves the unpaced batch path. Otherwise the
+// reservation covers one task, and start is called immediately before Do.
+type taskStartReserver interface {
+	ReserveTaskStart(TaskID) (start func(context.Context) error, cancel func(), allowed bool)
+}
+
+type taskStartReservation struct {
+	start  func(context.Context) error
+	cancel func()
+}
+
+func reserveTaskStart(impl TaskInterface, ids []TaskID) ([]TaskID, *taskStartReservation) {
+	gate, ok := impl.(taskStartReserver)
+	if !ok || len(ids) == 0 {
+		return ids, nil
+	}
+	start, cancel, allowed := gate.ReserveTaskStart(ids[0])
+	if !allowed {
+		return nil, nil
+	}
+	if start == nil && cancel == nil {
+		return ids, nil
+	}
+	if start == nil || cancel == nil {
+		if cancel != nil {
+			cancel()
+		}
+		return nil, nil
+	}
+	return ids[:1], &taskStartReservation{start: start, cancel: cancel}
+}
+
+func runWithStartReservation(ctx context.Context, reservation *taskStartReservation, run func() (bool, error)) (bool, error) {
+	return withStartReservationCleanup(reservation, func() (bool, error) {
+		if reservation != nil {
+			if err := ctx.Err(); err != nil {
+				return false, err
+			}
+			if err := reservation.start(ctx); err != nil {
+				return false, err
+			}
+		}
+		return run()
+	})
+}
+
+// Release before completion persistence, which can retry indefinitely. The
+// callback owns the single entry decision; cleanup never refunds a committed start.
+func withStartReservationCleanup(reservation *taskStartReservation, run func() (bool, error)) (bool, error) {
+	if reservation != nil {
+		defer reservation.cancel()
+	}
+	return run()
+}

--- a/harmony/harmonytask/start_reservation_cleanup_test.go
+++ b/harmony/harmonytask/start_reservation_cleanup_test.go
@@ -1,0 +1,86 @@
+package harmonytask
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Committing the interval is the last admission decision before Do. A later
+// cancellation belongs to that execution and must not refund the interval.
+func TestStartReservationNoCancellationGapAfterCommit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ran, cleaned := false, false
+	r := &taskStartReservation{start: func(context.Context) error { cancel(); return nil }, cancel: func() { cleaned = true }}
+	done, err := runWithStartReservation(ctx, r, func() (bool, error) { ran = true; return true, nil })
+	if !done || err != nil || !ran || !cleaned {
+		t.Fatalf("committed start did not enter Do: %v %v", done, err)
+	}
+}
+
+func TestStartReservationStandaloneCleanupPrecedesCompletion(t *testing.T) {
+	for _, mode := range []string{"cancelled-before-entry", "panic-before-entry", "preparation-error"} {
+		t.Run(mode, func(t *testing.T) {
+			var reserved atomic.Bool
+			reserved.Store(true)
+			r := &taskStartReservation{start: func(context.Context) error {
+				if mode == "panic-before-entry" {
+					panic("synthetic preparation panic")
+				}
+				return errors.New("synthetic preparation error")
+			}, cancel: func() { reserved.Store(false) }}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if mode == "cancelled-before-entry" {
+				cancel()
+			}
+			type outcome struct {
+				reserved, ran bool
+				err           error
+				panic         any
+			}
+			completion := make(chan outcome, 1)
+			release := make(chan struct{})
+			joined := make(chan struct{})
+			watchdog, stop := context.WithTimeout(context.Background(), 5*time.Second)
+			defer stop()
+			defer func() {
+				close(release)
+				select {
+				case <-joined:
+				case <-watchdog.Done():
+					t.Error("test participant did not exit")
+				}
+			}()
+			go func() {
+				defer close(joined)
+				defer r.cancel() // Existing outer safety defer runs after completion.
+				var result outcome
+				defer func() {
+					result.panic = recover()
+					result.reserved = reserved.Load()
+					completion <- result
+					select {
+					case <-release:
+					case <-watchdog.Done():
+					}
+				}()
+				_, result.err = runWithStartReservation(ctx, r, func() (bool, error) { result.ran = true; return true, nil })
+			}()
+			select {
+			case result := <-completion:
+				if result.reserved {
+					t.Fatal("reservation still held when completion persistence begins")
+				}
+				if result.ran || (mode == "cancelled-before-entry" && !errors.Is(result.err, context.Canceled)) || (mode == "panic-before-entry" && result.panic == nil) || (mode == "preparation-error" && result.err == nil) {
+					t.Fatalf("unexpected outcome: %+v", result)
+				}
+			case <-watchdog.Done():
+				t.Fatal("entry did not reach completion")
+			}
+		})
+	}
+}

--- a/harmony/harmonytask/start_reservation_test.go
+++ b/harmony/harmonytask/start_reservation_test.go
@@ -1,0 +1,222 @@
+package harmonytask
+
+import (
+	"context"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/curio/harmony/harmonytask/internal/acceptcache"
+	"github.com/filecoin-project/curio/harmony/harmonytask/internal/runregistry"
+	"github.com/filecoin-project/curio/harmony/resources"
+	"github.com/filecoin-project/curio/harmony/taskhelp"
+)
+
+type startReservationStub struct {
+	TaskInterface
+	reserve func(TaskID) (func(context.Context) error, func(), bool)
+}
+
+func (s startReservationStub) ReserveTaskStart(id TaskID) (func(context.Context) error, func(), bool) {
+	return s.reserve(id)
+}
+
+func TestStartReservationBatchAndDisabled(t *testing.T) {
+	ids := []TaskID{12, 23, 34}
+	for _, paced := range []bool{false, true} {
+		calls := 0
+		stub := startReservationStub{reserve: func(id TaskID) (func(context.Context) error, func(), bool) {
+			calls++
+			if id != ids[0] {
+				t.Fatal("candidate order changed")
+			}
+			if !paced {
+				return nil, nil, true
+			}
+			return func(context.Context) error { return nil }, func() {}, true
+		}}
+		selected, r := reserveTaskStart(stub, ids)
+		if calls != 1 || (paced && (len(selected) != 1 || r == nil)) || (!paced && (len(selected) != 3 || r != nil)) {
+			t.Fatalf("paced=%v selected=%v reservation=%v", paced, selected, r)
+		}
+	}
+}
+
+func TestStartReservationExecutionAndCancellation(t *testing.T) {
+	for _, mode := range []string{"success", "do-error", "cancelled", "start-error"} {
+		t.Run(mode, func(t *testing.T) {
+			started, cancelled, ran := 0, 0, 0
+			boom := errors.New("synthetic failure")
+			stub := startReservationStub{reserve: func(TaskID) (func(context.Context) error, func(), bool) {
+				return func(context.Context) error {
+					started++
+					if mode == "start-error" {
+						return boom
+					}
+					return nil
+				}, func() { cancelled++ }, true
+			}}
+			_, r := reserveTaskStart(stub, []TaskID{1})
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if mode == "cancelled" {
+				cancel()
+			}
+			done, err := runWithStartReservation(ctx, r, func() (bool, error) {
+				ran++
+				if started != 1 {
+					t.Fatal("Do entered before reservation commit")
+				}
+				if mode == "do-error" {
+					return false, boom
+				}
+				return true, nil
+			})
+			if cancelled != 1 || done != (mode == "success") || (err == nil) != (mode == "success") {
+				t.Fatalf("done=%v error=%v cancelled=%d", done, err, cancelled)
+			}
+			if (mode == "cancelled" && started != 0) || ((mode == "cancelled" || mode == "start-error") && ran != 0) {
+				t.Fatal("pre-execution failure entered task")
+			}
+		})
+	}
+}
+
+func TestStartReservationRealSchedulerCacheRecoveryAndResources(t *testing.T) {
+	for _, source := range []string{workSourcePoller, workSourceRecover, workSourcePreempt} {
+		for _, hasResources := range []bool{false, true} {
+			t.Run(source+"/resources="+map[bool]string{false: "none", true: "available"}[hasResources], func(t *testing.T) {
+				reserved := 0
+				accept := &stubAcceptTask{}
+				stub := startReservationStub{TaskInterface: accept, reserve: func(TaskID) (func(context.Context) error, func(), bool) {
+					reserved++
+					return nil, nil, false
+				}}
+				cpu := 0
+				if hasResources {
+					cpu = 2
+				}
+				h := &taskTypeHandler{
+					TaskInterface:   stub,
+					TaskTypeDetails: TaskTypeDetails{Name: "PacedStub", Max: taskhelp.Max(10), Cost: resources.Resources{Cpu: 1}},
+					TaskEngine:      &TaskEngine{cfg: taskEngineConfig{ctx: context.Background(), reg: &resources.Reg{Resources: resources.Resources{Cpu: cpu}}}},
+					running:         runregistry.New(), accept: acceptcache.New(time.Hour), storageFailures: map[TaskID]time.Time{},
+				}
+				h.accept.Add([]int64{1, 2})
+				// No DB is supplied: an accidental claim or recovered dispatch is
+				// a failure, not a connection to a fallback test target.
+				if h.considerWork(source, []task{{ID: 1}, {ID: 2}}, eventEmitter{}) {
+					t.Fatal("pacing refusal was bypassed")
+				}
+				if (hasResources && reserved != 1) || (!hasResources && reserved != 0) || accept.canAcceptCalls.Load() != 0 {
+					t.Fatalf("reserved=%d CanAccept calls=%d", reserved, accept.canAcceptCalls.Load())
+				}
+			})
+		}
+	}
+}
+
+type startReservationStorage struct{ claims int }
+
+func (*startReservationStorage) HasCapacity() bool { return true }
+
+func (s *startReservationStorage) Claim(int) (func() error, error) {
+	s.claims++
+	return nil, errors.New("synthetic storage claim failure")
+}
+
+func TestStartReservationRealClaimAndStorageFailures(t *testing.T) {
+	for _, mode := range []string{"claim-lost", "claim-error", "context-cancelled", "storage-error", "release-error", "recovery-storage-error"} {
+		t.Run(mode, func(t *testing.T) {
+			reserved, started, cancelled, claims, releases := 0, 0, 0, 0, 0
+			storage := &startReservationStorage{}
+			stub := startReservationStub{TaskInterface: &stubAcceptTask{}, reserve: func(TaskID) (func(context.Context) error, func(), bool) {
+				reserved++
+				return func(context.Context) error { started++; return nil }, func() { cancelled++ }, true
+			}}
+			h := &taskTypeHandler{
+				TaskInterface:   stub,
+				TaskTypeDetails: TaskTypeDetails{Name: "PacedStub", Max: taskhelp.Max(10), Cost: resources.Resources{Cpu: 1, Storage: storage}},
+				TaskEngine:      &TaskEngine{cfg: taskEngineConfig{ctx: context.Background(), reg: &resources.Reg{Resources: resources.Resources{Cpu: 2}}}},
+				running:         runregistry.New(), accept: acceptcache.New(time.Hour), storageFailures: map[TaskID]time.Time{},
+			}
+			source := workSourcePoller
+			if mode == "recovery-storage-error" {
+				source = workSourceRecover
+			}
+			ok := h.considerWorkWithOwnership(source, []task{{ID: 1}, {ID: 2}}, eventEmitter{},
+				func(ids []TaskID, _ int) ([]TaskID, error) {
+					claims++
+					if len(ids) != 1 || ids[0] != 1 {
+						t.Fatalf("unpaced claim batch: %v", ids)
+					}
+					switch mode {
+					case "claim-lost":
+						return nil, nil
+					case "claim-error":
+						return nil, errors.New("synthetic claim error")
+					case "context-cancelled":
+						return nil, context.Canceled
+					default:
+						return ids, nil
+					}
+				}, func(ids []TaskID) error {
+					releases++
+					if len(ids) != 1 || ids[0] != 1 {
+						t.Fatalf("wrong ownership release: %v", ids)
+					}
+					if mode == "release-error" {
+						return errors.New("synthetic ownership release error")
+					}
+					return nil
+				})
+			if ok || reserved != 1 || started != 0 || cancelled != 1 || h.Max.Active() != 0 {
+				t.Fatalf("accepted=%v reserved=%d started=%d cancelled=%d active=%d", ok, reserved, started, cancelled, h.Max.Active())
+			}
+			storagePhase := mode == "storage-error" || mode == "release-error" || mode == "recovery-storage-error"
+			if (storagePhase && (storage.claims != 1 || releases != 1)) || (!storagePhase && (storage.claims != 0 || releases != 0)) {
+				t.Fatalf("storage claims=%d ownership releases=%d", storage.claims, releases)
+			}
+			if (source == workSourceRecover && claims != 0) || (source != workSourceRecover && claims != 1) {
+				t.Fatalf("unexpected claim calls=%d for %s", claims, source)
+			}
+		})
+	}
+}
+
+func TestStartReservationProductionCallSites(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "task_type_handler.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reserve, claim, storage, run token.Pos
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fun := call.Fun.(type) {
+		case *ast.Ident:
+			switch fun.Name {
+			case "reserveTaskStart":
+				reserve = call.Pos()
+			case "claim":
+				claim = call.Pos()
+			case "runWithStartReservation":
+				run = call.Pos()
+			}
+		case *ast.SelectorExpr:
+			if fun.Sel.Name == "Claim" {
+				storage = call.Pos()
+			}
+		}
+		return true
+	})
+	if reserve == token.NoPos || reserve >= claim || claim >= storage || storage >= run {
+		t.Fatalf("production reserve/claim/storage/Do order not protected: %v %v %v %v", reserve, claim, storage, run)
+	}
+}

--- a/harmony/harmonytask/task_type_handler.go
+++ b/harmony/harmonytask/task_type_handler.go
@@ -99,6 +99,13 @@ const (
 // availability, but that's safe — resources can only increase, never
 // invalidating a "fits" decision made moments earlier.
 func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter eventEmitter) (workAccepted bool) {
+	return h.considerWorkWithOwnership(from, tasks, eventEmitter, h.claimTaskOwnership, h.releaseTaskOwnership)
+}
+
+// The ownership callbacks keep failure paths testable without changing the
+// production SQL or requiring a live database for admission lifecycle tests.
+func (h *taskTypeHandler) considerWorkWithOwnership(from string, tasks []task, eventEmitter eventEmitter,
+	claim func([]TaskID, int) ([]TaskID, error), release func([]TaskID) error) (workAccepted bool) {
 	if len(tasks) == 0 {
 		return true
 	}
@@ -160,24 +167,20 @@ func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter e
 	})
 	tIDs = reorderTaskIDsByPostedOrder(tasks, tIDs)
 
-	if from != workSourceRecover {
-		var tasksAccepted []TaskID
-		err := h.TaskEngine.cfg.db.Select(h.TaskEngine.cfg.ctx, &tasksAccepted, `
-		WITH candidates AS (
-			SELECT t.id
-			FROM harmony_task t
-			JOIN unnest($2::bigint[]) AS x(id) ON x.id = t.id
-			WHERE t.owner_id IS NULL
-			ORDER BY array_position($2, t.id::bigint)
-			LIMIT $3
-			FOR UPDATE SKIP LOCKED
-		)
-		UPDATE harmony_task t
-		SET owner_id = $1
-		FROM candidates c
-		WHERE t.id = c.id
-		RETURNING t.id;`, h.TaskEngine.cfg.ownerID, tIDs, maxAcceptable)
+	hadCandidates := len(tIDs) != 0
+	tIDs, startReservation := reserveTaskStart(h.TaskInterface, tIDs)
+	if hadCandidates && len(tIDs) == 0 {
+		return false
+	}
+	dispatched := false
+	defer func() {
+		if startReservation != nil && !dispatched {
+			startReservation.cancel()
+		}
+	}()
 
+	if from != workSourceRecover {
+		tasksAccepted, err := claim(tIDs, maxAcceptable)
 		if err != nil {
 			log.Error(err)
 			return false
@@ -221,7 +224,7 @@ func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter e
 		if len(failedTIDs) > 0 {
 			tIDs = goodTIDs
 			log.Errorw("did not accept task", "task_ids", failedTIDs, "reason", "storage claim failed", "name", h.Name)
-			_, err := h.TaskEngine.cfg.db.Exec(h.TaskEngine.cfg.ctx, `UPDATE harmony_task SET owner_id = NULL WHERE id = ANY($1)`, failedTIDs)
+			err := release(failedTIDs)
 			if err != nil {
 				log.Errorw("Could not reset failed tasks", "error", err)
 			}
@@ -270,6 +273,9 @@ func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter e
 		handle := h.running.Start(int64(tID), taskCancel)
 
 		go func(tID TaskID, releaseStorage func(), handle *runregistry.Handle) {
+			if startReservation != nil {
+				defer startReservation.cancel()
+			}
 			eventEmitter.EmitTaskStarted(h.Name, tID)
 			var done bool
 			var doErr error
@@ -324,42 +330,70 @@ func (h *taskTypeHandler) considerWork(from string, tasks []task, eventEmitter e
 
 			defer taskCancel()
 
-			done, doErr = h.Do(taskCtx, tID, func() bool {
-				if taskCtx.Err() != nil {
-					return false
-				}
-				if taskhelp.IsBackgroundTask(h.Name) || h.CanYield {
-					if h.TaskEngine.atomics.yieldBackground.Load() {
-						log.Infow("yielding background task", "name", h.Name, "id", tID)
+			done, doErr = runWithStartReservation(taskCtx, startReservation, func() (bool, error) {
+				return h.Do(taskCtx, tID, func() bool {
+					if taskCtx.Err() != nil {
 						return false
 					}
-				}
-				// Uninterruptible work (e.g. Send*) calls stillOwned before
-				// taking a per-sender lock. During shutdown drain, fail that
-				// check so hundreds of waiters can exit without starting a new
-				// critical section; in-flight holders do not call stillOwned
-				// and are waited on via Active() in GracefullyTerminate.
-				if h.Uninterruptible && h.TaskEngine.atomics.draining.Load() {
-					log.Infow("yielding uninterruptible task during shutdown drain", "name", h.Name, "id", tID)
-					return false
-				}
+					if taskhelp.IsBackgroundTask(h.Name) || h.CanYield {
+						if h.TaskEngine.atomics.yieldBackground.Load() {
+							log.Infow("yielding background task", "name", h.Name, "id", tID)
+							return false
+						}
+					}
+					// Uninterruptible work (e.g. Send*) calls stillOwned before
+					// taking a per-sender lock. During shutdown drain, fail that
+					// check so hundreds of waiters can exit without starting a new
+					// critical section; in-flight holders do not call stillOwned
+					// and are waited on via Active() in GracefullyTerminate.
+					if h.Uninterruptible && h.TaskEngine.atomics.draining.Load() {
+						log.Infow("yielding uninterruptible task during shutdown drain", "name", h.Name, "id", tID)
+						return false
+					}
 
-				var owner int
-				err := h.TaskEngine.cfg.db.QueryRow(taskCtx,
-					`SELECT owner_id FROM harmony_task WHERE id=$1`, tID).Scan(&owner)
-				if err != nil {
-					log.Error("Cannot determine ownership: ", err)
-					return false
-				}
-				return owner == h.TaskEngine.cfg.ownerID
+					var owner int
+					err := h.TaskEngine.cfg.db.QueryRow(taskCtx,
+						`SELECT owner_id FROM harmony_task WHERE id=$1`, tID).Scan(&owner)
+					if err != nil {
+						log.Error("Cannot determine ownership: ", err)
+						return false
+					}
+					return owner == h.TaskEngine.cfg.ownerID
+				})
 			})
 			if doErr != nil {
 				log.Errorw("Do() returned error", "type", h.Name, "id", strconv.Itoa(int(tID)), "error", doErr)
 			}
 		}(tID, releaseStorage[i], handle)
+		dispatched = true
 		i++
 	}
 	return true
+}
+
+func (h *taskTypeHandler) claimTaskOwnership(ids []TaskID, maxAcceptable int) ([]TaskID, error) {
+	var accepted []TaskID
+	err := h.TaskEngine.cfg.db.Select(h.TaskEngine.cfg.ctx, &accepted, `
+		WITH candidates AS (
+			SELECT t.id
+			FROM harmony_task t
+			JOIN unnest($2::bigint[]) AS x(id) ON x.id = t.id
+			WHERE t.owner_id IS NULL
+			ORDER BY array_position($2, t.id::bigint)
+			LIMIT $3
+			FOR UPDATE SKIP LOCKED
+		)
+		UPDATE harmony_task t
+		SET owner_id = $1
+		FROM candidates c
+		WHERE t.id = c.id
+		RETURNING t.id;`, h.TaskEngine.cfg.ownerID, ids, maxAcceptable)
+	return accepted, err
+}
+
+func (h *taskTypeHandler) releaseTaskOwnership(ids []TaskID) error {
+	_, err := h.TaskEngine.cfg.db.Exec(h.TaskEngine.cfg.ctx, `UPDATE harmony_task SET owner_id = NULL WHERE id = ANY($1)`, ids)
+	return err
 }
 
 // emitRetryTask re-adds a failed or preempted task to the scheduler after

--- a/tasks/seal/sdr_start_pacing.go
+++ b/tasks/seal/sdr_start_pacing.go
@@ -1,0 +1,171 @@
+package seal
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+)
+
+type sdrPacingTime struct {
+	elapsed time.Duration
+	wall    time.Time
+}
+
+// Wall time chooses a stable phase once. Elapsed time controls all subsequent
+// waiting and minimum intervals, independently of wall-clock adjustments.
+type sdrStartPacer struct {
+	mu         sync.Mutex
+	interval   time.Duration
+	jitter     bool
+	offset     time.Duration
+	now        func() sdrPacingTime
+	lastStart  time.Duration
+	started    bool
+	phaseStart time.Duration
+	phaseWait  time.Duration
+	phaseSet   bool
+	sequence   uint64
+	reserved   uint64
+	observer   sdrPacingObserver
+}
+
+func newSDRStartPacer(interval time.Duration, jitter bool, identity string, now func() sdrPacingTime) (*sdrStartPacer, error) {
+	if interval < 0 {
+		return nil, fmt.Errorf("SealSDRMinStartInterval must not be negative: %s", interval)
+	}
+	if interval == 0 {
+		return nil, nil
+	}
+	if jitter && strings.TrimSpace(identity) == "" {
+		return nil, fmt.Errorf("SDR start jitter requires a stable instance identity")
+	}
+	if now == nil {
+		origin := time.Now()
+		now = func() sdrPacingTime {
+			n := time.Now()
+			return sdrPacingTime{elapsed: n.Sub(origin), wall: n}
+		}
+	}
+	p := &sdrStartPacer{interval: interval, jitter: jitter, now: now}
+	if jitter {
+		sum := sha256.Sum256([]byte(identity))
+		p.offset = time.Duration(binary.BigEndian.Uint64(sum[:8]) % uint64(interval))
+	}
+	return p, nil
+}
+
+func (p *sdrStartPacer) reserve() (uint64, bool) {
+	token, ok, snapshot := p.reserveSnapshot()
+	if !ok {
+		p.observer.blocked(snapshot)
+	}
+	return token, ok
+}
+
+func (p *sdrStartPacer) reserveSnapshot() (uint64, bool, sdrPacingSnapshot) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.reserved != 0 {
+		return 0, false, p.snapshotLocked(p.now())
+	}
+	n := p.now()
+	if p.started && n.elapsed-p.lastStart < p.interval {
+		return 0, false, p.snapshotLocked(n)
+	}
+	// Subtraction avoids overflow for large configured durations.
+	idle := !p.started || (n.elapsed-p.lastStart > p.interval && n.elapsed-p.lastStart-p.interval > p.interval)
+	if p.jitter && !p.phaseSet && idle {
+		p.phaseStart = n.elapsed
+		p.phaseWait = nextSDRPhaseDelay(n.wall, p.interval, p.offset)
+		p.phaseSet = true
+	}
+	if p.phaseSet && n.elapsed-p.phaseStart < p.phaseWait {
+		return 0, false, p.snapshotLocked(n)
+	}
+	p.sequence++
+	if p.sequence == 0 {
+		p.sequence++
+	}
+	p.reserved = p.sequence
+	return p.reserved, true, sdrPacingSnapshot{}
+}
+
+func (p *sdrStartPacer) start(ctx context.Context, token uint64, taskID harmonytask.TaskID) error {
+	snapshot, err := p.startSnapshot(ctx, token)
+	if err == nil {
+		p.observer.emit(sdrPacingEvent{kind: sdrPacingStarted, snapshot: snapshot, token: token, taskID: taskID})
+	}
+	return err
+}
+
+func (p *sdrStartPacer) startSnapshot(ctx context.Context, token uint64) (sdrPacingSnapshot, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if token == 0 || p.reserved != token {
+		return sdrPacingSnapshot{}, fmt.Errorf("SDR start reservation no longer belongs to this attempt")
+	}
+	if err := ctx.Err(); err != nil {
+		p.reserved = 0
+		return sdrPacingSnapshot{}, err
+	}
+	n := p.now()
+	p.lastStart = n.elapsed
+	p.started = true
+	p.phaseSet = false
+	p.reserved = 0
+	return p.snapshotLocked(n), nil
+}
+
+func (p *sdrStartPacer) cancel(token uint64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if token != 0 && p.reserved == token {
+		p.reserved = 0
+	}
+}
+
+func nextSDRPhaseDelay(now time.Time, interval, offset time.Duration) time.Duration {
+	// Compute modulo in two steps to avoid overflowing UnixNano - offset.
+	rem := now.UnixNano() % int64(interval)
+	if rem < 0 {
+		rem += int64(interval)
+	}
+	if rem <= int64(offset) {
+		return offset - time.Duration(rem)
+	}
+	return interval - (time.Duration(rem) - offset)
+}
+
+// ConfigureStartPacing is called once before registering the task. The listen
+// identity separates instances sharing a host/name; it must remain stable
+// across restarts. No live config mutation API is introduced.
+func (s *SDRTask) ConfigureStartPacing(interval time.Duration, jitter bool, nodeName, listenIdentity string) error {
+	identity := strings.TrimSpace(nodeName) + "\x00" + strings.TrimSpace(listenIdentity)
+	if jitter && interval > 0 && (strings.TrimSpace(nodeName) == "" || strings.TrimSpace(listenIdentity) == "") {
+		return fmt.Errorf("SDR start jitter requires CURIO_NODE_NAME and a stable instance listen identity")
+	}
+	p, err := newSDRStartPacer(interval, jitter, identity, nil)
+	if err != nil {
+		return err
+	}
+	s.startPacer = p
+	p.logConfiguration(interval, jitter)
+	return nil
+}
+
+func (s *SDRTask) ReserveTaskStart(taskID harmonytask.TaskID) (func(context.Context) error, func(), bool) {
+	if s.startPacer == nil {
+		return nil, nil, true
+	}
+	token, ok := s.startPacer.reserve()
+	if !ok {
+		return nil, nil, false
+	}
+	return func(ctx context.Context) error { return s.startPacer.start(ctx, token, taskID) }, func() { s.startPacer.cancel(token) }, true
+}

--- a/tasks/seal/sdr_start_pacing_log.go
+++ b/tasks/seal/sdr_start_pacing_log.go
@@ -1,0 +1,135 @@
+package seal
+
+import (
+	"sync"
+	"time"
+
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+)
+
+const sdrBlockedLogInterval = time.Minute
+
+const (
+	sdrPacingConfigured = "SDR start pacing configured"
+	sdrPacingBlocked    = "SDR start delayed"
+	sdrPacingStarted    = "SDR Do entry committed"
+)
+
+// A value-only snapshot: formatting and logging never read the live pacer.
+// next_start_at is a wall-clock estimate from monotonic remaining time, not a
+// reservation or a cluster-wide start promise.
+type sdrPacingSnapshot struct {
+	observed  sdrPacingTime
+	interval  time.Duration
+	jitter    bool
+	offset    time.Duration
+	reserved  uint64
+	reason    string
+	remaining time.Duration
+	nextKnown bool
+}
+
+// The caller holds p.mu. Observation must not latch a phase, reserve a token,
+// consume an interval, or change the clock origin.
+func (p *sdrStartPacer) snapshotLocked(n sdrPacingTime) sdrPacingSnapshot {
+	s := sdrPacingSnapshot{observed: n, interval: p.interval, jitter: p.jitter, offset: p.offset, reserved: p.reserved}
+	switch {
+	case p.reserved != 0:
+		s.reason = "reservation pending"
+	case p.started && n.elapsed-p.lastStart < p.interval:
+		s.reason = "min start interval"
+		s.remaining = p.interval - (n.elapsed - p.lastStart)
+		s.nextKnown = true
+	case p.phaseSet && n.elapsed-p.phaseStart < p.phaseWait:
+		s.reason = "start jitter phase"
+		s.remaining = p.phaseWait - (n.elapsed - p.phaseStart)
+		s.nextKnown = true
+	default:
+		// Read-only diagnostics do not evaluate/latch a new idle phase.
+		s.reason = "no active wait; eligibility not evaluated"
+	}
+	return s
+}
+
+func (p *sdrStartPacer) snapshot() sdrPacingSnapshot {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.snapshotLocked(p.now())
+}
+
+type sdrPacingEvent struct {
+	kind     string
+	snapshot sdrPacingSnapshot
+	token    uint64
+	taskID   harmonytask.TaskID
+}
+
+// Diagnostic throttling is separate from admission state. The sink is fixed
+// before use; nil selects the ordinary seal logger. Neither mutex is held
+// across the sink, including when an observer re-enters diagnostics.
+type sdrPacingObserver struct {
+	mu             sync.Mutex
+	blockedLogged  bool
+	lastBlockedLog time.Duration
+	sink           func(sdrPacingEvent)
+}
+
+func (o *sdrPacingObserver) blocked(s sdrPacingSnapshot) {
+	o.mu.Lock()
+	shouldLog := !o.blockedLogged || s.observed.elapsed-o.lastBlockedLog >= sdrBlockedLogInterval
+	if shouldLog {
+		o.blockedLogged = true
+		o.lastBlockedLog = s.observed.elapsed
+	}
+	o.mu.Unlock()
+	if shouldLog {
+		o.emit(sdrPacingEvent{kind: sdrPacingBlocked, snapshot: s})
+	}
+}
+
+func (o *sdrPacingObserver) emit(e sdrPacingEvent) {
+	if o != nil && o.sink != nil {
+		o.sink(e)
+		return
+	}
+	log.Infow(e.kind, e.fields()...)
+}
+
+func (p *sdrStartPacer) logConfiguration(interval time.Duration, jitter bool) {
+	if p == nil {
+		// Preserve zero-interval behavior even when the jitter flag is set.
+		(*sdrPacingObserver)(nil).emit(sdrPacingEvent{kind: sdrPacingConfigured, snapshot: sdrPacingSnapshot{interval: interval, jitter: jitter}})
+		return
+	}
+	p.observer.emit(sdrPacingEvent{kind: sdrPacingConfigured, snapshot: p.snapshot()})
+}
+
+func (e sdrPacingEvent) fields() []interface{} {
+	s := e.snapshot
+	fields := []interface{}{
+		"pacing_unit", "process-local SDR Do entry",
+		"pacing_enabled", s.interval > 0,
+		"min_start_interval", s.interval.String(),
+		"start_jitter", s.jitter,
+		"jitter_offset", s.offset.String(),
+	}
+	if e.kind == sdrPacingConfigured {
+		return append(fields, "blocked_log_interval", sdrBlockedLogInterval.String())
+	}
+	remaining, next := "unknown", "unknown"
+	if s.nextKnown {
+		remaining = s.remaining.String()
+		next = s.observed.wall.Add(s.remaining).Format(time.RFC3339Nano)
+	}
+	fields = append(fields,
+		"observed_at", s.observed.wall.Format(time.RFC3339Nano),
+		"reason", s.reason,
+		"remaining", remaining,
+		"next_start_at", next,
+		"next_start_known", s.nextKnown,
+	)
+	if e.kind == sdrPacingStarted {
+		return append(fields, "task", e.taskID, "reservation_token", e.token)
+	}
+	return append(fields, "reservation_token", s.reserved)
+}

--- a/tasks/seal/sdr_start_pacing_log_test.go
+++ b/tasks/seal/sdr_start_pacing_log_test.go
@@ -1,0 +1,394 @@
+package seal
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+)
+
+// Deliberately excludes only the diagnostic rate limiter and immutable clock
+// function. Every admission field is compared, including the reservation token.
+func pacingState(p *sdrStartPacer) interface{} {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return struct {
+		interval, offset, lastStart, phaseStart, phaseWait time.Duration
+		jitter, started, phaseSet                          bool
+		sequence, reserved                                 uint64
+	}{p.interval, p.offset, p.lastStart, p.phaseStart, p.phaseWait, p.jitter, p.started, p.phaseSet, p.sequence, p.reserved}
+}
+
+func pacingFields(e sdrPacingEvent) map[string]interface{} {
+	f := e.fields()
+	m := make(map[string]interface{}, len(f)/2)
+	for i := 0; i < len(f); i += 2 {
+		m[f[i].(string)] = f[i+1]
+	}
+	return m
+}
+
+func TestSDRPacingDiagnosticsAreReadOnly(t *testing.T) {
+	for _, stage := range []string{"unlatched", "phase", "reserved", "started"} {
+		t.Run(stage, func(t *testing.T) {
+			p, n := testSDRPacer(t, time.Minute, true)
+			p.offset = 7 * time.Second
+			var events []sdrPacingEvent
+			p.observer.sink = func(e sdrPacingEvent) {
+				events = append(events, e)
+				_ = pacingFields(e)
+				// Snapshot values cannot modify the pacer, even from a sink.
+				e.snapshot.interval = 0
+				e.snapshot.reserved = 0
+			}
+			if stage != "unlatched" {
+				p.reserve()
+			}
+			if stage == "reserved" || stage == "started" {
+				n.elapsed = p.phaseWait
+				token, ok := p.reserve()
+				if !ok {
+					t.Fatal("phase fixture did not become eligible")
+				}
+				if stage == "started" {
+					if err := p.start(context.Background(), token, 7); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			before, clock := pacingState(p), *n
+			for range 100 {
+				p.logConfiguration(p.interval, p.jitter)
+				snapshot := p.snapshot()
+				_ = pacingFields(sdrPacingEvent{kind: sdrPacingBlocked, snapshot: snapshot})
+				if stage != "unlatched" {
+					p.observer.blocked(snapshot)
+				}
+			}
+			if !reflect.DeepEqual(before, pacingState(p)) || *n != clock {
+				t.Fatal("diagnostic generation/logging changed admission or clock state")
+			}
+			if len(events) < 100 {
+				t.Fatal("logging sink was not exercised")
+			}
+		})
+	}
+}
+
+func TestSDRPacingDiagnosticConfiguration(t *testing.T) {
+	for _, text := range []string{"43m45s", "25m20s"} {
+		t.Run(text, func(t *testing.T) {
+			interval, err := time.ParseDuration(text)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p, _ := testSDRPacer(t, interval, true)
+			var got sdrPacingEvent
+			p.observer.sink = func(e sdrPacingEvent) { got = e }
+			p.logConfiguration(interval, true)
+			f := pacingFields(got)
+			if got.kind != sdrPacingConfigured || f["pacing_enabled"] != true || f["min_start_interval"] != interval.String() || f["start_jitter"] != true || f["jitter_offset"] != p.offset.String() {
+				t.Fatalf("incomplete startup configuration: %v", f)
+			}
+		})
+	}
+	// The zero-interval startup event distinguishes the configured flag from
+	// effective pacing; it never implies a phase gate when pacing is disabled.
+	f := pacingFields(sdrPacingEvent{kind: sdrPacingConfigured, snapshot: sdrPacingSnapshot{jitter: true}})
+	if f["pacing_enabled"] != false || f["start_jitter"] != true || f["min_start_interval"] != "0s" {
+		t.Fatalf("disabled configuration misreported: %v", f)
+	}
+}
+
+func TestSDRPacingProductionLogPath(t *testing.T) {
+	// This non-parallel test captures the real logger, not the pacer test sink.
+	// Restore the package pointer without changing the shared logger's core.
+	previous := log
+	copyLogger := *log
+	core, entries := observer.New(zapcore.InfoLevel)
+	copyLogger.SugaredLogger = *zap.New(core).Sugar()
+	log = &copyLogger
+	t.Cleanup(func() { log = previous })
+	var s SDRTask
+	if err := s.ConfigureStartPacing(time.Minute, false, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	start, cancel, ok := s.ReserveTaskStart(42)
+	if !ok {
+		t.Fatal("first reservation refused")
+	}
+	defer cancel()
+	if entries.Len() != 1 {
+		t.Fatal("startup did not log exactly once, or reservation logged a start")
+	}
+	if err := start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, ok := s.ReserveTaskStart(43); ok {
+		t.Fatal("interval not enforced")
+	}
+	var disabled SDRTask
+	if err := disabled.ConfigureStartPacing(0, true, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := disabled.ConfigureStartPacing(-time.Minute, false, "", ""); err == nil {
+		t.Fatal("invalid configuration accepted")
+	}
+	got := entries.All()
+	want := []string{sdrPacingConfigured, sdrPacingStarted, sdrPacingBlocked, sdrPacingConfigured}
+	if len(got) != len(want) {
+		t.Fatalf("wrong production events: %+v", got)
+	}
+	for i, message := range want {
+		if got[i].Message != message {
+			t.Fatalf("event %d = %q; want %q", i, got[i].Message, message)
+		}
+	}
+	if got[3].ContextMap()["pacing_enabled"] != false || got[3].ContextMap()["start_jitter"] != true {
+		t.Fatal("disabled startup did not preserve the configured flag")
+	}
+}
+
+func TestSDRPacingBlockedDiagnostics(t *testing.T) {
+	for _, reason := range []string{"reservation pending", "min start interval", "start jitter phase"} {
+		t.Run(reason, func(t *testing.T) {
+			p, n := testSDRPacer(t, 10*time.Minute, reason == "start jitter phase")
+			p.offset = 7 * time.Second
+			var events []sdrPacingEvent
+			p.observer.sink = func(e sdrPacingEvent) { events = append(events, e) }
+			s := &SDRTask{startPacer: p}
+			if reason != "start jitter phase" {
+				start, cancel, ok := s.ReserveTaskStart(1)
+				if !ok {
+					t.Fatal("first reservation refused")
+				}
+				defer cancel()
+				if reason == "min start interval" {
+					if err := start(context.Background()); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			events = nil
+			if _, _, ok := s.ReserveTaskStart(2); ok {
+				t.Fatal("blocked fixture accepted")
+			}
+			before := pacingState(p)
+			for range 100 {
+				s.ReserveTaskStart(2)
+			}
+			if len(events) != 1 || events[0].kind != sdrPacingBlocked || events[0].snapshot.reason != reason {
+				t.Fatalf("expected one sampled %q event, got %+v", reason, events)
+			}
+			f := pacingFields(events[0])
+			if reason == "reservation pending" {
+				if f["remaining"] != "unknown" || f["next_start_at"] != "unknown" || f["next_start_known"] != false {
+					t.Fatalf("invented a pre-entry reservation deadline: %v", f)
+				}
+			} else {
+				remaining := 10 * time.Minute
+				if reason == "start jitter phase" {
+					remaining = p.phaseWait
+				}
+				if f["remaining"] != remaining.String() || f["next_start_at"] != n.wall.Add(remaining).Format(time.RFC3339Nano) || f["next_start_known"] != true {
+					t.Fatalf("incorrect wait diagnostic: %v", f)
+				}
+			}
+			// Wall jumps do not bypass log throttling or alter monotonic waits.
+			n.wall = n.wall.Add(48 * time.Hour)
+			n.elapsed = time.Minute - time.Nanosecond
+			s.ReserveTaskStart(2)
+			if len(events) != 1 {
+				t.Fatal("wall jump or early poll bypassed log throttle")
+			}
+			n.wall = n.wall.Add(-96 * time.Hour)
+			n.elapsed = time.Minute
+			s.ReserveTaskStart(2)
+			if len(events) != 2 {
+				t.Fatal("exact monotonic logging interval did not emit")
+			}
+			if reason != "reservation pending" {
+				if events[1].snapshot.remaining != events[0].snapshot.remaining-time.Minute {
+					t.Fatal("remaining time followed wall clock instead of elapsed time")
+				}
+			}
+			// A delayed diagnostic from another goroutine cannot rewind the limiter.
+			p.observer.blocked(events[0].snapshot)
+			if len(events) != 2 || !reflect.DeepEqual(before, pacingState(p)) {
+				t.Fatal("diagnostics changed pacing or replayed a stale event")
+			}
+		})
+	}
+}
+
+func TestSDRPacingLogsOnlyCommittedDoEntry(t *testing.T) {
+	p, n := testSDRPacer(t, time.Minute, false)
+	var committed []sdrPacingEvent
+	p.observer.sink = func(e sdrPacingEvent) {
+		if e.kind == sdrPacingStarted {
+			committed = append(committed, e)
+		}
+	}
+	s := &SDRTask{startPacer: p}
+	for range 10 {
+		if _, err := s.CanAccept([]harmonytask.TaskID{1}, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	staleStart, cancel, _ := s.ReserveTaskStart(1)
+	cancel()
+	if err := staleStart(context.Background()); err == nil {
+		t.Fatal("stale token accepted")
+	}
+	start, cancel, _ := s.ReserveTaskStart(2)
+	ctx, stop := context.WithCancel(context.Background())
+	stop()
+	if err := start(ctx); err != context.Canceled {
+		t.Fatalf("cancelled start: %v", err)
+	}
+	cancel()
+	start, cancel, ok := s.ReserveTaskStart(3)
+	if !ok || len(committed) != 0 {
+		t.Fatal("speculation or aborted reservation logged a committed start")
+	}
+	token := p.reserved
+	if err := start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	cancel() // Execution failure does not undo entry or its diagnostic.
+	if err := start(context.Background()); err == nil {
+		t.Fatal("double start accepted")
+	}
+	if len(committed) != 1 || committed[0].taskID != 3 || committed[0].token != token || committed[0].snapshot.observed != *n || committed[0].snapshot.remaining != time.Minute {
+		t.Fatalf("wrong committed Do-entry event: %+v", committed)
+	}
+	if _, _, ok := s.ReserveTaskStart(3); ok {
+		t.Fatal("logging refunded a committed interval")
+	}
+}
+
+func TestSDRPacingLoggingOutsideLocks(t *testing.T) {
+	p, _ := testSDRPacer(t, time.Minute, false)
+	var blocked atomic.Int32
+	p.observer.sink = func(e sdrPacingEvent) {
+		// TryLock gives an assertion (not a hung test) if either lock regresses.
+		if !p.mu.TryLock() {
+			t.Error("logging holds the pacer mutex")
+			return
+		}
+		p.mu.Unlock()
+		if !p.observer.mu.TryLock() {
+			t.Error("logging holds the diagnostic throttle mutex")
+			return
+		}
+		p.observer.mu.Unlock()
+		_ = pacingFields(sdrPacingEvent{kind: e.kind, snapshot: p.snapshot()})
+		if e.kind == sdrPacingBlocked {
+			blocked.Add(1)
+			p.observer.blocked(e.snapshot) // Re-entry is throttled, not deadlocked.
+		}
+	}
+	p.logConfiguration(p.interval, p.jitter)
+	token, ok := p.reserve()
+	if !ok {
+		t.Fatal("first reservation refused")
+	}
+	p.reserve()
+	if err := p.start(context.Background(), token, 1); err != nil {
+		t.Fatal(err)
+	}
+	if blocked.Load() != 1 {
+		t.Fatalf("re-entry logged %d blocked events", blocked.Load())
+	}
+}
+
+func TestSDRPacingConcurrentBlockedLogsAreBounded(t *testing.T) {
+	p, _ := testSDRPacer(t, time.Minute, false)
+	var logged atomic.Int32
+	p.observer.sink = func(e sdrPacingEvent) {
+		if e.kind == sdrPacingBlocked {
+			logged.Add(1)
+		}
+	}
+	token, _ := p.reserve()
+	defer p.cancel(token)
+	before := pacingState(p)
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			if _, ok := p.reserve(); ok {
+				t.Error("concurrent contender acquired an occupied reservation")
+			}
+		})
+	}
+	wg.Wait()
+	if logged.Load() != 1 || !reflect.DeepEqual(before, pacingState(p)) {
+		t.Fatalf("concurrent diagnostics changed pacing or emitted %d logs", logged.Load())
+	}
+}
+
+func TestSDRPacingSlowLoggerDoesNotHoldAdmission(t *testing.T) {
+	for _, event := range []string{sdrPacingBlocked, sdrPacingStarted} {
+		t.Run(event, func(t *testing.T) {
+			p, _ := testSDRPacer(t, time.Minute, false)
+			entered, release, done := make(chan struct{}), make(chan struct{}), make(chan struct{})
+			var unblock sync.Once
+			p.observer.sink = func(e sdrPacingEvent) {
+				if e.kind == event {
+					close(entered)
+					<-release
+				}
+			}
+			s := &SDRTask{startPacer: p}
+			start, cancel, _ := s.ReserveTaskStart(1)
+			go func() {
+				defer close(done)
+				if event == sdrPacingStarted {
+					if err := start(context.Background()); err != nil {
+						t.Error(err)
+					}
+				} else {
+					s.ReserveTaskStart(2)
+				}
+			}()
+			t.Cleanup(func() {
+				unblock.Do(func() { close(release) })
+				select {
+				case <-done:
+				case <-time.After(2 * time.Second):
+					t.Error("logging participant did not exit")
+				}
+			})
+			select {
+			case <-entered:
+			case <-time.After(2 * time.Second):
+				t.Fatal("logging sink not reached")
+			}
+			// No wait for the logger while withholding its release on failure.
+			if !p.mu.TryLock() {
+				t.Fatal("slow logger holds admission mutex")
+			}
+			p.mu.Unlock()
+			cancel()
+			_, cancelNext, ok := s.ReserveTaskStart(3)
+			if event == sdrPacingStarted && ok {
+				cancelNext()
+				t.Fatal("committed interval was not visible while logger was blocked")
+			}
+			if event == sdrPacingBlocked {
+				if !ok {
+					t.Fatal("cancellation could not release reservation during logging")
+				}
+				cancelNext()
+			}
+		})
+	}
+}

--- a/tasks/seal/sdr_start_pacing_test.go
+++ b/tasks/seal/sdr_start_pacing_test.go
@@ -1,0 +1,230 @@
+package seal
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/curio/harmony/harmonytask"
+)
+
+func testSDRPacer(t *testing.T, interval time.Duration, jitter bool) (*sdrStartPacer, *sdrPacingTime) {
+	t.Helper()
+	n := &sdrPacingTime{wall: time.Unix(100, 0)}
+	p, err := newSDRStartPacer(interval, jitter, "synthetic-instance", func() sdrPacingTime { return *n })
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p, n
+}
+
+func TestSDRPacingConfiguration(t *testing.T) {
+	for _, interval := range []time.Duration{0, -time.Second, time.Minute} {
+		p, err := newSDRStartPacer(interval, true, "", nil)
+		if interval == 0 {
+			if err != nil || p != nil {
+				t.Fatalf("zero must disable pacing: %v %v", p, err)
+			}
+		} else if err == nil {
+			t.Fatalf("invalid interval/identity accepted: %s", interval)
+		}
+	}
+	var s SDRTask
+	if err := s.ConfigureStartPacing(time.Minute, true, "", "loopback-instance"); err == nil {
+		t.Fatal("missing CURIO_NODE_NAME accepted")
+	}
+	if err := s.ConfigureStartPacing(time.Minute, true, "node", ""); err == nil {
+		t.Fatal("missing per-instance identity accepted")
+	}
+	if err := s.ConfigureStartPacing(0, true, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	start, cancel, ok := s.ReserveTaskStart(1)
+	if !ok || start != nil || cancel != nil {
+		t.Fatal("default must preserve unpaced scheduler batch")
+	}
+}
+
+func TestSDRPacingCanAcceptDoesNotConsume(t *testing.T) {
+	p, _ := testSDRPacer(t, time.Minute, false)
+	s := &SDRTask{startPacer: p}
+	for range 100 {
+		ids, err := s.CanAccept([]harmonytask.TaskID{1, 2}, nil)
+		if err != nil || len(ids) != 2 {
+			t.Fatalf("CanAccept must retain ordinary eligibility: %v %v", ids, err)
+		}
+	}
+	if p.started || p.reserved != 0 || p.phaseSet {
+		t.Fatal("speculative or cached eligibility consumed pacing state")
+	}
+}
+
+func TestSDRPacingAbortedClaimsReleaseWithoutConsuming(t *testing.T) {
+	for _, reason := range []string{"claim-lost", "claim-error", "storage-error", "pre-dispatch-cancel"} {
+		t.Run(reason, func(t *testing.T) {
+			p, _ := testSDRPacer(t, time.Minute, false)
+			s := &SDRTask{startPacer: p}
+			_, cancel, ok := s.ReserveTaskStart(1)
+			if !ok {
+				t.Fatal("first reservation refused")
+			}
+			cancel()
+			start2, cancel2, ok := s.ReserveTaskStart(2)
+			if !ok {
+				t.Fatal("aborted claim consumed the interval")
+			}
+			defer cancel2()
+			cancel() // A stale/double release must not clear the newer token.
+			if _, _, ok := s.ReserveTaskStart(3); ok {
+				t.Fatal("stale release broke a newer reservation")
+			}
+			if err := start2(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestSDRPacingCancelledStartAndStartedFailure(t *testing.T) {
+	p, n := testSDRPacer(t, time.Minute, false)
+	s := &SDRTask{startPacer: p}
+	start, cancel, _ := s.ReserveTaskStart(1)
+	ctx, stop := context.WithCancel(context.Background())
+	stop()
+	if err := start(ctx); err != context.Canceled {
+		t.Fatalf("cancelled start: %v", err)
+	}
+	cancel()
+	start, cancel, ok := s.ReserveTaskStart(2)
+	if !ok {
+		t.Fatal("cancelled execution consumed interval")
+	}
+	if err := start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	cancel() // Task failure/completion cleanup must not refund a real Do entry.
+	if _, _, ok := s.ReserveTaskStart(2); ok {
+		t.Fatal("immediate retry bypassed minimum interval")
+	}
+	n.elapsed = time.Minute
+	if _, cancel, ok := s.ReserveTaskStart(2); !ok {
+		t.Fatal("retry at exact interval rejected")
+	} else {
+		cancel()
+	}
+}
+
+func TestSDRPacingConcurrentReservations(t *testing.T) {
+	p, _ := testSDRPacer(t, time.Minute, false)
+	start := make(chan struct{})
+	results := make(chan uint64, 32)
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			<-start
+			if token, ok := p.reserve(); ok {
+				results <- token
+			}
+		})
+	}
+	close(start)
+	joined := make(chan struct{})
+	go func() { wg.Wait(); close(joined) }()
+	select {
+	case <-joined:
+	case <-time.After(time.Second):
+		t.Fatal("reservation deadlocked; no nested logging/mutex path is permitted")
+	}
+	close(results)
+	if len(results) != 1 {
+		t.Fatalf("simultaneous callers reserved %d slots", len(results))
+	}
+	for token := range results {
+		p.cancel(token)
+	}
+}
+
+func TestSDRPacingPhaseRestartIdleClockAndIntervals(t *testing.T) {
+	for _, text := range []string{"43m45s", "25m20s", "1m"} {
+		t.Run(text, func(t *testing.T) {
+			interval, err := time.ParseDuration(text)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p, n := testSDRPacer(t, interval, true)
+			p.offset = 7 * time.Second // deterministic alignment, independent of hash collisions
+			p.reserve()
+			if !p.phaseSet || p.phaseWait < 0 || p.phaseWait >= interval {
+				t.Fatalf("invalid first phase: %+v", p)
+			}
+			wait := p.phaseWait
+			n.wall = n.wall.Add(-24 * time.Hour)
+			for range 10 {
+				p.reserve()
+			}
+			if p.phaseWait != wait || p.phaseStart != 0 {
+				t.Fatal("repeated polling or clock jump moved phase deadline")
+			}
+			n.elapsed = wait
+			token, ok := p.reserve()
+			if !ok {
+				t.Fatal("monotonic phase wait did not expire")
+			}
+			if err := p.start(context.Background(), token, 1); err != nil {
+				t.Fatal(err)
+			}
+			n.wall = n.wall.Add(48 * time.Hour)
+			n.elapsed += interval - time.Nanosecond
+			if _, ok := p.reserve(); ok {
+				t.Fatal("wall clock leap bypassed monotonic interval")
+			}
+			n.elapsed += time.Nanosecond
+			token, ok = p.reserve()
+			if !ok {
+				t.Fatal("exact interval should be eligible")
+			}
+			p.cancel(token)
+			n.elapsed += 3 * interval
+			p.reserve()
+			if !p.phaseSet {
+				t.Fatal("long idle did not re-latch phase")
+			}
+			restarted, _ := testSDRPacer(t, interval, true)
+			if restarted.started || restarted.offset != hashSDROffset(t, interval, "synthetic-instance") {
+				t.Fatal("restart must reset local interval but preserve identity phase")
+			}
+		})
+	}
+}
+
+func hashSDROffset(t *testing.T, interval time.Duration, identity string) time.Duration {
+	t.Helper()
+	p, err := newSDRStartPacer(interval, true, identity, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p.offset
+}
+
+func TestSDRPacingInstanceIdentityAndConfigRestart(t *testing.T) {
+	var a, b, same, changed SDRTask
+	for _, c := range []struct {
+		task     *SDRTask
+		port     string
+		interval time.Duration
+	}{{&a, "host:12300", time.Minute}, {&same, "host:12300", time.Minute}, {&b, "host:12301", time.Minute}, {&changed, "host:12300", 2 * time.Minute}} {
+		if err := c.task.ConfigureStartPacing(c.interval, true, "name", c.port); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if a.startPacer.offset != same.startPacer.offset {
+		t.Fatal("same instance identity changed phase")
+	}
+	if a.startPacer.offset == b.startPacer.offset {
+		t.Fatal("chosen synthetic same-host instance fixtures unexpectedly collided")
+	}
+	if changed.startPacer.interval != 2*time.Minute || changed.startPacer.started {
+		t.Fatal("new config instance inherited old interval state")
+	}
+}

--- a/tasks/seal/task_sdr.go
+++ b/tasks/seal/task_sdr.go
@@ -52,8 +52,9 @@ type SDRTask struct {
 
 	sc *ffi2.SealCalls
 
-	max taskhelp.Limiter
-	min int
+	max        taskhelp.Limiter
+	min        int
+	startPacer *sdrStartPacer
 }
 
 func NewSDRTask(api SDRAPI, db *harmonydb.DB, sp *SealPoller, sc *ffi2.SealCalls, maxSDR taskhelp.Limiter, minSDR int) *SDRTask {


### PR DESCRIPTION
## Summary

Add optional per-instance SDR start pacing without changing the default unpaced scheduler. Operators can set a minimum interval between SDR task `Do` entries and optionally spread first/long-idle entry using a stable phase.

`SealSDRMinStartInterval` defaults to zero and `SealSDRStartJitter` to false. Positive-interval jitter requires a stable `CURIO_NODE_NAME` and instance listen identity; configuration is applied at task construction, not hot-reloaded.

## Scheduling contract

- Reserve only after ordinary resource/eligibility checks and before ownership/storage claims; speculative or cached `CanAccept` does not consume an interval.
- Cancel token-owned reservations after claim/storage failures or pre-entry cancellation. Commit immediately before `Do`; later task failure does not refund the interval.
- Preserve unpaced batch behavior. Pacing serializes provisional starts on one process, not task execution or cluster-wide admission.
- Use monotonic elapsed time for spacing and a latched wall-clock-derived phase. Restart forgets in-memory spacing; phases can collide. No scheduler sleeps, new DB writes, migrations, or background services.
- Emit startup, rate-limited blocked-reason/remaining/next-eligible estimates, and committed-entry diagnostics only after releasing admission and diagnostic locks.

This is not a native SDR computation-start guarantee, a global rate limiter, a sector quota, or a change to CPU accounting, storage capacity, FFI backends, UnsealSDR, or SupraSeal batches. There is no dependency on task-timing telemetry or a UI patch.

## Validation

On Go 1.26.1 with `cgo,fvm,nosupraseal`:

- Normal and race tests: `./deps/config ./harmony/harmonytask ./tasks/seal`.
- Matching-tag vet and scoped golangci-lint 2.11.4, including `./cmd/curio/tasks`; task wiring build.
- Config-document generation, generated default-field verification, canonical import formatting, and diff checks.
- Deterministic reservation, cancellation, failure, recovery, idle/restart, identity, phase, default, and real scheduler-admission regressions.
- Executed negative controls: mutating pacing state during diagnostics failed every read-only stage assertion; logging under the pacer mutex failed the lock assertion without hanging. Both mutations were discarded and the restored baseline passed.

Database-free tests exercise production admission/orchestration with injected ownership/storage outcomes; they are not PostgreSQL/Yugabyte concurrency or native CUDA execution evidence. Linux role builds and operational interval selection remain separate validation.
