### PR TITLE
pdp: accept urls array and provider host/cids in pull piece requests

### DIFF
--- a/pdp/README.md
+++ b/pdp/README.md
@@ -740,7 +740,12 @@ Uploads complete synchronously. A `204 No Content` response from the known-CID P
   "pieces": [
     {
       "pieceCid": "<CommP-v2-CID>",
-      "sourceUrl": "https://example.com/piece/bafy..."
+      "sourceUrl": "https://example.com/piece/bafy...",
+      "urls": ["https://backup.example.com/piece/bafy..."],
+      "provider": {
+        "host": "sp.example.com",
+        "cids": ["<optional-retrieval-CID>"]
+      }
     }
   ]
 }
@@ -752,7 +757,12 @@ Uploads complete synchronously. A `204 No Content` response from the known-CID P
     - `recordKeeper`: *(Required if dataSetId is 0 or omitted)* The contract address that will receive callbacks.
     - `pieces`: Array of pieces to pull. At most 40 entries, since the pull is validated as an `addPieces` batch (larger batches would exceed on-chain event-size limits and are rejected with `400 Bad Request`).
         - `pieceCid`: The piece CID in CommP v2 format.
-        - `sourceUrl`: HTTPS URL ending in `/piece/{pieceCid}` on a public host. Localhost and private IPs are blocked for security.
+        - `sourceUrl`: *(Optional)* A single HTTPS URL. The original single-URL form remains accepted.
+        - `urls`: *(Optional)* Additional HTTPS URLs to try for this piece.
+        - `provider`: *(Optional)* Remote SP used to assemble retrieval URLs on this provider:
+            - `host`: Hostname (optionally with port, or an `https://` URL).
+            - `cids`: *(Optional)* CIDs to fetch from that host. If omitted, `pieceCid` is used.
+        - At least one source URL must result after combining `sourceUrl`, `urls`, and `provider`. Duplicate URLs for the same piece are de-duplicated. The assembled list is stored as one pull item per URL, as before.
 
 #### Response
 
@@ -786,7 +796,7 @@ Returns JSON with an overall status and per-piece status:
 
 #### Errors
 
-- `400 Bad Request`: Validation error, missing parameters, more than 40 pieces in the batch, invalid pieceCid format, or invalid `sourceUrl`.
+- `400 Bad Request`: Validation error, missing parameters, more than 40 pieces in the batch, invalid pieceCid format, or invalid source URL.
 - `401 Unauthorized`: Missing or invalid JWT token.
 - `403 Forbidden`: `recordKeeper` is not allowed.
 - `500 Internal Server Error`: Failed to query or store pull task.

--- a/pdp/README.md
+++ b/pdp/README.md
@@ -740,14 +740,14 @@ Uploads complete synchronously. A `204 No Content` response from the known-CID P
   "pieces": [
     {
       "pieceCid": "<CommP-v2-CID>",
-      "sourceUrl": "https://example.com/piece/bafy...",
-      "urls": ["https://backup.example.com/piece/bafy..."],
-      "provider": {
-        "host": "sp.example.com",
-        "cids": ["<optional-retrieval-CID>"]
-      }
+      "sourceUrl": "https://example.com/piece/bafy..."
     }
-  ]
+  ],
+  "urls": ["https://backup.example.com/piece/bafy..."],
+  "provider": {
+    "host": "sp.example.com",
+    "cids": ["<optional-retrieval-CID>"]
+  }
 }
 ```
 
@@ -755,14 +755,14 @@ Uploads complete synchronously. A `204 No Content` response from the known-CID P
     - `extraData`: *(Required)* Hex-encoded bytes that will be validated against the PDPVerifier contract via `eth_call`. Used for authorization and idempotency.
     - `dataSetId`: *(Optional)* The target dataset ID. If omitted or `0`, validation simulates creating a new dataset.
     - `recordKeeper`: *(Required if dataSetId is 0 or omitted)* The contract address that will receive callbacks.
-    - `pieces`: Array of pieces to pull. At most 40 entries, since the pull is validated as an `addPieces` batch (larger batches would exceed on-chain event-size limits and are rejected with `400 Bad Request`).
+    - `pieces`: *(Optional)* Current form: `{pieceCid, sourceUrl}` entries. At most 40 unique piece CIDs across the whole request, since the pull is validated as an `addPieces` batch (larger batches would exceed on-chain event-size limits and are rejected with `400 Bad Request`).
         - `pieceCid`: The piece CID in CommP v2 format.
-        - `sourceUrl`: *(Optional)* A single HTTPS URL. The original single-URL form remains accepted.
-        - `urls`: *(Optional)* Additional HTTPS URLs to try for this piece.
-        - `provider`: *(Optional)* Remote SP used to assemble retrieval URLs on this provider:
-            - `host`: Hostname (optionally with port, or an `https://` URL).
-            - `cids`: *(Optional)* CIDs to fetch from that host. If omitted, `pieceCid` is used.
-        - At least one source URL must result after combining `sourceUrl`, `urls`, and `provider`. Duplicate URLs for the same piece are de-duplicated. The assembled list is stored as one pull item per URL, as before.
+        - `sourceUrl`: HTTPS URL for that piece.
+    - `urls`: *(Optional)* HTTPS URLs whose paths end in `/piece/{cid}`. The CID is taken from the path.
+    - `provider`: *(Optional)* Remote SP used to assemble retrieval URLs on this provider:
+        - `host`: Hostname (optionally with port, or an `https://` URL).
+        - `cids`: *(Optional)* CIDs to fetch from that host. If omitted, piece CIDs already collected from `pieces` and `urls` are used.
+    - `provider.cids` without `provider.host` is rejected. At least one source URL must result after combining `pieces`, `urls`, and `provider`. Duplicate `(pieceCid, URL)` pairs are de-duplicated. The assembled list is stored as one pull item per URL, as before.
 
 #### Response
 

