### PR TITLE
web: add an optional unclaimed SDR filter to the PoRep view

### DIFF
--- a/documentation/en/developer/porep-visibility.md
+++ b/documentation/en/developer/porep-visibility.md
@@ -4,6 +4,8 @@ The PoRep sector table initially shows every returned sector, preserving the
 existing default. The checkbox can hide sectors that are neither failed nor
 past SDR and have no current SDR owner. It affects this view only and is reset
 when the page is reconstructed; it does not change scheduling or shared API data.
+An embedding page can opt in initially with the `hide-pending-sdr` boolean
+attribute. The standard page does not set it; toggling remains reversible.
 
 The API still returns every sector. Page counts distinguish shown, hidden and
 returned rows, and existing waiting-stage counters use the full returned list.

--- a/documentation/en/developer/porep-visibility.md
+++ b/documentation/en/developer/porep-visibility.md
@@ -1,0 +1,20 @@
+# Optional PoRep visibility filter
+
+The PoRep sector table initially shows every returned sector, preserving the
+existing default. The checkbox can hide sectors that are neither failed nor
+past SDR and have no current SDR owner. It affects this view only and is reset
+when the page is reconstructed; it does not change scheduling or shared API data.
+
+The API still returns every sector. Page counts distinguish shown, hidden and
+returned rows, and existing waiting-stage counters use the full returned list.
+They are not claims about sectors omitted by the server's own query limits.
+
+`SDROwned` is additive owner telemetry from the same SQL statement as the sector
+snapshot. It is deliberately distinct from execution-start telemetry and from
+the older stage-dependent `StartedSDR`. Missing or NULL ownership in an older
+response stays visible: absent telemetry is not proof of an unowned sector.
+An owner may have claimed a task without entering Do. This filter does not make
+an execution-start or task-completion claim, and does not mutate pipeline state.
+
+The filter calculation and production call-site shape have database-free tests.
+Actual row-effect and query-cost validation are separate from those tests.

--- a/web/api/webrpcporep/pipeline_porep.go
+++ b/web/api/webrpcporep/pipeline_porep.go
@@ -26,6 +26,8 @@ type PipelineTask struct {
 	TaskSDR    NullInt64 `db:"task_id_sdr"` // 16 bytes (41-57, with padding)
 	AfterSDR   bool      `db:"after_sdr"`   // 1 byte
 	StartedSDR bool      `db:"started_sdr"` // 1 byte
+	// SDROwned supports an explicit view filter; it does not mean Do has started.
+	SDROwned bool `db:"sdr_owned"`
 	// Cache line 2 (bytes 64-128): Tree stages (accessed together)
 	TaskTreeD     NullInt64  `db:"task_id_tree_d"`  // 16 bytes
 	TreeD         NullString `db:"tree_d_cid"`      // 24 bytes
@@ -99,6 +101,8 @@ func (a *PoRep) PipelinePorepSectors(ctx context.Context) ([]sectorListEntry, er
 												sp.create_time,
 												sp.task_id_sdr, 
 												sp.after_sdr,
+												EXISTS (SELECT 1 FROM harmony_task ht_sdr_owner
+													WHERE ht_sdr_owner.id = sp.task_id_sdr AND ht_sdr_owner.owner_id > 0) AS sdr_owned,
 												sp.task_id_tree_d, 
 												sp.after_tree_d,
 												sp.task_id_tree_c, 

--- a/web/static/pages/pipeline_porep/pipeline-porep-sectors.mjs
+++ b/web/static/pages/pipeline_porep/pipeline-porep-sectors.mjs
@@ -75,7 +75,7 @@ export const pipelineStyles = css`
 class PipelinePorepSectors extends LitElement {
     static properties = {
         data: { type: Array },
-        hidePendingSDR: { type: Boolean },
+        hidePendingSDR: { type: Boolean, attribute: 'hide-pending-sdr' },
     };
 
     constructor() {

--- a/web/static/pages/pipeline_porep/pipeline-porep-sectors.mjs
+++ b/web/static/pages/pipeline_porep/pipeline-porep-sectors.mjs
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/all/lit-all.min.js';
 import RPCCall from '/lib/jsonrpc.mjs';
 import { formatDateTwo } from '/lib/dateutil.mjs';
+import { visiblePoRepSectors } from './visibility.mjs';
 import '/ux/compact-epoch.mjs';
 import '/ux/task.mjs';
 
@@ -74,11 +75,13 @@ export const pipelineStyles = css`
 class PipelinePorepSectors extends LitElement {
     static properties = {
         data: { type: Array },
+        hidePendingSDR: { type: Boolean },
     };
 
     constructor() {
         super();
         this.data = [];
+        this.hidePendingSDR = false;
         this.loadData();
     }
 
@@ -92,6 +95,7 @@ class PipelinePorepSectors extends LitElement {
     static styles = [pipelineStyles];
 
     render() {
+        const visibleSectors = visiblePoRepSectors(this.data, this.hidePendingSDR);
         // Count how many are "waiting for precommit":
         // (PreCommitReadyAt != null && !AfterPrecommitMsg && !TaskPrecommitMsg)
         const waitingForPrecommitCount = this.data.filter(
@@ -120,6 +124,13 @@ class PipelinePorepSectors extends LitElement {
       </div>
 
       <!-- Main table: one row per sector -->
+      <label>
+        <input type="checkbox" .checked=${this.hidePendingSDR}
+          @change=${(event) => { this.hidePendingSDR = event.target.checked; }} />
+        Hide unclaimed, unfinished SDR sectors in this view
+      </label>
+      <p>Showing ${visibleSectors.length} of ${this.data.length} sectors returned by the server.
+        ${this.data.length - visibleSectors.length} hidden locally; counters above include all returned sectors.</p>
       <table class="table table-dark table-striped">
         <thead>
           <tr>
@@ -133,7 +144,7 @@ class PipelinePorepSectors extends LitElement {
           </tr>
         </thead>
         <tbody>
-          ${this.data.map((sector) => this.renderSectorRow(sector))}
+          ${visibleSectors.map((sector) => this.renderSectorRow(sector))}
         </tbody>
       </table>
     `;

--- a/web/static/pages/pipeline_porep/visibility.mjs
+++ b/web/static/pages/pipeline_porep/visibility.mjs
@@ -1,0 +1,6 @@
+// Optional presentation filter only. Unknown ownership from an older backend
+// stays visible; missing telemetry must not silently hide a sector.
+export function visiblePoRepSectors(sectors, hidePendingSDR) {
+    if (!hidePendingSDR) return sectors;
+    return sectors.filter((sector) => sector.Failed || sector.AfterSDR || sector.SDROwned !== false);
+}

--- a/web/test/porep-visibility.test.mjs
+++ b/web/test/porep-visibility.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import {visiblePoRepSectors} from '../static/pages/pipeline_porep/visibility.mjs';
+
+test('optional PoRep filter preserves failures, completed SDR and owned SDR', () => {
+    const rows = [
+        {SectorNumber: 1, SDROwned: false, AfterSDR: false, Failed: false},
+        {SectorNumber: 2, SDROwned: true},
+        {SectorNumber: 3, SDROwned: false, AfterSDR: true},
+        {SectorNumber: 4, SDROwned: false, Failed: true},
+        {SectorNumber: 5}, // Legacy payload: do not pretend unknown is unowned.
+        {SectorNumber: 6, SDROwned: null},
+    ];
+    const original = structuredClone(rows);
+    assert.deepEqual(visiblePoRepSectors(rows, true).map(r => r.SectorNumber), [2, 3, 4, 5, 6]);
+    assert.equal(visiblePoRepSectors(rows, false), rows);
+    assert.deepEqual(rows, original);
+});
+
+test('actual page uses the filter without hiding RPC rows or falsifying totals', () => {
+    const page = readFileSync(new URL('../static/pages/pipeline_porep/pipeline-porep-sectors.mjs', import.meta.url), 'utf8');
+    assert.match(page, /visiblePoRepSectors\(this\.data, this\.hidePendingSDR\)/);
+    assert.match(page, /visibleSectors\.map\(/);
+    assert.match(page, /of \$\{this\.data\.length\}/);
+    assert.match(page, /this\.hidePendingSDR = false;/);
+    const api = readFileSync(new URL('../api/webrpcporep/pipeline_porep.go', import.meta.url), 'utf8');
+    assert.match(api, /ht_sdr_owner\.id = sp\.task_id_sdr AND ht_sdr_owner\.owner_id > 0\) AS sdr_owned/);
+    assert.doesNotMatch(api, /WHERE sp\.failed\s+OR sp\.after_sdr/);
+});
+
+test('empty and fully hidden sets remain reversible without altering source rows', () => {
+    assert.deepEqual(visiblePoRepSectors([], true), []);
+    const rows = [{SectorNumber: 7, SDROwned: false}];
+    assert.deepEqual(visiblePoRepSectors(rows, true), []);
+    assert.equal(visiblePoRepSectors(rows, false), rows);
+    assert.equal(rows.length, 1);
+});

--- a/web/test/porep-visibility.test.mjs
+++ b/web/test/porep-visibility.test.mjs
@@ -24,6 +24,7 @@ test('actual page uses the filter without hiding RPC rows or falsifying totals',
     assert.match(page, /visibleSectors\.map\(/);
     assert.match(page, /of \$\{this\.data\.length\}/);
     assert.match(page, /this\.hidePendingSDR = false;/);
+    assert.match(page, /attribute: 'hide-pending-sdr'/);
     const api = readFileSync(new URL('../api/webrpcporep/pipeline_porep.go', import.meta.url), 'utf8');
     assert.match(api, /ht_sdr_owner\.id = sp\.task_id_sdr AND ht_sdr_owner\.owner_id > 0\) AS sdr_owned/);
     assert.doesNotMatch(api, /WHERE sp\.failed\s+OR sp\.after_sdr/);


### PR DESCRIPTION
## Summary

Add an explicit, initially disabled PoRep view filter for unfinished SDR sectors
without a current owner. Failed sectors, sectors past SDR, owned tasks and older
responses with unknown ownership remain visible. The default still shows every
returned row; the checkbox is local to this page and does not change scheduling.

The additive `SDROwned` field comes from the same sector query snapshot. It is
ownership telemetry, not proof of execution start. Existing API rows and fields
remain intact. The page reports shown/hidden/returned counts and calculates its
existing waiting counters over the full returned result.

## Validation

- Executable filter and production call-site tests: `node --test
  web/test/porep-visibility.test.mjs`, three tests PASS.
- An intentional filter bypass caused both membership assertions to fail;
  the restored committed source passed.
- Actual Chromium/Lit page with intercepted synthetic responses: default all
  five rows, enabled four rows, disabled five rows; source rows and truthful
  counts preserved. No live Curio API was used.
- API package compilation, matching-tag vet, golangci-lint 2.11.4 and canonical
  fiximports PASS with `cgo,fvm,nosupraseal`; diff check PASS. The API package
  has no Go tests, so compilation is not claimed as executed SQL coverage.

No database row-effect, query-cost or live deployment result is claimed.
This is independent of Cluster Tasks timing, pacing and other proposed fixes.