--- a/pdp/handlers_pull.go
+++ b/pdp/handlers_pull.go
@@ -191,7 +191,13 @@ func NewPullHandler(auth Auth, store PullStore, validator AddPiecesValidator, db
 //
 //   - pieceCid: PieceCIDv2 format (encodes both CommP and raw size)
 //
-//   - sourceUrl: HTTPS URL ending in /piece/{pieceCid} on a public host
+//   - sourceUrl (optional): a single HTTPS URL
+//
+//   - urls (optional): additional HTTPS URLs
+//
+//   - provider (optional): {host, cids} assembled here into https://{host}/piece/{cid}
+//     URLs. If cids is omitted, pieceCid is used. At least one source URL must
+//     result after combining these fields.
 //
 // # ExtraData and Authorization
 //
@@ -238,8 +244,8 @@ func NewPullHandler(auth Auth, store PullStore, validator AddPiecesValidator, db
 //
 // Several safety measures protect against malicious sources:
 //
-//   - Source URL validation: Must be HTTPS, path must match /piece/{pieceCid},
-//     host must not be localhost/private IP/link-local
+//   - Source URL validation: Must be HTTPS. Hosts are checked against the SSRF
+//     policy at fetch time (localhost/private IP/link-local are blocked).
 //
 //   - Size limits: Piece size (encoded in PieceCIDv2) must not exceed PieceSizeMaxLimit.
 //     Downloads are capped at the declared size to prevent abuse.
@@ -408,13 +414,22 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build normalized pull pieces for persistence.
-	pullPieces := make([]PullPiece, len(pieceInfos))
+	// Build normalized pull pieces for persistence. Each request piece may
+	// expand into multiple source URLs (sourceUrl + urls + provider).
+	var pullPieces []PullPiece
 	for i, info := range pieceInfos {
-		pullPieces[i] = PullPiece{
-			CidV1:     info.CidV1,
-			RawSize:   info.RawSize,
-			SourceURL: req.Pieces[i].SourceURL,
+		urls, err := req.Pieces[i].SourceURLs()
+		if err != nil {
+			msg := fmt.Sprintf("Invalid piece[%d] sources: %s", i, err.Error())
+			httpServerError(w, http.StatusBadRequest, msg, err)
+			return
+		}
+		for _, sourceURL := range urls {
+			pullPieces = append(pullPieces, PullPiece{
+				CidV1:     info.CidV1,
+				RawSize:   info.RawSize,
+				SourceURL: sourceURL,
+			})
 		}
 	}
 

--- a/pdp/handlers_pull.go
+++ b/pdp/handlers_pull.go
@@ -187,17 +187,15 @@ func NewPullHandler(auth Auth, store PullStore, validator AddPiecesValidator, db
 //     will receive callbacks from PDPVerifier (typically FilecoinWarmStorageService).
 //     Must be in the allowed list for public services.
 //
-//   - pieces (required): Array of pieces to pull, each containing:
+//   - pieces (optional): Array of {pieceCid, sourceUrl} entries (current form)
 //
-//   - pieceCid: PieceCIDv2 format (encodes both CommP and raw size)
+//   - urls (optional): HTTPS URLs whose paths end in /piece/{cid}
 //
-//   - sourceUrl (optional): a single HTTPS URL
+//   - provider (optional): {host, cids} assembled here into https://{host}/piece/{cid}.
+//     If cids is omitted, piece CIDs already collected from pieces and urls are used.
+//     provider.cids without provider.host is rejected.
 //
-//   - urls (optional): additional HTTPS URLs
-//
-//   - provider (optional): {host, cids} assembled here into https://{host}/piece/{cid}
-//     URLs. If cids is omitted, pieceCid is used. At least one source URL must
-//     result after combining these fields.
+//     At least one source URL must result after combining these fields.
 //
 // # ExtraData and Authorization
 //
@@ -377,29 +375,37 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse all piece CIDs (validates PieceCIDv2 format, extracts v1, size info)
-	pieceInfos := make([]*PieceCidInfo, len(req.Pieces))
-	pieceData := make([]contract.CidsCid, len(req.Pieces))
-	for i, piece := range req.Pieces {
-		info, err := ParsePieceCidV2(piece.PieceCid)
-		if err != nil {
-			msg := fmt.Sprintf("Invalid pieceCid[%d]: %s", i, err.Error())
-			httpServerError(w, http.StatusBadRequest, msg, err)
+	sources, err := req.AssembledSources()
+	if err != nil {
+		httpServerError(w, http.StatusBadRequest, "Validation error: "+err.Error(), err)
+		return
+	}
 
+	// Parse unique piece CIDs for eth_call (validates PieceCIDv2, extracts v1, size).
+	infoByCid := make(map[string]*PieceCidInfo, len(sources))
+	var pieceData []contract.CidsCid
+	for _, source := range sources {
+		if _, ok := infoByCid[source.PieceCid]; ok {
+			continue
+		}
+		info, err := ParsePieceCidV2(source.PieceCid)
+		if err != nil {
+			msg := fmt.Sprintf("Invalid pieceCid %s: %s", source.PieceCid, err.Error())
+			httpServerError(w, http.StatusBadRequest, msg, err)
 			return
 		}
 		if info.RawSize < uint64(PieceSizeMinLimit) {
-			msg := fmt.Sprintf("pieceCid[%d]: size %d is below minimum %d", i, info.RawSize, PieceSizeMinLimit)
+			msg := fmt.Sprintf("pieceCid %s: size %d is below minimum %d", source.PieceCid, info.RawSize, PieceSizeMinLimit)
 			httpServerError(w, http.StatusBadRequest, msg, nil)
 			return
 		}
 		if info.RawSize > uint64(PieceSizeMaxLimit) {
-			msg := fmt.Sprintf("pieceCid[%d]: size %d exceeds maximum %d", i, info.RawSize, PieceSizeMaxLimit)
+			msg := fmt.Sprintf("pieceCid %s: size %d exceeds maximum %d", source.PieceCid, info.RawSize, PieceSizeMaxLimit)
 			httpServerError(w, http.StatusBadRequest, msg, nil)
 			return
 		}
-		pieceInfos[i] = info
-		pieceData[i] = contract.CidsCid{Data: info.CidV2.Bytes()}
+		infoByCid[source.PieceCid] = info
+		pieceData = append(pieceData, contract.CidsCid{Data: info.CidV2.Bytes()})
 	}
 
 	// Validate extraData via eth_call
@@ -414,23 +420,16 @@ func (h *PullHandler) HandlePull(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build normalized pull pieces for persistence. Each request piece may
-	// expand into multiple source URLs (sourceUrl + urls + provider).
-	var pullPieces []PullPiece
-	for i, info := range pieceInfos {
-		urls, err := req.Pieces[i].SourceURLs()
-		if err != nil {
-			msg := fmt.Sprintf("Invalid piece[%d] sources: %s", i, err.Error())
-			httpServerError(w, http.StatusBadRequest, msg, err)
-			return
-		}
-		for _, sourceURL := range urls {
-			pullPieces = append(pullPieces, PullPiece{
-				CidV1:     info.CidV1,
-				RawSize:   info.RawSize,
-				SourceURL: sourceURL,
-			})
-		}
+	// Build normalized pull pieces for persistence. Each assembled source is
+	// one (piece, URL) pull item, as before.
+	pullPieces := make([]PullPiece, 0, len(sources))
+	for _, source := range sources {
+		info := infoByCid[source.PieceCid]
+		pullPieces = append(pullPieces, PullPiece{
+			CidV1:     info.CidV1,
+			RawSize:   info.RawSize,
+			SourceURL: source.SourceURL,
+		})
 	}
 
 	// Create pull record

--- a/pdp/handlers_pull_test.go
+++ b/pdp/handlers_pull_test.go
@@ -226,7 +226,7 @@ func TestHandlePull_NoPieces(t *testing.T) {
 	handler.HandlePull(rec, req)
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
-	require.Contains(t, rec.Body.String(), "at least one piece")
+	require.Contains(t, rec.Body.String(), "at least one source URL is required")
 }
 
 func TestHandlePull_InvalidSourceURL(t *testing.T) {
@@ -328,13 +328,10 @@ func TestHandlePull_AssemblesMultipleSources(t *testing.T) {
 		ExtraData: testExtraData(t),
 		DataSetId: &testDataSetId,
 		Pieces: []PullPieceRequest{
-			{
-				PieceCid:  testCid1,
-				SourceURL: "https://legacy.example/piece/" + testCid1,
-				URLs:      []string{"https://backup.example/piece/" + testCid1},
-				Provider:  &PullPieceProvider{Host: "sp.example.com", CIDs: []string{testCid2}},
-			},
+			{PieceCid: testCid1, SourceURL: "https://legacy.example/piece/" + testCid1},
 		},
+		URLs:     []string{"https://backup.example/piece/" + testCid1},
+		Provider: &PullProvider{Host: "sp.example.com", CIDs: []string{testCid2}},
 	}
 	bodyBytes := must.One(json.Marshal(body))
 	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
@@ -346,17 +343,38 @@ func TestHandlePull_AssemblesMultipleSources(t *testing.T) {
 	require.True(t, store.createPullCalled)
 	require.Len(t, store.createdPieces, 3)
 
-	gotURLs := make([]string, len(store.createdPieces))
+	got := make([]string, len(store.createdPieces))
 	for i, piece := range store.createdPieces {
-		require.Equal(t, store.createdPieces[0].CidV1, piece.CidV1)
-		require.Equal(t, store.createdPieces[0].RawSize, piece.RawSize)
-		gotURLs[i] = piece.SourceURL
+		got[i] = piece.SourceURL
 	}
 	require.Equal(t, []string{
 		"https://legacy.example/piece/" + testCid1,
 		"https://backup.example/piece/" + testCid1,
 		"https://sp.example.com/piece/" + testCid2,
-	}, gotURLs)
+	}, got)
+}
+
+func TestHandlePull_ProviderOnly(t *testing.T) {
+	store := &mockPullStore{}
+	validator := &mockValidator{shouldPass: true}
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
+
+	body := PullRequest{
+		ExtraData: testExtraData(t),
+		DataSetId: &testDataSetId,
+		Provider:  &PullProvider{Host: "sp.example.com", CIDs: []string{testCid1, testCid2}},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, store.createPullCalled)
+	require.Len(t, store.createdPieces, 2)
+	require.Equal(t, "https://sp.example.com/piece/"+testCid1, store.createdPieces[0].SourceURL)
+	require.Equal(t, "https://sp.example.com/piece/"+testCid2, store.createdPieces[1].SourceURL)
 }
 
 func TestHandlePull_ExistingDataSetUsesFWSSPayer(t *testing.T) {

--- a/pdp/handlers_pull_test.go
+++ b/pdp/handlers_pull_test.go
@@ -319,6 +319,46 @@ func TestHandlePull_NewRequest_Success(t *testing.T) {
 	require.True(t, cidSet[testCid2])
 }
 
+func TestHandlePull_AssemblesMultipleSources(t *testing.T) {
+	store := &mockPullStore{}
+	validator := &mockValidator{shouldPass: true}
+	handler := NewPullHandler(&NullAuth{}, store, validator, nil)
+
+	body := PullRequest{
+		ExtraData: testExtraData(t),
+		DataSetId: &testDataSetId,
+		Pieces: []PullPieceRequest{
+			{
+				PieceCid:  testCid1,
+				SourceURL: "https://legacy.example/piece/" + testCid1,
+				URLs:      []string{"https://backup.example/piece/" + testCid1},
+				Provider:  &PullPieceProvider{Host: "sp.example.com", CIDs: []string{testCid2}},
+			},
+		},
+	}
+	bodyBytes := must.One(json.Marshal(body))
+	req := httptest.NewRequest(http.MethodPost, "/pdp/piece/pull", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+
+	handler.HandlePull(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, store.createPullCalled)
+	require.Len(t, store.createdPieces, 3)
+
+	gotURLs := make([]string, len(store.createdPieces))
+	for i, piece := range store.createdPieces {
+		require.Equal(t, store.createdPieces[0].CidV1, piece.CidV1)
+		require.Equal(t, store.createdPieces[0].RawSize, piece.RawSize)
+		gotURLs[i] = piece.SourceURL
+	}
+	require.Equal(t, []string{
+		"https://legacy.example/piece/" + testCid1,
+		"https://backup.example/piece/" + testCid1,
+		"https://sp.example.com/piece/" + testCid2,
+	}, gotURLs)
+}
+
 func TestHandlePull_ExistingDataSetUsesFWSSPayer(t *testing.T) {
 	store := &mockPullStore{}
 	payer := common.HexToAddress("0x2222222222222222222222222222222222222222")

--- a/pdp/pull_types.go
+++ b/pdp/pull_types.go
@@ -63,80 +63,23 @@ func ValidatePullSourceURL(sourceURL string) error {
 	return nil
 }
 
-// PullPieceProvider describes a remote SP from which piece URLs are assembled.
+// PullProvider describes a remote SP from which piece URLs are assembled.
 // Host is a hostname (optionally with port or https:// scheme). Each CID is
 // turned into https://{host}/piece/{cid} on this provider.
-type PullPieceProvider struct {
+type PullProvider struct {
 	Host string   `json:"host"`
 	CIDs []string `json:"cids,omitempty"`
 }
 
-// PullPieceRequest represents a single piece in a pull request.
-// Source locations are optional and combined into one URL list:
-//   - sourceUrl: a single URL (legacy form)
-//   - urls: additional explicit URLs
-//   - provider: host + optional CIDs assembled into /piece/{cid} URLs
+// PullPieceRequest is the current per-piece form: one piece CID and one source URL.
 type PullPieceRequest struct {
-	PieceCid  string             `json:"pieceCid"`
-	SourceURL string             `json:"sourceUrl,omitempty"`
-	URLs      []string           `json:"urls,omitempty"`
-	Provider  *PullPieceProvider `json:"provider,omitempty"`
+	PieceCid  string `json:"pieceCid"`
+	SourceURL string `json:"sourceUrl"`
 }
 
-// SourceURLs returns the de-duplicated source URLs for this piece, combining
-// sourceUrl, urls, and provider-assembled URLs. Provider URLs are built here
-// (on the receiving provider) from host + CIDs; if cids is empty the piece's
-// own pieceCid is used.
-func (p PullPieceRequest) SourceURLs() ([]string, error) {
-	urls := make([]string, 0, 1+len(p.URLs))
-	seen := make(map[string]struct{}, 1+len(p.URLs))
-	add := func(u string) {
-		if u == "" {
-			return
-		}
-		if _, ok := seen[u]; ok {
-			return
-		}
-		seen[u] = struct{}{}
-		urls = append(urls, u)
-	}
-
-	add(p.SourceURL)
-	for i, u := range p.URLs {
-		if u == "" {
-			return nil, fmt.Errorf("urls[%d] is empty", i)
-		}
-		add(u)
-	}
-
-	if p.Provider != nil {
-		host := strings.TrimSpace(p.Provider.Host)
-		if host == "" && len(p.Provider.CIDs) == 0 {
-			return urls, nil
-		}
-		if host == "" {
-			return nil, fmt.Errorf("provider.cids requires provider.host")
-		}
-		cids := p.Provider.CIDs
-		if len(cids) == 0 {
-			if p.PieceCid == "" {
-				return nil, fmt.Errorf("pieceCid is required to assemble provider URLs")
-			}
-			cids = []string{p.PieceCid}
-		}
-		for i, c := range cids {
-			if c == "" {
-				return nil, fmt.Errorf("provider.cids[%d] is empty", i)
-			}
-			assembled, err := assembleProviderPieceURL(host, c)
-			if err != nil {
-				return nil, err
-			}
-			add(assembled)
-		}
-	}
-
-	return urls, nil
+type pullSource struct {
+	PieceCid  string
+	SourceURL string
 }
 
 func assembleProviderPieceURL(host, pieceCID string) (string, error) {
@@ -156,12 +99,107 @@ func assembleProviderPieceURL(host, pieceCID string) (string, error) {
 	return parsed.JoinPath("piece", pieceCID).String(), nil
 }
 
-// PullRequest represents the incoming pull request body
+func pieceCIDFromSourceURL(sourceURL string) (string, error) {
+	parsed, err := url.Parse(sourceURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+
+	path := strings.TrimSuffix(parsed.Path, "/")
+	const marker = "/piece/"
+	idx := strings.LastIndex(path, marker)
+	if idx < 0 {
+		return "", fmt.Errorf("URL path must contain /piece/{cid}")
+	}
+	cidPart := path[idx+len(marker):]
+	if cidPart == "" || strings.Contains(cidPart, "/") {
+		return "", fmt.Errorf("URL path must end with /piece/{cid}")
+	}
+	return cidPart, nil
+}
+
+// PullRequest represents the incoming pull request body.
+// pieces, urls, and provider are optional and are assembled into the same
+// per-URL pull item list used today.
 type PullRequest struct {
 	ExtraData    string             `json:"extraData"`
 	DataSetId    *uint64            `json:"dataSetId,omitempty"`    // nil or 0 = create new dataset
 	RecordKeeper *string            `json:"recordKeeper,omitempty"` // required when dataSetId is nil/0
-	Pieces       []PullPieceRequest `json:"pieces"`
+	Pieces       []PullPieceRequest `json:"pieces,omitempty"`
+	URLs         []string           `json:"urls,omitempty"`
+	Provider     *PullProvider      `json:"provider,omitempty"`
+}
+
+// AssembledSources combines the current pieces form, top-level urls, and
+// provider {host, cids} into de-duplicated (pieceCid, sourceUrl) pairs.
+func (r *PullRequest) AssembledSources() ([]pullSource, error) {
+	sources := make([]pullSource, 0, len(r.Pieces)+len(r.URLs))
+	seen := make(map[string]struct{}, len(r.Pieces)+len(r.URLs))
+	var knownCids []string
+	seenCid := make(map[string]struct{}, len(r.Pieces)+len(r.URLs))
+
+	add := func(pieceCid, sourceURL string) {
+		key := pieceCid + "\x00" + sourceURL
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		sources = append(sources, pullSource{PieceCid: pieceCid, SourceURL: sourceURL})
+		if _, ok := seenCid[pieceCid]; !ok {
+			seenCid[pieceCid] = struct{}{}
+			knownCids = append(knownCids, pieceCid)
+		}
+	}
+
+	for i, piece := range r.Pieces {
+		if piece.PieceCid == "" {
+			return nil, fmt.Errorf("piece[%d]: pieceCid is required", i)
+		}
+		if piece.SourceURL == "" {
+			return nil, fmt.Errorf("piece[%d]: sourceUrl is required", i)
+		}
+		key := piece.PieceCid + "\x00" + piece.SourceURL
+		if _, ok := seen[key]; ok {
+			return nil, fmt.Errorf("piece[%d]: duplicate pieceCid/sourceUrl", i)
+		}
+		add(piece.PieceCid, piece.SourceURL)
+	}
+
+	for i, sourceURL := range r.URLs {
+		if sourceURL == "" {
+			return nil, fmt.Errorf("urls[%d] is empty", i)
+		}
+		pieceCid, err := pieceCIDFromSourceURL(sourceURL)
+		if err != nil {
+			return nil, fmt.Errorf("urls[%d]: %w", i, err)
+		}
+		add(pieceCid, sourceURL)
+	}
+
+	if r.Provider != nil {
+		host := strings.TrimSpace(r.Provider.Host)
+		if len(r.Provider.CIDs) > 0 && host == "" {
+			return nil, fmt.Errorf("provider.cids requires provider.host")
+		}
+		if host != "" {
+			cids := r.Provider.CIDs
+			if len(cids) == 0 {
+				cids = knownCids
+			}
+			for i, pieceCid := range cids {
+				if pieceCid == "" {
+					return nil, fmt.Errorf("provider.cids[%d] is empty", i)
+				}
+				assembled, err := assembleProviderPieceURL(host, pieceCid)
+				if err != nil {
+					return nil, err
+				}
+				add(pieceCid, assembled)
+			}
+		}
+	}
+
+	return sources, nil
 }
 
 // IsCreateNew returns true if this pull will create a new dataset (dataSetId is nil or 0)
@@ -182,39 +220,27 @@ func (r *PullRequest) Validate() error {
 		}
 	}
 
-	if len(r.Pieces) == 0 {
-		return fmt.Errorf("at least one piece is required")
+	sources, err := r.AssembledSources()
+	if err != nil {
+		return err
 	}
-	if len(r.Pieces) > MaxAddPiecesBatchSize {
-		return fmt.Errorf("piece count (%d) exceeds the maximum allowed per pull (%d)", len(r.Pieces), MaxAddPiecesBatchSize)
+	if len(sources) == 0 {
+		return fmt.Errorf("at least one source URL is required")
 	}
 
-	// Validate each piece (CID format validation is done later by ParsePieceCidV2).
-	// The same piece may appear more than once with different source URLs so
-	// the server can try all supplied sources. An exact duplicate is not useful
-	// and would collide with the pull item primary key.
-	seenPieceSources := make(map[string]struct{}, len(r.Pieces))
-	for i, piece := range r.Pieces {
-		if piece.PieceCid == "" {
-			return fmt.Errorf("piece[%d]: pieceCid is required", i)
+	// Unique piece CIDs are what addPieces will see. CID format is checked
+	// later by ParsePieceCidV2. The same piece may have several source URLs
+	// so the server can try all of them. An exact duplicate is dropped during
+	// assembly except for repeated pieces[] entries, which are rejected.
+	uniqueCids := make(map[string]struct{}, len(sources))
+	for _, source := range sources {
+		uniqueCids[source.PieceCid] = struct{}{}
+		if err := ValidatePullSourceURL(source.SourceURL); err != nil {
+			return fmt.Errorf("piece %s: %w", source.PieceCid, err)
 		}
-		urls, err := piece.SourceURLs()
-		if err != nil {
-			return fmt.Errorf("piece[%d]: %w", i, err)
-		}
-		if len(urls) == 0 {
-			return fmt.Errorf("piece[%d]: at least one source URL is required", i)
-		}
-		for j, sourceURL := range urls {
-			key := piece.PieceCid + "\x00" + sourceURL
-			if _, ok := seenPieceSources[key]; ok {
-				return fmt.Errorf("piece[%d]: duplicate pieceCid/sourceUrl", i)
-			}
-			seenPieceSources[key] = struct{}{}
-			if err := ValidatePullSourceURL(sourceURL); err != nil {
-				return fmt.Errorf("piece[%d] source[%d]: %w", i, j, err)
-			}
-		}
+	}
+	if len(uniqueCids) > MaxAddPiecesBatchSize {
+		return fmt.Errorf("piece count (%d) exceeds the maximum allowed per pull (%d)", len(uniqueCids), MaxAddPiecesBatchSize)
 	}
 
 	return nil

--- a/pdp/pull_types.go
+++ b/pdp/pull_types.go
@@ -115,7 +115,7 @@ func (p PullPieceRequest) SourceURLs() ([]string, error) {
 			return urls, nil
 		}
 		if host == "" {
-			return nil, fmt.Errorf("provider.host is required")
+			return nil, fmt.Errorf("provider.cids requires provider.host")
 		}
 		cids := p.Provider.CIDs
 		if len(cids) == 0 {

--- a/pdp/pull_types.go
+++ b/pdp/pull_types.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -62,10 +63,97 @@ func ValidatePullSourceURL(sourceURL string) error {
 	return nil
 }
 
-// PullPieceRequest represents a single piece in a pull request
+// PullPieceProvider describes a remote SP from which piece URLs are assembled.
+// Host is a hostname (optionally with port or https:// scheme). Each CID is
+// turned into https://{host}/piece/{cid} on this provider.
+type PullPieceProvider struct {
+	Host string   `json:"host"`
+	CIDs []string `json:"cids,omitempty"`
+}
+
+// PullPieceRequest represents a single piece in a pull request.
+// Source locations are optional and combined into one URL list:
+//   - sourceUrl: a single URL (legacy form)
+//   - urls: additional explicit URLs
+//   - provider: host + optional CIDs assembled into /piece/{cid} URLs
 type PullPieceRequest struct {
-	PieceCid  string `json:"pieceCid"`
-	SourceURL string `json:"sourceUrl"`
+	PieceCid  string             `json:"pieceCid"`
+	SourceURL string             `json:"sourceUrl,omitempty"`
+	URLs      []string           `json:"urls,omitempty"`
+	Provider  *PullPieceProvider `json:"provider,omitempty"`
+}
+
+// SourceURLs returns the de-duplicated source URLs for this piece, combining
+// sourceUrl, urls, and provider-assembled URLs. Provider URLs are built here
+// (on the receiving provider) from host + CIDs; if cids is empty the piece's
+// own pieceCid is used.
+func (p PullPieceRequest) SourceURLs() ([]string, error) {
+	urls := make([]string, 0, 1+len(p.URLs))
+	seen := make(map[string]struct{}, 1+len(p.URLs))
+	add := func(u string) {
+		if u == "" {
+			return
+		}
+		if _, ok := seen[u]; ok {
+			return
+		}
+		seen[u] = struct{}{}
+		urls = append(urls, u)
+	}
+
+	add(p.SourceURL)
+	for i, u := range p.URLs {
+		if u == "" {
+			return nil, fmt.Errorf("urls[%d] is empty", i)
+		}
+		add(u)
+	}
+
+	if p.Provider != nil {
+		host := strings.TrimSpace(p.Provider.Host)
+		if host == "" && len(p.Provider.CIDs) == 0 {
+			return urls, nil
+		}
+		if host == "" {
+			return nil, fmt.Errorf("provider.host is required")
+		}
+		cids := p.Provider.CIDs
+		if len(cids) == 0 {
+			if p.PieceCid == "" {
+				return nil, fmt.Errorf("pieceCid is required to assemble provider URLs")
+			}
+			cids = []string{p.PieceCid}
+		}
+		for i, c := range cids {
+			if c == "" {
+				return nil, fmt.Errorf("provider.cids[%d] is empty", i)
+			}
+			assembled, err := assembleProviderPieceURL(host, c)
+			if err != nil {
+				return nil, err
+			}
+			add(assembled)
+		}
+	}
+
+	return urls, nil
+}
+
+func assembleProviderPieceURL(host, pieceCID string) (string, error) {
+	raw := host
+	if !strings.Contains(host, "://") {
+		raw = "https://" + host
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid provider host %q: %w", host, err)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("invalid provider host %q: missing hostname", host)
+	}
+
+	return parsed.JoinPath("piece", pieceCID).String(), nil
 }
 
 // PullRequest represents the incoming pull request body
@@ -110,16 +198,22 @@ func (r *PullRequest) Validate() error {
 		if piece.PieceCid == "" {
 			return fmt.Errorf("piece[%d]: pieceCid is required", i)
 		}
-		if piece.SourceURL == "" {
-			return fmt.Errorf("piece[%d]: sourceUrl is required", i)
-		}
-		key := piece.PieceCid + "\x00" + piece.SourceURL
-		if _, ok := seenPieceSources[key]; ok {
-			return fmt.Errorf("piece[%d]: duplicate pieceCid/sourceUrl", i)
-		}
-		seenPieceSources[key] = struct{}{}
-		if err := ValidatePullSourceURL(piece.SourceURL); err != nil {
+		urls, err := piece.SourceURLs()
+		if err != nil {
 			return fmt.Errorf("piece[%d]: %w", i, err)
+		}
+		if len(urls) == 0 {
+			return fmt.Errorf("piece[%d]: at least one source URL is required", i)
+		}
+		for j, sourceURL := range urls {
+			key := piece.PieceCid + "\x00" + sourceURL
+			if _, ok := seenPieceSources[key]; ok {
+				return fmt.Errorf("piece[%d]: duplicate pieceCid/sourceUrl", i)
+			}
+			seenPieceSources[key] = struct{}{}
+			if err := ValidatePullSourceURL(sourceURL); err != nil {
+				return fmt.Errorf("piece[%d] source[%d]: %w", i, j, err)
+			}
 		}
 	}
 

--- a/pdp/pull_types_test.go
+++ b/pdp/pull_types_test.go
@@ -231,7 +231,23 @@ func TestPullRequest_Validate(t *testing.T) {
 				},
 			},
 			wantErr:     true,
-			errContains: "provider.host is required",
+			errContains: "provider.cids requires provider.host",
+		},
+		{
+			name: "provider cids without host even with sourceUrl",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{
+						PieceCid:  validCid,
+						SourceURL: validURL,
+						Provider:  &PullPieceProvider{CIDs: []string{validCid2}},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "provider.cids requires provider.host",
 		},
 		{
 			name: "empty urls entry",
@@ -362,6 +378,29 @@ func TestPullPieceRequest_SourceURLs(t *testing.T) {
 			"https://a.example/piece/" + validCid,
 			"https://sp.example.com/piece/" + v1Cid,
 		}, urls)
+	})
+
+	t.Run("cids without host", func(t *testing.T) {
+		p := PullPieceRequest{
+			PieceCid: validCid,
+			Provider: &PullPieceProvider{CIDs: []string{v1Cid}},
+		}
+		_, err := p.SourceURLs()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "provider.cids requires provider.host")
+	})
+
+	t.Run("json cids without host", func(t *testing.T) {
+		raw := `{
+			"pieceCid": "` + validCid + `",
+			"sourceUrl": "https://legacy.example/piece/` + validCid + `",
+			"provider": {"cids": ["` + v1Cid + `"]}
+		}`
+		var p PullPieceRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &p))
+		_, err := p.SourceURLs()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "provider.cids requires provider.host")
 	})
 }
 

--- a/pdp/pull_types_test.go
+++ b/pdp/pull_types_test.go
@@ -157,7 +157,7 @@ func TestPullRequest_Validate(t *testing.T) {
 				Pieces:    []PullPieceRequest{},
 			},
 			wantErr:     true,
-			errContains: "at least one piece",
+			errContains: "at least one source URL is required",
 		},
 		{
 			name: "piece missing pieceCid",
@@ -181,43 +181,48 @@ func TestPullRequest_Validate(t *testing.T) {
 				},
 			},
 			wantErr:     true,
-			errContains: "at least one source URL is required",
+			errContains: "sourceUrl is required",
 		},
 		{
 			name: "valid request with urls array",
 			req: PullRequest{
 				ExtraData: "0x1234",
 				DataSetId: &dataSetId,
-				Pieces: []PullPieceRequest{
-					{PieceCid: validCid, URLs: []string{validURL, "https://backup.example.com/piece/" + validCid}},
-				},
+				URLs:      []string{validURL, "https://backup.example.com/piece/" + validCid},
 			},
 			wantErr: false,
 		},
 		{
-			name: "valid request with provider host",
+			name: "valid request with provider host and cids",
 			req: PullRequest{
 				ExtraData: "0x1234",
 				DataSetId: &dataSetId,
-				Pieces: []PullPieceRequest{
-					{PieceCid: validCid, Provider: &PullPieceProvider{Host: "sp.example.com"}},
-				},
+				Provider:  &PullProvider{Host: "sp.example.com", CIDs: []string{validCid}},
 			},
 			wantErr: false,
 		},
 		{
-			name: "valid request combining sourceUrl urls and provider",
+			name: "valid request combining pieces urls and provider",
 			req: PullRequest{
 				ExtraData: "0x1234",
 				DataSetId: &dataSetId,
 				Pieces: []PullPieceRequest{
-					{
-						PieceCid:  validCid,
-						SourceURL: validURL,
-						URLs:      []string{"https://backup.example.com/piece/" + validCid},
-						Provider:  &PullPieceProvider{Host: "other.example.com", CIDs: []string{validCid2}},
-					},
+					{PieceCid: validCid, SourceURL: validURL},
 				},
+				URLs:     []string{"https://backup.example.com/piece/" + validCid},
+				Provider: &PullProvider{Host: "other.example.com", CIDs: []string{validCid2}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "provider host without cids uses pieces",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, SourceURL: validURL},
+				},
+				Provider: &PullProvider{Host: "sp.example.com"},
 			},
 			wantErr: false,
 		},
@@ -226,25 +231,20 @@ func TestPullRequest_Validate(t *testing.T) {
 			req: PullRequest{
 				ExtraData: "0x1234",
 				DataSetId: &dataSetId,
-				Pieces: []PullPieceRequest{
-					{PieceCid: validCid, Provider: &PullPieceProvider{CIDs: []string{validCid}}},
-				},
+				Provider:  &PullProvider{CIDs: []string{validCid}},
 			},
 			wantErr:     true,
 			errContains: "provider.cids requires provider.host",
 		},
 		{
-			name: "provider cids without host even with sourceUrl",
+			name: "provider cids without host even with pieces",
 			req: PullRequest{
 				ExtraData: "0x1234",
 				DataSetId: &dataSetId,
 				Pieces: []PullPieceRequest{
-					{
-						PieceCid:  validCid,
-						SourceURL: validURL,
-						Provider:  &PullPieceProvider{CIDs: []string{validCid2}},
-					},
+					{PieceCid: validCid, SourceURL: validURL},
 				},
+				Provider: &PullProvider{CIDs: []string{validCid2}},
 			},
 			wantErr:     true,
 			errContains: "provider.cids requires provider.host",
@@ -254,12 +254,20 @@ func TestPullRequest_Validate(t *testing.T) {
 			req: PullRequest{
 				ExtraData: "0x1234",
 				DataSetId: &dataSetId,
-				Pieces: []PullPieceRequest{
-					{PieceCid: validCid, URLs: []string{""}},
-				},
+				URLs:      []string{""},
 			},
 			wantErr:     true,
 			errContains: "urls[0] is empty",
+		},
+		{
+			name: "url missing piece path",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				URLs:      []string{"https://sp.example.com/not-a-piece"},
+			},
+			wantErr:     true,
+			errContains: "/piece/{cid}",
 		},
 		{
 			name: "invalid sourceUrl",
@@ -291,130 +299,137 @@ func TestPullRequest_Validate(t *testing.T) {
 	}
 }
 
-func TestPullPieceRequest_SourceURLs(t *testing.T) {
+func TestPullRequest_AssembledSources(t *testing.T) {
 	const validCid = "bafkzcibf6x7poaqtr2pqm6qki6sgetps74xutpclzrwbux5ow6rw4nsfu6tbf2zfnmnq"
 	const validCid2 = "bafkzcibf6x7poaqtihg2pifeyzwfy3ndaumj3ds6c5ddiqewo2dzfzr7pqlery5dwyba"
 	const v1Cid = "baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy"
 
-	t.Run("legacy sourceUrl", func(t *testing.T) {
-		p := PullPieceRequest{PieceCid: validCid, SourceURL: "https://sp.example.com/piece/" + validCid}
-		urls, err := p.SourceURLs()
-		require.NoError(t, err)
-		require.Equal(t, []string{"https://sp.example.com/piece/" + validCid}, urls)
-	})
+	got := func(sources []pullSource) [][2]string {
+		out := make([][2]string, len(sources))
+		for i, s := range sources {
+			out[i] = [2]string{s.PieceCid, s.SourceURL}
+		}
+		return out
+	}
 
-	t.Run("urls array", func(t *testing.T) {
-		p := PullPieceRequest{PieceCid: validCid, URLs: []string{
-			"https://a.example/piece/" + validCid,
-			"https://b.example/piece/" + validCid,
+	t.Run("legacy pieces sourceUrl", func(t *testing.T) {
+		r := PullRequest{Pieces: []PullPieceRequest{
+			{PieceCid: validCid, SourceURL: "https://sp.example.com/piece/" + validCid},
 		}}
-		urls, err := p.SourceURLs()
+		sources, err := r.AssembledSources()
 		require.NoError(t, err)
-		require.Equal(t, []string{
-			"https://a.example/piece/" + validCid,
-			"https://b.example/piece/" + validCid,
-		}, urls)
+		require.Equal(t, [][2]string{{validCid, "https://sp.example.com/piece/" + validCid}}, got(sources))
 	})
 
-	t.Run("provider host uses pieceCid", func(t *testing.T) {
-		p := PullPieceRequest{PieceCid: validCid, Provider: &PullPieceProvider{Host: "sp.example.com"}}
-		urls, err := p.SourceURLs()
+	t.Run("urls array extracts cid", func(t *testing.T) {
+		r := PullRequest{URLs: []string{
+			"https://a.example/piece/" + validCid,
+			"https://b.example/piece/" + validCid2,
+		}}
+		sources, err := r.AssembledSources()
 		require.NoError(t, err)
-		require.Equal(t, []string{"https://sp.example.com/piece/" + validCid}, urls)
+		require.Equal(t, [][2]string{
+			{validCid, "https://a.example/piece/" + validCid},
+			{validCid2, "https://b.example/piece/" + validCid2},
+		}, got(sources))
+	})
+
+	t.Run("provider host uses piece cids", func(t *testing.T) {
+		r := PullRequest{
+			Pieces: []PullPieceRequest{
+				{PieceCid: validCid, SourceURL: "https://legacy.example/piece/" + validCid},
+			},
+			Provider: &PullProvider{Host: "sp.example.com"},
+		}
+		sources, err := r.AssembledSources()
+		require.NoError(t, err)
+		require.Equal(t, [][2]string{
+			{validCid, "https://legacy.example/piece/" + validCid},
+			{validCid, "https://sp.example.com/piece/" + validCid},
+		}, got(sources))
 	})
 
 	t.Run("provider host with port and cids", func(t *testing.T) {
-		p := PullPieceRequest{
-			PieceCid: validCid,
-			Provider: &PullPieceProvider{Host: "sp.example.com:8080", CIDs: []string{v1Cid, validCid2}},
-		}
-		urls, err := p.SourceURLs()
+		r := PullRequest{Provider: &PullProvider{Host: "sp.example.com:8080", CIDs: []string{v1Cid, validCid2}}}
+		sources, err := r.AssembledSources()
 		require.NoError(t, err)
-		require.Equal(t, []string{
-			"https://sp.example.com:8080/piece/" + v1Cid,
-			"https://sp.example.com:8080/piece/" + validCid2,
-		}, urls)
+		require.Equal(t, [][2]string{
+			{v1Cid, "https://sp.example.com:8080/piece/" + v1Cid},
+			{validCid2, "https://sp.example.com:8080/piece/" + validCid2},
+		}, got(sources))
 	})
 
 	t.Run("provider host already has scheme", func(t *testing.T) {
-		p := PullPieceRequest{
-			PieceCid: validCid,
-			Provider: &PullPieceProvider{Host: "https://sp.example.com/pdp"},
-		}
-		urls, err := p.SourceURLs()
+		r := PullRequest{Provider: &PullProvider{Host: "https://sp.example.com/pdp", CIDs: []string{validCid}}}
+		sources, err := r.AssembledSources()
 		require.NoError(t, err)
-		require.Equal(t, []string{"https://sp.example.com/pdp/piece/" + validCid}, urls)
+		require.Equal(t, [][2]string{{validCid, "https://sp.example.com/pdp/piece/" + validCid}}, got(sources))
 	})
 
 	t.Run("combines and dedupes all sources", func(t *testing.T) {
 		legacy := "https://sp.example.com/piece/" + validCid
-		p := PullPieceRequest{
-			PieceCid:  validCid,
-			SourceURL: legacy,
-			URLs:      []string{legacy, "https://backup.example.com/piece/" + validCid},
-			Provider:  &PullPieceProvider{Host: "sp.example.com"},
+		r := PullRequest{
+			Pieces: []PullPieceRequest{
+				{PieceCid: validCid, SourceURL: legacy},
+			},
+			URLs:     []string{legacy, "https://backup.example.com/piece/" + validCid},
+			Provider: &PullProvider{Host: "sp.example.com"},
 		}
-		urls, err := p.SourceURLs()
+		sources, err := r.AssembledSources()
 		require.NoError(t, err)
-		require.Equal(t, []string{
-			"https://sp.example.com/piece/" + validCid,
-			"https://backup.example.com/piece/" + validCid,
-		}, urls)
+		require.Equal(t, [][2]string{
+			{validCid, "https://sp.example.com/piece/" + validCid},
+			{validCid, "https://backup.example.com/piece/" + validCid},
+		}, got(sources))
 	})
 
 	t.Run("json form", func(t *testing.T) {
 		raw := `{
-			"pieceCid": "` + validCid + `",
-			"sourceUrl": "https://legacy.example/piece/` + validCid + `",
+			"extraData": "0x1234",
+			"pieces": [{"pieceCid": "` + validCid + `", "sourceUrl": "https://legacy.example/piece/` + validCid + `"}],
 			"urls": ["https://a.example/piece/` + validCid + `"],
 			"provider": {"host": "sp.example.com", "cids": ["` + v1Cid + `"]}
 		}`
-		var p PullPieceRequest
-		require.NoError(t, json.Unmarshal([]byte(raw), &p))
-		urls, err := p.SourceURLs()
+		var r PullRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &r))
+		sources, err := r.AssembledSources()
 		require.NoError(t, err)
-		require.Equal(t, []string{
-			"https://legacy.example/piece/" + validCid,
-			"https://a.example/piece/" + validCid,
-			"https://sp.example.com/piece/" + v1Cid,
-		}, urls)
+		require.Equal(t, [][2]string{
+			{validCid, "https://legacy.example/piece/" + validCid},
+			{validCid, "https://a.example/piece/" + validCid},
+			{v1Cid, "https://sp.example.com/piece/" + v1Cid},
+		}, got(sources))
 	})
 
 	t.Run("cids without host", func(t *testing.T) {
-		p := PullPieceRequest{
-			PieceCid: validCid,
-			Provider: &PullPieceProvider{CIDs: []string{v1Cid}},
-		}
-		_, err := p.SourceURLs()
+		r := PullRequest{Provider: &PullProvider{CIDs: []string{v1Cid}}}
+		_, err := r.AssembledSources()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "provider.cids requires provider.host")
 	})
 
 	t.Run("json cids without host", func(t *testing.T) {
 		raw := `{
-			"pieceCid": "` + validCid + `",
-			"sourceUrl": "https://legacy.example/piece/` + validCid + `",
+			"pieces": [{"pieceCid": "` + validCid + `", "sourceUrl": "https://legacy.example/piece/` + validCid + `"}],
 			"provider": {"cids": ["` + v1Cid + `"]}
 		}`
-		var p PullPieceRequest
-		require.NoError(t, json.Unmarshal([]byte(raw), &p))
-		_, err := p.SourceURLs()
+		var r PullRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &r))
+		_, err := r.AssembledSources()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "provider.cids requires provider.host")
 	})
 }
 
 func TestPullRequest_ValidateBatchLimit(t *testing.T) {
-	const validCid = "bafkzcibf6x7poaqtr2pqm6qki6sgetps74xutpclzrwbux5ow6rw4nsfu6tbf2zfnmnq"
 	dataSetId := uint64(1)
 
-	// Distinct source URLs so the batch-size check is isolated from the
-	// duplicate and per-piece checks that run afterwards.
 	pieces := make([]PullPieceRequest, MaxAddPiecesBatchSize+1)
 	for i := range pieces {
+		cid := fmt.Sprintf("cid-%d", i)
 		pieces[i] = PullPieceRequest{
-			PieceCid:  validCid,
-			SourceURL: fmt.Sprintf("https://sp.example.com/piece/%s?n=%d", validCid, i),
+			PieceCid:  cid,
+			SourceURL: fmt.Sprintf("https://sp.example.com/piece/%s", cid),
 		}
 	}
 	req := PullRequest{ExtraData: "0x1234", DataSetId: &dataSetId, Pieces: pieces}

--- a/pdp/pull_types_test.go
+++ b/pdp/pull_types_test.go
@@ -1,6 +1,7 @@
 package pdp
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -180,7 +181,69 @@ func TestPullRequest_Validate(t *testing.T) {
 				},
 			},
 			wantErr:     true,
-			errContains: "sourceUrl is required",
+			errContains: "at least one source URL is required",
+		},
+		{
+			name: "valid request with urls array",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, URLs: []string{validURL, "https://backup.example.com/piece/" + validCid}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid request with provider host",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, Provider: &PullPieceProvider{Host: "sp.example.com"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid request combining sourceUrl urls and provider",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{
+						PieceCid:  validCid,
+						SourceURL: validURL,
+						URLs:      []string{"https://backup.example.com/piece/" + validCid},
+						Provider:  &PullPieceProvider{Host: "other.example.com", CIDs: []string{validCid2}},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "provider cids without host",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, Provider: &PullPieceProvider{CIDs: []string{validCid}}},
+				},
+			},
+			wantErr:     true,
+			errContains: "provider.host is required",
+		},
+		{
+			name: "empty urls entry",
+			req: PullRequest{
+				ExtraData: "0x1234",
+				DataSetId: &dataSetId,
+				Pieces: []PullPieceRequest{
+					{PieceCid: validCid, URLs: []string{""}},
+				},
+			},
+			wantErr:     true,
+			errContains: "urls[0] is empty",
 		},
 		{
 			name: "invalid sourceUrl",
@@ -210,6 +273,96 @@ func TestPullRequest_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPullPieceRequest_SourceURLs(t *testing.T) {
+	const validCid = "bafkzcibf6x7poaqtr2pqm6qki6sgetps74xutpclzrwbux5ow6rw4nsfu6tbf2zfnmnq"
+	const validCid2 = "bafkzcibf6x7poaqtihg2pifeyzwfy3ndaumj3ds6c5ddiqewo2dzfzr7pqlery5dwyba"
+	const v1Cid = "baga6ea4seaqpy7usqklokfx2vxuynmupslkeutzexe2uqurdg5vhtebhxqmpqmy"
+
+	t.Run("legacy sourceUrl", func(t *testing.T) {
+		p := PullPieceRequest{PieceCid: validCid, SourceURL: "https://sp.example.com/piece/" + validCid}
+		urls, err := p.SourceURLs()
+		require.NoError(t, err)
+		require.Equal(t, []string{"https://sp.example.com/piece/" + validCid}, urls)
+	})
+
+	t.Run("urls array", func(t *testing.T) {
+		p := PullPieceRequest{PieceCid: validCid, URLs: []string{
+			"https://a.example/piece/" + validCid,
+			"https://b.example/piece/" + validCid,
+		}}
+		urls, err := p.SourceURLs()
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"https://a.example/piece/" + validCid,
+			"https://b.example/piece/" + validCid,
+		}, urls)
+	})
+
+	t.Run("provider host uses pieceCid", func(t *testing.T) {
+		p := PullPieceRequest{PieceCid: validCid, Provider: &PullPieceProvider{Host: "sp.example.com"}}
+		urls, err := p.SourceURLs()
+		require.NoError(t, err)
+		require.Equal(t, []string{"https://sp.example.com/piece/" + validCid}, urls)
+	})
+
+	t.Run("provider host with port and cids", func(t *testing.T) {
+		p := PullPieceRequest{
+			PieceCid: validCid,
+			Provider: &PullPieceProvider{Host: "sp.example.com:8080", CIDs: []string{v1Cid, validCid2}},
+		}
+		urls, err := p.SourceURLs()
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"https://sp.example.com:8080/piece/" + v1Cid,
+			"https://sp.example.com:8080/piece/" + validCid2,
+		}, urls)
+	})
+
+	t.Run("provider host already has scheme", func(t *testing.T) {
+		p := PullPieceRequest{
+			PieceCid: validCid,
+			Provider: &PullPieceProvider{Host: "https://sp.example.com/pdp"},
+		}
+		urls, err := p.SourceURLs()
+		require.NoError(t, err)
+		require.Equal(t, []string{"https://sp.example.com/pdp/piece/" + validCid}, urls)
+	})
+
+	t.Run("combines and dedupes all sources", func(t *testing.T) {
+		legacy := "https://sp.example.com/piece/" + validCid
+		p := PullPieceRequest{
+			PieceCid:  validCid,
+			SourceURL: legacy,
+			URLs:      []string{legacy, "https://backup.example.com/piece/" + validCid},
+			Provider:  &PullPieceProvider{Host: "sp.example.com"},
+		}
+		urls, err := p.SourceURLs()
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"https://sp.example.com/piece/" + validCid,
+			"https://backup.example.com/piece/" + validCid,
+		}, urls)
+	})
+
+	t.Run("json form", func(t *testing.T) {
+		raw := `{
+			"pieceCid": "` + validCid + `",
+			"sourceUrl": "https://legacy.example/piece/` + validCid + `",
+			"urls": ["https://a.example/piece/` + validCid + `"],
+			"provider": {"host": "sp.example.com", "cids": ["` + v1Cid + `"]}
+		}`
+		var p PullPieceRequest
+		require.NoError(t, json.Unmarshal([]byte(raw), &p))
+		urls, err := p.SourceURLs()
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"https://legacy.example/piece/" + validCid,
+			"https://a.example/piece/" + validCid,
+			"https://sp.example.com/piece/" + v1Cid,
+		}, urls)
+	})
 }
 
 func TestPullRequest_ValidateBatchLimit(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/curio/issues/1252
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`POST /pdp/piece/pull` still accepts the current `pieces: [{pieceCid, sourceUrl}]` form. Additional sources are top-level so there is no nested plural under `pieces[]`:

```json
{
  "pieces": [
    { "pieceCid": "<CommP-v2-CID>", "sourceUrl": "https://example.com/piece/bafy..." }
  ],
  "urls": ["https://backup.example.com/piece/bafy..."],
  "provider": {
    "host": "sp.example.com",
    "cids": ["<optional-retrieval-CID>"]
  }
}
```

All three fields are optional. Curio assembles them into the same per-URL pull item list used today.

- `urls` entries must end in `/piece/{cid}`; the CID is taken from the path.
- Provider URLs are assembled as `https://{host}/piece/{cid}`.
- If `provider.cids` is omitted, piece CIDs already collected from `pieces` and `urls` are used.
- `provider.cids` without `provider.host` is rejected.

## Test plan
- [x] `AssembledSources()` covers legacy `pieces`, top-level `urls`, provider host/cids, host fallback to known CIDs, JSON form, and de-dupe
- [x] `provider.cids` without `provider.host` returns an error
- [x] Handler tests for mixed sources and provider-only requests
- [x] Existing pull validation and handler tests still pass (`go test ./pdp -tags skiff` for the non-DB pull cases)
- DB-backed backpressure tests were not run here (no local Yugabyte)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10216082-c43d-4ad3-9068-2215de27a02b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10216082-c43d-4ad3-9068-2215de27a02b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

